### PR TITLE
claude-code: Setup golang in the image

### DIFF
--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ARG GO_VERSION=1.25.0
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
@@ -15,12 +17,26 @@ RUN apt-get update && apt-get install -y \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
+RUN ARCH=$(dpkg --print-architecture) \
+    && TARBALL="go${GO_VERSION}.linux-${ARCH}.tar.gz" \
+    && curl -fsSL -o "/tmp/${TARBALL}" "https://dl.google.com/go/${TARBALL}" \
+    && curl -fsSL -o "/tmp/${TARBALL}.sha256" "https://dl.google.com/go/${TARBALL}.sha256" \
+    && echo "$(cat /tmp/${TARBALL}.sha256)  /tmp/${TARBALL}" | sha256sum -c - \
+    && tar -C /usr/local -xzf "/tmp/${TARBALL}" \
+    && rm "/tmp/${TARBALL}" "/tmp/${TARBALL}.sha256"
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 RUN npm install -g @anthropic-ai/claude-code
 
 RUN useradd -u 1100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude
 
 USER claude
+
+ENV GOPATH="/home/claude/go"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
 WORKDIR /workspace
 
 ENTRYPOINT ["claude"]


### PR DESCRIPTION
## Summary
- Install Go 1.25.0 from the official Go downloads in the claude-code container image
- The Go version is parameterized via `GO_VERSION` build arg, defaulting to 1.25.0 (matching `go.mod`)
- Configure `GOPATH` and `PATH` for the `claude` user so `go install`-ed tools are accessible
- Download the SHA256 checksum file from `dl.google.com` and verify the tarball integrity with `sha256sum -c` before extraction
- Add e2e test to verify `go` command is available in the container

Fixes #95

## Test plan
- [ ] Verify `make image WHAT=claude-code` builds successfully
- [ ] Verify `go version` returns 1.25.0 inside the container
- [ ] CI e2e tests pass with the updated image (including new `go` availability test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs Go 1.25.0 in the claude-code image and configures PATH/GOPATH so tasks can build and run Go projects. Addresses Axon Task #95.

- **New Features**
  - GO_VERSION build arg (default 1.25.0)
  - Verify dl.google.com tarball with SHA256 before extraction
  - Configure GOPATH for the claude user and add Go binaries to PATH

<sup>Written for commit 15ba90e5f4ca4fac5c41d3680257bab09f8c345f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

