### PR TITLE
Set TTL to singularity/axon-workers.yaml

### DIFF
--- a/singularity/axon-workers.yaml
+++ b/singularity/axon-workers.yaml
@@ -12,6 +12,7 @@ spec:
   taskTemplate:
     model: opus
     type: claude-code
+    ttlSecondsAfterFinished: 3600
     credentials:
       type: oauth
       secretRef:


### PR DESCRIPTION
## Summary
- Set `ttlSecondsAfterFinished: 3600` in `singularity/axon-workers.yaml` so that finished Tasks are automatically cleaned up after 1 hour, allowing the TaskSpawner to spawn new workers to handle follow-up work.

Closes #73

## Test plan
- [ ] Verify the YAML is valid and the field matches the CRD schema
- [ ] Deploy and confirm finished Tasks are deleted after 1 hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-delete finished Tasks after 1 hour by setting ttlSecondsAfterFinished: 3600 in singularity/axon-workers.yaml, freeing capacity so the TaskSpawner can launch follow-up workers. Closes #73.

<sup>Written for commit c133bc78eae4e127a45d6e750d00dfeae3c62a72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

