### PR TITLE
Add axon CLI for managing Tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,11 @@ jobs:
           kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never"}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
+      - name: Build CLI
+        run: make build WHAT=cmd/axon
+
       - name: E2E Test
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          AXON_BIN: ${{ github.workspace }}/bin/axon
         run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,14 @@ verify: controller-gen ## Verify everything is up-to-date and correct.
 
 ##@ Build
 
+WHAT ?= cmd/...
+
 .PHONY: build
-build: ## Build manager binary.
-	go build -o bin/manager ./cmd/manager
+build: ## Build binaries (use WHAT=cmd/axon to build specific binary).
+	@for dir in $$(go list ./$(WHAT)); do \
+		bin_name=$$(basename $$dir); \
+		go build -o bin/$$bin_name $$dir; \
+	done
 
 .PHONY: run
 run: ## Run a controller from your host.

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/gjkim/axon/internal/cli"
+)
+
+func main() {
+	if err := cli.NewRootCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.3
+	github.com/spf13/cobra v1.10.2
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -50,7 +51,6 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	axonv1alpha1 "github.com/gjkim/axon/api/v1alpha1"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+}
+
+// ClientConfig holds configuration for Kubernetes client creation.
+type ClientConfig struct {
+	Kubeconfig string
+	Namespace  string
+}
+
+// NewClient creates a controller-runtime client and resolves the namespace.
+func (c *ClientConfig) NewClient() (client.Client, string, error) {
+	restConfig, ns, err := c.resolveConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	cl, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, "", fmt.Errorf("creating client: %w", err)
+	}
+	return cl, ns, nil
+}
+
+// NewClientset creates a kubernetes.Clientset and resolves the namespace.
+func (c *ClientConfig) NewClientset() (*kubernetes.Clientset, string, error) {
+	restConfig, ns, err := c.resolveConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	cs, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, "", fmt.Errorf("creating clientset: %w", err)
+	}
+	return cs, ns, nil
+}
+
+func (c *ClientConfig) resolveConfig() (*rest.Config, string, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if c.Kubeconfig != "" {
+		rules.ExplicitPath = c.Kubeconfig
+	}
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
+
+	restConfig, err := config.ClientConfig()
+	if err != nil {
+		return nil, "", fmt.Errorf("loading kubeconfig: %w", err)
+	}
+
+	ns := c.Namespace
+	if ns == "" {
+		ns, _, err = config.Namespace()
+		if err != nil {
+			return nil, "", fmt.Errorf("resolving namespace: %w", err)
+		}
+		if ns == "" {
+			ns = "default"
+		}
+	}
+
+	return restConfig, ns, nil
+}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim/axon/api/v1alpha1"
+)
+
+func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			task := &axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), task); err != nil {
+				return fmt.Errorf("deleting task: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "task/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	axonv1alpha1 "github.com/gjkim/axon/api/v1alpha1"
+)
+
+func newGetCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [name]",
+		Short: "List tasks or get details of a specific task",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+
+			if len(args) == 1 {
+				task := &axonv1alpha1.Task{}
+				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, task); err != nil {
+					return fmt.Errorf("getting task: %w", err)
+				}
+				printTaskDetail(os.Stdout, task)
+				return nil
+			}
+
+			taskList := &axonv1alpha1.TaskList{}
+			if err := cl.List(ctx, taskList, client.InNamespace(ns)); err != nil {
+				return fmt.Errorf("listing tasks: %w", err)
+			}
+			printTaskTable(os.Stdout, taskList.Items)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	axonv1alpha1 "github.com/gjkim/axon/api/v1alpha1"
+)
+
+func newLogsCommand(cfg *ClientConfig) *cobra.Command {
+	var follow bool
+
+	cmd := &cobra.Command{
+		Use:   "logs <name>",
+		Short: "View logs from a task's pod",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			task := &axonv1alpha1.Task{}
+			if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, task); err != nil {
+				return fmt.Errorf("getting task: %w", err)
+			}
+
+			podName := task.Status.PodName
+			if podName == "" {
+				return fmt.Errorf("task %q has no pod yet", args[0])
+			}
+
+			cs, _, err := cfg.NewClientset()
+			if err != nil {
+				return err
+			}
+
+			opts := &corev1.PodLogOptions{Follow: follow}
+			stream, err := cs.CoreV1().Pods(ns).GetLogs(podName, opts).Stream(ctx)
+			if err != nil {
+				return fmt.Errorf("streaming logs: %w", err)
+			}
+			defer stream.Close()
+
+			if _, err := io.Copy(os.Stdout, stream); err != nil {
+				return fmt.Errorf("reading logs: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "follow log output")
+
+	return cmd
+}

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	axonv1alpha1 "github.com/gjkim/axon/api/v1alpha1"
+)
+
+func printTaskTable(w io.Writer, tasks []axonv1alpha1.Task) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tTYPE\tPHASE\tAGE")
+	for _, t := range tasks {
+		age := duration.HumanDuration(time.Since(t.CreationTimestamp.Time))
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", t.Name, t.Spec.Type, t.Status.Phase, age)
+	}
+	tw.Flush()
+}
+
+func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
+	printField(w, "Name", t.Name)
+	printField(w, "Namespace", t.Namespace)
+	printField(w, "Type", t.Spec.Type)
+	printField(w, "Phase", string(t.Status.Phase))
+	printField(w, "Prompt", t.Spec.Prompt)
+	printField(w, "Secret", t.Spec.Credentials.SecretRef.Name)
+	printField(w, "Credential Type", string(t.Spec.Credentials.Type))
+	if t.Spec.Model != "" {
+		printField(w, "Model", t.Spec.Model)
+	}
+	if t.Spec.Workspace != nil {
+		printField(w, "Workspace Repo", t.Spec.Workspace.Repo)
+		if t.Spec.Workspace.Ref != "" {
+			printField(w, "Workspace Ref", t.Spec.Workspace.Ref)
+		}
+	}
+	if t.Status.JobName != "" {
+		printField(w, "Job", t.Status.JobName)
+	}
+	if t.Status.PodName != "" {
+		printField(w, "Pod", t.Status.PodName)
+	}
+	if t.Status.StartTime != nil {
+		printField(w, "Start Time", t.Status.StartTime.Time.Format(time.RFC3339))
+	}
+	if t.Status.CompletionTime != nil {
+		printField(w, "Completion Time", t.Status.CompletionTime.Time.Format(time.RFC3339))
+	}
+	if t.Status.Message != "" {
+		printField(w, "Message", t.Status.Message)
+	}
+}
+
+func printField(w io.Writer, label, value string) {
+	fmt.Fprintf(w, "%-20s%s\n", label+":", value)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewRootCommand() *cobra.Command {
+	cfg := &ClientConfig{}
+
+	cmd := &cobra.Command{
+		Use:           "axon",
+		Short:         "CLI for managing AI agent Tasks on Kubernetes",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cmd.PersistentFlags().StringVar(&cfg.Kubeconfig, "kubeconfig", "", "path to kubeconfig file")
+	cmd.PersistentFlags().StringVarP(&cfg.Namespace, "namespace", "n", "", "Kubernetes namespace")
+
+	cmd.AddCommand(
+		newRunCommand(cfg),
+		newGetCommand(cfg),
+		newLogsCommand(cfg),
+		newDeleteCommand(cfg),
+	)
+
+	return cmd
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	axonv1alpha1 "github.com/gjkim/axon/api/v1alpha1"
+)
+
+func newRunCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		prompt         string
+		agentType      string
+		secret         string
+		credentialType string
+		model          string
+		name           string
+		watch          bool
+		workspaceRepo  string
+		workspaceRef   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Create and run a new Task",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			if name == "" {
+				name = "task-" + rand.String(5)
+			}
+
+			task := &axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   agentType,
+					Prompt: prompt,
+					Credentials: axonv1alpha1.Credentials{
+						Type: axonv1alpha1.CredentialType(credentialType),
+						SecretRef: axonv1alpha1.SecretReference{
+							Name: secret,
+						},
+					},
+					Model: model,
+				},
+			}
+
+			if workspaceRepo != "" {
+				task.Spec.Workspace = &axonv1alpha1.Workspace{
+					Repo: workspaceRepo,
+					Ref:  workspaceRef,
+				}
+			}
+
+			ctx := context.Background()
+			if err := cl.Create(ctx, task); err != nil {
+				return fmt.Errorf("creating task: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "task/%s created\n", name)
+
+			if watch {
+				return watchTask(ctx, cl, name, ns)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "task prompt (required)")
+	cmd.Flags().StringVarP(&agentType, "type", "t", "claude-code", "agent type")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (required)")
+	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
+	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&name, "name", "", "task name (auto-generated if omitted)")
+	cmd.Flags().StringVar(&workspaceRepo, "workspace-repo", "", "git repository URL to clone")
+	cmd.Flags().StringVar(&workspaceRef, "workspace-ref", "", "git reference (branch, tag, or commit SHA)")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch task status after creation")
+
+	cmd.MarkFlagRequired("prompt")
+	cmd.MarkFlagRequired("secret")
+
+	return cmd
+}
+
+func watchTask(ctx context.Context, cl client.Client, name, namespace string) error {
+	var lastPhase axonv1alpha1.TaskPhase
+	for {
+		task := &axonv1alpha1.Task{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, task); err != nil {
+			return fmt.Errorf("getting task: %w", err)
+		}
+
+		if task.Status.Phase != lastPhase {
+			fmt.Fprintf(os.Stdout, "task/%s %s\n", name, task.Status.Phase)
+			lastPhase = task.Status.Phase
+		}
+
+		if task.Status.Phase == axonv1alpha1.TaskPhaseSucceeded || task.Status.Phase == axonv1alpha1.TaskPhaseFailed {
+			return nil
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const cliTaskName = "e2e-cli-test-task"
+const cliWorkspaceTaskName = "e2e-cli-workspace-task"
+
+var _ = Describe("CLI", func() {
+	BeforeEach(func() {
+		By("cleaning up existing resources")
+		kubectl("delete", "secret", "claude-credentials", "--ignore-not-found")
+		kubectl("delete", "task", cliTaskName, "--ignore-not-found")
+		kubectl("delete", "task", cliWorkspaceTaskName, "--ignore-not-found")
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			By("collecting debug info on failure")
+			debugTask(cliTaskName)
+			debugTask(cliWorkspaceTaskName)
+		}
+
+		By("cleaning up test resources")
+		kubectl("delete", "task", cliTaskName, "--ignore-not-found")
+		kubectl("delete", "task", cliWorkspaceTaskName, "--ignore-not-found")
+		kubectl("delete", "secret", "claude-credentials", "--ignore-not-found")
+	})
+
+	It("should run a Task to completion", func() {
+		By("creating OAuth credentials secret")
+		Expect(kubectlWithInput("", "create", "secret", "generic", "claude-credentials",
+			"--from-literal=CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)).To(Succeed())
+
+		By("creating a Task via CLI")
+		axon("run",
+			"-p", "Print 'Hello from Axon CLI e2e test' to stdout",
+			"--secret", "claude-credentials",
+			"--credential-type", "oauth",
+			"--name", cliTaskName,
+		)
+
+		By("waiting for Job to complete")
+		Eventually(func() error {
+			return kubectlWithInput("", "wait", "--for=condition=complete", "job/"+cliTaskName, "--timeout=10s")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("verifying task status via CLI get (detail)")
+		output := axonOutput("get", cliTaskName)
+		Expect(output).To(ContainSubstring("Succeeded"))
+
+		By("verifying task logs via CLI")
+		logs := axonOutput("logs", cliTaskName)
+		Expect(logs).NotTo(BeEmpty())
+
+		By("deleting task via CLI")
+		axon("delete", cliTaskName)
+
+		By("verifying task is no longer listed")
+		output = axonOutput("get")
+		Expect(output).NotTo(ContainSubstring(cliTaskName))
+	})
+
+	It("should run a Task with workspace to completion", func() {
+		By("creating OAuth credentials secret")
+		Expect(kubectlWithInput("", "create", "secret", "generic", "claude-credentials",
+			"--from-literal=CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)).To(Succeed())
+
+		By("creating a Task with workspace via CLI")
+		axon("run",
+			"-p", "Run 'git log --oneline -1' and print the output",
+			"--secret", "claude-credentials",
+			"--credential-type", "oauth",
+			"--workspace-repo", "https://github.com/gjkim42/axon.git",
+			"--workspace-ref", "main",
+			"--name", cliWorkspaceTaskName,
+		)
+
+		By("waiting for Job to complete")
+		Eventually(func() error {
+			return kubectlWithInput("", "wait", "--for=condition=complete", "job/"+cliWorkspaceTaskName, "--timeout=10s")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("verifying task status via CLI get (detail)")
+		output := axonOutput("get", cliWorkspaceTaskName)
+		Expect(output).To(ContainSubstring("Succeeded"))
+		Expect(output).To(ContainSubstring("Workspace Repo"))
+
+		By("verifying task logs via CLI")
+		logs := axonOutput("logs", cliWorkspaceTaskName)
+		Expect(logs).NotTo(BeEmpty())
+
+		By("deleting task via CLI")
+		axon("delete", cliWorkspaceTaskName)
+
+		By("verifying task is no longer listed")
+		output = axonOutput("get")
+		Expect(output).NotTo(ContainSubstring(cliWorkspaceTaskName))
+	})
+})
+
+func axonBin() string {
+	if bin := os.Getenv("AXON_BIN"); bin != "" {
+		return bin
+	}
+	return "axon"
+}
+
+func axon(args ...string) {
+	cmd := exec.Command(axonBin(), args...)
+	cmd.Stdout = GinkgoWriter
+	cmd.Stderr = GinkgoWriter
+	err := cmd.Run()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func axonOutput(args ...string) string {
+	cmd := exec.Command(axonBin(), args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	Expect(err).NotTo(HaveOccurred())
+	return strings.TrimSpace(out.String())
+}


### PR DESCRIPTION
## Summary
- Add a cobra-based `axon` CLI tool with commands: `run`, `get`, `logs`, and `delete` for managing AI agent Tasks on Kubernetes without writing YAML
- Update Makefile `build` target to support `WHAT` variable (e.g., `make build WHAT=cmd/axon`); default builds all binaries under `cmd/`
- Add CLI e2e tests and update CI workflow to build the CLI binary before running e2e tests

## Test plan
- [x] `make build` builds both `bin/manager` and `bin/axon`
- [x] `make build WHAT=cmd/axon` builds only the CLI
- [x] `go vet ./...` passes
- [x] `make test` passes (existing unit tests unaffected)
- [ ] `make test-e2e` passes with cluster + `CLAUDE_CODE_OAUTH_TOKEN` + built CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)