### PR TITLE
Add agent image interface for custom agent images

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -50,6 +50,14 @@ type TaskSpec struct {
 	// +kubebuilder:validation:Required
 	Type string `json:"type"`
 
+	// Image optionally overrides the default container image for the agent type.
+	// The image must implement the axon agent image interface:
+	// - Provide /axon_entrypoint.sh as the entrypoint
+	// - Accept the prompt as the first argument
+	// - Use AXON_PROMPT and AXON_MODEL environment variables
+	// +optional
+	Image string `json:"image,omitempty"`
+
 	// Prompt is the task prompt to send to the agent.
 	// +kubebuilder:validation:Required
 	Prompt string `json:"prompt"`

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -59,6 +59,14 @@ type TaskTemplate struct {
 	// +kubebuilder:validation:Required
 	Type string `json:"type"`
 
+	// Image optionally overrides the default container image for the agent type.
+	// The image must implement the axon agent image interface:
+	// - Provide /axon_entrypoint.sh as the entrypoint
+	// - Accept the prompt as the first argument
+	// - Use AXON_PROMPT and AXON_MODEL environment variables
+	// +optional
+	Image string `json:"image,omitempty"`
+
 	// Credentials specifies how to authenticate with the agent.
 	// +kubebuilder:validation:Required
 	Credentials Credentials `json:"credentials"`

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -20,7 +20,9 @@ RUN npm install -g @anthropic-ai/claude-code
 RUN useradd -u 1100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude
 
+COPY --chmod=755 claude-code/axon_entrypoint.sh /axon_entrypoint.sh
+
 USER claude
 WORKDIR /workspace
 
-ENTRYPOINT ["claude"]
+ENTRYPOINT ["/axon_entrypoint.sh"]

--- a/claude-code/axon_entrypoint.sh
+++ b/claude-code/axon_entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# axon_entrypoint.sh - Standard axon agent image entrypoint for Claude Code.
+#
+# This script implements the axon agent image interface:
+#   - Receives the prompt as the first argument ($1)
+#   - Uses AXON_MODEL environment variable for the model (if set)
+#
+# Reserved environment variables set by axon:
+#   AXON_PROMPT - the task prompt (same as $1)
+#   AXON_MODEL  - the model to use (may be empty)
+set -euo pipefail
+
+PROMPT="${1:?Prompt argument is required}"
+
+ARGS=(
+    "--dangerously-skip-permissions"
+    "--output-format" "stream-json"
+    "--verbose"
+    "-p" "${PROMPT}"
+)
+
+if [ -n "${AXON_MODEL:-}" ]; then
+    ARGS+=("--model" "${AXON_MODEL}")
+fi
+
+exec claude "${ARGS[@]}"

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -154,6 +154,7 @@ func runCycle(ctx context.Context, cl client.Client, key types.NamespacedName, g
 			},
 			Spec: axonv1alpha1.TaskSpec{
 				Type:                    ts.Spec.TaskTemplate.Type,
+				Image:                   ts.Spec.TaskTemplate.Image,
 				Prompt:                  prompt,
 				Credentials:             ts.Spec.TaskTemplate.Credentials,
 				Model:                   ts.Spec.TaskTemplate.Model,

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -71,6 +71,14 @@ spec:
                 - secretRef
                 - type
                 type: object
+              image:
+                description: |-
+                  Image optionally overrides the default container image for the agent type.
+                  The image must implement the axon agent image interface:
+                  - Provide /axon_entrypoint.sh as the entrypoint
+                  - Accept the prompt as the first argument
+                  - Use AXON_PROMPT and AXON_MODEL environment variables
+                type: string
               model:
                 description: Model optionally overrides the default model.
                 type: string
@@ -226,6 +234,14 @@ spec:
                     - secretRef
                     - type
                     type: object
+                  image:
+                    description: |-
+                      Image optionally overrides the default container image for the agent type.
+                      The image must implement the axon agent image interface:
+                      - Provide /axon_entrypoint.sh as the entrypoint
+                      - Accept the prompt as the first argument
+                      - Use AXON_PROMPT and AXON_MODEL environment variables
+                    type: string
                   model:
                     description: Model optionally overrides the default model.
                     type: string

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -20,6 +20,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	var (
 		prompt         string
 		agentType      string
+		image          string
 		secret         string
 		credentialType string
 		model          string
@@ -126,6 +127,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				},
 				Spec: axonv1alpha1.TaskSpec{
 					Type:   agentType,
+					Image:  image,
 					Prompt: prompt,
 					Credentials: axonv1alpha1.Credentials{
 						Type: axonv1alpha1.CredentialType(credentialType),
@@ -158,6 +160,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 
 	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "task prompt (required)")
 	cmd.Flags().StringVarP(&agentType, "type", "t", "claude-code", "agent type")
+	cmd.Flags().StringVar(&image, "image", "", "custom agent image (overrides default image for the agent type)")
 	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
 	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
 	cmd.Flags().StringVar(&model, "model", "", "model override")

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -1,0 +1,197 @@
+package controller
+
+import (
+	"testing"
+
+	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+)
+
+func TestBuildClaudeCodeJob(t *testing.T) {
+	tests := []struct {
+		name          string
+		task          *axonv1alpha1.Task
+		workspace     *axonv1alpha1.WorkspaceSpec
+		wantImage     string
+		wantCommand   []string
+		wantArgs      []string
+		wantEnvNames  []string
+		wantEnvValues map[string]string // for non-secret env vars
+	}{
+		{
+			name: "Default image with API key",
+			task: &axonv1alpha1.Task{
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   AgentTypeClaudeCode,
+					Prompt: "Hello world",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      axonv1alpha1.CredentialTypeAPIKey,
+						SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+					},
+				},
+			},
+			wantImage:   ClaudeCodeImage,
+			wantCommand: []string{AgentEntrypoint},
+			wantArgs:    []string{"Hello world"},
+			wantEnvNames: []string{
+				EnvAxonPrompt,
+				EnvAxonModel,
+				"ANTHROPIC_API_KEY",
+			},
+			wantEnvValues: map[string]string{
+				EnvAxonPrompt: "Hello world",
+				EnvAxonModel:  "",
+			},
+		},
+		{
+			name: "Custom image override",
+			task: &axonv1alpha1.Task{
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   AgentTypeClaudeCode,
+					Image:  "my-agent:v2",
+					Prompt: "Do something",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      axonv1alpha1.CredentialTypeAPIKey,
+						SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+					},
+				},
+			},
+			wantImage:   "my-agent:v2",
+			wantCommand: []string{AgentEntrypoint},
+			wantArgs:    []string{"Do something"},
+			wantEnvNames: []string{
+				EnvAxonPrompt,
+				EnvAxonModel,
+				"ANTHROPIC_API_KEY",
+			},
+			wantEnvValues: map[string]string{
+				EnvAxonPrompt: "Do something",
+				EnvAxonModel:  "",
+			},
+		},
+		{
+			name: "With model specified",
+			task: &axonv1alpha1.Task{
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   AgentTypeClaudeCode,
+					Prompt: "Fix bug",
+					Model:  "claude-opus",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      axonv1alpha1.CredentialTypeOAuth,
+						SecretRef: axonv1alpha1.SecretReference{Name: "oauth-secret"},
+					},
+				},
+			},
+			wantImage:   ClaudeCodeImage,
+			wantCommand: []string{AgentEntrypoint},
+			wantArgs:    []string{"Fix bug"},
+			wantEnvNames: []string{
+				EnvAxonPrompt,
+				EnvAxonModel,
+				"CLAUDE_CODE_OAUTH_TOKEN",
+			},
+			wantEnvValues: map[string]string{
+				EnvAxonPrompt: "Fix bug",
+				EnvAxonModel:  "claude-opus",
+			},
+		},
+		{
+			name: "With workspace and secret",
+			task: &axonv1alpha1.Task{
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   AgentTypeClaudeCode,
+					Prompt: "Create PR",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      axonv1alpha1.CredentialTypeAPIKey,
+						SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+					},
+				},
+			},
+			workspace: &axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/example/repo.git",
+				SecretRef: &axonv1alpha1.SecretReference{
+					Name: "gh-token",
+				},
+			},
+			wantImage:   ClaudeCodeImage,
+			wantCommand: []string{AgentEntrypoint},
+			wantArgs:    []string{"Create PR"},
+			wantEnvNames: []string{
+				EnvAxonPrompt,
+				EnvAxonModel,
+				"ANTHROPIC_API_KEY",
+				"GITHUB_TOKEN",
+				"GH_TOKEN",
+			},
+			wantEnvValues: map[string]string{
+				EnvAxonPrompt: "Create PR",
+				EnvAxonModel:  "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewJobBuilder()
+			job, err := builder.Build(tt.task, tt.workspace)
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+
+			container := job.Spec.Template.Spec.Containers[0]
+
+			if container.Image != tt.wantImage {
+				t.Errorf("Image = %q, want %q", container.Image, tt.wantImage)
+			}
+
+			if len(container.Command) != len(tt.wantCommand) {
+				t.Fatalf("Command length = %d, want %d", len(container.Command), len(tt.wantCommand))
+			}
+			for i, cmd := range container.Command {
+				if cmd != tt.wantCommand[i] {
+					t.Errorf("Command[%d] = %q, want %q", i, cmd, tt.wantCommand[i])
+				}
+			}
+
+			if len(container.Args) != len(tt.wantArgs) {
+				t.Fatalf("Args length = %d, want %d", len(container.Args), len(tt.wantArgs))
+			}
+			for i, arg := range container.Args {
+				if arg != tt.wantArgs[i] {
+					t.Errorf("Args[%d] = %q, want %q", i, arg, tt.wantArgs[i])
+				}
+			}
+
+			if len(container.Env) != len(tt.wantEnvNames) {
+				t.Fatalf("Env length = %d, want %d", len(container.Env), len(tt.wantEnvNames))
+			}
+			for i, envName := range tt.wantEnvNames {
+				if container.Env[i].Name != envName {
+					t.Errorf("Env[%d].Name = %q, want %q", i, container.Env[i].Name, envName)
+				}
+				if expectedValue, ok := tt.wantEnvValues[envName]; ok {
+					if container.Env[i].Value != expectedValue {
+						t.Errorf("Env[%d].Value = %q, want %q", i, container.Env[i].Value, expectedValue)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBuildUnsupportedAgentType(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   "unsupported",
+			Prompt: "test",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "s"},
+			},
+		},
+	}
+	_, err := builder.Build(task, nil)
+	if err == nil {
+		t.Fatal("Build() expected error for unsupported agent type, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Define a standard interface for axon-compatible agent images: `/axon_entrypoint.sh` entrypoint that receives the prompt as the first argument
- Set reserved environment variables `AXON_PROMPT` and `AXON_MODEL` on all agent containers
- Add optional `image` field to `TaskSpec` and `TaskTemplate` to allow custom image overrides
- Add `--image` flag to the CLI `run` command
- Update `claude-code` Dockerfile to use `axon_entrypoint.sh` wrapper

## Agent Image Interface

Custom agent images must implement:
1. **Entrypoint**: Provide `/axon_entrypoint.sh` as the entrypoint script
2. **Prompt argument**: Accept the prompt as the first argument (`$1`)
3. **Environment variables**: Use `AXON_PROMPT` (task prompt) and `AXON_MODEL` (model name) environment variables

## Test plan
- [x] Unit tests for job builder (new `job_builder_test.go`)
- [x] Integration test for custom image override
- [x] Updated existing integration tests for new env vars and entrypoint
- [x] All unit tests pass (`make test`)
- [x] All integration tests pass (`make test-integration`)
- [x] Build succeeds (`make build`)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a standard agent image interface and enables per-task custom images. Fulfills axon-task-86 with a unified entrypoint, reserved env vars, and image overrides via spec and CLI.

- **New Features**
  - Standard entrypoint: /axon_entrypoint.sh; prompt passed as $1; AXON_PROMPT and AXON_MODEL set on all agents.
  - TaskSpec/TaskTemplate: optional image override; CLI run adds --image.
  - Controller/Spawner: propagates image overrides, runs via /axon_entrypoint.sh, sets AXON_PROMPT/AXON_MODEL.
  - claude-code image updated to use the axon_entrypoint.sh wrapper; CRDs updated; unit and integration tests added.

- **Migration**
  - To build a custom image: provide /axon_entrypoint.sh, accept prompt as $1, read AXON_PROMPT/AXON_MODEL.
  - Re-apply CRDs before using the new image field. Existing setups require no changes.

<sup>Written for commit 208e26902790e6a2ccded7736a25bcab01edaecf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

