### PR TITLE
Use make build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25 AS builder
 
 WORKDIR /workspace
 
@@ -11,14 +11,14 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager ./cmd/manager
+RUN make build WHAT=cmd/manager
 
 # Runtime stage
 FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /
 
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 
 USER 65532:65532
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ WHAT ?= cmd/...
 build: ## Build binaries (use WHAT=cmd/axon to build specific binary).
 	@for dir in $$(go list ./$(WHAT)); do \
 		bin_name=$$(basename $$dir); \
-		go build -o bin/$$bin_name $$dir; \
+		CGO_ENABLED=0 go build -o bin/$$bin_name $$dir; \
 	done
 
 .PHONY: run


### PR DESCRIPTION
## Summary
- Replace raw `go build` in Dockerfile with `make build WHAT=cmd/manager` to share build logic between local development and Docker image builds
- Add `CGO_ENABLED=0` to Makefile `build` target for static linking (required by distroless runtime image)
- Switch base image from `golang:1.25-alpine` to `golang:1.25` (Debian) which includes `make` out of the box
- Use `WHAT=cmd/manager` to build only the needed binary, avoiding unnecessary compilation of other binaries

## Test plan
- [x] `make build` — local build produces binaries in `bin/`
- [x] `make image` — Docker image builds successfully using `make build`
- [x] `make verify` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)