### PR TITLE
Add commit message convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 - **For CI/release workflows**, always use existing Makefile targets rather than reimplementing build logic in YAML.
 - **Better tests.** Always try to add or improve tests(including integration, e2e) when modifying code.
 - **Logging conventions.** Start log messages with capital letters and do not end with punctuation.
+- **Commit messages.** Do not include PR links in commit messages.
 
 ## Key Makefile Targets
 - `make verify` — run all verification checks (lint, fmt, vet, etc.), it will


### PR DESCRIPTION
## Summary
- Add a rule to CLAUDE.md instructing AI assistants not to include PR links in commit messages.

Fixes #98

## Test plan
- [x] Verify the CLAUDE.md change is correct and minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a commit message convention to CLAUDE.md: don’t include PR links to keep history clean and avoid brittle references. Fixes #98.

<sup>Written for commit c14f886fa4badbf5d89b9b87ae4fa9f0135ad8df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

