### PR TITLE
Sync spawner deployments with controller on upgrades

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           bin/axon install
           kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
-          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never"]}]}}}}'
+          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never","--controller-image=gjkim42/axon-controller:e2e"]}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
       - name: E2E Test

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -34,6 +34,7 @@ func main() {
 	var claudeCodeImagePullPolicy string
 	var spawnerImage string
 	var spawnerImagePullPolicy string
+	var controllerImage string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -44,6 +45,7 @@ func main() {
 	flag.StringVar(&claudeCodeImagePullPolicy, "claude-code-image-pull-policy", "", "The image pull policy for Claude Code agent containers (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&spawnerImage, "spawner-image", controller.DefaultSpawnerImage, "The image to use for spawner Deployments.")
 	flag.StringVar(&spawnerImagePullPolicy, "spawner-image-pull-policy", "", "The image pull policy for spawner Deployments (e.g., Always, Never, IfNotPresent).")
+	flag.StringVar(&controllerImage, "controller-image", "", "The controller image to annotate spawner pod templates with, so controller upgrades trigger a rolling update of spawner Deployments.")
 
 	opts := zap.Options{
 		Development: true,
@@ -79,6 +81,7 @@ func main() {
 	deploymentBuilder := controller.NewDeploymentBuilder()
 	deploymentBuilder.SpawnerImage = spawnerImage
 	deploymentBuilder.SpawnerImagePullPolicy = corev1.PullPolicy(spawnerImagePullPolicy)
+	deploymentBuilder.ControllerImage = controllerImage
 	if err = (&controller.TaskSpawnerReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),

--- a/install.yaml
+++ b/install.yaml
@@ -269,6 +269,7 @@ spec:
           image: gjkim42/axon-controller:latest
           args:
             - --leader-elect
+            - --controller-image=gjkim42/axon-controller:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -1,6 +1,147 @@
 package controller
 
-import "testing"
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func TestBuildControllerImageAnnotation(t *testing.T) {
+	ts := &axonv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpawnerSpec{},
+	}
+
+	t.Run("no annotation when ControllerImage is empty", func(t *testing.T) {
+		b := NewDeploymentBuilder()
+		deploy := b.Build(ts, nil)
+
+		ann := deploy.Spec.Template.Annotations
+		if v, ok := ann[ControllerImageAnnotation]; ok {
+			t.Errorf("expected no controller-image annotation, got %q", v)
+		}
+	})
+
+	t.Run("annotation set when ControllerImage is provided", func(t *testing.T) {
+		b := NewDeploymentBuilder()
+		b.ControllerImage = "gjkim42/axon-controller:v1.0"
+		deploy := b.Build(ts, nil)
+
+		ann := deploy.Spec.Template.Annotations
+		if v, ok := ann[ControllerImageAnnotation]; !ok {
+			t.Errorf("expected controller-image annotation, got none")
+		} else if v != "gjkim42/axon-controller:v1.0" {
+			t.Errorf("annotation = %q, want %q", v, "gjkim42/axon-controller:v1.0")
+		}
+	})
+
+	t.Run("annotation updates when ControllerImage changes", func(t *testing.T) {
+		b := NewDeploymentBuilder()
+		b.ControllerImage = "gjkim42/axon-controller:v1.0"
+		deploy1 := b.Build(ts, nil)
+
+		b.ControllerImage = "gjkim42/axon-controller:v2.0"
+		deploy2 := b.Build(ts, nil)
+
+		if deploy1.Spec.Template.Annotations[ControllerImageAnnotation] == deploy2.Spec.Template.Annotations[ControllerImageAnnotation] {
+			t.Errorf("expected different annotations, both got %q", deploy1.Spec.Template.Annotations[ControllerImageAnnotation])
+		}
+	})
+}
+
+func TestBuildImagePullPolicy(t *testing.T) {
+	ts := &axonv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpawnerSpec{},
+	}
+
+	t.Run("ImagePullPolicy propagated to container", func(t *testing.T) {
+		b := NewDeploymentBuilder()
+		b.SpawnerImagePullPolicy = corev1.PullAlways
+		deploy := b.Build(ts, nil)
+
+		container := deploy.Spec.Template.Spec.Containers[0]
+		if container.ImagePullPolicy != corev1.PullAlways {
+			t.Errorf("ImagePullPolicy = %q, want %q", container.ImagePullPolicy, corev1.PullAlways)
+		}
+	})
+}
+
+func TestEqualAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		a    map[string]string
+		b    map[string]string
+		want bool
+	}{
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "both empty",
+			a:    map[string]string{},
+			b:    map[string]string{},
+			want: true,
+		},
+		{
+			name: "nil vs empty",
+			a:    nil,
+			b:    map[string]string{},
+			want: true,
+		},
+		{
+			name: "equal annotations",
+			a:    map[string]string{"key": "value"},
+			b:    map[string]string{"key": "value"},
+			want: true,
+		},
+		{
+			name: "different values",
+			a:    map[string]string{"key": "v1"},
+			b:    map[string]string{"key": "v2"},
+			want: false,
+		},
+		{
+			name: "extra key in a",
+			a:    map[string]string{"key": "value", "extra": "stale"},
+			b:    map[string]string{"key": "value"},
+			want: false,
+		},
+		{
+			name: "extra key in b",
+			a:    map[string]string{"key": "value"},
+			b:    map[string]string{"key": "value", "extra": "new"},
+			want: false,
+		},
+		{
+			name: "different keys with empty string values",
+			a:    map[string]string{"key-a": ""},
+			b:    map[string]string{"key-b": ""},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := equalAnnotations(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("equalAnnotations(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestParseGitHubOwnerRepo(t *testing.T) {
 	tests := []struct {

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -269,6 +269,7 @@ spec:
           image: gjkim42/axon-controller:latest
           args:
             - --leader-elect
+            - --controller-image=gjkim42/axon-controller:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary
- Adds a `--controller-image` flag to axon-controller that annotates spawner pod templates with `axon.io/controller-image`, so controller image upgrades trigger a rolling update of all spawner Deployments
- Fixes `updateDeployment` to also compare `ImagePullPolicy` and pod template annotations, ensuring configuration changes are properly propagated
- Replaces the entire annotations map on update to prevent stale keys from causing infinite reconcile loops
- Uses two-value map access in `equalAnnotations` to correctly distinguish missing keys from empty string values
- Updates `install.yaml` and CI workflow to pass the new flag

## How it works
When the controller is deployed with `--controller-image=<image>`, it stores this value as a pod template annotation on every spawner Deployment it manages. When the controller is upgraded to a new image (and `--controller-image` is updated accordingly), the annotation value changes, which causes the reconciler to update the Deployment, triggering a rolling restart of spawner pods with the latest image.

This solves the problem where `:latest` tags don't change the image string, so the existing image comparison alone cannot detect that a new version is available.

## Test plan
- [x] Added unit tests for `DeploymentBuilder` controller image annotation behavior
- [x] Added unit tests for `equalAnnotations` helper (including empty string value edge case)
- [x] Added unit test for `ImagePullPolicy` propagation
- [x] Added integration test verifying stale annotations are removed after reconciliation
- [x] Existing integration tests pass (no annotation set when `ControllerImage` is empty)
- [x] CI e2e tests updated to pass `--controller-image` flag

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)