### PR TITLE
Use cheapest model in e2e test

### DIFF
--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -57,6 +57,7 @@ metadata:
   name: ` + taskName + `
 spec:
   type: claude-code
+  model: haiku
   prompt: "Print 'Hello from Axon e2e test' to stdout"
   credentials:
     type: oauth


### PR DESCRIPTION
## Summary
- Add `model: haiku` to the Task spec in the e2e test to use the cheapest available model instead of the default, reducing test costs

## Test plan
- [x] `make test` passes
- [ ] `make test-e2e` runs with haiku model (requires cluster + `CLAUDE_CODE_OAUTH_TOKEN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)