### PR TITLE
Check CI on merge_group

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add merge_group trigger to CI so GitHub’s merge queue runs checks and validates queued merges before merging.

<sup>Written for commit 866a9f505e06bdefbbf7dcee529d5acf10ab393f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

