### PR TITLE
ci: run e2e test in merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         run: make test-integration
 
   test-e2e:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `merge_group` event to the `test-e2e` job's `if` condition so that e2e tests run in the merge queue, not just on push and labeled PRs.

Fixes #127

## Test plan
- [ ] Verify CI passes on this PR (build, verify, test, test-integration, test-e2e)
- [ ] Confirm that the merge queue will now trigger e2e tests by checking the updated `if` condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run e2e tests in the merge queue by updating the test-e2e job’s condition to include the merge_group event. Aligns with Linear issue #127 to ensure merge queue validations include e2e.

<sup>Written for commit 09b356f51b6c1f9446b65a140ffbfd64e5111474. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

