### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Axon
 
+[![CI](https://github.com/gjkim42/axon/actions/workflows/ci.yaml/badge.svg)](https://github.com/gjkim42/axon/actions/workflows/ci.yaml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/gjkim42/axon)](https://github.com/gjkim42/axon)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 Kubernetes controller for running AI agents (e.g. Claude Code) as Jobs.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add CI status badge showing GitHub Actions workflow status
- Add Go version badge (dynamically pulled from go.mod)
- Add Apache 2.0 license badge

Improves project visibility and provides quick status indicators.

🤖 Generated with [Claude Code](https://claude.ai/code)