### PR TITLE
Add label workflow to apply needs-triage on new issues

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,33 @@
+name: Label
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  triage-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove needs-triage label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const hasTriageAccepted = labels.includes('triage-accepted');
+            const hasNeedsTriage = labels.includes('needs-triage');
+
+            if (!hasTriageAccepted && !hasNeedsTriage) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: ['needs-triage'],
+              });
+            } else if (hasTriageAccepted && hasNeedsTriage) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                name: 'needs-triage',
+              });
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`label.yaml`) that automatically manages the `needs-triage` label on issues
- Checks current labels on each event rather than relying on event types for reliability
- Adds `needs-triage` to newly opened issues that don't have `triage-accepted`
- Removes `needs-triage` when `triage-accepted` is added to an issue
- Re-adds `needs-triage` when `triage-accepted` is removed from an issue

Fixes #67

## Test plan
- [ ] Open a new issue without `triage-accepted` - verify `needs-triage` is added
- [ ] Open a new issue with `triage-accepted` already set - verify `needs-triage` is NOT added
- [ ] Add `triage-accepted` to an issue with `needs-triage` - verify `needs-triage` is removed
- [ ] Remove `triage-accepted` from an issue - verify `needs-triage` is re-added

🤖 Generated with [Claude Code](https://claude.com/claude-code)