### PR TITLE
Support -o yaml/json output for get taskspawner

### DIFF
--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -142,6 +142,18 @@ spec:
 		Expect(output).To(ContainSubstring(taskSpawnerName))
 		Expect(output).To(ContainSubstring("GitHub Issues"))
 
+		By("verifying YAML output for a single taskspawner")
+		output = axonOutput("get", "taskspawner", taskSpawnerName, "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		Expect(output).To(ContainSubstring("kind: TaskSpawner"))
+		Expect(output).To(ContainSubstring("name: " + taskSpawnerName))
+
+		By("verifying JSON output for a single taskspawner")
+		output = axonOutput("get", "taskspawner", taskSpawnerName, "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"kind": "TaskSpawner"`))
+		Expect(output).To(ContainSubstring(`"name": "` + taskSpawnerName + `"`))
+
 		By("deleting via kubectl")
 		kubectl("delete", "taskspawner", taskSpawnerName)
 
@@ -167,5 +179,21 @@ var _ = Describe("get taskspawner", func() {
 
 	It("should fail for a nonexistent taskspawner", func() {
 		axonFail("get", "taskspawner", "nonexistent-spawner")
+	})
+
+	It("should output taskspawner list in YAML format", func() {
+		output := axonOutput("get", "taskspawners", "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		Expect(output).To(ContainSubstring("kind: TaskSpawnerList"))
+	})
+
+	It("should output taskspawner list in JSON format", func() {
+		output := axonOutput("get", "taskspawners", "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"kind": "TaskSpawnerList"`))
+	})
+
+	It("should fail with unknown output format", func() {
+		axonFail("get", "taskspawners", "-o", "invalid")
 	})
 })


### PR DESCRIPTION
## Summary
- Add `-o/--output` flag to `get taskspawner` command, supporting `yaml` and `json` output formats
- Set `GroupVersionKind` on TaskSpawner/TaskSpawnerList objects before serialization so `apiVersion` and `kind` are included in output
- Add shell completion for the output flag

## Test plan
- [ ] `axon get taskspawner <name> -o yaml` outputs valid YAML with apiVersion and kind
- [ ] `axon get taskspawner <name> -o json` outputs valid JSON with apiVersion and kind
- [ ] `axon get taskspawners -o yaml` outputs TaskSpawnerList in YAML
- [ ] `axon get taskspawners -o json` outputs TaskSpawnerList in JSON
- [ ] `axon get taskspawners -o invalid` fails with error message
- [ ] Default output (no `-o` flag) still works as before

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add -o/--output to axon get taskspawner for YAML/JSON output per #56, matching get task. Serialized output includes apiVersion and kind; default human output is unchanged.

- **New Features**
  - Structured output for single taskspawner and list; errors on unknown formats.
  - Sets GroupVersionKind so apiVersion and kind appear in YAML/JSON (TaskSpawner and TaskSpawnerList).
  - Shell completion for -o with yaml and json options.

<sup>Written for commit 4dffb87e894308c45df1cb1cfbed6969e0dba579. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

