### PR TITLE
Install build-essential in claude-code container

### DIFF
--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y \
+    build-essential \
     curl \
     ca-certificates \
     git \


### PR DESCRIPTION
## Summary
- Add `build-essential` package to `claude-code/Dockerfile` so that `make` and other build tools are available in the container
- Add e2e test to verify `make` command is available in the claude-code container

Fixes #36

## Test plan
- [ ] Verify container builds successfully with the new package
- [ ] Run e2e test "Task with make available" to confirm `make` is accessible
- [ ] Existing e2e tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installed build-essential in the claude-code Docker image to provide make and other build tools for Axon Makefile targets, addressing axon-task-36. Added an e2e test to verify make is available and the Task/Job completes.

- **Dependencies**
  - Add build-essential to claude-code/Dockerfile

- **New Features**
  - e2e test "Task with make available" that runs make --version and verifies Job/Task succeed

<sup>Written for commit 24556cda67d1b6d7d40dfd2869db5d8fbd25cc1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

