### PR TITLE
Add kind label management to label workflow

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -3,9 +3,12 @@ name: Label
 on:
   issues:
     types: [opened, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, labeled, unlabeled]
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   triage-label:
@@ -15,7 +18,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = context.payload.issue.labels.map(l => l.name);
+            const item = context.payload.issue || context.payload.pull_request;
+            const labels = item.labels.map(l => l.name);
             const hasTriageAccepted = labels.includes('triage-accepted');
             const hasNeedsTriage = labels.includes('needs-triage');
 
@@ -23,14 +27,42 @@ jobs:
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
+                issue_number: item.number,
                 labels: ['needs-triage'],
               });
             } else if (hasTriageAccepted && hasNeedsTriage) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
+                issue_number: item.number,
                 name: 'needs-triage',
+              });
+            }
+
+  kind-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove needs-kind label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const item = context.payload.issue || context.payload.pull_request;
+            const labels = item.labels.map(l => l.name);
+            const hasKind = labels.some(l => l.startsWith('kind/'));
+            const hasNeedsKind = labels.includes('needs-kind');
+
+            if (!hasKind && !hasNeedsKind) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                labels: ['needs-kind'],
+              });
+            } else if (hasKind && hasNeedsKind) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                name: 'needs-kind',
               });
             }


### PR DESCRIPTION
## Summary
- Add `kind-label` job to the existing `label.yaml` workflow that automatically manages the `needs-kind` label for both issues and PRs
  - When an issue or PR is opened without a `kind/*` label, `needs-kind` is added
  - When a `kind/*` label is added, `needs-kind` is automatically removed
- Add `pull_request_target` trigger and `pull-requests: write` permission to support PR label management
- Update the `triage-label` job to handle both issues and PRs by using `context.payload.issue || context.payload.pull_request`

## Test plan
- [ ] Open an issue without a `kind/*` label and verify `needs-kind` is added
- [ ] Add a `kind/bug` label to an issue and verify `needs-kind` is removed
- [ ] Open a PR without a `kind/*` label and verify `needs-kind` is added
- [ ] Add a `kind/feature` label to a PR and verify `needs-kind` is removed
- [ ] Verify the triage-label job works correctly for both issues and PRs

Fixes #76

Generated with [Claude Code](https://claude.com/claude-code)