### PR TITLE
Add completion subcommand for shell completion scripts

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -62,4 +63,66 @@ func completeTaskSpawnerNames(cfg *ClientConfig) cobra.CompletionFunc {
 		}
 		return names, cobra.ShellCompDirectiveNoFileComp
 	}
+}
+
+func newCompletionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for axon.
+
+To load completions:
+
+Bash:
+  $ source <(axon completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ axon completion bash > /etc/bash_completion.d/axon
+  # macOS:
+  $ axon completion bash > $(brew --prefix)/etc/bash_completion.d/axon
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ axon completion zsh > "${fpath[1]}/_axon"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ axon completion fish | source
+
+  # To load completions for each session, execute once:
+  $ axon completion fish > ~/.config/fish/completions/axon.fish
+
+PowerShell:
+  PS> axon completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> axon completion powershell > axon.ps1
+  # and source this file from your PowerShell profile.
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletionV2(out, true)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(out)
+			case "fish":
+				return cmd.Root().GenFishCompletion(out, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(out)
+			}
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		},
+	}
+
+	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,7 @@ func NewRootCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Name() == "init" {
+			if cmd.Name() == "init" || cmd.Name() == "completion" {
 				return nil
 			}
 
@@ -43,6 +43,7 @@ func NewRootCommand() *cobra.Command {
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),
 		newInitCommand(cfg),
+		newCompletionCommand(),
 	)
 
 	return cmd


### PR DESCRIPTION
## Summary
- Add `axon completion [bash|zsh|fish|powershell]` subcommand that generates shell completion scripts for tab completion
- Skip config file loading for the `completion` command since it only generates scripts and does not require cluster access
- Add comprehensive tests for the completion subcommand (all shell types, invalid input, argument validation)

Closes #34

## Test plan
- [ ] Run `make test` to verify new unit tests pass
- [ ] Run `make verify` to ensure generated files and formatting are up-to-date
- [ ] Verify `axon completion bash | source` enables completions in bash
- [ ] Test `axon completion zsh`, `axon completion fish`, and `axon completion powershell` produce valid output
- [ ] Verify `axon completion invalid` returns an error
- [ ] Verify `axon completion` with no args returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `axon completion [bash|zsh|fish|powershell]` subcommand to generate shell completion scripts for tab completion. The command skips config loading and includes tests for all shells and argument validation. Addresses Linear #34.

<sup>Written for commit b969a5e729d176bb6e8fa7a6281a634c9d5580ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

