### PR TITLE
Fix E2E TaskSpawner test to use kind/bug label

### DIFF
--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -72,7 +72,7 @@ spec:
     githubIssues:
       workspaceRef:
         name: e2e-spawner-workspace
-      labels: [bug]
+      labels: [kind/bug]
       excludeLabels: [e2e-exclude-placeholder]
       state: open
   taskTemplate:


### PR DESCRIPTION
## Summary
- Update the TaskSpawner E2E test to use `kind/bug` label instead of `bug`
- The repository label scheme was changed from `bug` to `kind/bug` (as part of the label management workflow), but the E2E test was not updated
- This caused the spawner to discover 0 issues, resulting in a 3-minute timeout and test failure on every CI run

## Test plan
- [x] Verified that at least one open issue with `kind/bug` label exists (issue #107)
- [ ] CI E2E tests should pass with this change

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the TaskSpawner E2E test to use the kind/bug label to match the repo’s label scheme. This prevents zero-issue discovery and eliminates the 3-minute CI timeout.

<sup>Written for commit 85f1e302ab6849f2b5a9b29874cd0f9343e26605. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

