### PR TITLE
Add tab completion for resource names

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+const completionTimeout = 10 * time.Second
+
+// taskCompletionFunc returns a ValidArgsFunction that completes task names.
+func taskCompletionFunc(cfg *ClientConfig) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		cl, ns, err := cfg.NewClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), completionTimeout)
+		defer cancel()
+
+		taskList := &axonv1alpha1.TaskList{}
+		if err := cl.List(ctx, taskList, client.InNamespace(ns)); err != nil {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var names []string
+		for _, t := range taskList.Items {
+			names = append(names, t.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// taskSpawnerCompletionFunc returns a ValidArgsFunction that completes task spawner names.
+func taskSpawnerCompletionFunc(cfg *ClientConfig) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		cl, ns, err := cfg.NewClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), completionTimeout)
+		defer cancel()
+
+		tsList := &axonv1alpha1.TaskSpawnerList{}
+		if err := cl.List(ctx, tsList, client.InNamespace(ns)); err != nil {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var names []string
+		for _, ts := range tsList.Items {
+			names = append(names, ts.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func newCompletionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for axon.
+
+To load completions:
+
+Bash:
+  $ source <(axon completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ axon completion bash > /etc/bash_completion.d/axon
+  # macOS:
+  $ axon completion bash > $(brew --prefix)/etc/bash_completion.d/axon
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ axon completion zsh > "${fpath[1]}/_axon"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ axon completion fish | source
+
+  # To load completions for each session, execute once:
+  $ axon completion fish > ~/.config/fish/completions/axon.fish
+
+PowerShell:
+  PS> axon completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> axon completion powershell > axon.ps1
+  # and source this file from your PowerShell profile.
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletionV2(out, true)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(out)
+			case "fish":
+				return cmd.Root().GenFishCompletion(out, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(out)
+			}
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCompletionCommand_Bash(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"completion", "bash"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "bash completion") {
+		t.Error("expected bash completion output")
+	}
+}
+
+func TestCompletionCommand_Zsh(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"completion", "zsh"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Error("expected non-empty zsh completion output")
+	}
+}
+
+func TestCompletionCommand_Fish(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"completion", "fish"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Error("expected non-empty fish completion output")
+	}
+}
+
+func TestCompletionCommand_Powershell(t *testing.T) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"completion", "powershell"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Len() == 0 {
+		t.Error("expected non-empty powershell completion output")
+	}
+}
+
+func TestCompletionCommand_InvalidShell(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"completion", "invalid"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid shell")
+	}
+}
+
+func TestCompletionCommand_NoArgs(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"completion"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no shell specified")
+	}
+}
+
+func TestCompletionCommand_ValidArgs(t *testing.T) {
+	cmd := NewRootCommand()
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "completion" {
+			if len(sub.ValidArgs) != 4 {
+				t.Fatalf("expected 4 valid args, got %d", len(sub.ValidArgs))
+			}
+			expected := map[string]bool{"bash": true, "zsh": true, "fish": true, "powershell": true}
+			for _, arg := range sub.ValidArgs {
+				if !expected[arg] {
+					t.Errorf("unexpected valid arg: %s", arg)
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("completion subcommand not found")
+}
+
+func TestGetTaskCommand_HasValidArgsFunction(t *testing.T) {
+	cmd := NewRootCommand()
+	getCmd, _, err := cmd.Find([]string{"get", "task"})
+	if err != nil {
+		t.Fatalf("finding get task command: %v", err)
+	}
+	if getCmd.ValidArgsFunction == nil {
+		t.Error("expected ValidArgsFunction to be set on get task command")
+	}
+}
+
+func TestGetTaskSpawnerCommand_HasValidArgsFunction(t *testing.T) {
+	cmd := NewRootCommand()
+	getCmd, _, err := cmd.Find([]string{"get", "taskspawner"})
+	if err != nil {
+		t.Fatalf("finding get taskspawner command: %v", err)
+	}
+	if getCmd.ValidArgsFunction == nil {
+		t.Error("expected ValidArgsFunction to be set on get taskspawner command")
+	}
+}
+
+func TestDeleteTaskCommand_HasValidArgsFunction(t *testing.T) {
+	cmd := NewRootCommand()
+	deleteCmd, _, err := cmd.Find([]string{"delete", "task"})
+	if err != nil {
+		t.Fatalf("finding delete task command: %v", err)
+	}
+	if deleteCmd.ValidArgsFunction == nil {
+		t.Error("expected ValidArgsFunction to be set on delete task command")
+	}
+}
+
+func TestLogsCommand_HasValidArgsFunction(t *testing.T) {
+	cmd := NewRootCommand()
+	logsCmd, _, err := cmd.Find([]string{"logs"})
+	if err != nil {
+		t.Fatalf("finding logs command: %v", err)
+	}
+	if logsCmd.ValidArgsFunction == nil {
+		t.Error("expected ValidArgsFunction to be set on logs command")
+	}
+}
+
+func TestTaskCompletionFunc_NoClientReturnsError(t *testing.T) {
+	// With no kubeconfig, NewClient should fail and return error directive.
+	cfg := &ClientConfig{Kubeconfig: "/nonexistent/kubeconfig"}
+	fn := taskCompletionFunc(cfg)
+	completions, directive := fn(&cobra.Command{}, nil, "")
+	if completions != nil {
+		t.Errorf("expected nil completions, got %v", completions)
+	}
+	if directive&cobra.ShellCompDirectiveError == 0 {
+		t.Error("expected ShellCompDirectiveError")
+	}
+	if directive&cobra.ShellCompDirectiveNoFileComp == 0 {
+		t.Error("expected ShellCompDirectiveNoFileComp")
+	}
+}
+
+func TestTaskSpawnerCompletionFunc_NoClientReturnsError(t *testing.T) {
+	cfg := &ClientConfig{Kubeconfig: "/nonexistent/kubeconfig"}
+	fn := taskSpawnerCompletionFunc(cfg)
+	completions, directive := fn(&cobra.Command{}, nil, "")
+	if completions != nil {
+		t.Errorf("expected nil completions, got %v", completions)
+	}
+	if directive&cobra.ShellCompDirectiveError == 0 {
+		t.Error("expected ShellCompDirectiveError")
+	}
+	if directive&cobra.ShellCompDirectiveNoFileComp == 0 {
+		t.Error("expected ShellCompDirectiveNoFileComp")
+	}
+}
+
+func TestTaskCompletionFunc_NoCompletionAfterFirstArg(t *testing.T) {
+	cfg := &ClientConfig{}
+	fn := taskCompletionFunc(cfg)
+	completions, directive := fn(&cobra.Command{}, []string{"already-provided"}, "")
+	if completions != nil {
+		t.Errorf("expected nil completions when arg already provided, got %v", completions)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %d", directive)
+	}
+}
+
+func TestTaskSpawnerCompletionFunc_NoCompletionAfterFirstArg(t *testing.T) {
+	cfg := &ClientConfig{}
+	fn := taskSpawnerCompletionFunc(cfg)
+	completions, directive := fn(&cobra.Command{}, []string{"already-provided"}, "")
+	if completions != nil {
+		t.Errorf("expected nil completions when arg already provided, got %v", completions)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("expected ShellCompDirectiveNoFileComp, got %d", directive)
+	}
+}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -28,10 +28,11 @@ func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
 
 func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 	return &cobra.Command{
-		Use:     "task <name>",
-		Aliases: []string{"tasks"},
-		Short:   "Delete a task",
-		Args:    cobra.ExactArgs(1),
+		Use:               "task <name>",
+		Aliases:           []string{"tasks"},
+		Short:             "Delete a task",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: taskCompletionFunc(cfg),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -29,10 +29,11 @@ func newGetCommand(cfg *ClientConfig) *cobra.Command {
 
 func newGetTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 	return &cobra.Command{
-		Use:     "taskspawner [name]",
-		Aliases: []string{"taskspawners", "ts"},
-		Short:   "List task spawners or get details of a specific task spawner",
-		Args:    cobra.MaximumNArgs(1),
+		Use:               "taskspawner [name]",
+		Aliases:           []string{"taskspawners", "ts"},
+		Short:             "List task spawners or get details of a specific task spawner",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: taskSpawnerCompletionFunc(cfg),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {
@@ -64,10 +65,11 @@ func newGetTaskCommand(cfg *ClientConfig) *cobra.Command {
 	var output string
 
 	cmd := &cobra.Command{
-		Use:     "task [name]",
-		Aliases: []string{"tasks"},
-		Short:   "List tasks or get details of a specific task",
-		Args:    cobra.MaximumNArgs(1),
+		Use:               "task [name]",
+		Aliases:           []string{"tasks"},
+		Short:             "List tasks or get details of a specific task",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: taskCompletionFunc(cfg),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if output != "" && output != "yaml" && output != "json" {
 				return fmt.Errorf("unknown output format %q: must be one of yaml, json", output)
@@ -117,6 +119,9 @@ func newGetTaskCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (yaml or json)")
+	cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yaml", "json"}, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	return cmd
 }

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -20,9 +20,10 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 	var follow bool
 
 	cmd := &cobra.Command{
-		Use:   "logs <name>",
-		Short: "View logs from a task's pod",
-		Args:  cobra.ExactArgs(1),
+		Use:               "logs <name>",
+		Short:             "View logs from a task's pod",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: taskCompletionFunc(cfg),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,7 @@ func NewRootCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Name() == "init" {
+			if cmd.Name() == "init" || cmd.Name() == "completion" {
 				return nil
 			}
 
@@ -43,6 +43,7 @@ func NewRootCommand() *cobra.Command {
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),
 		newInitCommand(cfg),
+		newCompletionCommand(),
 	)
 
 	return cmd

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -146,6 +146,9 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch task status after creation")
 
 	cmd.MarkFlagRequired("prompt")
+	cmd.RegisterFlagCompletionFunc("credential-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"api-key", "oauth"}, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- Add dynamic tab completion for task and task spawner names in `get`, `delete`, and `logs` commands
- Add flag value completion for `--output` (yaml/json) and `--credential-type` (api-key/oauth)
- Add `completion` subcommand to generate shell completion scripts (bash, zsh, fish, powershell)
- Completion functions query the Kubernetes API with a 10s timeout for responsiveness

Closes #34

## Test plan
- [ ] Run `make test` to verify new unit tests pass
- [ ] Run `make verify` to ensure generated files and formatting are up-to-date
- [ ] Verify `axon completion bash | source` enables completions in bash
- [ ] Test `axon get task <TAB>` completes task names from cluster
- [ ] Test `axon delete task <TAB>` completes task names from cluster
- [ ] Test `axon logs <TAB>` completes task names from cluster
- [ ] Test `axon get taskspawner <TAB>` completes taskspawner names
- [ ] Test `axon get task -o <TAB>` completes with yaml/json
- [ ] Test `axon run --credential-type <TAB>` completes with api-key/oauth
- [ ] Verify graceful behavior when cluster is unreachable (no hang, no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic shell tab completion to the axon CLI for resource names and common flags, plus a new command to generate completion scripts. This speeds up get/delete/logs workflows and stays responsive even if the cluster is unreachable.

- **New Features**
  - Completes names for: get task, delete task, logs, and get taskspawner (Kubernetes lookup with a 10s timeout).
  - Flag value completion: get --output (yaml|json), run --credential-type (api-key|oauth).
  - New command: axon completion [bash|zsh|fish|powershell] to generate shell scripts; runs without requiring cluster access.

<sup>Written for commit 2eca5a86b580682d4b5d6a090ad4e3e486c45182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

