### PR TITLE
Add kind label management to label workflow

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -3,12 +3,16 @@ name: Label
 on:
   issues:
     types: [opened, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, labeled, unlabeled]
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   triage-label:
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
       - name: Add or remove needs-triage label
@@ -32,5 +36,35 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.payload.issue.number,
                 name: 'needs-triage',
+              });
+            }
+
+  kind-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove needs-kind label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isIssue = context.eventName === 'issues';
+            const item = isIssue ? context.payload.issue : context.payload.pull_request;
+            const itemNumber = item.number;
+            const labels = item.labels.map(l => l.name);
+            const hasKindLabel = labels.some(l => l.startsWith('kind/'));
+            const hasNeedsKind = labels.includes('needs-kind');
+
+            if (!hasKindLabel && !hasNeedsKind) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                labels: ['needs-kind'],
+              });
+            } else if (hasKindLabel && hasNeedsKind) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                name: 'needs-kind',
               });
             }


### PR DESCRIPTION
## Summary
- Add `kind-label` job to the existing `label.yaml` workflow that automatically manages the `needs-kind` label for both issues and PRs
  - When an issue or PR is opened without a `kind/*` label, `needs-kind` is added
  - When a `kind/*` label is added, `needs-kind` is automatically removed
- Add `pull_request_target` trigger and `pull-requests: write` permission so the workflow handles both issues and PRs
- Scope the existing `triage-label` job to issues only (via `if: github.event_name == 'issues'`) since triage is issue-specific

## Test plan
- [ ] Verify the label workflow triggers on issue/PR open, label, and unlabel events
- [ ] Open an issue without a `kind/*` label and verify `needs-kind` is added
- [ ] Add a `kind/bug` label to an issue and verify `needs-kind` is removed
- [ ] Open a PR without a `kind/*` label and verify `needs-kind` is added
- [ ] Add a `kind/feature` label to a PR and verify `needs-kind` is removed

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)