### PR TITLE
Configure git user identity for workspace task commits

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -20,6 +20,14 @@ type WorkspaceSpec struct {
 	// authentication and GitHub CLI (gh) operations.
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty"`
+
+	// GitUser is the user name to configure for git commits.
+	// +optional
+	GitUser string `json:"gitUser,omitempty"`
+
+	// GitEmail is the email address to configure for git commits.
+	// +optional
+	GitEmail string `json:"gitEmail,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -338,6 +338,12 @@ spec:
           spec:
             description: WorkspaceSpec defines the desired state of Workspace.
             properties:
+              gitEmail:
+                description: GitEmail is the email address to configure for git commits.
+                type: string
+              gitUser:
+                description: GitUser is the user name to configure for git commits.
+                type: string
               ref:
                 description: |-
                   Ref is the git reference to checkout (branch, tag, or commit SHA).


### PR DESCRIPTION
## Summary
- Adds `gitUser` and `gitEmail` optional fields to `WorkspaceSpec` API type
- When set, a `git-config` init container runs after `git-clone` to configure `user.name` and `user.email` in the cloned repository
- Commits made by the agent will use the user's identity instead of container defaults
- Uses shell positional parameters (`$1`, `$2`) to safely pass values without shell injection risk

## Test plan
- [x] Integration test: workspace with both `gitUser` and `gitEmail` set
- [x] Integration test: workspace with only `gitUser` set
- [x] Integration test: workspace with only `gitEmail` set
- [ ] Verify existing tests still pass (`make test-integration`)
- [ ] Run `make update` to regenerate CRD/deepcopy files

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for setting Git author for workspace commits by configuring a git-config init container after clone. Agent commits now use the user’s identity instead of container defaults (fixes #48).

- **New Features**
  - CRD adds optional fields to set commit author.
  - Job adds a git-config init container when values are provided.
  - Integration tests cover both, user-only, and email-only cases.

- **Migration**
  - Apply the updated CRD (install-crd.yaml).
  - Existing Workspaces are unaffected; opt in by setting the new fields.

<sup>Written for commit a7529d2866c4ff6e91f0ca29c3293ec958b7364d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

