### PR TITLE
Move module path from gjkim42/axon to axon-core/axon

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Load images into kind
         run: |
-          kind load docker-image gjkim42/axon-controller:e2e
-          kind load docker-image gjkim42/axon-spawner:e2e
+          kind load docker-image axon-core/axon-controller:e2e
+          kind load docker-image axon-core/axon-spawner:e2e
           kind load docker-image gjkim42/claude-code:e2e
 
       - name: Build CLI
@@ -88,8 +88,8 @@ jobs:
       - name: Deploy controller
         run: |
           bin/axon install
-          kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
-          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never"]}]}}}}'
+          kubectl set image deployment/axon-controller-manager manager=axon-core/axon-controller:e2e -n axon-system
+          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=axon-core/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never"]}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
       - name: E2E Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: gjkim42
+          username: axoncore
           password: ${{ secrets.DOCKERHUB_AXON_TOKEN }}
 
       - name: Build images

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image configuration
-REGISTRY ?= gjkim42
+REGISTRY ?= axoncore
 VERSION ?= latest
 IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner claude-code
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Run autonomous AI agents safely — at scale, in CI, on Kubernetes.**
 
-[![CI](https://github.com/gjkim42/axon/actions/workflows/ci.yaml/badge.svg)](https://github.com/gjkim42/axon/actions/workflows/ci.yaml)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/gjkim42/axon)](https://github.com/gjkim42/axon)
+[![CI](https://github.com/axon-core/axon/actions/workflows/ci.yaml/badge.svg)](https://github.com/axon-core/axon/actions/workflows/ci.yaml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/axon-core/axon)](https://github.com/axon-core/axon)
 [![License](https://img.shields.io/badge/License-BSL%201.1-blue.svg)](LICENSE)
 
 Axon is a Kubernetes controller that runs AI coding agents (like Claude Code) in isolated, ephemeral Pods with full autonomy. You get the speed of `--dangerously-skip-permissions` without the risk — and the ability to fan out hundreds of agents in parallel across repos and CI pipelines.
@@ -93,7 +93,7 @@ TaskSpawner watches external sources (e.g., GitHub Issues) and automatically cre
 ### 1. Install the CLI
 
 ```bash
-go install github.com/gjkim42/axon/cmd/axon@latest
+go install github.com/axon-core/axon/cmd/axon@latest
 ```
 
 ### 2. Install Axon

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/controller"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/controller"
 )
 
 var (

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/source"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/source"
 )
 
 var scheme = runtime.NewScheme()

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/gjkim42/axon/internal/cli"
+	"github.com/axon-core/axon/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gjkim42/axon
+module github.com/axon-core/axon
 
 go 1.25.0
 

--- a/install.yaml
+++ b/install.yaml
@@ -266,7 +266,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: gjkim42/axon-controller:latest
+          image: axon-core/axon-controller:latest
           args:
             - --leader-elect
           securityContext:

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func newDeleteCommand(cfg *ClientConfig) *cobra.Command {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func newGetCommand(cfg *ClientConfig) *cobra.Command {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -9,7 +9,7 @@ import (
 )
 
 const configTemplate = `# Axon configuration file
-# See: https://github.com/gjkim42/axon
+# See: https://github.com/axon-core/axon
 
 # OAuth token (axon auto-creates the Kubernetes secret for you)
 oauthToken: ""

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
-	"github.com/gjkim42/axon/internal/manifests"
+	"github.com/axon-core/axon/internal/manifests"
 )
 
 const fieldManager = "axon"

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"testing"
 
-	"github.com/gjkim42/axon/internal/manifests"
+	"github.com/axon-core/axon/internal/manifests"
 )
 
 func TestParseManifests_SingleDocument(t *testing.T) {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func newLogsCommand(cfg *ClientConfig) *cobra.Command {

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"sigs.k8s.io/yaml"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func printTaskTable(w io.Writer, tasks []axonv1alpha1.Task) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func newRunCommand(cfg *ClientConfig) *cobra.Command {

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -7,12 +7,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 const (
 	// ClaudeCodeImage is the default image for Claude Code agent.
-	ClaudeCodeImage = "gjkim42/claude-code:latest"
+	ClaudeCodeImage = "axoncore/claude-code:latest"
 
 	// AgentTypeClaudeCode is the agent type for Claude Code.
 	AgentTypeClaudeCode = "claude-code"

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/task_controller_test.go
+++ b/internal/controller/task_controller_test.go
@@ -6,7 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 func TestTTLExpired(t *testing.T) {

--- a/internal/controller/taskspawner_controller.go
+++ b/internal/controller/taskspawner_controller.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/taskspawner_deployment_builder.go
+++ b/internal/controller/taskspawner_deployment_builder.go
@@ -9,12 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 const (
 	// DefaultSpawnerImage is the default image for the spawner binary.
-	DefaultSpawnerImage = "gjkim42/axon-spawner:latest"
+	DefaultSpawnerImage = "axon-core/axon-spawner:latest"
 
 	// SpawnerServiceAccount is the service account used by spawner Deployments.
 	SpawnerServiceAccount = "axon-spawner"

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -11,32 +11,32 @@ func TestParseGitHubOwnerRepo(t *testing.T) {
 	}{
 		{
 			name:      "HTTPS URL",
-			repoURL:   "https://github.com/gjkim42/axon.git",
-			wantOwner: "gjkim42",
+			repoURL:   "https://github.com/axon-core/axon.git",
+			wantOwner: "axon-core",
 			wantRepo:  "axon",
 		},
 		{
 			name:      "HTTPS URL without .git",
-			repoURL:   "https://github.com/gjkim42/axon",
-			wantOwner: "gjkim42",
+			repoURL:   "https://github.com/axon-core/axon",
+			wantOwner: "axon-core",
 			wantRepo:  "axon",
 		},
 		{
 			name:      "HTTPS URL with trailing slash",
-			repoURL:   "https://github.com/gjkim42/axon/",
-			wantOwner: "gjkim42",
+			repoURL:   "https://github.com/axon-core/axon/",
+			wantOwner: "axon-core",
 			wantRepo:  "axon",
 		},
 		{
 			name:      "SSH URL",
-			repoURL:   "git@github.com:gjkim42/axon.git",
-			wantOwner: "gjkim42",
+			repoURL:   "git@github.com:axon-core/axon.git",
+			wantOwner: "axon-core",
 			wantRepo:  "axon",
 		},
 		{
 			name:      "SSH URL without .git",
-			repoURL:   "git@github.com:gjkim42/axon",
-			wantOwner: "gjkim42",
+			repoURL:   "git@github.com:axon-core/axon",
+			wantOwner: "axon-core",
 			wantRepo:  "axon",
 		},
 		{

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -266,7 +266,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: gjkim42/axon-controller:latest
+          image: axon-core/axon-controller:latest
           args:
             - --leader-elect
           securityContext:

--- a/local-run.sh
+++ b/local-run.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 make image
 make push
-go install github.com/gjkim42/axon/cmd/axon
+go install github.com/axon-core/axon/cmd/axon
 
 kubectl apply -f install-crd.yaml
 kubectl apply -f install.yaml

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -121,7 +121,7 @@ kind: Workspace
 metadata:
   name: e2e-cli-workspace
 spec:
-  repo: https://github.com/gjkim42/axon.git
+  repo: https://github.com/axon-core/axon.git
   ref: main
 `
 		Expect(kubectlWithInput(wsYAML, "apply", "-f", "-")).To(Succeed())

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Config", func() {
 		By("writing a temp config file with oauthToken and inline workspace")
 		dir := GinkgoT().TempDir()
 		configPath = filepath.Join(dir, "config.yaml")
-		configContent := "oauthToken: " + oauthToken + "\nworkspace:\n  repo: https://github.com/gjkim42/axon.git\n  ref: main\n"
+		configContent := "oauthToken: " + oauthToken + "\nworkspace:\n  repo: https://github.com/axon-core/axon.git\n  ref: main\n"
 		Expect(os.WriteFile(configPath, []byte(configContent), 0o644)).To(Succeed())
 
 		By("creating a Task via CLI using config defaults (no --secret or --credential-type)")
@@ -78,7 +78,7 @@ kind: Workspace
 metadata:
   name: e2e-config-ws-override
 spec:
-  repo: https://github.com/gjkim42/axon.git
+  repo: https://github.com/axon-core/axon.git
   ref: main
 `
 		Expect(kubectlWithInput(overrideWsYAML, "apply", "-f", "-")).To(Succeed())
@@ -86,7 +86,7 @@ spec:
 		By("writing a temp config file with oauthToken and inline workspace (bad ref)")
 		dir := GinkgoT().TempDir()
 		configPath = filepath.Join(dir, "config.yaml")
-		configContent := "oauthToken: " + oauthToken + "\nworkspace:\n  repo: https://github.com/gjkim42/axon.git\n  ref: v0.0.0\n"
+		configContent := "oauthToken: " + oauthToken + "\nworkspace:\n  repo: https://github.com/axon-core/axon.git\n  ref: v0.0.0\n"
 		Expect(os.WriteFile(configPath, []byte(configContent), 0o644)).To(Succeed())
 
 		By("creating a Task with CLI flag overriding config workspace")

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -184,7 +184,7 @@ kind: Workspace
 metadata:
   name: e2e-workspace
 spec:
-  repo: https://github.com/gjkim42/axon.git
+  repo: https://github.com/axon-core/axon.git
   ref: main
 `
 		Expect(kubectlWithInput(wsYAML, "apply", "-f", "-")).To(Succeed())
@@ -275,7 +275,7 @@ kind: Workspace
 metadata:
   name: e2e-github-workspace
 spec:
-  repo: https://github.com/gjkim42/axon.git
+  repo: https://github.com/axon-core/axon.git
   ref: main
   secretRef:
     name: workspace-credentials

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -55,7 +55,7 @@ kind: Workspace
 metadata:
   name: e2e-spawner-workspace
 spec:
-  repo: https://github.com/gjkim42/axon.git
+  repo: https://github.com/axon-core/axon.git
   ref: main
   secretRef:
     name: github-token
@@ -109,7 +109,7 @@ kind: Workspace
 metadata:
   name: e2e-spawner-workspace
 spec:
-  repo: https://github.com/gjkim42/axon.git
+  repo: https://github.com/axon-core/axon.git
 `
 		Expect(kubectlWithInput(wsYAML, "apply", "-f", "-")).To(Succeed())
 

--- a/test/integration/completion_test.go
+++ b/test/integration/completion_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/cli"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/cli"
 )
 
 func writeEnvtestKubeconfig() string {

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/cli"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/cli"
 )
 
 // clearNamespaceFinalizers removes finalizers from the axon-system namespace

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -16,8 +16,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/controller"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/controller"
 )
 
 var (

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/controller"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/controller"
 )
 
 func logJobSpec(job *batchv1.Job) {

--- a/test/integration/taskspawner_test.go
+++ b/test/integration/taskspawner_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/gjkim42/axon/api/v1alpha1"
-	"github.com/gjkim42/axon/internal/controller"
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/controller"
 )
 
 var _ = Describe("TaskSpawner Controller", func() {
@@ -38,7 +38,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 					Namespace: ns.Name,
 				},
 				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/gjkim42/axon.git",
+					Repo: "https://github.com/axon-core/axon.git",
 					Ref:  "main",
 				},
 			}
@@ -170,7 +170,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 					Namespace: ns.Name,
 				},
 				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/gjkim42/axon.git",
+					Repo: "https://github.com/axon-core/axon.git",
 					Ref:  "main",
 					SecretRef: &axonv1alpha1.SecretReference{
 						Name: "github-token",
@@ -241,7 +241,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 					Namespace: ns.Name,
 				},
 				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/gjkim42/axon.git",
+					Repo: "https://github.com/axon-core/axon.git",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
@@ -312,7 +312,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 					Namespace: ns.Name,
 				},
 				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/gjkim42/axon.git",
+					Repo: "https://github.com/axon-core/axon.git",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
@@ -402,7 +402,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 					Namespace: ns.Name,
 				},
 				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/gjkim42/axon.git",
+					Repo: "https://github.com/axon-core/axon.git",
 					Ref:  "main",
 				},
 			}


### PR DESCRIPTION
## Summary
- Replace all references of `github.com/gjkim42/axon` with `github.com/axon-core/axon` across Go module path, imports, container image references, CI workflows, README badges, and test fixtures (34 files, 60 occurrences)
- Update test expectations in `taskspawner_deployment_builder_test.go` to match the new org name

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] `make test-integration` passes
- [ ] `make test-e2e` passes
- [ ] Transfer repo on GitHub and update git remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the repository and module path from github.com/gjkim42/axon to github.com/axon-core/axon. Updates all Go imports, Docker image names, CI workflow references, manifests, README badges, and tests; default spawner image now axon-core/axon-spawner:latest.

- **Migration**
  - Update your CLI install: go install github.com/axon-core/axon/cmd/axon@latest
  - Update any imports or hard-coded image overrides to use axon-core/axon (e.g., axon-core/axon-controller, axon-core/axon-spawner)
  - After the GitHub transfer, update your git remote URLs if needed

<sup>Written for commit 82498efa0de5574c07a1b17e2ffee288238e356e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

