### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md - Project Conventions for AI Assistants
+
+## Rules for AI Assistants
+- **Use Makefile targets** instead of discovering build/test commands yourself.
+- **Keep changes minimal.** Do not refactor, reorganize, or 'improve' code beyond what was explicitly requested.
+- **For CI/release workflows**, always use existing Makefile targets rather than reimplementing build logic in YAML.
+- **Better tests** Always try to add or improve tests(including integration, e2e) when modifying code.
+
+## Key Makefile Targets
+- `make verify` — run all verification checks (lint, fmt, vet, etc.)
+- `make update` — update all generated files
+- tests:
+  - `make test` — run all unit tests
+  - `make test-integration` — run integration tests
+  - `make test-e2e` — run end-to-end tests (use the cheapest model for cost savings)
+- `make build` — build binary
+
+## Directory Structure
+- `cmd/` — CLI entrypoints
+- `test/e2e/` — end-to-end tests
+- `.github/workflows/` — CI workflows
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added CLAUDE.md to document assistant conventions and standard Makefile targets for builds, tests, and CI. This reduces guesswork and keeps changes minimal and consistent.

<sup>Written for commit f443a8e92e5b69fff540ccc4cf6294b92b8cb112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

