### PR TITLE
Add CLI commands to manage all axon CRDs

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -37,6 +37,33 @@ func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {
 	}
 }
 
+func completeWorkspaceNames(cfg *ClientConfig) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		cl, ns, err := cfg.NewClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		wsList := &axonv1alpha1.WorkspaceList{}
+		if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var names []string
+		for _, ws := range wsList.Items {
+			names = append(names, ws.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 func completeTaskSpawnerNames(cfg *ClientConfig) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -16,7 +16,10 @@ func TestValidArgsFunctionWired(t *testing.T) {
 	}{
 		{"get task", []string{"get", "task"}},
 		{"get taskspawner", []string{"get", "taskspawner"}},
+		{"get workspace", []string{"get", "workspace"}},
 		{"delete task", []string{"delete", "task"}},
+		{"delete workspace", []string{"delete", "workspace"}},
+		{"delete taskspawner", []string{"delete", "taskspawner"}},
 		{"logs", []string{"logs"}},
 	}
 
@@ -39,6 +42,7 @@ func TestCompletionWithInvalidKubeconfig(t *testing.T) {
 	}{
 		{"completeTaskNames", completeTaskNames(cfg)},
 		{"completeTaskSpawnerNames", completeTaskSpawnerNames(cfg)},
+		{"completeWorkspaceNames", completeWorkspaceNames(cfg)},
 	}
 
 	for _, tt := range fns {
@@ -63,6 +67,7 @@ func TestCompletionSkipsAfterFirstArg(t *testing.T) {
 	}{
 		{"completeTaskNames", completeTaskNames(cfg)},
 		{"completeTaskSpawnerNames", completeTaskSpawnerNames(cfg)},
+		{"completeWorkspaceNames", completeWorkspaceNames(cfg)},
 	}
 
 	for _, tt := range fns {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func newCreateCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create resources",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Help()
+			return fmt.Errorf("must specify a resource type")
+		},
+	}
+
+	cmd.AddCommand(newCreateWorkspaceCommand(cfg))
+	cmd.AddCommand(newCreateTaskSpawnerCommand(cfg))
+
+	return cmd
+}
+
+func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		repo   string
+		ref    string
+		token  string
+		name   string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "workspace",
+		Aliases: []string{"workspaces", "ws"},
+		Short:   "Create a workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: repo,
+					Ref:  ref,
+				},
+			}
+
+			if token != "" {
+				if err := ensureCredentialSecret(cfg, name+"-credentials", "GITHUB_TOKEN", token); err != nil {
+					return err
+				}
+				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+					Name: name + "-credentials",
+				}
+			}
+
+			if err := cl.Create(context.Background(), ws); err != nil {
+				return fmt.Errorf("creating workspace: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "workspace/%s created\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "workspace name (required)")
+	cmd.Flags().StringVar(&repo, "repo", "", "git repository URL (required)")
+	cmd.Flags().StringVar(&ref, "ref", "", "git reference (branch, tag, or commit SHA)")
+	cmd.Flags().StringVar(&token, "token", "", "GitHub token for authentication")
+
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("repo")
+
+	return cmd
+}
+
+func newCreateTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		name           string
+		workspace      string
+		secret         string
+		credentialType string
+		agentType      string
+		model          string
+		pollInterval   string
+		labels         []string
+		excludeLabels  []string
+		types          []string
+		state          string
+		promptTemplate string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "taskspawner",
+		Aliases: []string{"taskspawners", "ts"},
+		Short:   "Create a task spawner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if c := cfg.Config; c != nil {
+				if !cmd.Flags().Changed("secret") && c.Secret != "" {
+					secret = c.Secret
+				}
+				if !cmd.Flags().Changed("credential-type") && c.CredentialType != "" {
+					credentialType = c.CredentialType
+				}
+				if !cmd.Flags().Changed("model") && c.Model != "" {
+					model = c.Model
+				}
+			}
+
+			// Auto-create secret from token if no explicit secret is set.
+			if secret == "" && cfg.Config != nil {
+				if cfg.Config.OAuthToken != "" && cfg.Config.APIKey != "" {
+					return fmt.Errorf("config file must specify either oauthToken or apiKey, not both")
+				}
+				if token := cfg.Config.OAuthToken; token != "" {
+					if err := ensureCredentialSecret(cfg, "axon-credentials", "CLAUDE_CODE_OAUTH_TOKEN", token); err != nil {
+						return err
+					}
+					secret = "axon-credentials"
+					credentialType = "oauth"
+				} else if key := cfg.Config.APIKey; key != "" {
+					if err := ensureCredentialSecret(cfg, "axon-credentials", "ANTHROPIC_API_KEY", key); err != nil {
+						return err
+					}
+					secret = "axon-credentials"
+					credentialType = "api-key"
+				}
+			}
+
+			if secret == "" {
+				return fmt.Errorf("no credentials configured (set oauthToken/apiKey in config file, or use --secret flag)")
+			}
+
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{
+						GitHubIssues: &axonv1alpha1.GitHubIssues{
+							WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+								Name: workspace,
+							},
+							Types:         types,
+							Labels:        labels,
+							ExcludeLabels: excludeLabels,
+							State:         state,
+						},
+					},
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: agentType,
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialType(credentialType),
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: secret,
+							},
+						},
+						Model:          model,
+						PromptTemplate: promptTemplate,
+					},
+					PollInterval: pollInterval,
+				},
+			}
+
+			if err := cl.Create(context.Background(), ts); err != nil {
+				return fmt.Errorf("creating task spawner: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "taskspawner/%s created\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "task spawner name (required)")
+	cmd.Flags().StringVar(&workspace, "workspace", "", "workspace resource name (required)")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
+	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
+	cmd.Flags().StringVarP(&agentType, "type", "t", "claude-code", "agent type")
+	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&pollInterval, "poll-interval", "5m", "poll interval (e.g., 5m)")
+	cmd.Flags().StringSliceVar(&labels, "labels", nil, "filter issues by labels")
+	cmd.Flags().StringSliceVar(&excludeLabels, "exclude-labels", nil, "exclude issues with these labels")
+	cmd.Flags().StringSliceVar(&types, "types", []string{"issues"}, "item types to discover (issues, pulls)")
+	cmd.Flags().StringVar(&state, "state", "open", "issue state filter (open, closed, all)")
+	cmd.Flags().StringVar(&promptTemplate, "prompt-template", "", "Go text/template for rendering the task prompt")
+
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("workspace")
+
+	_ = cmd.RegisterFlagCompletionFunc("credential-type", cobra.FixedCompletions([]string{"api-key", "oauth"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = cmd.RegisterFlagCompletionFunc("state", cobra.FixedCompletions([]string{"open", "closed", "all"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = cmd.RegisterFlagCompletionFunc("types", cobra.FixedCompletions([]string{"issues", "pulls"}, cobra.ShellCompDirectiveNoFileComp))
+
+	return cmd
+}

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestCreateCommand_RequiresSubcommand(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no resource type specified")
+	}
+}
+
+func TestCreateWorkspaceCommand_RequiresName(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "workspace", "--repo", "https://github.com/example/repo.git"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --name not specified")
+	}
+}
+
+func TestCreateWorkspaceCommand_RequiresRepo(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "workspace", "--name", "my-workspace"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --repo not specified")
+	}
+}
+
+func TestCreateTaskSpawnerCommand_RequiresName(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "taskspawner", "--workspace", "my-workspace"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --name not specified")
+	}
+}
+
+func TestCreateTaskSpawnerCommand_RequiresWorkspace(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "taskspawner", "--name", "my-spawner"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --workspace not specified")
+	}
+}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -22,6 +22,8 @@ func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(newDeleteTaskCommand(cfg))
+	cmd.AddCommand(newDeleteWorkspaceCommand(cfg))
+	cmd.AddCommand(newDeleteTaskSpawnerCommand(cfg))
 
 	return cmd
 }
@@ -54,6 +56,70 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.ValidArgsFunction = completeTaskNames(cfg)
+
+	return cmd
+}
+
+func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "workspace <name>",
+		Aliases: []string{"workspaces", "ws"},
+		Short:   "Delete a workspace",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), ws); err != nil {
+				return fmt.Errorf("deleting workspace: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "workspace/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeWorkspaceNames(cfg)
+
+	return cmd
+}
+
+func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "taskspawner <name>",
+		Aliases: []string{"taskspawners", "ts"},
+		Short:   "Delete a task spawner",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), ts); err != nil {
+				return fmt.Errorf("deleting task spawner: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "taskspawner/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeTaskSpawnerNames(cfg)
 
 	return cmd
 }

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -23,6 +23,7 @@ func newGetCommand(cfg *ClientConfig) *cobra.Command {
 
 	cmd.AddCommand(newGetTaskCommand(cfg))
 	cmd.AddCommand(newGetTaskSpawnerCommand(cfg))
+	cmd.AddCommand(newGetWorkspaceCommand(cfg))
 
 	return cmd
 }
@@ -60,6 +61,70 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.ValidArgsFunction = completeTaskSpawnerNames(cfg)
+
+	return cmd
+}
+
+func newGetWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:     "workspace [name]",
+		Aliases: []string{"workspaces", "ws"},
+		Short:   "List workspaces or get details of a specific workspace",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if output != "" && output != "yaml" && output != "json" {
+				return fmt.Errorf("unknown output format %q: must be one of yaml, json", output)
+			}
+
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+
+			if len(args) == 1 {
+				ws := &axonv1alpha1.Workspace{}
+				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, ws); err != nil {
+					return fmt.Errorf("getting workspace: %w", err)
+				}
+
+				ws.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("Workspace"))
+				switch output {
+				case "yaml":
+					return printYAML(os.Stdout, ws)
+				case "json":
+					return printJSON(os.Stdout, ws)
+				default:
+					printWorkspaceDetail(os.Stdout, ws)
+					return nil
+				}
+			}
+
+			wsList := &axonv1alpha1.WorkspaceList{}
+			if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
+				return fmt.Errorf("listing workspaces: %w", err)
+			}
+
+			wsList.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("WorkspaceList"))
+			switch output {
+			case "yaml":
+				return printYAML(os.Stdout, wsList)
+			case "json":
+				return printJSON(os.Stdout, wsList)
+			default:
+				printWorkspaceTable(os.Stdout, wsList.Items)
+				return nil
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (yaml or json)")
+
+	cmd.ValidArgsFunction = completeWorkspaceNames(cfg)
+	_ = cmd.RegisterFlagCompletionFunc("output", cobra.FixedCompletions([]string{"yaml", "json"}, cobra.ShellCompDirectiveNoFileComp))
 
 	return cmd
 }

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -54,6 +54,28 @@ func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
 	}
 }
 
+func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tREPO\tREF\tAGE")
+	for _, ws := range workspaces {
+		age := duration.HumanDuration(time.Since(ws.CreationTimestamp.Time))
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ws.Name, ws.Spec.Repo, ws.Spec.Ref, age)
+	}
+	tw.Flush()
+}
+
+func printWorkspaceDetail(w io.Writer, ws *axonv1alpha1.Workspace) {
+	printField(w, "Name", ws.Name)
+	printField(w, "Namespace", ws.Namespace)
+	printField(w, "Repo", ws.Spec.Repo)
+	if ws.Spec.Ref != "" {
+		printField(w, "Ref", ws.Spec.Ref)
+	}
+	if ws.Spec.SecretRef != nil {
+		printField(w, "Secret", ws.Spec.SecretRef.Name)
+	}
+}
+
 func printTaskSpawnerTable(w io.Writer, spawners []axonv1alpha1.TaskSpawner) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(tw, "NAME\tSOURCE\tPHASE\tDISCOVERED\tTASKS\tAGE")

--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func TestPrintWorkspaceTable(t *testing.T) {
+	workspaces := []axonv1alpha1.Workspace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "ws-1",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/example/repo.git",
+				Ref:  "main",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "ws-2",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-24 * time.Hour)},
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/example/repo2.git",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceTable(&buf, workspaces)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAME") || !strings.Contains(output, "REPO") || !strings.Contains(output, "REF") || !strings.Contains(output, "AGE") {
+		t.Fatalf("expected table headers, got: %s", output)
+	}
+	if !strings.Contains(output, "ws-1") {
+		t.Fatalf("expected ws-1 in output, got: %s", output)
+	}
+	if !strings.Contains(output, "ws-2") {
+		t.Fatalf("expected ws-2 in output, got: %s", output)
+	}
+	if !strings.Contains(output, "https://github.com/example/repo.git") {
+		t.Fatalf("expected repo URL in output, got: %s", output)
+	}
+}
+
+func TestPrintWorkspaceDetail(t *testing.T) {
+	ws := &axonv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ws",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/example/repo.git",
+			Ref:  "main",
+			SecretRef: &axonv1alpha1.SecretReference{
+				Name: "my-secret",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceDetail(&buf, ws)
+	output := buf.String()
+
+	if !strings.Contains(output, "test-ws") {
+		t.Fatalf("expected workspace name in output, got: %s", output)
+	}
+	if !strings.Contains(output, "default") {
+		t.Fatalf("expected namespace in output, got: %s", output)
+	}
+	if !strings.Contains(output, "https://github.com/example/repo.git") {
+		t.Fatalf("expected repo in output, got: %s", output)
+	}
+	if !strings.Contains(output, "main") {
+		t.Fatalf("expected ref in output, got: %s", output)
+	}
+	if !strings.Contains(output, "my-secret") {
+		t.Fatalf("expected secret in output, got: %s", output)
+	}
+}
+
+func TestPrintWorkspaceDetail_NoOptionalFields(t *testing.T) {
+	ws := &axonv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ws",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/example/repo.git",
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceDetail(&buf, ws)
+	output := buf.String()
+
+	if strings.Contains(output, "Ref:") {
+		t.Fatalf("unexpected Ref field in output for empty ref, got: %s", output)
+	}
+	if strings.Contains(output, "Secret:") {
+		t.Fatalf("unexpected Secret field in output for nil secretRef, got: %s", output)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.AddCommand(
 		newRunCommand(cfg),
+		newCreateCommand(cfg),
 		newGetCommand(cfg),
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),


### PR DESCRIPTION
## Summary
- Add `axon create workspace` and `axon create taskspawner` commands for creating Workspace and TaskSpawner resources directly from the CLI
- Add `axon get workspace` subcommand with table, detail, YAML, and JSON output formats
- Add `axon delete workspace` and `axon delete taskspawner` subcommands for complete resource lifecycle management
- Add shell completion support for workspace names across all new commands
- Add unit tests for new commands and printer functions

## New Commands

```bash
# Create a workspace
axon create workspace --name my-workspace --repo https://github.com/org/repo.git --ref main --token <github-token>

# Create a task spawner
axon create taskspawner --name my-spawner --workspace my-workspace --secret my-secret --credential-type oauth

# List/get workspaces
axon get workspaces
axon get workspace my-workspace -o yaml

# Delete workspaces and task spawners
axon delete workspace my-workspace
axon delete taskspawner my-spawner
```

## Test plan
- [x] Unit tests for `create` command validation (required flags)
- [x] Unit tests for workspace printer functions (table and detail)
- [x] Updated completion tests for new subcommands
- [x] All existing unit tests pass
- [x] `go vet` passes
- [ ] CI verification

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI support to create, list/get, and delete Workspace and TaskSpawner CRDs with YAML/JSON output and shell completion. This satisfies axon-task-#38 by enabling full lifecycle management of Axon CRDs from the CLI.

- **New Features**
  - Create: axon create workspace and axon create taskspawner.
  - Get: axon get workspace [name] with table/detail and -o yaml|json.
  - Delete: axon delete workspace and axon delete taskspawner.
  - Shell completion for workspace names and flag value completions.
  - TaskSpawner credentials: auto-create secret from config (oauthToken or apiKey) and validate not both.

<sup>Written for commit 8525d06827013333329d0d16fff137b87bce468a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

