### PR TITLE
Add --no-single-branch to git clone init container

### DIFF
--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -152,7 +152,7 @@ func (b *JobBuilder) buildClaudeCodeJob(task *axonv1alpha1.Task, workspace *axon
 		if workspace.Ref != "" {
 			cloneArgs = append(cloneArgs, "--branch", workspace.Ref)
 		}
-		cloneArgs = append(cloneArgs, "--depth", "1", "--", workspace.Repo, WorkspaceMountPath+"/repo")
+		cloneArgs = append(cloneArgs, "--no-single-branch", "--depth", "1", "--", workspace.Repo, WorkspaceMountPath+"/repo")
 
 		initContainer := corev1.Container{
 			Name:         "git-clone",

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(initContainer.Name).To(Equal("git-clone"))
 			Expect(initContainer.Image).To(Equal(controller.GitCloneImage))
 			Expect(initContainer.Args).To(Equal([]string{
-				"clone", "--branch", "main", "--depth", "1",
+				"clone", "--branch", "main", "--no-single-branch", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 
@@ -460,7 +460,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(initContainer.Command).To(HaveLen(3))
 			Expect(initContainer.Command[0]).To(Equal("sh"))
 			Expect(initContainer.Args).To(Equal([]string{
-				"--", "clone", "--branch", "main", "--depth", "1",
+				"--", "clone", "--branch", "main", "--no-single-branch", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 		})
@@ -538,7 +538,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(createdJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			initContainer := createdJob.Spec.Template.Spec.InitContainers[0]
 			Expect(initContainer.Args).To(Equal([]string{
-				"clone", "--depth", "1",
+				"clone", "--no-single-branch", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",
 			}))
 


### PR DESCRIPTION
## Summary
- `--depth` implies `--single-branch`, which prevents remote tracking refs from being created for non-default branches
- Add `--no-single-branch` to override this so `git fetch origin` populates `origin/<branch>` refs and the agent can checkout existing task branches

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Integration test assertions updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds --no-single-branch to the git-clone init container to fix missing remote refs when using --depth 1. This allows git fetch to populate origin/<branch> and lets the agent checkout existing task branches.

- **Bug Fixes**
  - Add --no-single-branch to clone args so shallow clones include all remote tracking refs.
  - Update integration tests to expect the new flag and ensure branch refs are available.

<sup>Written for commit 4411204bcd9463b389bddb38ba4dda150204b909. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

