### PR TITLE
Add create, get, and delete commands for all axon CRDs

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -37,6 +37,33 @@ func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {
 	}
 }
 
+func completeWorkspaceNames(cfg *ClientConfig) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		cl, ns, err := cfg.NewClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		wsList := &axonv1alpha1.WorkspaceList{}
+		if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var names []string
+		for _, ws := range wsList.Items {
+			names = append(names, ws.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 func completeTaskSpawnerNames(cfg *ClientConfig) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -16,7 +16,10 @@ func TestValidArgsFunctionWired(t *testing.T) {
 	}{
 		{"get task", []string{"get", "task"}},
 		{"get taskspawner", []string{"get", "taskspawner"}},
+		{"get workspace", []string{"get", "workspace"}},
 		{"delete task", []string{"delete", "task"}},
+		{"delete workspace", []string{"delete", "workspace"}},
+		{"delete taskspawner", []string{"delete", "taskspawner"}},
 		{"logs", []string{"logs"}},
 	}
 
@@ -39,6 +42,7 @@ func TestCompletionWithInvalidKubeconfig(t *testing.T) {
 	}{
 		{"completeTaskNames", completeTaskNames(cfg)},
 		{"completeTaskSpawnerNames", completeTaskSpawnerNames(cfg)},
+		{"completeWorkspaceNames", completeWorkspaceNames(cfg)},
 	}
 
 	for _, tt := range fns {
@@ -63,6 +67,7 @@ func TestCompletionSkipsAfterFirstArg(t *testing.T) {
 	}{
 		{"completeTaskNames", completeTaskNames(cfg)},
 		{"completeTaskSpawnerNames", completeTaskSpawnerNames(cfg)},
+		{"completeWorkspaceNames", completeWorkspaceNames(cfg)},
 	}
 
 	for _, tt := range fns {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func newCreateCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create resources",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Help()
+			return fmt.Errorf("must specify a resource type")
+		},
+	}
+
+	cmd.AddCommand(newCreateWorkspaceCommand(cfg))
+	cmd.AddCommand(newCreateTaskSpawnerCommand(cfg))
+
+	return cmd
+}
+
+func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		repo   string
+		ref    string
+		secret string
+		token  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "workspace <name>",
+		Short: "Create a new workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			if token != "" && secret != "" {
+				return fmt.Errorf("cannot specify both --token and --secret")
+			}
+
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: repo,
+					Ref:  ref,
+				},
+			}
+
+			if secret != "" {
+				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+					Name: secret,
+				}
+			} else if token != "" {
+				secretName := name + "-credentials"
+				if err := ensureCredentialSecret(cfg, secretName, "GITHUB_TOKEN", token); err != nil {
+					return err
+				}
+				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+					Name: secretName,
+				}
+			}
+
+			ctx := context.Background()
+			if err := cl.Create(ctx, ws); err != nil {
+				return fmt.Errorf("creating workspace: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "workspace/%s created\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&repo, "repo", "", "git repository URL (required)")
+	cmd.Flags().StringVar(&ref, "ref", "", "git reference to checkout (branch, tag, or commit SHA)")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name containing GITHUB_TOKEN")
+	cmd.Flags().StringVar(&token, "token", "", "GitHub token (auto-creates a secret)")
+
+	cmd.MarkFlagRequired("repo")
+
+	return cmd
+}
+
+func newCreateTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		workspace      string
+		agentType      string
+		secret         string
+		credentialType string
+		model          string
+		promptTemplate string
+		pollInterval   string
+		labels         []string
+		excludeLabels  []string
+		types          []string
+		state          string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "taskspawner <name>",
+		Aliases: []string{"ts"},
+		Short:   "Create a new task spawner",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			if c := cfg.Config; c != nil {
+				if !cmd.Flags().Changed("secret") && c.Secret != "" {
+					secret = c.Secret
+				}
+				if !cmd.Flags().Changed("credential-type") && c.CredentialType != "" {
+					credentialType = c.CredentialType
+				}
+				if !cmd.Flags().Changed("model") && c.Model != "" {
+					model = c.Model
+				}
+				if !cmd.Flags().Changed("workspace") && c.Workspace.Name != "" {
+					workspace = c.Workspace.Name
+				}
+			}
+
+			// Auto-create secret from token if no explicit secret is set.
+			if secret == "" && cfg.Config != nil {
+				if cfg.Config.OAuthToken != "" && cfg.Config.APIKey != "" {
+					return fmt.Errorf("config file must specify either oauthToken or apiKey, not both")
+				}
+				if token := cfg.Config.OAuthToken; token != "" {
+					if err := ensureCredentialSecret(cfg, "axon-credentials", "CLAUDE_CODE_OAUTH_TOKEN", token); err != nil {
+						return err
+					}
+					secret = "axon-credentials"
+					credentialType = "oauth"
+				} else if key := cfg.Config.APIKey; key != "" {
+					if err := ensureCredentialSecret(cfg, "axon-credentials", "ANTHROPIC_API_KEY", key); err != nil {
+						return err
+					}
+					secret = "axon-credentials"
+					credentialType = "api-key"
+				}
+			}
+
+			if secret == "" {
+				return fmt.Errorf("no credentials configured (set oauthToken/apiKey in config file, or use --secret flag)")
+			}
+
+			if workspace == "" {
+				return fmt.Errorf("workspace is required (use --workspace flag or set workspace.name in config)")
+			}
+
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{
+						GitHubIssues: &axonv1alpha1.GitHubIssues{
+							WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+								Name: workspace,
+							},
+							Types:         types,
+							Labels:        labels,
+							ExcludeLabels: excludeLabels,
+							State:         state,
+						},
+					},
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: agentType,
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialType(credentialType),
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: secret,
+							},
+						},
+						Model:          model,
+						PromptTemplate: promptTemplate,
+					},
+					PollInterval: pollInterval,
+				},
+			}
+
+			ctx := context.Background()
+			if err := cl.Create(ctx, ts); err != nil {
+				return fmt.Errorf("creating task spawner: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "taskspawner/%s created\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&workspace, "workspace", "", "name of Workspace resource (required)")
+	cmd.Flags().StringVarP(&agentType, "type", "t", "claude-code", "agent type")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
+	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
+	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&promptTemplate, "prompt-template", "", "Go text/template for rendering the task prompt")
+	cmd.Flags().StringVar(&pollInterval, "poll-interval", "5m", "how often to poll the source for new items")
+	cmd.Flags().StringSliceVar(&labels, "labels", nil, "filter issues by labels")
+	cmd.Flags().StringSliceVar(&excludeLabels, "exclude-labels", nil, "exclude issues with these labels")
+	cmd.Flags().StringSliceVar(&types, "types", []string{"issues"}, "item types to discover (issues, pulls)")
+	cmd.Flags().StringVar(&state, "state", "open", "filter issues by state (open, closed, all)")
+
+	_ = cmd.RegisterFlagCompletionFunc("credential-type", cobra.FixedCompletions([]string{"api-key", "oauth"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = cmd.RegisterFlagCompletionFunc("state", cobra.FixedCompletions([]string{"open", "closed", "all"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = cmd.RegisterFlagCompletionFunc("types", cobra.FixedCompletions([]string{"issues", "pulls"}, cobra.ShellCompDirectiveNoFileComp))
+
+	return cmd
+}

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCreateCommand_RequiresSubcommand(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no subcommand specified")
+	}
+}
+
+func TestCreateCommand_HasWorkspaceSubcommand(t *testing.T) {
+	root := NewRootCommand()
+	cmd := findSubcommand(t, root, []string{"create", "workspace"})
+	if cmd == nil {
+		t.Fatal("expected workspace subcommand under create")
+	}
+}
+
+func TestCreateCommand_HasTaskSpawnerSubcommand(t *testing.T) {
+	root := NewRootCommand()
+	cmd := findSubcommand(t, root, []string{"create", "taskspawner"})
+	if cmd == nil {
+		t.Fatal("expected taskspawner subcommand under create")
+	}
+}
+
+func TestCreateWorkspace_RequiresName(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "workspace", "--repo", "https://github.com/org/repo"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+}
+
+func TestCreateWorkspace_RequiresRepo(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "workspace", "my-workspace"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --repo is missing")
+	}
+}
+
+func TestCreateWorkspace_RejectsTokenAndSecret(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "workspace", "my-workspace", "--repo", "https://github.com/org/repo", "--token", "tok", "--secret", "sec"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --token and --secret specified")
+	}
+	if !strings.Contains(err.Error(), "cannot specify both") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateTaskSpawner_RequiresName(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "taskspawner", "--workspace", "ws"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+}
+
+func TestCreateTaskSpawner_RequiresWorkspace(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "taskspawner", "my-ts", "--secret", "sec"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --workspace is missing")
+	}
+	if !strings.Contains(err.Error(), "workspace is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateTaskSpawner_RequiresCredentials(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"create", "taskspawner", "my-ts", "--workspace", "ws"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no credentials configured")
+	}
+	if !strings.Contains(err.Error(), "no credentials configured") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateTaskSpawner_NoValidArgsFunction(t *testing.T) {
+	root := NewRootCommand()
+	cmd := findSubcommand(t, root, []string{"create", "taskspawner"})
+	if cmd.ValidArgsFunction != nil {
+		t.Error("create taskspawner should not have ValidArgsFunction since it creates new resources")
+	}
+}
+
+func TestFlagCompletionCreateTaskSpawnerCredentialType(t *testing.T) {
+	root := NewRootCommand()
+
+	root.SetArgs([]string{"__complete", "create", "taskspawner", "--credential-type", ""})
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.Execute()
+
+	output := out.String()
+	if !strings.Contains(output, "api-key") {
+		t.Errorf("expected api-key in credential-type completions, got %q", output)
+	}
+	if !strings.Contains(output, "oauth") {
+		t.Errorf("expected oauth in credential-type completions, got %q", output)
+	}
+}
+
+func TestFlagCompletionCreateTaskSpawnerState(t *testing.T) {
+	root := NewRootCommand()
+
+	root.SetArgs([]string{"__complete", "create", "taskspawner", "--state", ""})
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.Execute()
+
+	output := out.String()
+	if !strings.Contains(output, "open") {
+		t.Errorf("expected open in state completions, got %q", output)
+	}
+	if !strings.Contains(output, "closed") {
+		t.Errorf("expected closed in state completions, got %q", output)
+	}
+	if !strings.Contains(output, "all") {
+		t.Errorf("expected all in state completions, got %q", output)
+	}
+}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -22,6 +22,8 @@ func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(newDeleteTaskCommand(cfg))
+	cmd.AddCommand(newDeleteWorkspaceCommand(cfg))
+	cmd.AddCommand(newDeleteTaskSpawnerCommand(cfg))
 
 	return cmd
 }
@@ -54,6 +56,70 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.ValidArgsFunction = completeTaskNames(cfg)
+
+	return cmd
+}
+
+func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "workspace <name>",
+		Aliases: []string{"workspaces", "ws"},
+		Short:   "Delete a workspace",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), ws); err != nil {
+				return fmt.Errorf("deleting workspace: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "workspace/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeWorkspaceNames(cfg)
+
+	return cmd
+}
+
+func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "taskspawner <name>",
+		Aliases: []string{"taskspawners", "ts"},
+		Short:   "Delete a task spawner",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), ts); err != nil {
+				return fmt.Errorf("deleting task spawner: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "taskspawner/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeTaskSpawnerNames(cfg)
 
 	return cmd
 }

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -108,6 +108,28 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 	}
 }
 
+func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tREPO\tREF\tAGE")
+	for _, ws := range workspaces {
+		age := duration.HumanDuration(time.Since(ws.CreationTimestamp.Time))
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ws.Name, ws.Spec.Repo, ws.Spec.Ref, age)
+	}
+	tw.Flush()
+}
+
+func printWorkspaceDetail(w io.Writer, ws *axonv1alpha1.Workspace) {
+	printField(w, "Name", ws.Name)
+	printField(w, "Namespace", ws.Namespace)
+	printField(w, "Repo", ws.Spec.Repo)
+	if ws.Spec.Ref != "" {
+		printField(w, "Ref", ws.Spec.Ref)
+	}
+	if ws.Spec.SecretRef != nil {
+		printField(w, "Secret", ws.Spec.SecretRef.Name)
+	}
+}
+
 func printField(w io.Writer, label, value string) {
 	fmt.Fprintf(w, "%-20s%s\n", label+":", value)
 }

--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func TestPrintWorkspaceTable(t *testing.T) {
+	workspaces := []axonv1alpha1.Workspace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ws-1",
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/org/repo1.git",
+				Ref:  "main",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ws-2",
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/org/repo2.git",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceTable(&buf, workspaces)
+
+	output := buf.String()
+	if !strings.Contains(output, "NAME") {
+		t.Error("expected NAME header")
+	}
+	if !strings.Contains(output, "REPO") {
+		t.Error("expected REPO header")
+	}
+	if !strings.Contains(output, "REF") {
+		t.Error("expected REF header")
+	}
+	if !strings.Contains(output, "AGE") {
+		t.Error("expected AGE header")
+	}
+	if !strings.Contains(output, "ws-1") {
+		t.Error("expected ws-1 in output")
+	}
+	if !strings.Contains(output, "ws-2") {
+		t.Error("expected ws-2 in output")
+	}
+	if !strings.Contains(output, "https://github.com/org/repo1.git") {
+		t.Error("expected repo1 URL in output")
+	}
+}
+
+func TestPrintWorkspaceTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	printWorkspaceTable(&buf, nil)
+
+	output := buf.String()
+	if !strings.Contains(output, "NAME") {
+		t.Error("expected header even for empty list")
+	}
+}
+
+func TestPrintWorkspaceDetail(t *testing.T) {
+	ws := &axonv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-ws",
+			Namespace: "test-ns",
+		},
+		Spec: axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/org/repo.git",
+			Ref:  "develop",
+			SecretRef: &axonv1alpha1.SecretReference{
+				Name: "my-secret",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceDetail(&buf, ws)
+
+	output := buf.String()
+	if !strings.Contains(output, "my-ws") {
+		t.Error("expected workspace name in output")
+	}
+	if !strings.Contains(output, "test-ns") {
+		t.Error("expected namespace in output")
+	}
+	if !strings.Contains(output, "https://github.com/org/repo.git") {
+		t.Error("expected repo in output")
+	}
+	if !strings.Contains(output, "develop") {
+		t.Error("expected ref in output")
+	}
+	if !strings.Contains(output, "my-secret") {
+		t.Error("expected secret in output")
+	}
+}
+
+func TestPrintWorkspaceDetail_Minimal(t *testing.T) {
+	ws := &axonv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic-ws",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/org/repo.git",
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceDetail(&buf, ws)
+
+	output := buf.String()
+	if !strings.Contains(output, "basic-ws") {
+		t.Error("expected workspace name in output")
+	}
+	if strings.Contains(output, "Ref:") {
+		t.Error("expected no Ref field when ref is empty")
+	}
+	if strings.Contains(output, "Secret:") {
+		t.Error("expected no Secret field when secretRef is nil")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.AddCommand(
 		newRunCommand(cfg),
+		newCreateCommand(cfg),
 		newGetCommand(cfg),
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -1,0 +1,312 @@
+package integration
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	"github.com/gjkim42/axon/internal/cli"
+)
+
+const (
+	cliTimeout  = time.Second * 10
+	cliInterval = time.Millisecond * 250
+)
+
+var _ = Describe("CLI Workspace Commands", func() {
+	Context("When completing Workspace names", func() {
+		It("Should return Workspace names from the cluster", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-complete-workspace",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating Workspaces")
+			for _, name := range []string{"ws-alpha", "ws-beta"} {
+				ws := &axonv1alpha1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: ns.Name,
+					},
+					Spec: axonv1alpha1.WorkspaceSpec{
+						Repo: "https://github.com/org/repo.git",
+					},
+				}
+				Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+			}
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+			output := runComplete(kubeconfigPath, ns.Name, "get", "workspace", "")
+			Expect(output).To(ContainSubstring("ws-alpha"))
+			Expect(output).To(ContainSubstring("ws-beta"))
+			Expect(output).To(ContainSubstring(":4"))
+		})
+	})
+
+	Context("When completing Workspace names for delete", func() {
+		It("Should return Workspace names from the cluster", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-complete-ws-delete",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Workspace")
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ws-to-delete",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/org/repo.git",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+			output := runComplete(kubeconfigPath, ns.Name, "delete", "workspace", "")
+			Expect(output).To(ContainSubstring("ws-to-delete"))
+			Expect(output).To(ContainSubstring(":4"))
+		})
+	})
+
+	Context("When completing TaskSpawner names for delete", func() {
+		It("Should return TaskSpawner names from the cluster", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-complete-ts-delete",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a TaskSpawner")
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ts-to-delete",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: "claude-code",
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialTypeAPIKey,
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: "test-secret",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+			output := runComplete(kubeconfigPath, ns.Name, "delete", "taskspawner", "")
+			Expect(output).To(ContainSubstring("ts-to-delete"))
+			Expect(output).To(ContainSubstring(":4"))
+		})
+	})
+
+	Context("When using create workspace via CLI", func() {
+		It("Should create a Workspace resource in the cluster", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-create-ws",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Running create workspace command")
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"create", "workspace", "cli-test-ws",
+				"--repo", "https://github.com/org/repo.git",
+				"--ref", "develop",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Verifying the Workspace exists in the cluster")
+			ws := &axonv1alpha1.Workspace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "cli-test-ws",
+				Namespace: ns.Name,
+			}, ws)).To(Succeed())
+			Expect(ws.Spec.Repo).To(Equal("https://github.com/org/repo.git"))
+			Expect(ws.Spec.Ref).To(Equal("develop"))
+		})
+	})
+
+	Context("When using get workspace via CLI", func() {
+		It("Should execute successfully for list and detail", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-get-ws",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Workspace")
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "get-test-ws",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/org/repo.git",
+					Ref:  "main",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Listing workspaces")
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"get", "workspace",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Getting workspace detail")
+			root = cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"get", "workspace", "get-test-ws",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Getting workspace in YAML format")
+			root = cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"get", "workspace", "get-test-ws", "-o", "yaml",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Getting workspace in JSON format")
+			root = cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"get", "workspace", "get-test-ws", "-o", "json",
+			})
+			Expect(root.Execute()).To(Succeed())
+		})
+	})
+
+	Context("When using delete workspace via CLI", func() {
+		It("Should delete the Workspace resource", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-delete-ws",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Workspace")
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delete-test-ws",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/org/repo.git",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Deleting workspace via CLI")
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"delete", "workspace", "delete-test-ws",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Verifying the Workspace is deleted")
+			deleted := &axonv1alpha1.Workspace{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "delete-test-ws",
+				Namespace: ns.Name,
+			}, deleted)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When using delete taskspawner via CLI", func() {
+		It("Should delete the TaskSpawner resource", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-delete-ts",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a TaskSpawner")
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delete-test-ts",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: "claude-code",
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialTypeAPIKey,
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: "test-secret",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Deleting taskspawner via CLI")
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"-n", ns.Name,
+				"delete", "taskspawner", "delete-test-ts",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			By("Verifying the TaskSpawner is eventually deleted")
+			Eventually(func() bool {
+				deleted := &axonv1alpha1.TaskSpawner{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "delete-test-ts",
+					Namespace: ns.Name,
+				}, deleted)
+				return err != nil
+			}, cliTimeout, cliInterval).Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Adds `axon create workspace` and `axon create taskspawner` commands for creating Workspace and TaskSpawner CRDs directly from the CLI
- Adds `axon get workspace` command for listing and viewing workspace details (with yaml/json output support)
- Adds `axon delete workspace` and `axon delete taskspawner` commands for deleting all resource types
- Adds shell completion support for workspace names across all relevant commands
- Fixes incorrect `ValidArgsFunction` on `create taskspawner` (was suggesting existing workspace names for a new resource name)
- Includes unit tests, integration tests (envtest), and e2e tests for all new commands

## Test plan
- [x] Unit tests pass (`go test ./internal/cli/...`)
- [x] `go vet ./...` passes
- [x] Build succeeds (`go build ./cmd/axon/`)
- [x] Integration tests added for create/get/delete workspace and completion
- [x] E2E tests added for workspace CRUD, get/delete error cases, create validation
- [ ] CI integration and e2e tests

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)