### PR TITLE
Document e2e anchor issue dependency in TaskSpawner test

### DIFF
--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -40,6 +40,8 @@ var _ = Describe("TaskSpawner", func() {
 		kubectl("delete", "secret", "claude-credentials", "--ignore-not-found")
 	})
 
+	// This test requires at least one open GitHub issue in axon-core/axon
+	// with the "do-not-remove/e2e-anchor" label. See issue #117.
 	It("should create a spawner Deployment and discover issues", func() {
 		By("creating GitHub token secret")
 		Expect(kubectlWithInput("", "create", "secret", "generic", "github-token",


### PR DESCRIPTION
## Summary
- Added a comment in the TaskSpawner e2e test documenting the dependency on issue #117 as the anchor issue with the `do-not-remove/e2e-anchor` label
- Updated issue #117 body to reference the correct label (`do-not-remove/e2e-anchor` instead of `e2e-test`)

Fixes #117

## Test plan
- [ ] Verify `make test` passes
- [ ] Verify `make test-e2e` passes (requires `GITHUB_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the TaskSpawner e2e test’s dependency on an open GitHub anchor issue (#117) with the "do-not-remove/e2e-anchor" label. Updated issue #117 to reference the correct label.

<sup>Written for commit f749ea3fd06b6d5a872952e1db43888bc2ea73cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

