### PR TITLE
Add release workflow to build and push Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: gjkim42
+          password: ${{ secrets.DOCKERHUB_AXON_TOKEN }}
+
+      - name: Build image
+        run: make image
+
+      - name: Push image
+        run: make push


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and push Docker image when main branch is updated
- Uses `make image` and `make push` targets
- Pushes to Docker Hub as `gjkim42/axon-controller:latest`

## Required Setup
- `DOCKERHUB_AXON_TOKEN` secret must be configured in repository settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)