### PR TITLE
Update self-development/axon-workers.yaml

### DIFF
--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -44,7 +44,7 @@ spec:
       - 5. Make sure the PR passes all CI tests.
 
       Post-checklist:
-      - Add axon/needs-input label to the issue (gh issue edit {{.Number}} --add-label axon/needs-input) if any of the following applies:
+      - Add axon/needs-input label to the issue (gh issue edit {{.Number}} --add-label axon/needs-input) and leave a comment for the reason if any of the following applies:
         - The PR is ready for review, please take a look.
         - Commented on the issue or the PR for more information.
         - You cannot make any progress on the issue, explain why.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require leaving a short comment explaining the reason whenever the axon/needs-input label is added in the Axon workers post-checklist. This adds context for reviewers and reduces back-and-forth.

<sup>Written for commit 207b9fcf81994c4908a334a4b73fbeb8a6962007. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

