### PR TITLE
Fix workspace file permission by running git-clone as claude user

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,18 +72,20 @@ jobs:
         run: |
           make image WHAT=cmd/axon-controller VERSION=e2e
           make image WHAT=cmd/axon-spawner VERSION=e2e
+          make image WHAT=claude-code VERSION=e2e
 
       - name: Load images into kind
         run: |
           kind load docker-image gjkim42/axon-controller:e2e
           kind load docker-image gjkim42/axon-spawner:e2e
+          kind load docker-image gjkim42/claude-code:e2e
 
       - name: Deploy controller
         run: |
           kubectl apply -f install-crd.yaml
           kubectl apply -f install.yaml
           kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
-          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never"]}]}}}}'
+          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never"]}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
       - name: Build CLI

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN npm install -g @anthropic-ai/claude-code
 
-RUN useradd -m -s /bin/bash claude
+RUN useradd -u 1100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude
 
 USER claude

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -30,6 +30,8 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var claudeCodeImage string
+	var claudeCodeImagePullPolicy string
 	var spawnerImage string
 	var spawnerImagePullPolicy string
 
@@ -38,6 +40,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&claudeCodeImage, "claude-code-image", controller.ClaudeCodeImage, "The image to use for Claude Code agent containers.")
+	flag.StringVar(&claudeCodeImagePullPolicy, "claude-code-image-pull-policy", "", "The image pull policy for Claude Code agent containers (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&spawnerImage, "spawner-image", controller.DefaultSpawnerImage, "The image to use for spawner Deployments.")
 	flag.StringVar(&spawnerImagePullPolicy, "spawner-image-pull-policy", "", "The image pull policy for spawner Deployments (e.g., Always, Never, IfNotPresent).")
 
@@ -60,10 +64,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	jobBuilder := controller.NewJobBuilder()
+	jobBuilder.ClaudeCodeImage = claudeCodeImage
+	jobBuilder.ClaudeCodeImagePullPolicy = corev1.PullPolicy(claudeCodeImagePullPolicy)
 	if err = (&controller.TaskReconciler{
 		Client:     mgr.GetClient(),
 		Scheme:     mgr.GetScheme(),
-		JobBuilder: controller.NewJobBuilder(),
+		JobBuilder: jobBuilder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Task")
 		os.Exit(1)

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -123,7 +123,7 @@ metadata:
 spec:
   type: claude-code
   model: ` + testModel + `
-  prompt: "Run 'git log --oneline -1' and print the output"
+  prompt: "Create a file called 'test.txt' with the content 'hello' in the current directory and print 'done'"
   credentials:
     type: oauth
     secretRef:
@@ -151,6 +151,11 @@ spec:
 		By("getting Job logs")
 		logs := kubectlOutput("logs", "job/"+workspaceTaskName)
 		GinkgoWriter.Printf("Job logs:\n%s\n", logs)
+
+		By("verifying no permission errors in logs")
+		Expect(logs).NotTo(ContainSubstring("permission denied"))
+		Expect(logs).NotTo(ContainSubstring("Permission denied"))
+		Expect(logs).NotTo(ContainSubstring("EACCES"))
 	})
 })
 

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -308,6 +308,16 @@ var _ = Describe("Task Controller", func() {
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 
+			By("Verifying the init container runs as claude user")
+			Expect(initContainer.SecurityContext).NotTo(BeNil())
+			Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+			Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(controller.ClaudeCodeUID))
+
+			By("Verifying the pod security context sets FSGroup")
+			Expect(createdJob.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+			Expect(createdJob.Spec.Template.Spec.SecurityContext.FSGroup).NotTo(BeNil())
+			Expect(*createdJob.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(controller.ClaudeCodeUID))
+
 			By("Verifying the workspace volume")
 			Expect(createdJob.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			Expect(createdJob.Spec.Template.Spec.Volumes[0].Name).To(Equal(controller.WorkspaceVolumeName))
@@ -390,6 +400,16 @@ var _ = Describe("Task Controller", func() {
 				"clone", "--single-branch", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
+
+			By("Verifying the init container runs as claude user")
+			Expect(initContainer.SecurityContext).NotTo(BeNil())
+			Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+			Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(controller.ClaudeCodeUID))
+
+			By("Verifying the pod security context sets FSGroup")
+			Expect(createdJob.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+			Expect(createdJob.Spec.Template.Spec.SecurityContext.FSGroup).NotTo(BeNil())
+			Expect(*createdJob.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(controller.ClaudeCodeUID))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Set `SecurityContext.RunAsUser=1000` on the git-clone init container so cloned files are owned by the same UID as the claude-code container
- Add integration test assertions verifying the SecurityContext on both workspace test cases
- Update e2e workspace test to write a file instead of read-only `git log`, directly validating the permission fix

Fixes #31

## Test plan
- [x] `make test` — unit tests pass
- [x] `make test-integration` — integration tests pass with new SecurityContext assertions
- [ ] `make test-e2e` — workspace write test succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix workspace write permissions by running the git-clone init container as UID 1100 (claude) and setting FSGroup so cloned files are writable. Fixes #31.

- **Bug Fixes**
  - Set SecurityContext.RunAsUser=1100 on git-clone and PodSecurityContext.FSGroup=1100.
  - Pin claude user to UID 1100 in the claude-code image; add --claude-code-image and pull-policy flags; update CI to build/load and use the local image.
  - Tests: integration asserts RunAsUser and FSGroup; e2e writes a file and sees no permission errors.

<sup>Written for commit bcdc70a171b94edb7da2fe77fde06b2f9b32d042. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

