### PR TITLE
Fix branch checkout in task prompt

### DIFF
--- a/singularity/axon-workers.yaml
+++ b/singularity/axon-workers.yaml
@@ -34,9 +34,10 @@ spec:
         - gh pr edit <number> --add-label generated-by-axon --add-label ok-to-test
 
       Task:
-      - 0. You always use a branch named axon-task-{{.Number}} for each issue #{{.Number}}, use the existing branch if it already exists.
-        - git fetch origin axon-task-{{.Number}} and git checkout axon-task-{{.Number}} to switch to the branch if it exists.
-        - Rebase the branch if needed, e.g. there is a conflict with the default branch in the PR.
+      - 0. Set up your working branch axon-task-{{.Number}}. Run this exactly:
+        ```
+        git fetch origin axon-task-{{.Number}} 2>/dev/null && git checkout -B axon-task-{{.Number}} origin/axon-task-{{.Number}} && git rebase main || git checkout -b axon-task-{{.Number}} main
+        ```
       - 1. Investigate the issue #{{.Number}} and its PR if exists.
       - 3. Create a commit that fixes the issue.
       - 4. /review the PR and get feedbacks from the PR to refine the patch.


### PR DESCRIPTION
## Summary
- Replace ambiguous prose instructions for branch checkout with an explicit shell command
- Handles both cases: existing remote branch (fetch + checkout + rebase) and new branch (create from main)

## Test plan
- [x] Verified the command works for both existing and non-existing remote branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes branch checkout in the axon-workers task prompt by replacing prose with a single explicit shell command for setting up axon-task-{{.Number}}. It fetches/checkout/rebases if the remote branch exists, or creates the branch from main if not, making branch setup reliable and reducing wasted turns.

<sup>Written for commit a6c0c813579a5b276ee5a37afacb73c339ebcb16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

