### PR TITLE
Add --output/-o flag to axon get for YAML/JSON output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260202103230-8ebd0ffa23d3
 	sigs.k8s.io/controller-tools v0.20.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -81,5 +82,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"text/tabwriter"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/duration"
+	"sigs.k8s.io/yaml"
 
 	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
 )
@@ -57,4 +59,22 @@ func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
 
 func printField(w io.Writer, label, value string) {
 	fmt.Fprintf(w, "%-20s%s\n", label+":", value)
+}
+
+func printYAML(w io.Writer, obj interface{}) error {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func printJSON(w io.Writer, obj interface{}) error {
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
 }

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -57,6 +57,18 @@ var _ = Describe("CLI", func() {
 		output := axonOutput("get", "task", cliTaskName)
 		Expect(output).To(ContainSubstring("Succeeded"))
 
+		By("verifying YAML output for a single task")
+		output = axonOutput("get", "task", cliTaskName, "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		Expect(output).To(ContainSubstring("kind: Task"))
+		Expect(output).To(ContainSubstring("name: " + cliTaskName))
+
+		By("verifying JSON output for a single task")
+		output = axonOutput("get", "task", cliTaskName, "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"kind": "Task"`))
+		Expect(output).To(ContainSubstring(`"name": "` + cliTaskName + `"`))
+
 		By("verifying task logs via CLI")
 		logs := axonOutput("logs", cliTaskName)
 		Expect(logs).NotTo(BeEmpty())
@@ -122,6 +134,22 @@ var _ = Describe("get", func() {
 
 	It("should fail for a nonexistent task", func() {
 		axonFail("get", "task", "nonexistent-task-name")
+	})
+
+	It("should output task list in YAML format", func() {
+		output := axonOutput("get", "tasks", "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		Expect(output).To(ContainSubstring("kind: TaskList"))
+	})
+
+	It("should output task list in JSON format", func() {
+		output := axonOutput("get", "tasks", "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"kind": "TaskList"`))
+	})
+
+	It("should fail with unknown output format", func() {
+		axonFail("get", "tasks", "-o", "invalid")
 	})
 })
 


### PR DESCRIPTION
## Summary
- Add `--output`/`-o` flag to `axon get task` supporting `yaml` and `json` formats, similar to `kubectl get -o yaml`
- Set GVK on objects before serialization since controller-runtime's client doesn't populate TypeMeta
- Add e2e tests for list output formats (YAML, JSON, invalid) and single-task output formats

## Test plan
- [ ] `make build` compiles successfully
- [ ] `make verify` passes all checks
- [ ] `make test-e2e` — new `get` tests verify YAML/JSON list output and invalid format rejection
- [ ] `make test-e2e` — existing CLI test verifies single-task YAML/JSON output after task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)