### PR TITLE
Add config file support with direct token credentials

### DIFF
--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -25,6 +25,7 @@ func init() {
 type ClientConfig struct {
 	Kubeconfig string
 	Namespace  string
+	Config     *Config
 }
 
 // NewClient creates a controller-runtime client and resolves the namespace.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Config holds configuration loaded from the axon config file.
+type Config struct {
+	OAuthToken     string          `json:"oauthToken,omitempty"`
+	APIKey         string          `json:"apiKey,omitempty"`
+	Secret         string          `json:"secret,omitempty"`
+	CredentialType string          `json:"credentialType,omitempty"`
+	Model          string          `json:"model,omitempty"`
+	Namespace      string          `json:"namespace,omitempty"`
+	Workspace      WorkspaceConfig `json:"workspace,omitempty"`
+}
+
+// WorkspaceConfig holds workspace-related configuration.
+type WorkspaceConfig struct {
+	Repo string `json:"repo,omitempty"`
+	Ref  string `json:"ref,omitempty"`
+}
+
+// DefaultConfigPath returns the default config file path (~/.axon/config.yaml).
+func DefaultConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".axon", "config.yaml"), nil
+}
+
+// LoadConfig reads and parses the config file at the given path.
+// If path is empty, the default path (~/.axon/config.yaml) is used.
+// If the file does not exist, an empty Config is returned without error.
+func LoadConfig(path string) (*Config, error) {
+	if path == "" {
+		var err error
+		path, err = DefaultConfigPath()
+		if err != nil {
+			return &Config{}, nil
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	cfg := &Config{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+	return cfg, nil
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_ValidFull(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `
+secret: my-secret
+credentialType: oauth
+model: claude-sonnet-4-5-20250929
+namespace: my-namespace
+workspace:
+  repo: https://github.com/org/repo.git
+  ref: main
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Secret != "my-secret" {
+		t.Errorf("Secret = %q, want %q", cfg.Secret, "my-secret")
+	}
+	if cfg.CredentialType != "oauth" {
+		t.Errorf("CredentialType = %q, want %q", cfg.CredentialType, "oauth")
+	}
+	if cfg.Model != "claude-sonnet-4-5-20250929" {
+		t.Errorf("Model = %q, want %q", cfg.Model, "claude-sonnet-4-5-20250929")
+	}
+	if cfg.Namespace != "my-namespace" {
+		t.Errorf("Namespace = %q, want %q", cfg.Namespace, "my-namespace")
+	}
+	if cfg.Workspace.Repo != "https://github.com/org/repo.git" {
+		t.Errorf("Workspace.Repo = %q, want %q", cfg.Workspace.Repo, "https://github.com/org/repo.git")
+	}
+	if cfg.Workspace.Ref != "main" {
+		t.Errorf("Workspace.Ref = %q, want %q", cfg.Workspace.Ref, "main")
+	}
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	cfg, err := LoadConfig("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.Secret != "" {
+		t.Errorf("expected empty Secret, got %q", cfg.Secret)
+	}
+}
+
+func TestLoadConfig_MalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("secret: [invalid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestLoadConfig_Partial(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `secret: only-secret
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Secret != "only-secret" {
+		t.Errorf("Secret = %q, want %q", cfg.Secret, "only-secret")
+	}
+	if cfg.CredentialType != "" {
+		t.Errorf("CredentialType = %q, want empty", cfg.CredentialType)
+	}
+	if cfg.Workspace.Repo != "" {
+		t.Errorf("Workspace.Repo = %q, want empty", cfg.Workspace.Repo)
+	}
+}
+
+func TestLoadConfig_DefaultPath(t *testing.T) {
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestLoadConfig_ExplicitPathOverridesDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.yaml")
+	content := `secret: custom-secret
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Secret != "custom-secret" {
+		t.Errorf("Secret = %q, want %q", cfg.Secret, "custom-secret")
+	}
+}
+
+func TestLoadConfig_OAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `oauthToken: my-oauth-token
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.OAuthToken != "my-oauth-token" {
+		t.Errorf("OAuthToken = %q, want %q", cfg.OAuthToken, "my-oauth-token")
+	}
+	if cfg.Secret != "" {
+		t.Errorf("Secret = %q, want empty", cfg.Secret)
+	}
+}
+
+func TestLoadConfig_APIKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `apiKey: my-api-key
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.APIKey != "my-api-key" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "my-api-key")
+	}
+	if cfg.Secret != "" {
+		t.Errorf("Secret = %q, want empty", cfg.Secret)
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+const configTemplate = `# Axon configuration file
+# See: https://github.com/gjkim42/axon
+
+# OAuth token (axon auto-creates the Kubernetes secret for you)
+oauthToken: ""
+
+# Or use an API key instead:
+# apiKey: ""
+
+# Model override (optional)
+# model: ""
+
+# Default namespace (optional)
+# namespace: default
+
+# Default workspace (optional)
+# workspace:
+#   repo: https://github.com/org/repo.git
+#   ref: main
+
+# Advanced: provide your own Kubernetes secret directly
+# secret: ""
+# credentialType: oauth
+`
+
+func newInitCommand(_ *ClientConfig) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize a config file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, _ := cmd.Flags().GetString("config")
+			if path == "" {
+				var err error
+				path, err = DefaultConfigPath()
+				if err != nil {
+					return err
+				}
+			}
+
+			if !force {
+				if _, err := os.Stat(path); err == nil {
+					return fmt.Errorf("config file already exists: %s (use --force to overwrite)", path)
+				}
+			}
+
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("creating directory: %w", err)
+			}
+
+			if err := os.WriteFile(path, []byte(configTemplate), 0o600); err != nil {
+				return fmt.Errorf("writing config file: %w", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "Config file created: %s\n", path)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "overwrite existing config file")
+
+	return cmd
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitCommand_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"init", "--config", path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading created file: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty config file")
+	}
+}
+
+func TestInitCommand_CreatesParentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "config.yaml")
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"init", "--config", path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+}
+
+func TestInitCommand_RefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"init", "--config", path})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when file exists without --force")
+	}
+}
+
+func TestInitCommand_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"init", "--config", path, "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	if string(data) == "existing" {
+		t.Fatal("expected file to be overwritten")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,19 +1,39 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
 func NewRootCommand() *cobra.Command {
 	cfg := &ClientConfig{}
+	var configPath string
 
 	cmd := &cobra.Command{
 		Use:           "axon",
 		Short:         "CLI for managing AI agent Tasks on Kubernetes",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Name() == "init" {
+				return nil
+			}
+
+			config, err := LoadConfig(configPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			cfg.Config = config
+
+			if !cmd.Flags().Changed("namespace") && config.Namespace != "" {
+				cfg.Namespace = config.Namespace
+			}
+			return nil
+		},
 	}
 
+	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to config file (default ~/.axon/config.yaml)")
 	cmd.PersistentFlags().StringVar(&cfg.Kubeconfig, "kubeconfig", "", "path to kubeconfig file")
 	cmd.PersistentFlags().StringVarP(&cfg.Namespace, "namespace", "n", "", "Kubernetes namespace")
 
@@ -22,6 +42,7 @@ func NewRootCommand() *cobra.Command {
 		newGetCommand(cfg),
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),
+		newInitCommand(cfg),
 	)
 
 	return cmd

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +33,48 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		Use:   "run",
 		Short: "Create and run a new Task",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if c := cfg.Config; c != nil {
+				if !cmd.Flags().Changed("secret") && c.Secret != "" {
+					secret = c.Secret
+				}
+				if !cmd.Flags().Changed("credential-type") && c.CredentialType != "" {
+					credentialType = c.CredentialType
+				}
+				if !cmd.Flags().Changed("model") && c.Model != "" {
+					model = c.Model
+				}
+				if !cmd.Flags().Changed("workspace-repo") && c.Workspace.Repo != "" {
+					workspaceRepo = c.Workspace.Repo
+				}
+				if !cmd.Flags().Changed("workspace-ref") && c.Workspace.Ref != "" {
+					workspaceRef = c.Workspace.Ref
+				}
+			}
+
+			// Auto-create secret from token if no explicit secret is set.
+			if secret == "" && cfg.Config != nil {
+				if cfg.Config.OAuthToken != "" && cfg.Config.APIKey != "" {
+					return fmt.Errorf("config file must specify either oauthToken or apiKey, not both")
+				}
+				if token := cfg.Config.OAuthToken; token != "" {
+					if err := ensureCredentialSecret(cfg, "axon-credentials", "CLAUDE_CODE_OAUTH_TOKEN", token); err != nil {
+						return err
+					}
+					secret = "axon-credentials"
+					credentialType = "oauth"
+				} else if key := cfg.Config.APIKey; key != "" {
+					if err := ensureCredentialSecret(cfg, "axon-credentials", "ANTHROPIC_API_KEY", key); err != nil {
+						return err
+					}
+					secret = "axon-credentials"
+					credentialType = "api-key"
+				}
+			}
+
+			if secret == "" {
+				return fmt.Errorf("no credentials configured (set oauthToken/apiKey in config file, or use --secret flag)")
+			}
+
 			cl, ns, err := cfg.NewClient()
 			if err != nil {
 				return err
@@ -80,7 +124,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 
 	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "task prompt (required)")
 	cmd.Flags().StringVarP(&agentType, "type", "t", "claude-code", "agent type")
-	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (required)")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
 	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
 	cmd.Flags().StringVar(&model, "model", "", "model override")
 	cmd.Flags().StringVar(&name, "name", "", "task name (auto-generated if omitted)")
@@ -89,7 +133,6 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch task status after creation")
 
 	cmd.MarkFlagRequired("prompt")
-	cmd.MarkFlagRequired("secret")
 
 	return cmd
 }
@@ -113,4 +156,42 @@ func watchTask(ctx context.Context, cl client.Client, name, namespace string) er
 
 		time.Sleep(2 * time.Second)
 	}
+}
+
+// ensureCredentialSecret creates or updates a Secret with the given credential key and value.
+func ensureCredentialSecret(cfg *ClientConfig, name, key, value string) error {
+	cs, ns, err := cfg.NewClientset()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		StringData: map[string]string{
+			key: value,
+		},
+	}
+
+	existing, err := cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := cs.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("creating credentials secret: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking credentials secret: %w", err)
+	}
+
+	// Update existing secret, clearing stale keys.
+	existing.Data = nil
+	existing.StringData = secret.StringData
+	if _, err := cs.CoreV1().Secrets(ns).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating credentials secret: %w", err)
+	}
+	return nil
 }

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -185,3 +185,10 @@ func axonFail(args ...string) {
 	err := cmd.Run()
 	Expect(err).To(HaveOccurred())
 }
+
+func axonCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command(axonBin(), args...)
+	cmd.Stdout = GinkgoWriter
+	cmd.Stderr = GinkgoWriter
+	return cmd
+}

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1,0 +1,118 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const configTaskName = "e2e-config-test-task"
+const configOverrideTaskName = "e2e-config-override-task"
+
+var _ = Describe("Config", func() {
+	var configPath string
+
+	BeforeEach(func() {
+		By("cleaning up existing resources")
+		kubectl("delete", "secret", "axon-credentials", "--ignore-not-found")
+		kubectl("delete", "task", configTaskName, "--ignore-not-found")
+		kubectl("delete", "task", configOverrideTaskName, "--ignore-not-found")
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			By("collecting debug info on failure")
+			debugTask(configTaskName)
+			debugTask(configOverrideTaskName)
+		}
+
+		By("cleaning up test resources")
+		kubectl("delete", "task", configTaskName, "--ignore-not-found")
+		kubectl("delete", "task", configOverrideTaskName, "--ignore-not-found")
+		kubectl("delete", "secret", "axon-credentials", "--ignore-not-found")
+		if configPath != "" {
+			os.Remove(configPath)
+		}
+	})
+
+	It("should run a Task using config file defaults", func() {
+		By("writing a temp config file with oauthToken")
+		dir := GinkgoT().TempDir()
+		configPath = filepath.Join(dir, "config.yaml")
+		configContent := "oauthToken: " + oauthToken + "\nworkspace:\n  repo: https://github.com/gjkim42/axon.git\n  ref: main\n"
+		Expect(os.WriteFile(configPath, []byte(configContent), 0o644)).To(Succeed())
+
+		By("creating a Task via CLI using config defaults (no --secret or --credential-type)")
+		axon("run",
+			"-p", "Run 'git log --oneline -1' and print the output",
+			"--config", configPath,
+			"--name", configTaskName,
+		)
+
+		By("waiting for Job to complete")
+		Eventually(func() error {
+			return kubectlWithInput("", "wait", "--for=condition=complete", "job/"+configTaskName, "--timeout=10s")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("verifying task status via CLI get")
+		output := axonOutput("get", "task", configTaskName)
+		Expect(output).To(ContainSubstring("Succeeded"))
+		Expect(output).To(ContainSubstring("Workspace Repo"))
+
+		By("deleting task via CLI")
+		axon("delete", configTaskName)
+	})
+
+	It("should allow CLI flags to override config file", func() {
+		By("writing a temp config file with oauthToken and a workspace repo")
+		dir := GinkgoT().TempDir()
+		configPath = filepath.Join(dir, "config.yaml")
+		configContent := "oauthToken: " + oauthToken + "\nworkspace:\n  repo: https://github.com/gjkim42/axon.git\n  ref: v0.0.0\n"
+		Expect(os.WriteFile(configPath, []byte(configContent), 0o644)).To(Succeed())
+
+		By("creating a Task with CLI flag overriding config workspace-ref")
+		axon("run",
+			"-p", "Run 'git log --oneline -1' and print the output",
+			"--config", configPath,
+			"--workspace-ref", "main",
+			"--name", configOverrideTaskName,
+		)
+
+		By("waiting for Job to complete")
+		Eventually(func() error {
+			return kubectlWithInput("", "wait", "--for=condition=complete", "job/"+configOverrideTaskName, "--timeout=10s")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("verifying the CLI flag value was used")
+		output := axonOutput("get", "task", configOverrideTaskName)
+		Expect(output).To(ContainSubstring("Succeeded"))
+		Expect(output).To(ContainSubstring("main"))
+
+		By("deleting task via CLI")
+		axon("delete", configOverrideTaskName)
+	})
+
+	It("should initialize config file via init command", func() {
+		dir := GinkgoT().TempDir()
+		configPath = filepath.Join(dir, "test-config.yaml")
+
+		By("running axon init")
+		axon("init", "--config", configPath)
+
+		By("verifying file was created with template content")
+		data, err := os.ReadFile(configPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("oauthToken:"))
+		Expect(string(data)).To(ContainSubstring("apiKey:"))
+
+		By("running axon init again without --force (should fail)")
+		cmd := axonCommand("init", "--config", configPath)
+		Expect(cmd.Run()).To(HaveOccurred())
+
+		By("running axon init with --force (should succeed)")
+		axon("init", "--config", configPath, "--force")
+	})
+})


### PR DESCRIPTION
## Summary
- Add `~/.axon/config.yaml` config file to set defaults for credentials, model, namespace, and workspace
- Add `axon init` command to scaffold a config file with commented examples
- Add `--config` persistent flag to override the default config file path
- Allow `oauthToken` or `apiKey` directly in config — Axon auto-creates the Kubernetes secret, removing the `kubectl create secret` step
- CLI flags take precedence over config file values: `--secret` flag > `secret` in config > `oauthToken`/`apiKey` in config
- Config file and directory use owner-only permissions (0600/0700) since they may contain tokens

## Test plan
- [x] `make build` compiles successfully
- [x] `make test` passes (unit tests for config loading, init command, and token fields)
- [x] `make verify` passes (go vet, go fmt, go mod tidy)
- [ ] `make test-e2e` passes (e2e tests for config defaults, CLI flag overrides, token auto-create, and init command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)