### PR TITLE
Sync spawner deployments with controller on upgrades

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           bin/axon install
           kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
-          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never","--codex-image=gjkim42/codex:e2e","--codex-image-pull-policy=Never"]}]}}}}'
+          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never","--codex-image=gjkim42/codex:e2e","--codex-image-pull-policy=Never","--controller-image=gjkim42/axon-controller:e2e"]}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
       - name: E2E Test

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -38,6 +38,7 @@ func main() {
 	var geminiImagePullPolicy string
 	var spawnerImage string
 	var spawnerImagePullPolicy string
+	var controllerImage string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -52,6 +53,7 @@ func main() {
 	flag.StringVar(&geminiImagePullPolicy, "gemini-image-pull-policy", "", "The image pull policy for Gemini CLI agent containers (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&spawnerImage, "spawner-image", controller.DefaultSpawnerImage, "The image to use for spawner Deployments.")
 	flag.StringVar(&spawnerImagePullPolicy, "spawner-image-pull-policy", "", "The image pull policy for spawner Deployments (e.g., Always, Never, IfNotPresent).")
+	flag.StringVar(&controllerImage, "controller-image", "", "The controller image, used to trigger spawner rolling updates on upgrades.")
 
 	opts := zap.Options{
 		Development: true,
@@ -91,6 +93,7 @@ func main() {
 	deploymentBuilder := controller.NewDeploymentBuilder()
 	deploymentBuilder.SpawnerImage = spawnerImage
 	deploymentBuilder.SpawnerImagePullPolicy = corev1.PullPolicy(spawnerImagePullPolicy)
+	deploymentBuilder.ControllerImage = controllerImage
 	if err = (&controller.TaskSpawnerReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),

--- a/install.yaml
+++ b/install.yaml
@@ -269,6 +269,7 @@ spec:
           image: gjkim42/axon-controller:latest
           args:
             - --leader-elect
+            - --controller-image=gjkim42/axon-controller:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -269,6 +269,7 @@ spec:
           image: gjkim42/axon-controller:latest
           args:
             - --leader-elect
+            - --controller-image=gjkim42/axon-controller:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary
- Add a `--controller-image` flag to axon-controller that annotates spawner pod templates with `axon.io/controller-image`, so controller image upgrades trigger a rolling update of all spawner Deployments
- Fix `updateDeployment` to also compare `ImagePullPolicy` and pod template annotations, ensuring configuration changes are properly propagated
- Replace the entire annotations map on update to prevent stale keys from causing infinite reconcile loops

## How it works
When the controller is deployed with `--controller-image=<image>`, it stores this value as a pod template annotation on every spawner Deployment it manages. When the controller is upgraded to a new image (and `--controller-image` is updated accordingly), the annotation value changes, which causes the reconciler to update the Deployment, triggering a rolling restart of spawner pods with the latest image.

This solves the problem where `:latest` tags don't change the image string, so the existing image comparison alone cannot detect that a new version is available.

## Test plan
- [x] Added unit tests for `DeploymentBuilder` controller image annotation behavior
- [x] Added unit tests for `equalAnnotations` helper (including empty string value edge case)
- [x] Added unit test for `ImagePullPolicy` propagation
- [x] Added integration test verifying no annotation set when `ControllerImage` is empty
- [x] Existing unit and integration tests pass
- [x] CI e2e tests updated to pass `--controller-image` flag

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)