### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,45 @@
 # Axon
 
+**Run autonomous AI agents safely — at scale, in CI, on Kubernetes.**
+
 [![CI](https://github.com/gjkim42/axon/actions/workflows/ci.yaml/badge.svg)](https://github.com/gjkim42/axon/actions/workflows/ci.yaml)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/gjkim42/axon)](https://github.com/gjkim42/axon)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Kubernetes controller for running AI agents (e.g. Claude Code) as Jobs.
+## Why Axon?
 
-## Overview
+AI coding agents like Claude Code are most powerful when they run with `--dangerously-skip-permissions` — no human in the loop, fully autonomous. But on your laptop, that flag lives up to its name: the agent can touch your filesystem, network, and everything else on the host. And there's no easy way to fan out dozens of agents across repos, or plug them into a CI pipeline.
 
-Axon manages AI agent workloads on Kubernetes. Create a `Task` resource and Axon will run the specified agent as a Kubernetes Job, tracking its progress and status.
+**Kubernetes solves both problems at once.** Inside a Pod, "dangerously skip permissions" isn't dangerous anymore — the agent gets full autonomy *within* an isolated, ephemeral container while the blast radius stays at zero for the host. And because it's Kubernetes, you get parallelism, scheduling, and CI integration for free.
 
-Currently supported agents:
-- `claude-code` - Anthropic's Claude Code CLI
+Axon is the controller that ties it together. Define what you want the agent to do, and Axon runs it as an isolated Job with `--dangerously-skip-permissions` enabled by default.
+
+- **Safe autonomy** — agents run with `--dangerously-skip-permissions` inside isolated, ephemeral Pods. Full speed, zero risk to the host.
+- **Scale out** — launch hundreds of agents in parallel across repositories. Kubernetes handles scheduling and resource management.
+- **CI-native** — trigger agents from any pipeline. A Task is just a Kubernetes resource — create it with `kubectl`, Helm, Argo, or your own tooling.
+- **Observable** — watch agents move through `Pending → Running → Succeeded/Failed` with kubectl.
+- **Simple** — one CRD, one controller, zero dependencies beyond a running cluster.
+
+## How It Works
+
+```mermaid
+flowchart LR
+    T1["Task: refactor auth"] --> AC[Axon Controller]
+    T2["Task: add tests"] --> AC
+    T3["Task: update docs"] --> AC
+
+    AC --> J1[Job 1] --> P1["Pod 1 (--dangerously-skip-permissions)"] --> S1[Succeeded]
+    AC --> J2[Job 2] --> P2["Pod 2 (--dangerously-skip-permissions)"] --> S2[Succeeded]
+    AC --> J3[Job 3] --> P3["Pod 3 (--dangerously-skip-permissions)"] --> F3[Failed]
+```
+
+1. You **apply a Task** manifest with a prompt, agent type, credential reference, and optionally a git repo to clone.
+2. The **Axon controller** creates a Kubernetes **Job**.
+3. If a workspace is specified, an **init container clones the repo**. Then the agent Pod starts with `--dangerously-skip-permissions`.
+4. The agent runs **fully autonomous** inside the container — no permission prompts, no risk to the host.
+5. Axon **tracks status** (phase, pod name, timestamps, messages). Delete the Task and the Job + Pod are automatically cleaned up via owner references.
+
+Currently supported agents: **Claude Code** (`claude-code`).
 
 ## Quick Start
 
@@ -20,37 +48,47 @@ Currently supported agents:
 - Kubernetes cluster (1.28+)
 - kubectl configured
 
-### Installation
+### Install
 
-```bash
-# Install CRDs and controller
-kubectl apply -f install-crd.yaml
-kubectl apply -f install.yaml
-```
-
-Or install directly from GitHub:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/gjkim42/axon/main/install-crd.yaml
 kubectl apply -f https://raw.githubusercontent.com/gjkim42/axon/main/install.yaml
 ```
 
-To uninstall:
-```bash
-kubectl delete -f install.yaml
-kubectl delete -f install-crd.yaml
-```
+### Run Your First Task
 
-### Create a Task
+1. Create a Secret with your Anthropic API key:
 
-#### Using API Key
-
-1. Create a Secret with your API key:
 ```bash
 kubectl create secret generic anthropic-api-key \
   --from-literal=ANTHROPIC_API_KEY=<your-api-key>
 ```
 
-2. Create a Task:
+2. Run a task:
+
+```bash
+axon run -p "Create a hello world program in Python" --secret anthropic-api-key -w
+```
+
+3. Watch it go:
+
+```
+NAME              TYPE          PHASE      AGE
+task-a1b2c        claude-code   Pending    0s
+task-a1b2c        claude-code   Running    3s
+task-a1b2c        claude-code   Succeeded  42s
+```
+
+Run against a git repo:
+
+```bash
+axon run -p "Add unit tests" --secret anthropic-api-key \
+  --workspace-repo https://github.com/your-org/repo.git --workspace-ref main -w
+```
+
+<details>
+<summary>Using kubectl and YAML instead of the CLI</summary>
+
 ```yaml
 apiVersion: axon.io/v1alpha1
 kind: Task
@@ -65,73 +103,145 @@ spec:
       name: anthropic-api-key
 ```
 
-#### Using OAuth
-
-1. Create a Secret with your OAuth token:
-```bash
-kubectl create secret generic claude-oauth \
-  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-oauth-token>
-```
-
-2. Create a Task:
-```yaml
-apiVersion: axon.io/v1alpha1
-kind: Task
-metadata:
-  name: hello-world
-spec:
-  type: claude-code
-  prompt: "Create a hello world program in Python"
-  credentials:
-    type: oauth
-    secretRef:
-      name: claude-oauth
-```
-
-#### Apply and Watch
-
 ```bash
 kubectl apply -f task.yaml
 kubectl get tasks -w
 ```
 
-## Task Spec
+Add `spec.workspace` to clone a repo before the agent starts:
+
+```yaml
+  workspace:
+    repo: https://github.com/your-org/your-repo.git
+    ref: main
+```
+
+</details>
+
+<details>
+<summary>Using OAuth instead of an API key</summary>
+
+```bash
+kubectl create secret generic claude-oauth \
+  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-oauth-token>
+```
+
+Then pass `--credential-type oauth --secret claude-oauth` to `axon run`, or set `spec.credentials.type: oauth` in YAML.
+
+</details>
+
+## Features
+
+| Feature | Details |
+|---------|---------|
+| Safe Autonomy | Agents run with `--dangerously-skip-permissions` inside isolated, ephemeral Pods |
+| Scale Out | Run hundreds of agents in parallel — Kubernetes handles scheduling |
+| CI-Native | Trigger agents from any pipeline via `kubectl`, Helm, Argo, or your own tooling |
+| Git Workspace | Clone a repo into the agent's working directory via `spec.workspace` |
+| CLI | `axon run`, `axon get`, `axon logs`, `axon delete` — manage tasks without writing YAML |
+| Full Lifecycle | `Pending` → `Running` → `Succeeded` / `Failed` |
+| Owner References | Delete a Task and its Job + Pod are automatically cleaned up |
+| Credential Management | API key and OAuth supported via Kubernetes Secrets |
+| Model Selection | Override the default model per-task with `spec.model` |
+| Status Tracking | Job name, pod name, start/completion times, and messages |
+| Leader Election | Safe multi-replica deployment out of the box |
+| Minimal Footprint | Distroless container, 10m CPU / 64Mi memory requests |
+| Extensible | Pluggable agent type — add new agents via the `switch` in `job_builder.go` |
+
+## Use Cases
+
+- **Hands-free CI** — let an autonomous agent generate, refactor, or fix code as a pipeline step, with no permission prompts blocking the run.
+- **Batch refactoring at scale** — spin up dozens of agents in parallel to apply the same prompt across microservices, each safely isolated in its own Pod.
+- **Scheduled maintenance** — pair with a CronJob or workflow engine to run recurring code-health agents on a schedule.
+- **Developer self-service** — expose agent execution through an internal portal so any developer can run a fully autonomous AI agent without local setup.
+- **AI in your internal platform** — embed Axon as the execution layer for AI-powered features in your developer platform.
+
+## Reference
+
+### Task Spec
 
 | Field | Description | Required |
 |-------|-------------|----------|
-| `type` | Agent type (`claude-code`) | Yes |
-| `prompt` | Task prompt for the agent | Yes |
-| `credentials.type` | `api-key` or `oauth` | Yes |
-| `credentials.secretRef.name` | Secret name with credentials | Yes |
-| `model` | Model override (e.g., `claude-sonnet-4-20250514`) | No |
+| `spec.type` | Agent type (`claude-code`) | Yes |
+| `spec.prompt` | Task prompt for the agent | Yes |
+| `spec.credentials.type` | `api-key` or `oauth` | Yes |
+| `spec.credentials.secretRef.name` | Secret name with credentials | Yes |
+| `spec.model` | Model override (e.g., `claude-sonnet-4-20250514`) | No |
+| `spec.workspace.repo` | Git repository URL to clone (HTTPS, git://, or SSH) | No |
+| `spec.workspace.ref` | Branch, tag, or commit SHA to checkout (defaults to repo's default branch) | No |
 
-## Task Status
+### Task Status
 
-| Phase | Description |
+| Field | Description |
 |-------|-------------|
-| `Pending` | Task accepted, Job not yet running |
-| `Running` | Job is actively running |
-| `Succeeded` | Job completed successfully |
-| `Failed` | Job failed |
+| `status.phase` | Current phase: `Pending`, `Running`, `Succeeded`, or `Failed` |
+| `status.jobName` | Name of the Job created for this Task |
+| `status.podName` | Name of the Pod running the Task |
+| `status.startTime` | When the Task started running |
+| `status.completionTime` | When the Task completed |
+| `status.message` | Additional information about the current status |
+
+### CLI
+
+The `axon` CLI lets you manage tasks without writing YAML.
+
+```bash
+# Run a task and watch its status
+axon run -p "Refactor auth to use JWT" --secret anthropic-api-key -w
+
+# Run against a git repo
+axon run -p "Add unit tests" --secret anthropic-api-key \
+  --workspace-repo https://github.com/your-org/repo.git --workspace-ref main -w
+
+# List tasks
+axon get
+
+# View logs (follow mode)
+axon logs my-task -f
+
+# Delete a task
+axon delete my-task
+```
+
+## Uninstall
+
+```bash
+kubectl delete -f https://raw.githubusercontent.com/gjkim42/axon/main/install.yaml
+kubectl delete -f https://raw.githubusercontent.com/gjkim42/axon/main/install-crd.yaml
+```
 
 ## Development
 
+Build, test, and iterate with `make`:
+
 ```bash
-# Generate code and CRDs
-make update
-
-# Verify (generate, fmt, vet, tidy check)
-make verify
-
-# Run tests
-make test        # unit tests
-make test-e2e    # e2e tests
-
-# Build
-make build       # binary
-make image       # docker image
+make update             # generate code, CRDs, fmt, tidy
+make verify             # generate + vet + tidy-diff check
+make test               # unit tests
+make test-integration   # integration tests (envtest)
+make test-e2e           # e2e tests (requires cluster)
+make build              # build binary
+make image              # build docker image
 ```
+
+## Roadmap
+
+- **Task dependencies** — chain tasks so one waits for another to finish before starting, enabling agent pipelines in pure Kubernetes.
+
+```mermaid
+flowchart LR
+    T1["Task: scaffold service"] --> T2["Task: write tests"]
+    T2 --> T3["Task: generate docs"]
+```
+
+## Contributing
+
+1. Fork the repo and create a feature branch.
+2. Make your changes and run `make verify` to ensure everything passes.
+3. Open a pull request with a clear description of the change.
+
+For significant changes, please open an issue first to discuss the approach.
 
 ## License
 
-Apache 2.0
+[Apache 2.0](LICENSE)


### PR DESCRIPTION
## Summary
- Rewrite README from minimal technical docs into a compelling project page
- Center narrative on three value props: safe autonomy via container isolation (`--dangerously-skip-permissions`), scale, and CI integration
- Lead Quick Start with the `axon` CLI as the happy path; collapse `kubectl`/YAML into a details block
- Add new sections: Why Axon?, How It Works (Mermaid diagrams), Features table, Use Cases, CLI reference, Contributing, Roadmap
- Document workspace feature (`spec.workspace`) and CLI (`axon run/get/logs/delete`)
- Expand Reference with full Task Status fields and workspace spec fields

## Test plan
- [ ] Verify Mermaid diagrams render correctly on GitHub
- [ ] Confirm all `kubectl`/CLI commands and YAML examples match the actual CRD and CLI flags
- [ ] Verify expected output matches printer columns (Type, Phase, Age)
- [ ] Confirm all feature claims are backed by code (distroless in Dockerfile, leader election in main.go, resource limits in install.yaml, workspace init container in job_builder.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)