### PR TITLE
Fix label workflow by adding issues write permission

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, labeled, unlabeled]
 
+permissions:
+  issues: write
+
 jobs:
   triage-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fix the label GitHub workflow that was failing with a 403 "Resource not accessible by integration" error
- The default `GITHUB_TOKEN` permissions only included `contents: read`, `metadata: read`, and `packages: read`, but the workflow needs `issues: write` to add/remove labels
- Added explicit `permissions: issues: write` at the workflow level

Fixes #91

## Test plan
- [ ] Verify the label workflow succeeds when a new issue is opened (should auto-add `needs-triage` label)
- [ ] Verify the label workflow removes `needs-triage` when `triage-accepted` is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant issues: write permission to the label workflow so it can add and remove labels, fixing the 403 "Resource not accessible by integration" failures. Restores auto-adding needs-triage on new issues and removing it when triage-accepted is applied.

<sup>Written for commit be36492499d004c4cd8382ba2a6f10fcae2f9b22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

