### PR TITLE
Show tool input details in axon logs output

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ axon logs <task-name> -f
 
 --- Turn 1 ---
 I'll create a hello world program in Python.
-[tool] Write
+[tool] Write: hello.py
 
 --- Turn 2 ---
 The file has been created.

--- a/internal/cli/logparser.go
+++ b/internal/cli/logparser.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+	"unicode/utf8"
 )
 
 // StreamEvent represents a single NDJSON event from claude-code --output-format stream-json.
@@ -26,9 +28,10 @@ type MessagePayload struct {
 
 // ContentBlock represents a single content block (text or tool_use).
 type ContentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
-	Name string `json:"name,omitempty"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 // ParseAndFormatLogs reads NDJSON lines from r and writes formatted output:
@@ -68,7 +71,11 @@ func ParseAndFormatLogs(r io.Reader, stdout, stderr io.Writer) error {
 							fmt.Fprintf(stdout, "%s\n", block.Text)
 						}
 					case "tool_use":
-						fmt.Fprintf(stderr, "[tool] %s\n", block.Name)
+						if summary := toolInputSummary(block.Name, block.Input); summary != "" {
+							fmt.Fprintf(stderr, "[tool] %s: %s\n", block.Name, summary)
+						} else {
+							fmt.Fprintf(stderr, "[tool] %s\n", block.Name)
+						}
 					}
 				}
 			}
@@ -87,4 +94,63 @@ func ParseAndFormatLogs(r io.Reader, stdout, stderr io.Writer) error {
 	}
 
 	return scanner.Err()
+}
+
+// maxSummaryLen is the maximum number of runes for a tool input summary line.
+const maxSummaryLen = 120
+
+// toolInputSummary extracts a concise summary string from tool input parameters.
+// Returns an empty string if the input is empty or cannot be parsed.
+func toolInputSummary(toolName string, raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var input map[string]interface{}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return ""
+	}
+
+	var summary string
+	switch toolName {
+	case "Read", "Write", "Edit":
+		summary = stringField(input, "file_path")
+	case "Bash":
+		summary = stringField(input, "command")
+	case "Glob", "Grep":
+		summary = stringField(input, "pattern")
+	case "WebFetch":
+		summary = stringField(input, "url")
+	case "Task":
+		summary = stringField(input, "description")
+	case "WebSearch":
+		summary = stringField(input, "query")
+	}
+
+	if summary == "" {
+		return ""
+	}
+
+	// Collapse newlines for display
+	summary = strings.ReplaceAll(summary, "\n", "\\n")
+
+	if utf8.RuneCountInString(summary) > maxSummaryLen {
+		runes := []rune(summary)
+		summary = string(runes[:maxSummaryLen]) + "..."
+	}
+
+	return summary
+}
+
+// stringField returns the value of a string field from a map, or empty string if not found.
+func stringField(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }

--- a/internal/cli/logparser_test.go
+++ b/internal/cli/logparser_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -26,16 +27,46 @@ func TestParseAndFormatLogs(t *testing.T) {
 			wantStderr: "\n--- Turn 1 ---\n",
 		},
 		{
-			name:       "assistant tool_use",
+			name:       "assistant tool_use without input",
 			input:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read"}]}}`,
 			wantStdout: "",
 			wantStderr: "\n--- Turn 1 ---\n[tool] Read\n",
 		},
 		{
-			name:       "assistant text and tool_use",
-			input:      `{"type":"assistant","message":{"content":[{"type":"text","text":"Let me check."},{"type":"tool_use","name":"Edit"}]}}`,
+			name:       "assistant tool_use with input",
+			input:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}}`,
+			wantStdout: "",
+			wantStderr: "\n--- Turn 1 ---\n[tool] Read: /src/main.go\n",
+		},
+		{
+			name:       "assistant text and tool_use with input",
+			input:      `{"type":"assistant","message":{"content":[{"type":"text","text":"Let me check."},{"type":"tool_use","name":"Edit","input":{"file_path":"/src/main.go","old_string":"foo","new_string":"bar"}}]}}`,
 			wantStdout: "Let me check.\n",
-			wantStderr: "\n--- Turn 1 ---\n[tool] Edit\n",
+			wantStderr: "\n--- Turn 1 ---\n[tool] Edit: /src/main.go\n",
+		},
+		{
+			name:       "bash tool shows command",
+			input:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+			wantStdout: "",
+			wantStderr: "\n--- Turn 1 ---\n[tool] Bash: go test ./...\n",
+		},
+		{
+			name:       "glob tool shows pattern",
+			input:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Glob","input":{"pattern":"**/*.go"}}]}}`,
+			wantStdout: "",
+			wantStderr: "\n--- Turn 1 ---\n[tool] Glob: **/*.go\n",
+		},
+		{
+			name:       "grep tool shows pattern",
+			input:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"func main","path":"/src"}}]}}`,
+			wantStdout: "",
+			wantStderr: "\n--- Turn 1 ---\n[tool] Grep: func main\n",
+		},
+		{
+			name:       "unknown tool shows only name",
+			input:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"CustomTool","input":{"foo":"bar"}}]}}`,
+			wantStdout: "",
+			wantStderr: "\n--- Turn 1 ---\n[tool] CustomTool\n",
 		},
 		{
 			name:       "result success",
@@ -62,16 +93,16 @@ func TestParseAndFormatLogs(t *testing.T) {
 			wantStderr: "",
 		},
 		{
-			name: "mixed events sequence",
+			name: "mixed events sequence with tool inputs",
 			input: strings.Join([]string{
 				`{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}`,
-				`{"type":"assistant","message":{"content":[{"type":"text","text":"I'll fix the bug."},{"type":"tool_use","name":"Read"}]}}`,
+				`{"type":"assistant","message":{"content":[{"type":"text","text":"I'll fix the bug."},{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}}`,
 				`{"type":"user","message":{"content":[{"type":"tool_result"}]}}`,
-				`{"type":"assistant","message":{"content":[{"type":"text","text":"Done."},{"type":"tool_use","name":"Edit"}]}}`,
+				`{"type":"assistant","message":{"content":[{"type":"text","text":"Done."},{"type":"tool_use","name":"Edit","input":{"file_path":"/src/main.go","old_string":"old","new_string":"new"}}]}}`,
 				`{"type":"result","result":"done","is_error":false,"num_turns":2,"total_cost_usd":0.05}`,
 			}, "\n"),
 			wantStdout: "I'll fix the bug.\nDone.\n",
-			wantStderr: "[init] model=claude-sonnet-4-20250514\n\n--- Turn 1 ---\n[tool] Read\n\n--- Turn 2 ---\n[tool] Edit\n\n[result] completed (2 turns, $0.0500)\n",
+			wantStderr: "[init] model=claude-sonnet-4-20250514\n\n--- Turn 1 ---\n[tool] Read: /src/main.go\n\n--- Turn 2 ---\n[tool] Edit: /src/main.go\n\n[result] completed (2 turns, $0.0500)\n",
 		},
 		{
 			name:       "empty lines skipped",
@@ -86,13 +117,139 @@ func TestParseAndFormatLogs(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			err := ParseAndFormatLogs(strings.NewReader(tt.input), &stdout, &stderr)
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("Unexpected error: %v", err)
 			}
 			if got := stdout.String(); got != tt.wantStdout {
 				t.Errorf("stdout:\n got: %q\nwant: %q", got, tt.wantStdout)
 			}
 			if got := stderr.String(); got != tt.wantStderr {
 				t.Errorf("stderr:\n got: %q\nwant: %q", got, tt.wantStderr)
+			}
+		})
+	}
+}
+
+func TestToolInputSummary(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		input    interface{}
+		rawJSON  string // if set, used directly instead of marshaling input
+		want     string
+	}{
+		{
+			name:     "Read with file_path",
+			toolName: "Read",
+			input:    map[string]interface{}{"file_path": "/workspace/main.go"},
+			want:     "/workspace/main.go",
+		},
+		{
+			name:     "Write with file_path",
+			toolName: "Write",
+			input:    map[string]interface{}{"file_path": "/workspace/out.txt", "content": "hello"},
+			want:     "/workspace/out.txt",
+		},
+		{
+			name:     "Edit with file_path",
+			toolName: "Edit",
+			input:    map[string]interface{}{"file_path": "/workspace/main.go", "old_string": "a", "new_string": "b"},
+			want:     "/workspace/main.go",
+		},
+		{
+			name:     "Bash with command",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": "make test"},
+			want:     "make test",
+		},
+		{
+			name:     "Glob with pattern",
+			toolName: "Glob",
+			input:    map[string]interface{}{"pattern": "**/*.ts"},
+			want:     "**/*.ts",
+		},
+		{
+			name:     "Grep with pattern",
+			toolName: "Grep",
+			input:    map[string]interface{}{"pattern": "TODO", "path": "/src"},
+			want:     "TODO",
+		},
+		{
+			name:     "WebFetch with url",
+			toolName: "WebFetch",
+			input:    map[string]interface{}{"url": "https://example.com"},
+			want:     "https://example.com",
+		},
+		{
+			name:     "Task with description",
+			toolName: "Task",
+			input:    map[string]interface{}{"description": "Run unit tests"},
+			want:     "Run unit tests",
+		},
+		{
+			name:     "WebSearch with query",
+			toolName: "WebSearch",
+			input:    map[string]interface{}{"query": "golang context"},
+			want:     "golang context",
+		},
+		{
+			name:     "nil input returns empty",
+			toolName: "Read",
+			input:    nil,
+			want:     "",
+		},
+		{
+			name:     "empty input object returns empty",
+			toolName: "Read",
+			input:    map[string]interface{}{},
+			want:     "",
+		},
+		{
+			name:     "unknown tool returns empty",
+			toolName: "CustomTool",
+			input:    map[string]interface{}{"query": "hello"},
+			want:     "",
+		},
+		{
+			name:     "invalid JSON input returns empty",
+			toolName: "Read",
+			rawJSON:  `{invalid json}`,
+			want:     "",
+		},
+		{
+			name:     "long summary is truncated",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": strings.Repeat("a", 200)},
+			want:     strings.Repeat("a", 120) + "...",
+		},
+		{
+			name:     "multibyte runes are not split on truncation",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": strings.Repeat("\u4e16", 200)},
+			want:     strings.Repeat("\u4e16", 120) + "...",
+		},
+		{
+			name:     "newlines in summary are escaped",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": "echo hello\necho world"},
+			want:     "echo hello\\necho world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tt.rawJSON != "" {
+				raw = json.RawMessage(tt.rawJSON)
+			} else if tt.input != nil {
+				b, err := json.Marshal(tt.input)
+				if err != nil {
+					t.Fatalf("Failed to marshal input: %v", err)
+				}
+				raw = b
+			}
+			got := toolInputSummary(tt.toolName, raw)
+			if got != tt.want {
+				t.Errorf("toolInputSummary(%q, ...):\n got: %q\nwant: %q", tt.toolName, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Parse the `input` field from `tool_use` content blocks in the stream-json output and display a concise summary alongside the tool name
- For known tools, the most relevant parameter is extracted: `file_path` for Read/Write/Edit, `command` for Bash, `pattern` for Glob/Grep, `url` for WebFetch, `description` for Task, `query` for WebSearch
- Long summaries are truncated at 120 runes (Unicode-safe) to keep output readable
- Unknown tools fall back to showing only the tool name

**Before:**
```
[tool] Read
[tool] Bash
[tool] Edit
```

**After:**
```
[tool] Read: /src/main.go
[tool] Bash: go test ./...
[tool] Edit: /src/main.go
```

## Test plan
- [x] Updated existing unit tests to include tool input data
- [x] Added new integration-style test cases for each supported tool type (Read, Write, Edit, Bash, Glob, Grep, WebFetch, Task, WebSearch)
- [x] Added test for unknown tools falling back to name-only display
- [x] Added `TestToolInputSummary` unit test covering all tool types, edge cases (nil input, empty input, invalid JSON), truncation, multi-byte rune safety, and newline escaping
- [ ] CI should run `make verify` and `make test`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse tool_use input from stream-json and show a concise summary next to the tool name in axon logs. This makes runs easier to follow and closes #26.

- **New Features**
  - Render "[tool] Name: summary" by extracting key params per tool: file_path (Read/Write/Edit), command (Bash), pattern (Glob/Grep), url (WebFetch), description (Task), query (WebSearch).
  - Truncate summaries at 120 runes and escape newlines (Unicode-safe); unknown tools fall back to name-only.
  - Updated README example and added tests covering all supported tools and edge cases.

<sup>Written for commit b52023c6747dc50d121208129b5156c5080225c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

