### PR TITLE
Revise Additional Use Grant in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,17 @@ Parameters
 
 Licensor:             Gunju Kim
 Licensed Work:        Axon. The Licensed Work is (c) 2025 Gunju Kim.
-Additional Use Grant: None
+Additional Use Grant: You may use the Licensed Work in production,
+                      provided that such use does not include:
+                      (a) developing a product or service that is primarily
+                          intended as a framework, platform, or toolkit
+                          for building AI agents or automated software
+                          systems, where such product or service competes
+                          with or serves as a substitute for the Licensed
+                          Work; or
+                      (b) offering the Licensed Work, or any derivative
+                          work thereof, to third parties as a commercial
+                          hosted or managed service.
 Change Date:          2030-02-07
 Change License:       Apache License, Version 2.0
 


### PR DESCRIPTION
Updated the Additional Use Grant in the LICENSE file to specify conditions for production use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows production use of Axon under the LICENSE, with clear limits on competitive platforms and commercial hosting. Prohibits products primarily intended as frameworks/platforms/toolkits for AI agents or automated software systems that compete with or substitute Axon, and bans offering Axon or derivatives as a hosted or managed service.

<sup>Written for commit 51ac55eb65216c62d0152b4c55b84bad250fe6ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

