### PR TITLE
Add types filter to GitHubIssues for PR support

### DIFF
--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -32,6 +32,12 @@ type GitHubIssues struct {
 	// +kubebuilder:validation:Required
 	WorkspaceRef *WorkspaceReference `json:"workspaceRef"`
 
+	// Types specifies which item types to discover: "issues", "pulls", or both.
+	// +kubebuilder:validation:Items:Enum=issues;pulls
+	// +kubebuilder:default={"issues"}
+	// +optional
+	Types []string `json:"types,omitempty"`
+
 	// Labels filters issues by labels.
 	// +optional
 	Labels []string `json:"labels,omitempty"`
@@ -62,7 +68,7 @@ type TaskTemplate struct {
 	Model string `json:"model,omitempty"`
 
 	// PromptTemplate is a Go text/template for rendering the task prompt.
-	// Available variables: {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}.
+	// Available variables: {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}.
 	// +optional
 	PromptTemplate string `json:"promptTemplate,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -48,6 +48,11 @@ func (in *GitHubIssues) DeepCopyInto(out *GitHubIssues) {
 		*out = new(WorkspaceReference)
 		**out = **in
 	}
+	if in.Types != nil {
+		in, out := &in.Types, &out.Types
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make([]string, len(*in))

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -202,6 +202,7 @@ func buildSource(ts *axonv1alpha1.TaskSpawner, owner, repo string) (source.Sourc
 		return &source.GitHubSource{
 			Owner:         owner,
 			Repo:          repo,
+			Types:         gh.Types,
 			Labels:        gh.Labels,
 			ExcludeLabels: gh.ExcludeLabels,
 			State:         gh.State,

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -220,7 +220,7 @@ spec:
                   promptTemplate:
                     description: |-
                       PromptTemplate is a Go text/template for rendering the task prompt.
-                      Available variables: {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}.
+                      Available variables: {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}.
                     type: string
                   type:
                     description: Type specifies the agent type (e.g., claude-code).
@@ -255,6 +255,14 @@ spec:
                         - closed
                         - all
                         type: string
+                      types:
+                        default:
+                        - issues
+                        description: 'Types specifies which item types to discover:
+                          "issues", "pulls", or both.'
+                        items:
+                          type: string
+                        type: array
                       workspaceRef:
                         description: WorkspaceRef references the Workspace that defines
                           the GitHub repository.

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -80,6 +80,9 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 		if gh.WorkspaceRef != nil {
 			printField(w, "Workspace", gh.WorkspaceRef.Name)
 		}
+		if len(gh.Types) > 0 {
+			printField(w, "Types", fmt.Sprintf("%v", gh.Types))
+		}
 		if gh.State != "" {
 			printField(w, "State", gh.State)
 		}

--- a/internal/source/prompt.go
+++ b/internal/source/prompt.go
@@ -7,7 +7,7 @@ import (
 	"text/template"
 )
 
-const defaultPromptTemplate = `Issue #{{.Number}}: {{.Title}}
+const defaultPromptTemplate = `{{.Kind}} #{{.Number}}: {{.Title}}
 
 {{.Body}}
 {{- if .Comments}}
@@ -29,6 +29,11 @@ func RenderPrompt(promptTemplate string, item WorkItem) (string, error) {
 		return "", fmt.Errorf("parsing prompt template: %w", err)
 	}
 
+	kind := item.Kind
+	if kind == "" {
+		kind = "Issue"
+	}
+
 	data := struct {
 		ID       string
 		Number   int
@@ -37,6 +42,7 @@ func RenderPrompt(promptTemplate string, item WorkItem) (string, error) {
 		URL      string
 		Labels   string
 		Comments string
+		Kind     string
 	}{
 		ID:       item.ID,
 		Number:   item.Number,
@@ -45,6 +51,7 @@ func RenderPrompt(promptTemplate string, item WorkItem) (string, error) {
 		URL:      item.URL,
 		Labels:   strings.Join(item.Labels, ", "),
 		Comments: item.Comments,
+		Kind:     kind,
 	}
 
 	var buf bytes.Buffer

--- a/internal/source/prompt_test.go
+++ b/internal/source/prompt_test.go
@@ -13,6 +13,7 @@ func TestRenderPromptDefault(t *testing.T) {
 		Body:   "Users cannot log in after the update.",
 		URL:    "https://github.com/o/r/issues/42",
 		Labels: []string{"bug"},
+		Kind:   "Issue",
 	}
 
 	result, err := RenderPrompt("", item)
@@ -20,14 +21,51 @@ func TestRenderPromptDefault(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(result, "#42") {
-		t.Errorf("expected issue number in output: %s", result)
+	if !strings.Contains(result, "Issue #42") {
+		t.Errorf("expected 'Issue #42' in output: %s", result)
 	}
 	if !strings.Contains(result, "Fix the login bug") {
 		t.Errorf("expected title in output: %s", result)
 	}
 	if !strings.Contains(result, "Users cannot log in") {
 		t.Errorf("expected body in output: %s", result)
+	}
+}
+
+func TestRenderPromptDefaultPR(t *testing.T) {
+	item := WorkItem{
+		ID:     "10",
+		Number: 10,
+		Title:  "Add feature",
+		Body:   "This PR adds a feature.",
+		URL:    "https://github.com/o/r/pull/10",
+		Kind:   "PR",
+	}
+
+	result, err := RenderPrompt("", item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "PR #10") {
+		t.Errorf("expected 'PR #10' in output: %s", result)
+	}
+}
+
+func TestRenderPromptDefaultKindFallback(t *testing.T) {
+	item := WorkItem{
+		Number: 5,
+		Title:  "Test",
+		Body:   "Body",
+	}
+
+	result, err := RenderPrompt("", item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "Issue #5") {
+		t.Errorf("expected 'Issue #5' fallback in output: %s", result)
 	}
 }
 
@@ -89,15 +127,16 @@ func TestRenderPromptAllVariables(t *testing.T) {
 		URL:      "U",
 		Labels:   []string{"a", "b"},
 		Comments: "C",
+		Kind:     "PR",
 	}
 
-	tmpl := "{{.ID}} {{.Number}} {{.Title}} {{.Body}} {{.URL}} {{.Labels}} {{.Comments}}"
+	tmpl := "{{.ID}} {{.Number}} {{.Title}} {{.Body}} {{.URL}} {{.Labels}} {{.Comments}} {{.Kind}}"
 	result, err := RenderPrompt(tmpl, item)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := "99 99 T B U a, b C"
+	expected := "99 99 T B U a, b C PR"
 	if result != expected {
 		t.Errorf("expected %q, got %q", expected, result)
 	}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -11,6 +11,7 @@ type WorkItem struct {
 	URL      string
 	Labels   []string
 	Comments string
+	Kind     string // "Issue" or "PR"
 }
 
 // Source discovers work items from an external system.


### PR DESCRIPTION
## Summary
- Add `types` field to `GitHubIssues` spec (values: `"issues"`, `"pulls"`) with backward-compatible default of `["issues"]`
- Filter discovered items client-side based on `pull_request` field presence in GitHub API response
- Add `Kind` field (`"Issue"` or `"PR"`) to `WorkItem` and expose it in prompt templates via `{{.Kind}}`

## Test plan
- [x] Unit tests for type filtering: issues-only, pulls-only, both, default behavior
- [x] Unit tests for prompt rendering with Kind (Issue, PR, fallback)
- [x] Integration test for TaskSpawner with `types: [issues, pulls]`
- [x] `make test` passes
- [x] `make test-integration` passes (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PR discovery to GitHubIssues via a new types filter and exposes item kind in prompts. Backward compatible; existing TaskSpawners still discover issues only.

- **New Features**
  - New spec field: types accepts "issues", "pulls", or both; defaults to ["issues"].
  - Client-side type filtering using the pull_request field in GitHub responses.
  - WorkItem includes Kind ("Issue" or "PR"); available in templates as {{.Kind}} (defaults to "Issue").
  - Default prompt updated to start with "{{.Kind}} #{{.Number}}".
  - CLI shows Types; CRD updated to validate and document it.

- **Migration**
  - No changes needed for existing users.
  - To discover PRs, set types: ["pulls"] or ["issues", "pulls"] in when.githubIssues.
  - Optional: use {{.Kind}} in custom prompt templates for clearer context.

<sup>Written for commit dbc60d71a0fdf7c5d256f2a0a0b0b80a895ae76e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

