### PR TITLE
Support codex agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image configuration
 REGISTRY ?= gjkim42
 VERSION ?= latest
-IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner claude-code
+IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner claude-code codex
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -32,6 +32,8 @@ func main() {
 	var probeAddr string
 	var claudeCodeImage string
 	var claudeCodeImagePullPolicy string
+	var codexImage string
+	var codexImagePullPolicy string
 	var spawnerImage string
 	var spawnerImagePullPolicy string
 
@@ -42,6 +44,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&claudeCodeImage, "claude-code-image", controller.ClaudeCodeImage, "The image to use for Claude Code agent containers.")
 	flag.StringVar(&claudeCodeImagePullPolicy, "claude-code-image-pull-policy", "", "The image pull policy for Claude Code agent containers (e.g., Always, Never, IfNotPresent).")
+	flag.StringVar(&codexImage, "codex-image", controller.CodexImage, "The image to use for Codex agent containers.")
+	flag.StringVar(&codexImagePullPolicy, "codex-image-pull-policy", "", "The image pull policy for Codex agent containers (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&spawnerImage, "spawner-image", controller.DefaultSpawnerImage, "The image to use for spawner Deployments.")
 	flag.StringVar(&spawnerImagePullPolicy, "spawner-image-pull-policy", "", "The image pull policy for spawner Deployments (e.g., Always, Never, IfNotPresent).")
 
@@ -67,6 +71,8 @@ func main() {
 	jobBuilder := controller.NewJobBuilder()
 	jobBuilder.ClaudeCodeImage = claudeCodeImage
 	jobBuilder.ClaudeCodeImagePullPolicy = corev1.PullPolicy(claudeCodeImagePullPolicy)
+	jobBuilder.CodexImage = codexImage
+	jobBuilder.CodexImagePullPolicy = corev1.PullPolicy(codexImagePullPolicy)
 	if err = (&controller.TaskReconciler{
 		Client:     mgr.GetClient(),
 		Scheme:     mgr.GetScheme(),

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    ca-certificates \
+    git \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @openai/codex
+
+RUN useradd -u 1200 -m -s /bin/bash codex
+RUN mkdir -p /home/codex/.codex && chown -R codex:codex /home/codex
+
+USER codex
+WORKDIR /workspace
+
+ENTRYPOINT ["codex"]

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -1,0 +1,304 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func TestBuildCodexJob(t *testing.T) {
+	builder := NewJobBuilder()
+
+	t.Run("Basic codex job with API key", func(t *testing.T) {
+		task := &axonv1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-codex-task",
+				Namespace: "default",
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type:   AgentTypeCodex,
+				Prompt: "Fix the bug",
+				Credentials: axonv1alpha1.Credentials{
+					Type: axonv1alpha1.CredentialTypeAPIKey,
+					SecretRef: axonv1alpha1.SecretReference{
+						Name: "openai-api-key",
+					},
+				},
+			},
+		}
+
+		job, err := builder.Build(task, nil)
+		if err != nil {
+			t.Fatalf("Build() error = %v", err)
+		}
+
+		if job.Name != "test-codex-task" {
+			t.Errorf("Job name = %v, want test-codex-task", job.Name)
+		}
+
+		containers := job.Spec.Template.Spec.Containers
+		if len(containers) != 1 {
+			t.Fatalf("Expected 1 container, got %d", len(containers))
+		}
+
+		container := containers[0]
+		if container.Name != "codex" {
+			t.Errorf("Container name = %v, want codex", container.Name)
+		}
+
+		if container.Image != CodexImage {
+			t.Errorf("Container image = %v, want %v", container.Image, CodexImage)
+		}
+
+		expectedArgs := []string{"exec", "--full-auto", "--json", "Fix the bug"}
+		if len(container.Args) != len(expectedArgs) {
+			t.Fatalf("Args length = %d, want %d", len(container.Args), len(expectedArgs))
+		}
+		for i, arg := range container.Args {
+			if arg != expectedArgs[i] {
+				t.Errorf("Args[%d] = %v, want %v", i, arg, expectedArgs[i])
+			}
+		}
+
+		if len(container.Env) != 1 {
+			t.Fatalf("Expected 1 env var, got %d", len(container.Env))
+		}
+		if container.Env[0].Name != "OPENAI_API_KEY" {
+			t.Errorf("Env[0].Name = %v, want OPENAI_API_KEY", container.Env[0].Name)
+		}
+		if container.Env[0].ValueFrom.SecretKeyRef.Name != "openai-api-key" {
+			t.Errorf("SecretKeyRef.Name = %v, want openai-api-key", container.Env[0].ValueFrom.SecretKeyRef.Name)
+		}
+		if container.Env[0].ValueFrom.SecretKeyRef.Key != "OPENAI_API_KEY" {
+			t.Errorf("SecretKeyRef.Key = %v, want OPENAI_API_KEY", container.Env[0].ValueFrom.SecretKeyRef.Key)
+		}
+	})
+
+	t.Run("Codex job with model override", func(t *testing.T) {
+		task := &axonv1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-codex-model",
+				Namespace: "default",
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type:   AgentTypeCodex,
+				Prompt: "Create a test",
+				Credentials: axonv1alpha1.Credentials{
+					Type: axonv1alpha1.CredentialTypeAPIKey,
+					SecretRef: axonv1alpha1.SecretReference{
+						Name: "openai-api-key",
+					},
+				},
+				Model: "o3",
+			},
+		}
+
+		job, err := builder.Build(task, nil)
+		if err != nil {
+			t.Fatalf("Build() error = %v", err)
+		}
+
+		container := job.Spec.Template.Spec.Containers[0]
+		expectedArgs := []string{"exec", "--full-auto", "--json", "Create a test", "-m", "o3"}
+		if len(container.Args) != len(expectedArgs) {
+			t.Fatalf("Args length = %d, want %d", len(container.Args), len(expectedArgs))
+		}
+		for i, arg := range container.Args {
+			if arg != expectedArgs[i] {
+				t.Errorf("Args[%d] = %v, want %v", i, arg, expectedArgs[i])
+			}
+		}
+	})
+
+	t.Run("Codex job with workspace", func(t *testing.T) {
+		task := &axonv1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-codex-workspace",
+				Namespace: "default",
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type:   AgentTypeCodex,
+				Prompt: "Fix the bug",
+				Credentials: axonv1alpha1.Credentials{
+					Type: axonv1alpha1.CredentialTypeAPIKey,
+					SecretRef: axonv1alpha1.SecretReference{
+						Name: "openai-api-key",
+					},
+				},
+			},
+		}
+
+		workspace := &axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/example/repo.git",
+			Ref:  "main",
+		}
+
+		job, err := builder.Build(task, workspace)
+		if err != nil {
+			t.Fatalf("Build() error = %v", err)
+		}
+
+		// Verify init container
+		initContainers := job.Spec.Template.Spec.InitContainers
+		if len(initContainers) != 1 {
+			t.Fatalf("Expected 1 init container, got %d", len(initContainers))
+		}
+		if initContainers[0].Name != "git-clone" {
+			t.Errorf("Init container name = %v, want git-clone", initContainers[0].Name)
+		}
+
+		// Verify init container runs as codex user
+		if initContainers[0].SecurityContext == nil || initContainers[0].SecurityContext.RunAsUser == nil {
+			t.Fatal("Init container SecurityContext or RunAsUser is nil")
+		}
+		if *initContainers[0].SecurityContext.RunAsUser != CodexUID {
+			t.Errorf("Init container RunAsUser = %v, want %v", *initContainers[0].SecurityContext.RunAsUser, CodexUID)
+		}
+
+		// Verify pod security context FSGroup
+		if job.Spec.Template.Spec.SecurityContext == nil || job.Spec.Template.Spec.SecurityContext.FSGroup == nil {
+			t.Fatal("Pod SecurityContext or FSGroup is nil")
+		}
+		if *job.Spec.Template.Spec.SecurityContext.FSGroup != CodexUID {
+			t.Errorf("Pod FSGroup = %v, want %v", *job.Spec.Template.Spec.SecurityContext.FSGroup, CodexUID)
+		}
+
+		// Verify volume mounts on main container
+		container := job.Spec.Template.Spec.Containers[0]
+		if len(container.VolumeMounts) != 1 {
+			t.Fatalf("Expected 1 volume mount, got %d", len(container.VolumeMounts))
+		}
+		if container.WorkingDir != "/workspace/repo" {
+			t.Errorf("WorkingDir = %v, want /workspace/repo", container.WorkingDir)
+		}
+	})
+
+	t.Run("Codex job with workspace and secretRef", func(t *testing.T) {
+		task := &axonv1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-codex-ws-secret",
+				Namespace: "default",
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type:   AgentTypeCodex,
+				Prompt: "Create a PR",
+				Credentials: axonv1alpha1.Credentials{
+					Type: axonv1alpha1.CredentialTypeAPIKey,
+					SecretRef: axonv1alpha1.SecretReference{
+						Name: "openai-api-key",
+					},
+				},
+			},
+		}
+
+		workspace := &axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/example/repo.git",
+			Ref:  "main",
+			SecretRef: &axonv1alpha1.SecretReference{
+				Name: "github-token",
+			},
+		}
+
+		job, err := builder.Build(task, workspace)
+		if err != nil {
+			t.Fatalf("Build() error = %v", err)
+		}
+
+		// Verify main container has OPENAI_API_KEY, GITHUB_TOKEN, GH_TOKEN
+		container := job.Spec.Template.Spec.Containers[0]
+		if len(container.Env) != 3 {
+			t.Fatalf("Expected 3 env vars, got %d", len(container.Env))
+		}
+		if container.Env[0].Name != "OPENAI_API_KEY" {
+			t.Errorf("Env[0].Name = %v, want OPENAI_API_KEY", container.Env[0].Name)
+		}
+		if container.Env[1].Name != "GITHUB_TOKEN" {
+			t.Errorf("Env[1].Name = %v, want GITHUB_TOKEN", container.Env[1].Name)
+		}
+		if container.Env[2].Name != "GH_TOKEN" {
+			t.Errorf("Env[2].Name = %v, want GH_TOKEN", container.Env[2].Name)
+		}
+
+		// Verify init container has credential helper
+		initContainer := job.Spec.Template.Spec.InitContainers[0]
+		if len(initContainer.Command) != 3 {
+			t.Fatalf("Expected init container command length 3, got %d", len(initContainer.Command))
+		}
+		if initContainer.Command[0] != "sh" {
+			t.Errorf("Init container Command[0] = %v, want sh", initContainer.Command[0])
+		}
+
+		// Verify init container has GITHUB_TOKEN and GH_TOKEN
+		if len(initContainer.Env) != 2 {
+			t.Fatalf("Expected 2 init container env vars, got %d", len(initContainer.Env))
+		}
+		if initContainer.Env[0].Name != "GITHUB_TOKEN" {
+			t.Errorf("Init container Env[0].Name = %v, want GITHUB_TOKEN", initContainer.Env[0].Name)
+		}
+		if initContainer.Env[1].Name != "GH_TOKEN" {
+			t.Errorf("Init container Env[1].Name = %v, want GH_TOKEN", initContainer.Env[1].Name)
+		}
+	})
+
+	t.Run("Unsupported agent type", func(t *testing.T) {
+		task := &axonv1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-unknown",
+				Namespace: "default",
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type:   "unknown-agent",
+				Prompt: "Do something",
+				Credentials: axonv1alpha1.Credentials{
+					Type: axonv1alpha1.CredentialTypeAPIKey,
+					SecretRef: axonv1alpha1.SecretReference{
+						Name: "some-secret",
+					},
+				},
+			},
+		}
+
+		_, err := builder.Build(task, nil)
+		if err == nil {
+			t.Fatal("Build() expected error for unsupported agent type")
+		}
+	})
+}
+
+func TestBuildClaudeCodeJob(t *testing.T) {
+	builder := NewJobBuilder()
+
+	t.Run("Basic claude-code job", func(t *testing.T) {
+		task := &axonv1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-claude-task",
+				Namespace: "default",
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type:   AgentTypeClaudeCode,
+				Prompt: "Fix the bug",
+				Credentials: axonv1alpha1.Credentials{
+					Type: axonv1alpha1.CredentialTypeAPIKey,
+					SecretRef: axonv1alpha1.SecretReference{
+						Name: "anthropic-api-key",
+					},
+				},
+			},
+		}
+
+		job, err := builder.Build(task, nil)
+		if err != nil {
+			t.Fatalf("Build() error = %v", err)
+		}
+
+		container := job.Spec.Template.Spec.Containers[0]
+		if container.Name != "claude-code" {
+			t.Errorf("Container name = %v, want claude-code", container.Name)
+		}
+		if container.Image != ClaudeCodeImage {
+			t.Errorf("Container image = %v, want %v", container.Image, ClaudeCodeImage)
+		}
+	})
+}

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -786,6 +786,229 @@ var _ = Describe("Task Controller", func() {
 		})
 	})
 
+	Context("When creating a Codex Task with API key credentials", func() {
+		It("Should create a Job with Codex agent configuration", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-codex-apikey",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Secret with OpenAI API key")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openai-api-key",
+					Namespace: ns.Name,
+				},
+				StringData: map[string]string{
+					"OPENAI_API_KEY": "test-openai-key",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a Codex Task")
+			task := &axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-codex-task",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   "codex",
+					Prompt: "Create a hello world program",
+					Credentials: axonv1alpha1.Credentials{
+						Type: axonv1alpha1.CredentialTypeAPIKey,
+						SecretRef: axonv1alpha1.SecretReference{
+							Name: "openai-api-key",
+						},
+					},
+					Model: "o3",
+				},
+			}
+			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
+
+			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
+			createdTask := &axonv1alpha1.Task{}
+
+			By("Verifying the Task has a finalizer")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
+				if err != nil {
+					return false
+				}
+				for _, f := range createdTask.Finalizers {
+					if f == "axon.io/finalizer" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying a Job is created")
+			jobLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
+			createdJob := &batchv1.Job{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, jobLookupKey, createdJob)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Logging the Job spec")
+			logJobSpec(createdJob)
+
+			By("Verifying the Job spec")
+			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := createdJob.Spec.Template.Spec.Containers[0]
+			Expect(container.Name).To(Equal("codex"))
+			Expect(container.Args).To(ContainElements(
+				"exec",
+				"--full-auto",
+				"--json",
+				"Create a hello world program",
+				"-m", "o3",
+			))
+
+			By("Verifying the Job has OpenAI API key env var")
+			Expect(container.Env).To(HaveLen(1))
+			Expect(container.Env[0].Name).To(Equal("OPENAI_API_KEY"))
+			Expect(container.Env[0].ValueFrom.SecretKeyRef.Name).To(Equal("openai-api-key"))
+			Expect(container.Env[0].ValueFrom.SecretKeyRef.Key).To(Equal("OPENAI_API_KEY"))
+
+			By("Verifying the Job has owner reference")
+			Expect(createdJob.OwnerReferences).To(HaveLen(1))
+			Expect(createdJob.OwnerReferences[0].Name).To(Equal(task.Name))
+			Expect(createdJob.OwnerReferences[0].Kind).To(Equal("Task"))
+
+			By("Verifying Task status has JobName")
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
+				if err != nil {
+					return ""
+				}
+				return createdTask.Status.JobName
+			}, timeout, interval).Should(Equal(task.Name))
+		})
+	})
+
+	Context("When creating a Codex Task with workspace", func() {
+		It("Should create a Job with init container and workspace volume", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-codex-workspace",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Secret with OpenAI API key")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openai-api-key",
+					Namespace: ns.Name,
+				},
+				StringData: map[string]string{
+					"OPENAI_API_KEY": "test-openai-key",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a Secret with GITHUB_TOKEN")
+			ghSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "github-token",
+					Namespace: ns.Name,
+				},
+				StringData: map[string]string{
+					"GITHUB_TOKEN": "test-gh-token",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ghSecret)).Should(Succeed())
+
+			By("Creating a Workspace resource with secretRef")
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-codex-workspace",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/example/repo.git",
+					Ref:  "main",
+					SecretRef: &axonv1alpha1.SecretReference{
+						Name: "github-token",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+
+			By("Creating a Codex Task with workspace ref")
+			task := &axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-codex-workspace",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   "codex",
+					Prompt: "Fix the bug",
+					Credentials: axonv1alpha1.Credentials{
+						Type: axonv1alpha1.CredentialTypeAPIKey,
+						SecretRef: axonv1alpha1.SecretReference{
+							Name: "openai-api-key",
+						},
+					},
+					WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+						Name: "test-codex-workspace",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
+
+			By("Verifying a Job is created")
+			jobLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
+			createdJob := &batchv1.Job{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, jobLookupKey, createdJob)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Logging the Job spec")
+			logJobSpec(createdJob)
+
+			By("Verifying the main container has OPENAI_API_KEY, GITHUB_TOKEN, and GH_TOKEN env vars")
+			mainContainer := createdJob.Spec.Template.Spec.Containers[0]
+			Expect(mainContainer.Name).To(Equal("codex"))
+			Expect(mainContainer.Env).To(HaveLen(3))
+			Expect(mainContainer.Env[0].Name).To(Equal("OPENAI_API_KEY"))
+			Expect(mainContainer.Env[0].ValueFrom.SecretKeyRef.Name).To(Equal("openai-api-key"))
+			Expect(mainContainer.Env[1].Name).To(Equal("GITHUB_TOKEN"))
+			Expect(mainContainer.Env[1].ValueFrom.SecretKeyRef.Name).To(Equal("github-token"))
+			Expect(mainContainer.Env[2].Name).To(Equal("GH_TOKEN"))
+			Expect(mainContainer.Env[2].ValueFrom.SecretKeyRef.Name).To(Equal("github-token"))
+
+			By("Verifying the init container")
+			Expect(createdJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			initContainer := createdJob.Spec.Template.Spec.InitContainers[0]
+			Expect(initContainer.Name).To(Equal("git-clone"))
+
+			By("Verifying the init container runs as codex user")
+			Expect(initContainer.SecurityContext).NotTo(BeNil())
+			Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+			Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(controller.CodexUID))
+
+			By("Verifying the pod security context sets FSGroup for codex")
+			Expect(createdJob.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+			Expect(createdJob.Spec.Template.Spec.SecurityContext.FSGroup).NotTo(BeNil())
+			Expect(*createdJob.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(controller.CodexUID))
+
+			By("Verifying the workspace volume and mount")
+			Expect(createdJob.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			Expect(createdJob.Spec.Template.Spec.Volumes[0].Name).To(Equal(controller.WorkspaceVolumeName))
+			Expect(mainContainer.VolumeMounts).To(HaveLen(1))
+			Expect(mainContainer.WorkingDir).To(Equal("/workspace/repo"))
+		})
+	})
+
 	Context("When creating a Task with a nonexistent workspace", func() {
 		It("Should fail with a meaningful error", func() {
 			By("Creating a namespace")


### PR DESCRIPTION
## Summary
- Add OpenAI Codex as a new agent type alongside Claude Code
- Add `codex` agent type in JobBuilder with Codex-specific CLI flags (`exec --full-auto --json`) and `OPENAI_API_KEY` environment variable
- Add `--codex-image` and `--codex-image-pull-policy` controller flags
- Add `codex/Dockerfile` based on `@openai/codex` npm package
- Add unit tests for codex job builder and integration tests for codex tasks

## Test plan
- [x] Unit tests for codex job builder pass (`make test`)
- [x] Integration tests for codex tasks with API key and workspace pass (`make test-integration`)
- [x] Build succeeds (`make build`)
- [ ] CI passes

Fixes #84

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAI Codex as a first-class agent to run Codex tasks in Kubernetes like Claude Code. Fixes #84 with new controller flags, a Codex image, API key auth, optional model override, and workspace cloning.

- **New Features**
  - Agent: new codex type in JobBuilder (exec --full-auto --json, optional -m).
  - Controller: --codex-image and --codex-image-pull-policy; default gjkim42/codex:latest; added codex/Dockerfile and Makefile target.
  - Auth/workspace: OPENAI_API_KEY from Secret; GITHUB_TOKEN/GH_TOKEN; git-clone init with credential helper; run as UID 1200 with FSGroup.
  - Tests: unit tests for Codex jobs; integration tests for API key and workspace.

<sup>Written for commit 93f3c96a823898023552fb0d6ac974c003af6ada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

