### PR TITLE
Verify task result in e2e tests to detect application-level failures

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -78,6 +78,11 @@ var _ = Describe("CLI", func() {
 		logs := axonOutput("logs", cliTaskName)
 		Expect(logs).NotTo(BeEmpty())
 
+		By("verifying task result is not an error")
+		rawLogs := kubectlOutput("logs", "job/"+cliTaskName)
+		GinkgoWriter.Printf("Raw job logs:\n%s\n", rawLogs)
+		verifyTaskResult(rawLogs)
+
 		By("deleting task via CLI")
 		axon("delete", "task", cliTaskName)
 
@@ -102,8 +107,8 @@ var _ = Describe("CLI", func() {
 		stdout, stderr := axonOutputWithStderr("logs", cliFollowTaskName, "-f")
 		By("verifying stderr contains streaming status")
 		Expect(stderr).To(ContainSubstring("Streaming container (claude-code) logs..."))
-		By("verifying stderr contains result summary")
-		Expect(stderr).To(ContainSubstring("[result]"))
+		By("verifying stderr contains successful result summary")
+		Expect(stderr).To(ContainSubstring("[result] completed"))
 		By("verifying stdout contains log output")
 		Expect(stdout).NotTo(BeEmpty())
 	})
@@ -137,6 +142,11 @@ var _ = Describe("CLI", func() {
 		By("verifying task logs via CLI")
 		logs := axonOutput("logs", cliWorkspaceTaskName)
 		Expect(logs).NotTo(BeEmpty())
+
+		By("verifying task result is not an error")
+		rawLogs := kubectlOutput("logs", "job/"+cliWorkspaceTaskName)
+		GinkgoWriter.Printf("Raw job logs:\n%s\n", rawLogs)
+		verifyTaskResult(rawLogs)
 
 		By("deleting task via CLI")
 		axon("delete", "task", cliWorkspaceTaskName)


### PR DESCRIPTION
## Summary
- Add `verifyTaskResult` helper that parses raw NDJSON logs from claude-code for the `result` event and asserts `is_error` is not `true`
- Add result verification to all 6 e2e tests that run tasks to completion (3 in `task_test.go`, 3 in `cli_test.go`)
- Tighten the follow-log test to check for `[result] completed` instead of just `[result]`

## Context
Claude Code exits with code 0 even when a task fails, reporting failure via `is_error: true` in its stream-json NDJSON output. The Kubernetes Job treats exit 0 as success, so the Task status becomes `Succeeded`. The e2e tests only checked Task/Job status, missing actual application-level task failures.

## Test plan
- [ ] Verify e2e tests now fail when Claude Code reports `is_error: true` in a result event
- [ ] Verify e2e tests fail if no result event is found in the logs
- [ ] Verify existing passing e2e tests continue to pass

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
E2E tests now verify the task’s result event from claude-code NDJSON logs to catch application-level failures that exit 0. Addresses Linear issue #33 by failing tests when is_error is true or when no result event is present.

- **Bug Fixes**
  - Added verifyTaskResult helper to parse result events and assert is_error is false.
  - Applied result checks to 6 tests (3 in task_test.go, 3 in cli_test.go).
  - Tightened CLI follow logs to expect “[result] completed” instead of “[result]”.

<sup>Written for commit f103a7e196021cc5a22156624fad4b143e9a013a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

