### PR TITLE
Restrict e2e tests to push events to protect OAuth credentials

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   build:
@@ -56,6 +57,7 @@ jobs:
         run: make test-integration
 
   test-e2e:
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Restrict the `test-e2e` CI job to only run on `push` events (not `pull_request` events) to prevent potential OAuth credential exposure
- When running on PR events, a malicious PR could modify e2e test code to exfiltrate the `CLAUDE_CODE_OAUTH_TOKEN` secret
- GitHub does not provide secrets to fork PRs by default, but same-repo PRs from collaborators would still have access

Fixes #50

## Test plan
- [ ] Verify the `test-e2e` job only runs on pushes to main
- [ ] Verify other CI jobs (build, verify, test, test-integration) still run on both push and PR events
- [ ] Confirm e2e tests still pass when triggered by a push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate e2e tests to run only on pushes to main and on PRs labeled ok-to-test, protecting the CLAUDE_CODE_OAUTH_TOKEN. Fixes #50; build, verify, test, and test-integration still run on both push and pull_request.

- **New Features**
  - Listen to pull_request labeled events so adding ok-to-test triggers e2e on PRs.

<sup>Written for commit fcd3ba0d4fae532fd5945a63a9cf0c745ca5c9a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

