### PR TITLE
Use cheapest model (haiku) in all e2e tests

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -45,6 +45,7 @@ var _ = Describe("CLI", func() {
 			"-p", "Print 'Hello from Axon CLI e2e test' to stdout",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
+			"--model", testModel,
 			"--name", cliTaskName,
 		)
 
@@ -91,6 +92,7 @@ var _ = Describe("CLI", func() {
 			"-p", "Run 'git log --oneline -1' and print the output",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
+			"--model", testModel,
 			"--workspace-repo", "https://github.com/gjkim42/axon.git",
 			"--workspace-ref", "main",
 			"--name", cliWorkspaceTaskName,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const testModel = "haiku"
+
 var oauthToken string
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -61,7 +61,7 @@ metadata:
   name: ` + taskName + `
 spec:
   type: claude-code
-  model: haiku
+  model: ` + testModel + `
   prompt: "Print 'Hello from Axon e2e test' to stdout"
   credentials:
     type: oauth
@@ -122,6 +122,7 @@ metadata:
   name: ` + workspaceTaskName + `
 spec:
   type: claude-code
+  model: ` + testModel + `
   prompt: "Run 'git log --oneline -1' and print the output"
   credentials:
     type: oauth


### PR DESCRIPTION
## Summary
- Add a shared `testModel` constant (`"haiku"`) in `suite_test.go` and use it across all four e2e test cases
- Previously only one of four tests specified `model: haiku`; the other three fell back to the default (more expensive) model

## Test plan
- [ ] `make verify` passes (after committing)
- [ ] `make test-e2e` confirms all four e2e tests pass with the explicit haiku model

🤖 Generated with [Claude Code](https://claude.com/claude-code)