### PR TITLE
Add install/uninstall commands with embedded manifests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,16 +82,15 @@ jobs:
           kind load docker-image gjkim42/axon-spawner:e2e
           kind load docker-image gjkim42/claude-code:e2e
 
+      - name: Build CLI
+        run: make build WHAT=cmd/axon
+
       - name: Deploy controller
         run: |
-          kubectl apply -f install-crd.yaml
-          kubectl apply -f install.yaml
+          bin/axon install
           kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
           kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never"]}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
-
-      - name: Build CLI
-        run: make build WHAT=cmd/axon
 
       - name: E2E Test
         env:

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ test-e2e: ginkgo ## Run e2e tests (requires cluster and CLAUDE_CODE_OAUTH_TOKEN)
 update: controller-gen ## Run all generators and formatters.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(CONTROLLER_GEN) crd paths="./..." output:crd:stdout > install-crd.yaml
+	cp install-crd.yaml internal/manifests/install-crd.yaml
+	cp install.yaml internal/manifests/install.yaml
 	go fmt ./...
 	go mod tidy
 
@@ -55,6 +57,8 @@ update: controller-gen ## Run all generators and formatters.
 verify: controller-gen ## Verify everything is up-to-date and correct.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(CONTROLLER_GEN) crd paths="./..." output:crd:stdout > install-crd.yaml
+	cp install-crd.yaml internal/manifests/install-crd.yaml
+	cp install.yaml internal/manifests/install.yaml
 	go fmt ./...
 	go mod tidy
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -92,17 +92,16 @@ flowchart LR
 - Kubernetes cluster (1.28+)
 - kubectl configured
 
-### 1. Install Axon
-
-```bash
-kubectl apply -f https://raw.githubusercontent.com/gjkim42/axon/main/install-crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/gjkim42/axon/main/install.yaml
-```
-
-### 2. Install the CLI
+### 1. Install the CLI
 
 ```bash
 go install github.com/gjkim42/axon/cmd/axon@latest
+```
+
+### 2. Install Axon
+
+```bash
+axon install
 ```
 
 ### 3. Run Your First Task
@@ -263,7 +262,7 @@ The key pattern here is `excludeLabels: [axon/needs-input]` — this creates a f
 | Git Workspace | Clone a repo into the agent's working directory via a Workspace resource, with optional `GITHUB_TOKEN` for private repos and PR creation |
 | Config File | Set token, model, namespace, and workspace in `~/.axon/config.yaml` — secrets are auto-created |
 | TaskSpawner | Automatically create Tasks from GitHub Issues (or other sources) via a long-running spawner |
-| CLI | `axon init`, `axon run`, `axon get`, `axon logs`, `axon delete` — manage tasks without writing YAML |
+| CLI | `axon install`, `axon uninstall`, `axon init`, `axon run`, `axon get`, `axon logs`, `axon delete` — manage the full lifecycle without writing YAML |
 | Full Lifecycle | `Pending` → `Running` → `Succeeded` / `Failed` |
 | Owner References | Delete a Task and its Job + Pod are automatically cleaned up |
 | Credential Management | API key and OAuth supported via Kubernetes Secrets |
@@ -404,9 +403,12 @@ If both `name` and `repo` are set, `name` takes precedence. The `--workspace` CL
 <details>
 <summary><strong>CLI</strong></summary>
 
-The `axon` CLI lets you manage tasks without writing YAML.
+The `axon` CLI lets you manage the full lifecycle without writing YAML.
 
 ```bash
+# Install axon into a cluster
+axon install
+
 # Initialize a config file
 axon init
 
@@ -430,6 +432,9 @@ axon logs my-task -f
 
 # Delete a task
 axon delete my-task
+
+# Uninstall axon from the cluster
+axon uninstall
 ```
 
 </details>
@@ -437,8 +442,7 @@ axon delete my-task
 ## Uninstall
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/gjkim42/axon/main/install.yaml
-kubectl delete -f https://raw.githubusercontent.com/gjkim42/axon/main/install-crd.yaml
+axon uninstall
 ```
 
 ## Development

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260202103230-8ebd0ffa23d3
 	sigs.k8s.io/controller-tools v0.20.0
@@ -78,7 +79,6 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
+	"github.com/gjkim42/axon/internal/manifests"
+)
+
+const fieldManager = "axon"
+
+func newInstallCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install axon CRDs and controller into the cluster",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restConfig, _, err := cfg.resolveConfig()
+			if err != nil {
+				return err
+			}
+
+			dc, err := discovery.NewDiscoveryClientForConfig(restConfig)
+			if err != nil {
+				return fmt.Errorf("creating discovery client: %w", err)
+			}
+			dyn, err := dynamic.NewForConfig(restConfig)
+			if err != nil {
+				return fmt.Errorf("creating dynamic client: %w", err)
+			}
+
+			ctx := cmd.Context()
+
+			fmt.Fprintf(os.Stdout, "Installing axon CRDs\n")
+			if err := applyManifests(ctx, dc, dyn, manifests.InstallCRD); err != nil {
+				return fmt.Errorf("installing CRDs: %w", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "Installing axon controller\n")
+			if err := applyManifests(ctx, dc, dyn, manifests.InstallController); err != nil {
+				return fmt.Errorf("installing controller: %w", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "Axon installed successfully\n")
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func newUninstallCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall axon controller and CRDs from the cluster",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restConfig, _, err := cfg.resolveConfig()
+			if err != nil {
+				return err
+			}
+
+			dc, err := discovery.NewDiscoveryClientForConfig(restConfig)
+			if err != nil {
+				return fmt.Errorf("creating discovery client: %w", err)
+			}
+			dyn, err := dynamic.NewForConfig(restConfig)
+			if err != nil {
+				return fmt.Errorf("creating dynamic client: %w", err)
+			}
+
+			ctx := cmd.Context()
+
+			fmt.Fprintf(os.Stdout, "Removing axon controller\n")
+			if err := deleteManifests(ctx, dc, dyn, manifests.InstallController); err != nil {
+				return fmt.Errorf("removing controller: %w", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "Removing axon CRDs\n")
+			if err := deleteManifests(ctx, dc, dyn, manifests.InstallCRD); err != nil {
+				return fmt.Errorf("removing CRDs: %w", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "Axon uninstalled successfully\n")
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// parseManifests splits a multi-document YAML byte slice into individual
+// unstructured objects, skipping empty documents.
+func parseManifests(data []byte) ([]*unstructured.Unstructured, error) {
+	var objs []*unstructured.Unstructured
+	reader := yamlutil.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	for {
+		doc, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("reading YAML document: %w", err)
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal(doc, &obj.Object); err != nil {
+			return nil, fmt.Errorf("unmarshaling manifest: %w", err)
+		}
+		if obj.Object == nil {
+			continue
+		}
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}
+
+// newRESTMapper creates a REST mapper using the discovery client to resolve
+// API group resources. This should be called once and the mapper reused
+// across multiple objects to avoid redundant API server calls.
+func newRESTMapper(dc discovery.DiscoveryInterface) (meta.RESTMapper, error) {
+	gr, err := restmapper.GetAPIGroupResources(dc)
+	if err != nil {
+		return nil, fmt.Errorf("discovering API resources: %w", err)
+	}
+	return restmapper.NewDiscoveryRESTMapper(gr), nil
+}
+
+// resourceClient returns a dynamic resource client for the given object,
+// using the provided REST mapper to resolve the GVR and determine whether
+// the resource is namespaced.
+func resourceClient(mapper meta.RESTMapper, dyn dynamic.Interface, obj *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
+	gvk := obj.GroupVersionKind()
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("mapping resource for %s: %w", gvk, err)
+	}
+
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		return dyn.Resource(mapping.Resource).Namespace(obj.GetNamespace()), nil
+	}
+	return dyn.Resource(mapping.Resource), nil
+}
+
+// applyManifests parses multi-document YAML and applies each object using
+// server-side apply.
+func applyManifests(ctx context.Context, dc discovery.DiscoveryInterface, dyn dynamic.Interface, data []byte) error {
+	objs, err := parseManifests(data)
+	if err != nil {
+		return err
+	}
+	mapper, err := newRESTMapper(dc)
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		rc, err := resourceClient(mapper, dyn, obj)
+		if err != nil {
+			return err
+		}
+		objData, err := yaml.Marshal(obj.Object)
+		if err != nil {
+			return fmt.Errorf("marshaling %s %s: %w", obj.GetKind(), obj.GetName(), err)
+		}
+		if _, err := rc.Patch(ctx, obj.GetName(), types.ApplyPatchType, objData, metav1.PatchOptions{
+			FieldManager: fieldManager,
+			Force:        ptr.To(true),
+		}); err != nil {
+			return fmt.Errorf("applying %s %s: %w", obj.GetKind(), obj.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// deleteManifests parses multi-document YAML and deletes each object,
+// ignoring not-found errors for idempotent uninstalls.
+func deleteManifests(ctx context.Context, dc discovery.DiscoveryInterface, dyn dynamic.Interface, data []byte) error {
+	objs, err := parseManifests(data)
+	if err != nil {
+		return err
+	}
+	mapper, err := newRESTMapper(dc)
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		rc, err := resourceClient(mapper, dyn, obj)
+		if err != nil {
+			// If the resource type is not found (e.g. CRDs already deleted),
+			// skip it for idempotent uninstalls.
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			return err
+		}
+		if err := rc.Delete(ctx, obj.GetName(), metav1.DeleteOptions{}); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("deleting %s %s: %w", obj.GetKind(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/gjkim42/axon/internal/manifests"
+)
+
+func TestParseManifests_SingleDocument(t *testing.T) {
+	data := []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`)
+	objs, err := parseManifests(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	if objs[0].GetKind() != "Namespace" {
+		t.Errorf("expected kind Namespace, got %s", objs[0].GetKind())
+	}
+	if objs[0].GetName() != "test-ns" {
+		t.Errorf("expected name test-ns, got %s", objs[0].GetName())
+	}
+}
+
+func TestParseManifests_MultiDocument(t *testing.T) {
+	data := []byte(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa1
+  namespace: ns1
+`)
+	objs, err := parseManifests(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+	if objs[0].GetKind() != "Namespace" {
+		t.Errorf("expected first object to be Namespace, got %s", objs[0].GetKind())
+	}
+	if objs[1].GetKind() != "ServiceAccount" {
+		t.Errorf("expected second object to be ServiceAccount, got %s", objs[1].GetKind())
+	}
+	if objs[1].GetNamespace() != "ns1" {
+		t.Errorf("expected namespace ns1, got %s", objs[1].GetNamespace())
+	}
+}
+
+func TestParseManifests_SkipsEmptyDocuments(t *testing.T) {
+	data := []byte(`---
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+---
+`)
+	objs, err := parseManifests(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+}
+
+func TestParseManifests_EmptyInput(t *testing.T) {
+	objs, err := parseManifests([]byte(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(objs) != 0 {
+		t.Fatalf("expected 0 objects, got %d", len(objs))
+	}
+}
+
+func TestParseManifests_PreservesOrder(t *testing.T) {
+	data := []byte(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: first
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: second
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: third
+  namespace: default
+`)
+	objs, err := parseManifests(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(objs) != 3 {
+		t.Fatalf("expected 3 objects, got %d", len(objs))
+	}
+	names := []string{objs[0].GetName(), objs[1].GetName(), objs[2].GetName()}
+	expected := []string{"first", "second", "third"}
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("object %d: expected name %s, got %s", i, expected[i], name)
+		}
+	}
+}
+
+func TestParseManifests_EmbeddedCRDs(t *testing.T) {
+	objs, err := parseManifests(manifests.InstallCRD)
+	if err != nil {
+		t.Fatalf("parsing embedded CRD manifest: %v", err)
+	}
+	if len(objs) == 0 {
+		t.Fatal("expected at least one CRD object")
+	}
+	for _, obj := range objs {
+		if obj.GetKind() != "CustomResourceDefinition" {
+			t.Errorf("expected kind CustomResourceDefinition, got %s", obj.GetKind())
+		}
+	}
+}
+
+func TestParseManifests_EmbeddedController(t *testing.T) {
+	objs, err := parseManifests(manifests.InstallController)
+	if err != nil {
+		t.Fatalf("parsing embedded controller manifest: %v", err)
+	}
+	if len(objs) == 0 {
+		t.Fatal("expected at least one controller object")
+	}
+	kinds := make(map[string]bool)
+	for _, obj := range objs {
+		kinds[obj.GetKind()] = true
+	}
+	for _, expected := range []string{"Namespace", "ServiceAccount", "ClusterRole", "Deployment"} {
+		if !kinds[expected] {
+			t.Errorf("expected to find %s in controller manifest", expected)
+		}
+	}
+}
+
+func TestInstallCommand_SkipsConfigLoading(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--config", "/nonexistent/path/config.yaml"})
+	err := cmd.Execute()
+	// We expect an error (no cluster), but not a config-loading error.
+	if err != nil && err.Error() == "loading config: open /nonexistent/path/config.yaml: no such file or directory" {
+		t.Fatal("install should not fail on missing config file")
+	}
+}
+
+func TestUninstallCommand_SkipsConfigLoading(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"uninstall", "--config", "/nonexistent/path/config.yaml"})
+	err := cmd.Execute()
+	if err != nil && err.Error() == "loading config: open /nonexistent/path/config.yaml: no such file or directory" {
+		t.Fatal("uninstall should not fail on missing config file")
+	}
+}
+
+func TestInstallCommand_RejectsExtraArgs(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "extra-arg"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when extra arguments are provided")
+	}
+}
+
+func TestUninstallCommand_RejectsExtraArgs(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"uninstall", "extra-arg"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when extra arguments are provided")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,8 @@ func NewRootCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Name() == "init" {
+			switch cmd.Name() {
+			case "init", "install", "uninstall":
 				return nil
 			}
 
@@ -43,6 +44,8 @@ func NewRootCommand() *cobra.Command {
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),
 		newInitCommand(cfg),
+		newInstallCommand(cfg),
+		newUninstallCommand(cfg),
 	)
 
 	return cmd

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -1,0 +1,404 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: tasks.axon.io
+spec:
+  group: axon.io
+  names:
+    kind: Task
+    listKind: TaskList
+    plural: tasks
+    singular: task
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Task is the Schema for the tasks API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TaskSpec defines the desired state of Task.
+            properties:
+              credentials:
+                description: Credentials specifies how to authenticate with the agent.
+                properties:
+                  secretRef:
+                    description: SecretRef references the Secret containing credentials.
+                    properties:
+                      name:
+                        description: Name is the name of the secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: Type specifies the credential type (api-key or oauth).
+                    enum:
+                    - api-key
+                    - oauth
+                    type: string
+                required:
+                - secretRef
+                - type
+                type: object
+              model:
+                description: Model optionally overrides the default model.
+                type: string
+              prompt:
+                description: Prompt is the task prompt to send to the agent.
+                type: string
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished limits the lifetime of a Task that has finished
+                  execution (either Succeeded or Failed). If set, the Task will be
+                  automatically deleted after the given number of seconds once it reaches
+                  a terminal phase, allowing TaskSpawner to create a new Task.
+                  If this field is unset, the Task will not be automatically deleted.
+                  If this field is set to zero, the Task will be eligible to be deleted
+                  immediately after it finishes.
+                format: int32
+                minimum: 0
+                type: integer
+              type:
+                description: Type specifies the agent type (e.g., claude-code).
+                type: string
+              workspaceRef:
+                description: WorkspaceRef optionally references a Workspace resource
+                  for the agent to work in.
+                properties:
+                  name:
+                    description: Name is the name of the Workspace resource.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - credentials
+            - prompt
+            - type
+            type: object
+          status:
+            description: TaskStatus defines the observed state of Task.
+            properties:
+              completionTime:
+                description: CompletionTime is when the Task completed.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job created for this Task.
+                type: string
+              message:
+                description: Message provides additional information about the current
+                  status.
+                type: string
+              phase:
+                description: Phase represents the current phase of the Task.
+                type: string
+              podName:
+                description: PodName is the name of the Pod running the Task.
+                type: string
+              startTime:
+                description: StartTime is when the Task started running.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: taskspawners.axon.io
+spec:
+  group: axon.io
+  names:
+    kind: TaskSpawner
+    listKind: TaskSpawnerList
+    plural: taskspawners
+    singular: taskspawner
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.when.githubIssues.workspaceRef.name
+      name: Workspace
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.totalDiscovered
+      name: Discovered
+      type: integer
+    - jsonPath: .status.totalTasksCreated
+      name: Tasks
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TaskSpawner is the Schema for the taskspawners API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TaskSpawnerSpec defines the desired state of TaskSpawner.
+            properties:
+              pollInterval:
+                default: 5m
+                description: PollInterval is how often to poll the source for new
+                  items (e.g., "5m"). Defaults to "5m".
+                type: string
+              taskTemplate:
+                description: TaskTemplate defines the template for spawned Tasks.
+                properties:
+                  credentials:
+                    description: Credentials specifies how to authenticate with the
+                      agent.
+                    properties:
+                      secretRef:
+                        description: SecretRef references the Secret containing credentials.
+                        properties:
+                          name:
+                            description: Name is the name of the secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type:
+                        description: Type specifies the credential type (api-key or
+                          oauth).
+                        enum:
+                        - api-key
+                        - oauth
+                        type: string
+                    required:
+                    - secretRef
+                    - type
+                    type: object
+                  model:
+                    description: Model optionally overrides the default model.
+                    type: string
+                  promptTemplate:
+                    description: |-
+                      PromptTemplate is a Go text/template for rendering the task prompt.
+                      Available variables: {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}.
+                    type: string
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      TTLSecondsAfterFinished limits the lifetime of a Task that has finished
+                      execution (either Succeeded or Failed). If set, spawned Tasks will be
+                      automatically deleted after the given number of seconds once they reach
+                      a terminal phase, allowing TaskSpawner to create a new Task.
+                      If this field is unset, spawned Tasks will not be automatically deleted.
+                      If this field is set to zero, spawned Tasks will be eligible to be deleted
+                      immediately after they finish.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  type:
+                    description: Type specifies the agent type (e.g., claude-code).
+                    type: string
+                required:
+                - credentials
+                - type
+                type: object
+              when:
+                description: When defines the conditions that trigger task spawning.
+                properties:
+                  githubIssues:
+                    description: GitHubIssues discovers issues from a GitHub repository.
+                    properties:
+                      excludeLabels:
+                        description: ExcludeLabels filters out issues that have any
+                          of these labels (client-side).
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        description: Labels filters issues by labels.
+                        items:
+                          type: string
+                        type: array
+                      state:
+                        default: open
+                        description: State filters issues by state (open, closed,
+                          all). Defaults to open.
+                        enum:
+                        - open
+                        - closed
+                        - all
+                        type: string
+                      types:
+                        default:
+                        - issues
+                        description: 'Types specifies which item types to discover:
+                          "issues", "pulls", or both.'
+                        items:
+                          type: string
+                        type: array
+                      workspaceRef:
+                        description: WorkspaceRef references the Workspace that defines
+                          the GitHub repository.
+                        properties:
+                          name:
+                            description: Name is the name of the Workspace resource.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - workspaceRef
+                    type: object
+                type: object
+            required:
+            - taskTemplate
+            - when
+            type: object
+          status:
+            description: TaskSpawnerStatus defines the observed state of TaskSpawner.
+            properties:
+              deploymentName:
+                description: DeploymentName is the name of the Deployment running
+                  the spawner.
+                type: string
+              lastDiscoveryTime:
+                description: LastDiscoveryTime is the last time the source was polled.
+                format: date-time
+                type: string
+              message:
+                description: Message provides additional information about the current
+                  status.
+                type: string
+              phase:
+                description: Phase represents the current phase of the TaskSpawner.
+                type: string
+              totalDiscovered:
+                description: TotalDiscovered is the total number of work items discovered.
+                type: integer
+              totalTasksCreated:
+                description: TotalTasksCreated is the total number of Tasks created.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: workspaces.axon.io
+spec:
+  group: axon.io
+  names:
+    kind: Workspace
+    listKind: WorkspaceList
+    plural: workspaces
+    singular: workspace
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Workspace is the Schema for the workspaces API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkspaceSpec defines the desired state of Workspace.
+            properties:
+              ref:
+                description: |-
+                  Ref is the git reference to checkout (branch, tag, or commit SHA).
+                  Defaults to the repository's default branch if not specified.
+                type: string
+              repo:
+                description: Repo is the git repository URL to clone.
+                pattern: ^(https?://|git://|git@).*
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef references a Secret containing a GITHUB_TOKEN key for git
+                  authentication and GitHub CLI (gh) operations.
+                properties:
+                  name:
+                    description: Name is the name of the secret.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - repo
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -1,0 +1,302 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: axon-system
+  labels:
+    app.kubernetes.io/name: axon
+    app.kubernetes.io/component: manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: axon-controller
+  namespace: axon-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: axon-controller-role
+rules:
+  # Tasks
+  - apiGroups:
+      - axon.io
+    resources:
+      - tasks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - axon.io
+    resources:
+      - tasks/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - axon.io
+    resources:
+      - tasks/finalizers
+    verbs:
+      - update
+  # TaskSpawners
+  - apiGroups:
+      - axon.io
+    resources:
+      - taskspawners
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - axon.io
+    resources:
+      - taskspawners/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - axon.io
+    resources:
+      - taskspawners/finalizers
+    verbs:
+      - update
+  # Workspaces
+  - apiGroups:
+      - axon.io
+    resources:
+      - workspaces
+    verbs:
+      - get
+      - list
+      - watch
+  # Jobs
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # Deployments
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # Pods (for status)
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  # Secrets (for token mounting)
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  # ServiceAccounts (for spawner RBAC setup)
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  # RoleBindings (for spawner RBAC setup)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: axon-spawner-role
+rules:
+  - apiGroups:
+      - axon.io
+    resources:
+      - taskspawners
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - axon.io
+    resources:
+      - taskspawners/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - axon.io
+    resources:
+      - tasks
+    verbs:
+      - create
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: axon-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: axon-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: axon-controller
+    namespace: axon-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: axon-leader-election-role
+  namespace: axon-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: axon-leader-election-rolebinding
+  namespace: axon-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: axon-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: axon-controller
+    namespace: axon-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: axon-controller-manager
+  namespace: axon-system
+  labels:
+    app.kubernetes.io/name: axon
+    app.kubernetes.io/component: manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: axon
+      app.kubernetes.io/component: manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: axon
+        app.kubernetes.io/component: manager
+    spec:
+      serviceAccountName: axon-controller
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: manager
+          image: gjkim42/axon-controller:latest
+          args:
+            - --leader-elect
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -1,0 +1,9 @@
+package manifests
+
+import _ "embed"
+
+//go:embed install-crd.yaml
+var InstallCRD []byte
+
+//go:embed install.yaml
+var InstallController []byte

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -1,0 +1,185 @@
+package integration
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	"github.com/gjkim42/axon/internal/cli"
+)
+
+// clearNamespaceFinalizers removes finalizers from the axon-system namespace
+// so it can be deleted in envtest (which has no namespace controller).
+func clearNamespaceFinalizers() {
+	ns := &corev1.Namespace{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: "axon-system"}, ns)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred())
+	if len(ns.Spec.Finalizers) > 0 {
+		ns.Spec.Finalizers = nil
+		Expect(k8sClient.SubResource("finalize").Update(ctx, ns)).To(Succeed())
+	}
+}
+
+// deleteControllerResources removes the non-CRD resources created by install
+// without touching the CRDs, keeping the envtest environment intact.
+func deleteControllerResources() {
+	for _, obj := range []client.Object{
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "axon-controller-rolebinding"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "axon-controller-role"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "axon-spawner-role"}},
+	} {
+		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, obj))
+	}
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "axon-system"}}
+	_ = client.IgnoreNotFound(k8sClient.Delete(ctx, ns))
+
+	// Clear finalizers so the namespace can be deleted in envtest.
+	clearNamespaceFinalizers()
+
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: "axon-system"}, &corev1.Namespace{})
+		return apierrors.IsNotFound(err)
+	}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+}
+
+// restoreCRDs re-applies CRDs by running install followed by cleanup of
+// non-CRD resources. This restores the envtest environment after uninstall
+// removes CRDs that were originally loaded by the BeforeSuite.
+func restoreCRDs(kubeconfigPath string) {
+	// Wait for namespace termination to complete before re-installing.
+	clearNamespaceFinalizers()
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: "axon-system"}, &corev1.Namespace{})
+		return apierrors.IsNotFound(err)
+	}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+	reinstall := cli.NewRootCommand()
+	reinstall.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
+	Expect(reinstall.Execute()).To(Succeed())
+
+	// Wait for CRDs to be fully established before subsequent tests
+	// can create custom resources. We verify by attempting to list Tasks.
+	Eventually(func() error {
+		return k8sClient.List(ctx, &axonv1alpha1.TaskList{})
+	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+
+	deleteControllerResources()
+}
+
+var _ = Describe("Install/Uninstall", Ordered, func() {
+	var kubeconfigPath string
+
+	BeforeEach(func() {
+		kubeconfigPath = writeEnvtestKubeconfig()
+	})
+
+	Context("axon install", func() {
+		AfterEach(func() {
+			deleteControllerResources()
+		})
+
+		It("Should create axon-system namespace and controller resources", func() {
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Verifying the axon-system namespace exists")
+			ns := &corev1.Namespace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "axon-system"}, ns)).To(Succeed())
+
+			By("Verifying the controller ServiceAccount exists")
+			sa := &corev1.ServiceAccount{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "axon-controller",
+				Namespace: "axon-system",
+			}, sa)).To(Succeed())
+
+			By("Verifying the ClusterRole exists")
+			cr := &rbacv1.ClusterRole{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: "axon-controller-role",
+			}, cr)).To(Succeed())
+
+			By("Verifying the ClusterRoleBinding exists")
+			crb := &rbacv1.ClusterRoleBinding{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: "axon-controller-rolebinding",
+			}, crb)).To(Succeed())
+
+			By("Verifying the Deployment exists")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "axon-controller-manager",
+				Namespace: "axon-system",
+			}, dep)).To(Succeed())
+		})
+
+		It("Should be idempotent", func() {
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
+			Expect(root.Execute()).To(Succeed())
+
+			root2 := cli.NewRootCommand()
+			root2.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
+			Expect(root2.Execute()).To(Succeed())
+		})
+	})
+
+	Context("axon uninstall", func() {
+		AfterEach(func() {
+			restoreCRDs(kubeconfigPath)
+		})
+
+		It("Should remove controller resources", func() {
+			By("Installing first")
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Uninstalling")
+			root2 := cli.NewRootCommand()
+			root2.SetArgs([]string{"uninstall", "--kubeconfig", kubeconfigPath})
+			Expect(root2.Execute()).To(Succeed())
+
+			By("Verifying the Deployment is gone")
+			dep := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "axon-controller-manager",
+				Namespace: "axon-system",
+			}, dep)
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+			if err == nil {
+				Fail("expected Deployment to be deleted")
+			}
+
+			By("Verifying the ClusterRole is gone")
+			cr := &rbacv1.ClusterRole{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name: "axon-controller-role",
+			}, cr)
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
+			if err == nil {
+				Fail("expected ClusterRole to be deleted")
+			}
+		})
+
+		It("Should be idempotent", func() {
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{"uninstall", "--kubeconfig", kubeconfigPath})
+			Expect(root.Execute()).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Add `axon install` and `axon uninstall` commands using Kubernetes client-go SDK
- Embed installation YAML manifests into the binary using `go:embed` (works with `go install`)
- Use dynamic client with server-side apply (ApplyPatchType) for creating resources
- Use dynamic client with standard delete for removing resources, with NotFound/NoMatch tolerance for idempotent uninstalls
- Parse multi-document YAML into unstructured objects using discovery-based REST mapper to resolve GVRs
- REST mapper is created once per manifest set (outside the loop) to avoid redundant API server calls
- Update CI workflow to use `axon install` instead of `kubectl apply`
- Update README.md with install/uninstall documentation
- Add unit tests covering YAML parsing, embedded manifests, config skip, and argument rejection
- Add integration tests using envtest for install/uninstall lifecycle

Closes #29

## Test plan
- [x] `make test` passes (unit tests for YAML parsing, embedded manifests, config skip, argument rejection)
- [x] `make test-integration` passes (install/uninstall integration tests with envtest)
- [ ] `axon install` applies embedded CRDs then controller to a real cluster
- [ ] `axon uninstall` removes controller then CRDs from a real cluster
- [ ] `axon install --kubeconfig /path/to/config` uses custom kubeconfig
- [ ] `axon install extra-arg` returns an error
- [ ] `axon uninstall` is idempotent (no errors on already-uninstalled cluster)
- [ ] Works with `go install github.com/gjkim42/axon/cmd/axon@latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)