### PR TITLE
Remove --single-branch from git clone init container

### DIFF
--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -152,7 +152,7 @@ func (b *JobBuilder) buildClaudeCodeJob(task *axonv1alpha1.Task, workspace *axon
 		if workspace.Ref != "" {
 			cloneArgs = append(cloneArgs, "--branch", workspace.Ref)
 		}
-		cloneArgs = append(cloneArgs, "--single-branch", "--depth", "1", "--", workspace.Repo, WorkspaceMountPath+"/repo")
+		cloneArgs = append(cloneArgs, "--depth", "1", "--", workspace.Repo, WorkspaceMountPath+"/repo")
 
 		initContainer := corev1.Container{
 			Name:         "git-clone",

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(initContainer.Name).To(Equal("git-clone"))
 			Expect(initContainer.Image).To(Equal(controller.GitCloneImage))
 			Expect(initContainer.Args).To(Equal([]string{
-				"clone", "--branch", "main", "--single-branch", "--depth", "1",
+				"clone", "--branch", "main", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 
@@ -460,7 +460,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(initContainer.Command).To(HaveLen(3))
 			Expect(initContainer.Command[0]).To(Equal("sh"))
 			Expect(initContainer.Args).To(Equal([]string{
-				"--", "clone", "--branch", "main", "--single-branch", "--depth", "1",
+				"--", "clone", "--branch", "main", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 		})
@@ -538,7 +538,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(createdJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			initContainer := createdJob.Spec.Template.Spec.InitContainers[0]
 			Expect(initContainer.Args).To(Equal([]string{
-				"clone", "--single-branch", "--depth", "1",
+				"clone", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 


### PR DESCRIPTION
## Summary
- Remove `--single-branch` flag from the git clone init container so that `git fetch origin <branch>` properly creates remote tracking refs for non-default branches.
- This fixes an issue where the agent could not checkout existing task branches (e.g., `axon-task-N`) because `--single-branch` restricted the fetch refspec to only the default branch.

## Test plan
- [x] Unit tests pass (`make test`)
- [ ] Integration tests updated and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the --single-branch flag from the git clone init container so non-default branches get remote tracking refs and agents can check out existing task branches (e.g., axon-task-N). Updated integration tests to reflect the new clone args (keeps --depth 1 and optional --branch).

<sup>Written for commit e45300311f1b1c8602c5ca6cc010cdb2f23752dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

