### PR TITLE
Add GitHub App authentication for Workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image configuration
 REGISTRY ?= gjkim42
 VERSION ?= latest
-IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner claude-code codex gemini
+IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner cmd/axon-token-refresher claude-code codex gemini
 
 # Version injection for the axon CLI – only set ldflags when an explicit
 # version is given so that dev builds fall through to runtime/debug info.

--- a/cmd/axon-spawner/main_test.go
+++ b/cmd/axon-spawner/main_test.go
@@ -105,7 +105,7 @@ func newTask(name, namespace, spawnerName string, phase axonv1alpha1.TaskPhase) 
 func TestBuildSource_GitHubIssuesWithBaseURL(t *testing.T) {
 	ts := newTaskSpawner("spawner", "default", nil)
 
-	src, err := buildSource(ts, "my-org", "my-repo", "https://github.example.com/api/v3")
+	src, err := buildSource(ts, "my-org", "my-repo", "https://github.example.com/api/v3", "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestBuildSource_GitHubIssuesWithBaseURL(t *testing.T) {
 func TestBuildSource_GitHubIssuesDefaultBaseURL(t *testing.T) {
 	ts := newTaskSpawner("spawner", "default", nil)
 
-	src, err := buildSource(ts, "axon-core", "axon", "")
+	src, err := buildSource(ts, "axon-core", "axon", "", "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/cmd/axon-token-refresher/Dockerfile
+++ b/cmd/axon-token-refresher/Dockerfile
@@ -1,0 +1,25 @@
+# Build stage
+FROM golang:1.25 AS builder
+
+WORKDIR /workspace
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Build
+RUN make build WHAT=cmd/axon-token-refresher
+
+# Runtime stage
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /
+
+COPY --from=builder /workspace/bin/axon-token-refresher .
+
+USER 65532:65532
+
+ENTRYPOINT ["/axon-token-refresher"]

--- a/cmd/axon-token-refresher/main.go
+++ b/cmd/axon-token-refresher/main.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/axon-core/axon/internal/githubapp"
+)
+
+const (
+	refreshInterval  = 45 * time.Minute
+	initialRetryWait = 10 * time.Second
+	maxInitialRetry  = 6
+	tokenDir         = "/shared/token"
+	tokenFile        = "GITHUB_TOKEN"
+	privateKeyPath   = "/etc/github-app/privateKey"
+)
+
+func main() {
+	appID := os.Getenv("APP_ID")
+	installationID := os.Getenv("INSTALLATION_ID")
+
+	if appID == "" || installationID == "" {
+		fmt.Fprintln(os.Stderr, "APP_ID and INSTALLATION_ID environment variables are required")
+		os.Exit(1)
+	}
+
+	keyData, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Reading private key from %s: %v\n", privateKeyPath, err)
+		os.Exit(1)
+	}
+
+	creds, err := githubapp.ParseCredentials(map[string][]byte{
+		"appID":          []byte(appID),
+		"installationID": []byte(installationID),
+		"privateKey":     keyData,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Parsing credentials: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	tc := githubapp.NewTokenClient()
+
+	fmt.Println("Starting token refresher")
+
+	// Initial token generation with retries
+	var initialized bool
+	for attempt := 0; attempt < maxInitialRetry; attempt++ {
+		if err := refreshToken(ctx, tc, creds); err != nil {
+			fmt.Fprintf(os.Stderr, "Initial token generation attempt %d/%d failed: %v\n", attempt+1, maxInitialRetry, err)
+			select {
+			case <-ctx.Done():
+				fmt.Println("Shutting down")
+				return
+			case <-time.After(initialRetryWait):
+			}
+			continue
+		}
+		fmt.Println("Initial token generated successfully")
+		initialized = true
+		break
+	}
+	if !initialized {
+		fmt.Fprintln(os.Stderr, "Failed to generate initial token after all retries")
+		os.Exit(1)
+	}
+
+	// Periodic refresh
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("Shutting down")
+			return
+		case <-time.After(refreshInterval):
+		}
+
+		if err := refreshToken(ctx, tc, creds); err != nil {
+			fmt.Fprintf(os.Stderr, "Refreshing token: %v\n", err)
+		} else {
+			fmt.Println("Token refreshed successfully")
+		}
+	}
+}
+
+func refreshToken(ctx context.Context, tc *githubapp.TokenClient, creds *githubapp.Credentials) error {
+	resp, err := tc.GenerateInstallationToken(ctx, creds)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(tokenDir, 0o755); err != nil {
+		return fmt.Errorf("creating token directory: %w", err)
+	}
+
+	// Atomic write: write to temp file, then rename
+	tmpFile := filepath.Join(tokenDir, "."+tokenFile+".tmp")
+	if err := os.WriteFile(tmpFile, []byte(resp.Token), 0o644); err != nil {
+		return fmt.Errorf("writing temp token file: %w", err)
+	}
+	if err := os.Rename(tmpFile, filepath.Join(tokenDir, tokenFile)); err != nil {
+		return fmt.Errorf("renaming token file: %w", err)
+	}
+
+	return nil
+}

--- a/install.yaml
+++ b/install.yaml
@@ -23,7 +23,6 @@ rules:
   - ""
   resources:
   - pods
-  - secrets
   verbs:
   - get
   - list
@@ -34,6 +33,16 @@ rules:
   - pods/log
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -24,10 +24,18 @@ type Config struct {
 // If Name is set, it references an existing Workspace CR.
 // If Repo is set, the CLI auto-creates a Workspace CR.
 type WorkspaceConfig struct {
-	Name  string `json:"name,omitempty"`
-	Repo  string `json:"repo,omitempty"`
-	Ref   string `json:"ref,omitempty"`
-	Token string `json:"token,omitempty"`
+	Name      string           `json:"name,omitempty"`
+	Repo      string           `json:"repo,omitempty"`
+	Ref       string           `json:"ref,omitempty"`
+	Token     string           `json:"token,omitempty"`
+	GitHubApp *GitHubAppConfig `json:"githubApp,omitempty"`
+}
+
+// GitHubAppConfig holds GitHub App credentials for workspace authentication.
+type GitHubAppConfig struct {
+	AppID          string `json:"appID"`
+	InstallationID string `json:"installationID"`
+	PrivateKeyPath string `json:"privateKeyPath"`
 }
 
 // DefaultConfigPath returns the default config file path (~/.axon/config.yaml).

--- a/internal/githubapp/token.go
+++ b/internal/githubapp/token.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubapp
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultGitHubAPIURL = "https://api.github.com"
+)
+
+// Credentials holds parsed GitHub App credentials.
+type Credentials struct {
+	AppID          string
+	InstallationID string
+	PrivateKey     *rsa.PrivateKey
+}
+
+// TokenResponse holds the result of a token exchange.
+type TokenResponse struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+// TokenClient generates GitHub App installation tokens.
+type TokenClient struct {
+	BaseURL string
+	Client  *http.Client
+}
+
+// NewTokenClient creates a new TokenClient with default settings.
+func NewTokenClient() *TokenClient {
+	return &TokenClient{
+		BaseURL: defaultGitHubAPIURL,
+		Client:  http.DefaultClient,
+	}
+}
+
+// IsGitHubApp returns true if the Secret data contains GitHub App keys.
+func IsGitHubApp(secretData map[string][]byte) bool {
+	_, hasAppID := secretData["appID"]
+	_, hasInstID := secretData["installationID"]
+	_, hasKey := secretData["privateKey"]
+	return hasAppID && hasInstID && hasKey
+}
+
+// ParseCredentials parses GitHub App credentials from Secret data.
+func ParseCredentials(data map[string][]byte) (*Credentials, error) {
+	appID, ok := data["appID"]
+	if !ok || len(appID) == 0 {
+		return nil, fmt.Errorf("missing appID in secret data")
+	}
+	installationID, ok := data["installationID"]
+	if !ok || len(installationID) == 0 {
+		return nil, fmt.Errorf("missing installationID in secret data")
+	}
+	privateKeyPEM, ok := data["privateKey"]
+	if !ok || len(privateKeyPEM) == 0 {
+		return nil, fmt.Errorf("missing privateKey in secret data")
+	}
+
+	key, err := parsePrivateKey(privateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+
+	return &Credentials{
+		AppID:          strings.TrimSpace(string(appID)),
+		InstallationID: strings.TrimSpace(string(installationID)),
+		PrivateKey:     key,
+	}, nil
+}
+
+// parsePrivateKey supports PKCS1 and PKCS8 PEM-encoded RSA private keys.
+func parsePrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in private key")
+	}
+
+	// Try PKCS1 first
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+
+	// Try PKCS8
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key as PKCS1 or PKCS8: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("PKCS8 key is not RSA")
+	}
+	return key, nil
+}
+
+// GenerateInstallationToken exchanges GitHub App credentials for an installation token.
+func (tc *TokenClient) GenerateInstallationToken(ctx context.Context, creds *Credentials) (*TokenResponse, error) {
+	jwt, err := generateJWT(creds)
+	if err != nil {
+		return nil, fmt.Errorf("generating JWT: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/app/installations/%s/access_tokens", tc.baseURL(), creds.InstallationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := tc.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting installation token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return &TokenResponse{
+		Token:     result.Token,
+		ExpiresAt: result.ExpiresAt,
+	}, nil
+}
+
+func (tc *TokenClient) baseURL() string {
+	if tc.BaseURL != "" {
+		return tc.BaseURL
+	}
+	return defaultGitHubAPIURL
+}
+
+func (tc *TokenClient) httpClient() *http.Client {
+	if tc.Client != nil {
+		return tc.Client
+	}
+	return http.DefaultClient
+}
+
+// generateJWT creates a signed RS256 JWT for GitHub App authentication.
+func generateJWT(creds *Credentials) (string, error) {
+	now := time.Now()
+	header := base64URLEncode([]byte(`{"alg":"RS256","typ":"JWT"}`))
+
+	payload := fmt.Sprintf(`{"iss":%q,"iat":%d,"exp":%d}`,
+		creds.AppID,
+		now.Add(-60*time.Second).Unix(),
+		now.Add(10*time.Minute).Unix(),
+	)
+	encodedPayload := base64URLEncode([]byte(payload))
+
+	signingInput := header + "." + encodedPayload
+	hash := sha256.Sum256([]byte(signingInput))
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, creds.PrivateKey, crypto.SHA256, hash[:])
+	if err != nil {
+		return "", fmt.Errorf("signing JWT: %w", err)
+	}
+
+	return signingInput + "." + base64URLEncode(sig), nil
+}
+
+func base64URLEncode(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}

--- a/internal/githubapp/token_test.go
+++ b/internal/githubapp/token_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubapp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func generateTestKey(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return key, keyPEM
+}
+
+func generateTestKeyPKCS8(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling PKCS8 key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	})
+	return key, keyPEM
+}
+
+func TestIsGitHubApp(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string][]byte
+		want bool
+	}{
+		{
+			name: "PAT secret",
+			data: map[string][]byte{"GITHUB_TOKEN": []byte("ghp_xxx")},
+			want: false,
+		},
+		{
+			name: "GitHub App secret",
+			data: map[string][]byte{
+				"appID":          []byte("12345"),
+				"installationID": []byte("67890"),
+				"privateKey":     []byte("fake-key"),
+			},
+			want: true,
+		},
+		{
+			name: "Missing installationID",
+			data: map[string][]byte{
+				"appID":      []byte("12345"),
+				"privateKey": []byte("fake-key"),
+			},
+			want: false,
+		},
+		{
+			name: "Empty secret",
+			data: map[string][]byte{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsGitHubApp(tt.data)
+			if got != tt.want {
+				t.Errorf("IsGitHubApp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCredentials(t *testing.T) {
+	_, keyPEM := generateTestKey(t)
+	_, keyPKCS8PEM := generateTestKeyPKCS8(t)
+
+	tests := []struct {
+		name    string
+		data    map[string][]byte
+		wantErr bool
+	}{
+		{
+			name: "Valid PKCS1 key",
+			data: map[string][]byte{
+				"appID":          []byte("12345"),
+				"installationID": []byte("67890"),
+				"privateKey":     keyPEM,
+			},
+		},
+		{
+			name: "Valid PKCS8 key",
+			data: map[string][]byte{
+				"appID":          []byte("12345"),
+				"installationID": []byte("67890"),
+				"privateKey":     keyPKCS8PEM,
+			},
+		},
+		{
+			name: "Missing appID",
+			data: map[string][]byte{
+				"installationID": []byte("67890"),
+				"privateKey":     keyPEM,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing installationID",
+			data: map[string][]byte{
+				"appID":      []byte("12345"),
+				"privateKey": keyPEM,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing privateKey",
+			data: map[string][]byte{
+				"appID":          []byte("12345"),
+				"installationID": []byte("67890"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid PEM",
+			data: map[string][]byte{
+				"appID":          []byte("12345"),
+				"installationID": []byte("67890"),
+				"privateKey":     []byte("not-a-pem"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := ParseCredentials(tt.data)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseCredentials() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseCredentials() unexpected error: %v", err)
+			}
+			if creds.AppID != "12345" {
+				t.Errorf("AppID = %q, want %q", creds.AppID, "12345")
+			}
+			if creds.InstallationID != "67890" {
+				t.Errorf("InstallationID = %q, want %q", creds.InstallationID, "67890")
+			}
+			if creds.PrivateKey == nil {
+				t.Error("PrivateKey is nil")
+			}
+		})
+	}
+}
+
+func TestGenerateInstallationToken(t *testing.T) {
+	_, keyPEM := generateTestKey(t)
+
+	expiresAt := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/app/installations/67890/access_tokens" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		auth := r.Header.Get("Authorization")
+		if auth == "" || len(auth) < 8 {
+			t.Error("missing or invalid Authorization header")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      "ghs_test_token_123",
+			"expires_at": expiresAt.Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	creds, err := ParseCredentials(map[string][]byte{
+		"appID":          []byte("12345"),
+		"installationID": []byte("67890"),
+		"privateKey":     keyPEM,
+	})
+	if err != nil {
+		t.Fatalf("ParseCredentials: %v", err)
+	}
+
+	tc := &TokenClient{
+		BaseURL: server.URL,
+		Client:  server.Client(),
+	}
+
+	resp, err := tc.GenerateInstallationToken(context.Background(), creds)
+	if err != nil {
+		t.Fatalf("GenerateInstallationToken: %v", err)
+	}
+
+	if resp.Token != "ghs_test_token_123" {
+		t.Errorf("Token = %q, want %q", resp.Token, "ghs_test_token_123")
+	}
+	if !resp.ExpiresAt.Equal(expiresAt) {
+		t.Errorf("ExpiresAt = %v, want %v", resp.ExpiresAt, expiresAt)
+	}
+}
+
+func TestGenerateInstallationToken_Error(t *testing.T) {
+	_, keyPEM := generateTestKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer server.Close()
+
+	creds, err := ParseCredentials(map[string][]byte{
+		"appID":          []byte("12345"),
+		"installationID": []byte("67890"),
+		"privateKey":     keyPEM,
+	})
+	if err != nil {
+		t.Fatalf("ParseCredentials: %v", err)
+	}
+
+	tc := &TokenClient{
+		BaseURL: server.URL,
+		Client:  server.Client(),
+	}
+
+	_, err = tc.GenerateInstallationToken(context.Background(), creds)
+	if err == nil {
+		t.Error("expected error for 401 response")
+	}
+}

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -23,7 +23,6 @@ rules:
   - ""
   resources:
   - pods
-  - secrets
   verbs:
   - get
   - list
@@ -34,6 +33,16 @@ rules:
   - pods/log
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -23,12 +23,13 @@ Create a Workspace that points to your repository:
 apiVersion: axon.io/v1alpha1
 kind: Workspace
 metadata:
-  name: axon-workspace
+  name: axon-agent
 spec:
   repo: https://github.com/your-org/your-repo.git
   ref: main
   secretRef:
     name: github-token  # For pushing branches and creating PRs
+  # or authenticate with githubApp
 ```
 
 ### 2. GitHub Token Secret
@@ -80,12 +81,13 @@ kubectl apply -f - <<EOF
 apiVersion: axon.io/v1alpha1
 kind: Workspace
 metadata:
-  name: axon-workspace
+  name: axon-agent
 spec:
   repo: https://github.com/your-org/your-repo.git
   ref: main
   secretRef:
     name: github-token
+  # or authenticate with githubApp
 EOF
 
 # Then deploy the TaskSpawner

--- a/self-development/axon-fake-strategist.yaml
+++ b/self-development/axon-fake-strategist.yaml
@@ -8,7 +8,7 @@ spec:
       schedule: "0 */12 * * *"
   taskTemplate:
     workspaceRef:
-      name: axon-workspace
+      name: axon-agent
     model: opus
     type: claude-code
     credentials:

--- a/self-development/axon-fake-user.yaml
+++ b/self-development/axon-fake-user.yaml
@@ -8,7 +8,7 @@ spec:
       schedule: "0 9 * * *"
   taskTemplate:
     workspaceRef:
-      name: axon-workspace
+      name: axon-agent
     model: sonnet
     type: claude-code
     credentials:

--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -11,7 +11,7 @@ spec:
         - axon/needs-input
   taskTemplate:
     workspaceRef:
-      name: axon-workspace
+      name: axon-agent
     model: opus
     type: claude-code
     ttlSecondsAfterFinished: 3600


### PR DESCRIPTION
## Summary
- Support GitHub App credentials as an alternative to PAT-based authentication for Workspaces
- Auto-detect auth type by inspecting Secret keys at runtime (`appID` + `installationID` + `privateKey` = GitHub App, `GITHUB_TOKEN` = PAT)
- For short-lived Task Jobs: controller generates an installation token at Job creation time and stores it in a Task-owned Secret (garbage collected with the Task)
- For long-running TaskSpawner Deployments: a `token-refresher` sidecar container refreshes the token every 45 minutes via a shared emptyDir volume
- No API type changes — fully backward compatible via existing `SecretRef` field

### New components
- `internal/githubapp/` package: JWT generation + GitHub App installation token exchange (no new dependencies)
- `cmd/axon-token-refresher/` sidecar binary + Dockerfile
- CLI support: `workspace.githubApp` config with `appID`, `installationID`, `privateKeyPath`

## Test plan
- [x] Unit tests for `internal/githubapp/` (ParseCredentials, IsGitHubApp, GenerateInstallationToken)
- [x] Unit tests for DeploymentBuilder (GitHub App produces 2 containers + 2 volumes, PAT unchanged)
- [x] Integration test: Task with GitHub App Secret creates generated token Secret + Job referencing it
- [x] Integration test: TaskSpawner with GitHub App Secret creates Deployment with token-refresher sidecar
- [x] All existing tests pass (backward compatibility)
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub App authentication for Workspaces as an alternative to PATs. Auth is auto‑detected; Tasks get short‑lived installation tokens and TaskSpawner uses a sidecar that refreshes tokens and writes them to a shared file.

- **New Features**
  - Support GitHub App creds via SecretRef keys appID, installationID, privateKey; PATs still work.
  - Tasks: controller exchanges an installation token via internal githubapp client and stores it in a Task‑owned Secret (GITHUB_TOKEN).
  - TaskSpawner: adds axon-token-refresher sidecar (refreshes every 45m with atomic writes); spawner reads via --github-token-file and falls back to GITHUB_TOKEN; handles missing token file on start.
  - New githubapp package and axon-token-refresher binary/image; controller flags for sidecar image and pull policy; default sidecar image constant; Makefile builds the image.
  - CLI: workspace.githubApp config (appID, installationID, privateKeyPath) and a secret helper; prevents using both token and githubApp; RBAC updated to allow Secret create/update/watch.

- **Migration**
  - No API changes; existing PAT-based Workspaces continue to work.
  - To use a GitHub App: create a Secret with appID, installationID, privateKey (or use the CLI helper), ensure controller has Secret permissions, and set sidecar image flags if needed.

<sup>Written for commit ccc92cdddcfa890f4ab973b3a1716605c04a076d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

