### PR TITLE
Add sample YAML manifests matching README examples

### DIFF
--- a/samples/fix-all-github-repo-issues/README.md
+++ b/samples/fix-all-github-repo-issues/README.md
@@ -1,0 +1,33 @@
+# Fix All GitHub Repo Issues
+
+This sample matches the [Auto-fix GitHub issues with TaskSpawner](../../README.md#auto-fix-github-issues-with-taskspawner) example from the README.
+
+It creates a TaskSpawner that polls a GitHub repository for open issues labeled `bug` and automatically creates a Task for each one.
+
+## Prerequisites
+
+- Axon installed on your cluster
+- A Claude OAuth token
+- A GitHub token with access to the target repository
+
+## Usage
+
+1. Edit `secret-oauth.yaml` and replace `<your-oauth-token>` with your Claude OAuth token.
+2. Edit `secret-github-token.yaml` and replace `<your-github-token>` with your GitHub token.
+3. Edit `workspace.yaml` and replace the repo URL with your target repository.
+4. Apply the resources:
+
+```bash
+kubectl apply -f secret-oauth.yaml
+kubectl apply -f secret-github-token.yaml
+kubectl apply -f workspace.yaml
+kubectl apply -f taskspawner.yaml
+```
+
+5. Watch the TaskSpawner:
+
+```bash
+kubectl get taskspawners -w
+```
+
+The TaskSpawner polls for new issues every 5 minutes and creates a Task for each one matching the filter.

--- a/samples/fix-all-github-repo-issues/secret-github-token.yaml
+++ b/samples/fix-all-github-repo-issues/secret-github-token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+type: Opaque
+stringData:
+  GITHUB_TOKEN: "<your-github-token>"

--- a/samples/fix-all-github-repo-issues/secret-oauth.yaml
+++ b/samples/fix-all-github-repo-issues/secret-oauth.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: claude-credentials
+type: Opaque
+stringData:
+  CLAUDE_CODE_OAUTH_TOKEN: "<your-oauth-token>"

--- a/samples/fix-all-github-repo-issues/taskspawner.yaml
+++ b/samples/fix-all-github-repo-issues/taskspawner.yaml
@@ -1,0 +1,19 @@
+apiVersion: axon.io/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: fix-bugs
+spec:
+  when:
+    githubIssues:
+      workspaceRef:
+        name: my-workspace
+      labels: [bug]
+      state: open
+  taskTemplate:
+    type: claude-code
+    credentials:
+      type: oauth
+      secretRef:
+        name: claude-credentials
+    promptTemplate: "Fix: {{.Title}}\n{{.Body}}"
+  pollInterval: 5m

--- a/samples/fix-all-github-repo-issues/workspace.yaml
+++ b/samples/fix-all-github-repo-issues/workspace.yaml
@@ -1,0 +1,9 @@
+apiVersion: axon.io/v1alpha1
+kind: Workspace
+metadata:
+  name: my-workspace
+spec:
+  repo: https://github.com/your-org/your-repo.git
+  ref: main
+  secretRef:
+    name: github-token

--- a/samples/make-hello-world/README.md
+++ b/samples/make-hello-world/README.md
@@ -1,0 +1,28 @@
+# Make Hello World
+
+This sample matches the [Quick Start kubectl/YAML](../../README.md#3-run-your-first-task) example from the README.
+
+It runs a single Task that creates a hello world program in Python, using a Workspace to clone a git repo.
+
+## Prerequisites
+
+- Axon installed on your cluster
+- A Claude OAuth token
+
+## Usage
+
+1. Edit `secret.yaml` and replace `<your-oauth-token>` with your actual token.
+2. Edit `workspace.yaml` and replace the repo URL with your target repository.
+3. Apply the resources:
+
+```bash
+kubectl apply -f secret.yaml
+kubectl apply -f workspace.yaml
+kubectl apply -f task.yaml
+```
+
+4. Watch the Task progress:
+
+```bash
+kubectl get tasks -w
+```

--- a/samples/make-hello-world/secret.yaml
+++ b/samples/make-hello-world/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: claude-oauth
+type: Opaque
+stringData:
+  CLAUDE_CODE_OAUTH_TOKEN: "<your-oauth-token>"

--- a/samples/make-hello-world/task.yaml
+++ b/samples/make-hello-world/task.yaml
@@ -1,0 +1,13 @@
+apiVersion: axon.io/v1alpha1
+kind: Task
+metadata:
+  name: hello-world
+spec:
+  type: claude-code
+  prompt: "Create a hello world program in Python"
+  credentials:
+    type: oauth
+    secretRef:
+      name: claude-oauth
+  workspaceRef:
+    name: my-workspace

--- a/samples/make-hello-world/workspace.yaml
+++ b/samples/make-hello-world/workspace.yaml
@@ -1,0 +1,7 @@
+apiVersion: axon.io/v1alpha1
+kind: Workspace
+metadata:
+  name: my-workspace
+spec:
+  repo: https://github.com/your-org/your-repo.git
+  ref: main


### PR DESCRIPTION
## Summary
- Add a `samples/` directory with two practical examples that correspond to the YAML examples in the README
- `samples/make-hello-world`: Workspace, Task, and OAuth Secret matching the Quick Start kubectl/YAML guide
- `samples/fix-all-github-repo-issues`: Workspace, TaskSpawner, OAuth Secret, and GitHub token Secret matching the TaskSpawner example
- Each directory includes all required Kubernetes resources and a README with usage instructions

Closes #25

## Test plan
- [ ] Verify the sample YAMLs are valid Kubernetes manifests (`kubectl apply --dry-run=client -f samples/`)
- [ ] Verify Secret key names match what the controller expects (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GITHUB_TOKEN`)
- [ ] Verify the samples match the YAML examples in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)