### PR TITLE
Fix status update conflict errors in controllers

### DIFF
--- a/internal/controller/taskspawner_controller.go
+++ b/internal/controller/taskspawner_controller.go
@@ -96,12 +96,13 @@ func (r *TaskSpawnerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Update status with deployment name if not set
 	if ts.Status.DeploymentName != deploy.Name {
+		patch := client.MergeFrom(ts.DeepCopy())
 		ts.Status.DeploymentName = deploy.Name
 		if ts.Status.Phase == "" {
 			ts.Status.Phase = axonv1alpha1.TaskSpawnerPhasePending
 		}
-		if err := r.Status().Update(ctx, &ts); err != nil {
-			logger.Error(err, "unable to update TaskSpawner status")
+		if err := r.Status().Patch(ctx, &ts, patch); err != nil {
+			logger.Error(err, "Unable to patch TaskSpawner status")
 			return ctrl.Result{}, err
 		}
 	}
@@ -149,10 +150,11 @@ func (r *TaskSpawnerReconciler) createDeployment(ctx context.Context, ts *axonv1
 	logger.Info("created Deployment", "deployment", deploy.Name)
 
 	// Update status
+	patch := client.MergeFrom(ts.DeepCopy())
 	ts.Status.Phase = axonv1alpha1.TaskSpawnerPhasePending
 	ts.Status.DeploymentName = deploy.Name
-	if err := r.Status().Update(ctx, ts); err != nil {
-		logger.Error(err, "unable to update TaskSpawner status")
+	if err := r.Status().Patch(ctx, ts, patch); err != nil {
+		logger.Error(err, "Unable to patch TaskSpawner status")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
## Summary
- Replace `Status().Update()` with `Status().Patch()` using `client.MergeFrom` in both `TaskSpawnerReconciler` and `TaskReconciler`
- Status update operations require an exact `resourceVersion` match, causing conflict errors when the object metadata is modified concurrently (e.g., by finalizer additions or owner reference updates from owned resources)
- Merge patch operations are resilient to concurrent metadata modifications, eliminating the `"the object has been modified"` errors

## Test plan
- [x] Add integration test that verifies status updates succeed even when TaskSpawner metadata is modified concurrently
- [ ] Run `make test-integration` to verify existing integration tests still pass
- [ ] Run `make verify` to verify lint/vet/fmt checks pass

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch the status subresource in Task and TaskSpawner controllers using client.MergeFrom to prevent resourceVersion conflicts during concurrent metadata changes. Addresses Linear task #24 by eliminating “object has been modified” errors and making reconciles reliable.

- **Bug Fixes**
  - Replace Status().Update with Status().Patch(client.MergeFrom(...)) in both controllers to avoid conflicts from finalizers and owner reference updates.
  - Add integration test that simulates concurrent metadata updates and verifies status is patched successfully.

<sup>Written for commit d9cc9c1d2cef3eedba5589739d3b274788982a68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

