### PR TITLE
Fix flaky integration tests: CRD readiness race condition

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -70,10 +70,16 @@ func restoreCRDs(kubeconfigPath string) {
 	reinstall.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
 	Expect(reinstall.Execute()).To(Succeed())
 
-	// Wait for CRDs to be fully established before subsequent tests
-	// can create custom resources. We verify by attempting to list Tasks.
+	// Wait for all CRDs to be fully established before subsequent tests
+	// can create custom resources. We verify by attempting to list each type.
 	Eventually(func() error {
 		return k8sClient.List(ctx, &axonv1alpha1.TaskList{})
+	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+	Eventually(func() error {
+		return k8sClient.List(ctx, &axonv1alpha1.TaskSpawnerList{})
+	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+	Eventually(func() error {
+		return k8sClient.List(ctx, &axonv1alpha1.WorkspaceList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 
 	deleteControllerResources()

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -82,8 +82,19 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// Wait for cache to sync
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the manager cache to sync before running any tests
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+
+	// Verify all CRDs are fully established by attempting to list each custom resource type
+	Eventually(func() error {
+		return k8sClient.List(ctx, &axonv1alpha1.TaskList{})
+	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+	Eventually(func() error {
+		return k8sClient.List(ctx, &axonv1alpha1.TaskSpawnerList{})
+	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+	Eventually(func() error {
+		return k8sClient.List(ctx, &axonv1alpha1.WorkspaceList{})
+	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
## Summary
- Replace fragile `time.Sleep(100ms)` in `BeforeSuite` with proper `mgr.GetCache().WaitForCacheSync()` call followed by `Eventually` checks that verify all CRDs are fully established
- Extend `restoreCRDs()` to verify all three CRD types (Task, TaskSpawner, Workspace) are established after re-install, not just Tasks
- This prevents "create not allowed while custom resource definition is terminating" errors in integration tests

## Test plan
- [ ] Verify `make test-integration` passes consistently (no more flaky failures)
- [ ] Verify that the install/uninstall ordered tests still work correctly with the extended CRD readiness checks

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky integration tests by waiting for the manager cache to sync and verifying CRDs are ready before tests. Prevents “create not allowed while custom resource definition is terminating” errors. Fixes #104.

- **Bug Fixes**
  - Replace time.Sleep with mgr.GetCache().WaitForCacheSync() in BeforeSuite.
  - Add Eventually checks that list Task, TaskSpawner, and Workspace to confirm CRDs are established.
  - Extend restoreCRDs() to verify all three CRDs after reinstall.

<sup>Written for commit 1ce6972fc61552cfc4ab31af4a3bf4e804a95b3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

