### PR TITLE
Add create, get, and delete commands for all axon CRDs

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -63,3 +63,30 @@ func completeTaskSpawnerNames(cfg *ClientConfig) cobra.CompletionFunc {
 		return names, cobra.ShellCompDirectiveNoFileComp
 	}
 }
+
+func completeWorkspaceNames(cfg *ClientConfig) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		cl, ns, err := cfg.NewClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		wsList := &axonv1alpha1.WorkspaceList{}
+		if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var names []string
+		for _, ws := range wsList.Items {
+			names = append(names, ws.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -16,7 +16,10 @@ func TestValidArgsFunctionWired(t *testing.T) {
 	}{
 		{"get task", []string{"get", "task"}},
 		{"get taskspawner", []string{"get", "taskspawner"}},
+		{"get workspace", []string{"get", "workspace"}},
 		{"delete task", []string{"delete", "task"}},
+		{"delete workspace", []string{"delete", "workspace"}},
+		{"delete taskspawner", []string{"delete", "taskspawner"}},
 		{"logs", []string{"logs"}},
 	}
 
@@ -39,6 +42,7 @@ func TestCompletionWithInvalidKubeconfig(t *testing.T) {
 	}{
 		{"completeTaskNames", completeTaskNames(cfg)},
 		{"completeTaskSpawnerNames", completeTaskSpawnerNames(cfg)},
+		{"completeWorkspaceNames", completeWorkspaceNames(cfg)},
 	}
 
 	for _, tt := range fns {
@@ -63,6 +67,7 @@ func TestCompletionSkipsAfterFirstArg(t *testing.T) {
 	}{
 		{"completeTaskNames", completeTaskNames(cfg)},
 		{"completeTaskSpawnerNames", completeTaskSpawnerNames(cfg)},
+		{"completeWorkspaceNames", completeWorkspaceNames(cfg)},
 	}
 
 	for _, tt := range fns {
@@ -112,6 +117,49 @@ func TestFlagCompletionCredentialType(t *testing.T) {
 	}
 	if !strings.Contains(output, "oauth") {
 		t.Errorf("expected oauth in credential-type completions, got %q", output)
+	}
+	if !strings.Contains(output, ":4") {
+		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in output, got %q", output)
+	}
+}
+
+func TestFlagCompletionCreateTaskSpawnerCredentialType(t *testing.T) {
+	root := NewRootCommand()
+
+	root.SetArgs([]string{"__complete", "create", "taskspawner", "--credential-type", ""})
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.Execute()
+
+	output := out.String()
+	if !strings.Contains(output, "api-key") {
+		t.Errorf("expected api-key in credential-type completions, got %q", output)
+	}
+	if !strings.Contains(output, "oauth") {
+		t.Errorf("expected oauth in credential-type completions, got %q", output)
+	}
+	if !strings.Contains(output, ":4") {
+		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in output, got %q", output)
+	}
+}
+
+func TestFlagCompletionCreateTaskSpawnerState(t *testing.T) {
+	root := NewRootCommand()
+
+	root.SetArgs([]string{"__complete", "create", "taskspawner", "--state", ""})
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.Execute()
+
+	output := out.String()
+	if !strings.Contains(output, "open") {
+		t.Errorf("expected open in state completions, got %q", output)
+	}
+	if !strings.Contains(output, "closed") {
+		t.Errorf("expected closed in state completions, got %q", output)
+	}
+	if !strings.Contains(output, "all") {
+		t.Errorf("expected all in state completions, got %q", output)
 	}
 	if !strings.Contains(output, ":4") {
 		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in output, got %q", output)

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+)
+
+func newCreateCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create resources",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Help()
+			return fmt.Errorf("must specify a resource type")
+		},
+	}
+
+	cmd.AddCommand(newCreateWorkspaceCommand(cfg))
+	cmd.AddCommand(newCreateTaskSpawnerCommand(cfg))
+
+	return cmd
+}
+
+func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		name   string
+		repo   string
+		ref    string
+		secret string
+		token  string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "workspace",
+		Aliases: []string{"ws"},
+		Short:   "Create a workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if secret != "" && token != "" {
+				return fmt.Errorf("cannot specify both --secret and --token")
+			}
+
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: repo,
+					Ref:  ref,
+				},
+			}
+
+			if token != "" {
+				secretName := name + "-credentials"
+				if err := ensureCredentialSecret(cfg, secretName, "GITHUB_TOKEN", token); err != nil {
+					return err
+				}
+				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+					Name: secretName,
+				}
+			} else if secret != "" {
+				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+					Name: secret,
+				}
+			}
+
+			if err := cl.Create(context.Background(), ws); err != nil {
+				return fmt.Errorf("creating workspace: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "workspace/%s created\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "workspace name (required)")
+	cmd.Flags().StringVar(&repo, "repo", "", "git repository URL (required)")
+	cmd.Flags().StringVar(&ref, "ref", "", "git reference (branch, tag, or commit SHA)")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name containing GITHUB_TOKEN for git authentication")
+	cmd.Flags().StringVar(&token, "token", "", "GitHub token (auto-creates a secret)")
+
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("repo")
+
+	return cmd
+}
+
+func newCreateTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
+	var (
+		name           string
+		workspace      string
+		secret         string
+		credentialType string
+		model          string
+		schedule       string
+		state          string
+		promptTemplate string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "taskspawner",
+		Aliases: []string{"ts"},
+		Short:   "Create a task spawner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if workspace == "" && schedule == "" {
+				return fmt.Errorf("must specify either --workspace (for GitHub issues source) or --schedule (for cron source)")
+			}
+			if workspace != "" && schedule != "" {
+				return fmt.Errorf("cannot specify both --workspace and --schedule")
+			}
+
+			if c := cfg.Config; c != nil {
+				if !cmd.Flags().Changed("secret") && c.Secret != "" {
+					secret = c.Secret
+				}
+				if !cmd.Flags().Changed("credential-type") && c.CredentialType != "" {
+					credentialType = c.CredentialType
+				}
+				if !cmd.Flags().Changed("model") && c.Model != "" {
+					model = c.Model
+				}
+			}
+
+			if secret == "" {
+				return fmt.Errorf("no credentials configured (set secret in config file, or use --secret flag)")
+			}
+
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: "claude-code",
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialType(credentialType),
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: secret,
+							},
+						},
+						Model:          model,
+						PromptTemplate: promptTemplate,
+					},
+				},
+			}
+
+			if workspace != "" {
+				ts.Spec.When.GitHubIssues = &axonv1alpha1.GitHubIssues{
+					WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+						Name: workspace,
+					},
+					State: state,
+				}
+			} else {
+				ts.Spec.When.Cron = &axonv1alpha1.Cron{
+					Schedule: schedule,
+				}
+			}
+
+			if err := cl.Create(context.Background(), ts); err != nil {
+				return fmt.Errorf("creating task spawner: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "taskspawner/%s created\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "task spawner name (required)")
+	cmd.Flags().StringVar(&workspace, "workspace", "", "workspace name (for GitHub issues source)")
+	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials")
+	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
+	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&schedule, "schedule", "", "cron schedule expression (for cron source)")
+	cmd.Flags().StringVar(&state, "state", "open", "GitHub issue state filter (open, closed, all)")
+	cmd.Flags().StringVar(&promptTemplate, "prompt-template", "", "Go text/template for rendering the task prompt")
+
+	cmd.MarkFlagRequired("name")
+
+	_ = cmd.RegisterFlagCompletionFunc("credential-type", cobra.FixedCompletions([]string{"api-key", "oauth"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = cmd.RegisterFlagCompletionFunc("state", cobra.FixedCompletions([]string{"open", "closed", "all"}, cobra.ShellCompDirectiveNoFileComp))
+
+	return cmd
+}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -22,6 +22,8 @@ func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(newDeleteTaskCommand(cfg))
+	cmd.AddCommand(newDeleteWorkspaceCommand(cfg))
+	cmd.AddCommand(newDeleteTaskSpawnerCommand(cfg))
 
 	return cmd
 }
@@ -54,6 +56,70 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.ValidArgsFunction = completeTaskNames(cfg)
+
+	return cmd
+}
+
+func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "workspace <name>",
+		Aliases: []string{"workspaces", "ws"},
+		Short:   "Delete a workspace",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), ws); err != nil {
+				return fmt.Errorf("deleting workspace: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "workspace/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeWorkspaceNames(cfg)
+
+	return cmd
+}
+
+func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "taskspawner <name>",
+		Aliases: []string{"taskspawners", "ts"},
+		Short:   "Delete a task spawner",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, ns, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args[0],
+					Namespace: ns,
+				},
+			}
+
+			if err := cl.Delete(context.Background(), ts); err != nil {
+				return fmt.Errorf("deleting task spawner: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "taskspawner/%s deleted\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeTaskSpawnerNames(cfg)
 
 	return cmd
 }

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -113,6 +113,28 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 	}
 }
 
+func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tREPO\tREF\tAGE")
+	for _, ws := range workspaces {
+		age := duration.HumanDuration(time.Since(ws.CreationTimestamp.Time))
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ws.Name, ws.Spec.Repo, ws.Spec.Ref, age)
+	}
+	tw.Flush()
+}
+
+func printWorkspaceDetail(w io.Writer, ws *axonv1alpha1.Workspace) {
+	printField(w, "Name", ws.Name)
+	printField(w, "Namespace", ws.Namespace)
+	printField(w, "Repo", ws.Spec.Repo)
+	if ws.Spec.Ref != "" {
+		printField(w, "Ref", ws.Spec.Ref)
+	}
+	if ws.Spec.SecretRef != nil {
+		printField(w, "Secret", ws.Spec.SecretRef.Name)
+	}
+}
+
 func printField(w io.Writer, label, value string) {
 	fmt.Fprintf(w, "%-20s%s\n", label+":", value)
 }

--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+)
+
+func TestPrintWorkspaceTable(t *testing.T) {
+	workspaces := []axonv1alpha1.Workspace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "ws-one",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/org/repo.git",
+				Ref:  "main",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "ws-two",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/org/other.git",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceTable(&buf, workspaces)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("expected header NAME in output, got %q", output)
+	}
+	if !strings.Contains(output, "REPO") {
+		t.Errorf("expected header REPO in output, got %q", output)
+	}
+	if !strings.Contains(output, "ws-one") {
+		t.Errorf("expected ws-one in output, got %q", output)
+	}
+	if !strings.Contains(output, "ws-two") {
+		t.Errorf("expected ws-two in output, got %q", output)
+	}
+	if !strings.Contains(output, "https://github.com/org/repo.git") {
+		t.Errorf("expected repo URL in output, got %q", output)
+	}
+}
+
+func TestPrintWorkspaceDetail(t *testing.T) {
+	ws := &axonv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-workspace",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/org/repo.git",
+			Ref:  "main",
+			SecretRef: &axonv1alpha1.SecretReference{
+				Name: "gh-token",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceDetail(&buf, ws)
+	output := buf.String()
+
+	if !strings.Contains(output, "my-workspace") {
+		t.Errorf("expected workspace name in output, got %q", output)
+	}
+	if !strings.Contains(output, "https://github.com/org/repo.git") {
+		t.Errorf("expected repo URL in output, got %q", output)
+	}
+	if !strings.Contains(output, "main") {
+		t.Errorf("expected ref in output, got %q", output)
+	}
+	if !strings.Contains(output, "gh-token") {
+		t.Errorf("expected secret name in output, got %q", output)
+	}
+}
+
+func TestPrintWorkspaceDetailWithoutOptionalFields(t *testing.T) {
+	ws := &axonv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "minimal-ws",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/org/repo.git",
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceDetail(&buf, ws)
+	output := buf.String()
+
+	if !strings.Contains(output, "minimal-ws") {
+		t.Errorf("expected workspace name in output, got %q", output)
+	}
+	if strings.Contains(output, "Ref:") {
+		t.Errorf("expected no Ref field when ref is empty, got %q", output)
+	}
+	if strings.Contains(output, "Secret:") {
+		t.Errorf("expected no Secret field when secretRef is nil, got %q", output)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,6 +40,7 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.AddCommand(
 		newRunCommand(cfg),
+		newCreateCommand(cfg),
 		newGetCommand(cfg),
 		newLogsCommand(cfg),
 		newDeleteCommand(cfg),

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -160,6 +160,12 @@ spec:
 	})
 })
 
+var _ = Describe("create", func() {
+	It("should fail without a resource type", func() {
+		axonFail("create")
+	})
+})
+
 var _ = Describe("delete", func() {
 	It("should fail without a resource type", func() {
 		axonFail("delete")
@@ -167,6 +173,14 @@ var _ = Describe("delete", func() {
 
 	It("should fail for a nonexistent task", func() {
 		axonFail("delete", "task", "nonexistent-task-name")
+	})
+
+	It("should fail for a nonexistent workspace", func() {
+		axonFail("delete", "workspace", "nonexistent-workspace-name")
+	})
+
+	It("should fail for a nonexistent taskspawner", func() {
+		axonFail("delete", "taskspawner", "nonexistent-spawner-name")
 	})
 })
 
@@ -183,8 +197,20 @@ var _ = Describe("get", func() {
 		axonOutput("get", "task")
 	})
 
+	It("should succeed with 'workspaces' alias", func() {
+		axonOutput("get", "workspaces")
+	})
+
+	It("should succeed with 'workspace' subcommand", func() {
+		axonOutput("get", "workspace")
+	})
+
 	It("should fail for a nonexistent task", func() {
 		axonFail("get", "task", "nonexistent-task-name")
+	})
+
+	It("should fail for a nonexistent workspace", func() {
+		axonFail("get", "workspace", "nonexistent-workspace-name")
 	})
 
 	It("should output task list in YAML format", func() {
@@ -199,8 +225,67 @@ var _ = Describe("get", func() {
 		Expect(output).To(ContainSubstring(`"kind": "TaskList"`))
 	})
 
+	It("should output workspace list in YAML format", func() {
+		output := axonOutput("get", "workspaces", "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		Expect(output).To(ContainSubstring("kind: WorkspaceList"))
+	})
+
+	It("should output workspace list in JSON format", func() {
+		output := axonOutput("get", "workspaces", "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"kind": "WorkspaceList"`))
+	})
+
 	It("should fail with unknown output format", func() {
 		axonFail("get", "tasks", "-o", "invalid")
+	})
+})
+
+var _ = Describe("workspace CRUD", func() {
+	const wsName = "e2e-test-workspace"
+
+	BeforeEach(func() {
+		kubectl("delete", "workspace", wsName, "--ignore-not-found")
+	})
+
+	AfterEach(func() {
+		kubectl("delete", "workspace", wsName, "--ignore-not-found")
+	})
+
+	It("should create, get, and delete a workspace", func() {
+		By("creating a workspace via CLI")
+		axon("create", "workspace",
+			"--name", wsName,
+			"--repo", "https://github.com/axon-core/axon.git",
+			"--ref", "main",
+		)
+
+		By("verifying workspace exists via get")
+		output := axonOutput("get", "workspace", wsName)
+		Expect(output).To(ContainSubstring(wsName))
+		Expect(output).To(ContainSubstring("https://github.com/axon-core/axon.git"))
+
+		By("verifying workspace in list")
+		output = axonOutput("get", "workspaces")
+		Expect(output).To(ContainSubstring(wsName))
+
+		By("verifying YAML output")
+		output = axonOutput("get", "workspace", wsName, "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		Expect(output).To(ContainSubstring("kind: Workspace"))
+		Expect(output).To(ContainSubstring("name: " + wsName))
+
+		By("verifying JSON output")
+		output = axonOutput("get", "workspace", wsName, "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"kind": "Workspace"`))
+
+		By("deleting workspace via CLI")
+		axon("delete", "workspace", wsName)
+
+		By("verifying workspace is deleted")
+		axonFail("get", "workspace", wsName)
 	})
 })
 

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -1,0 +1,340 @@
+package integration
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	"github.com/axon-core/axon/internal/cli"
+)
+
+func runCLI(kubeconfigPath, namespace string, args ...string) error {
+	root := cli.NewRootCommand()
+	fullArgs := append([]string{"--kubeconfig", kubeconfigPath, "-n", namespace}, args...)
+	root.SetArgs(fullArgs)
+	return root.Execute()
+}
+
+var _ = Describe("CLI Workspace Commands", func() {
+	Context("When creating a workspace via CLI", func() {
+		It("Should create and get and delete a workspace", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-workspace",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Creating a workspace via CLI")
+			err := runCLI(kubeconfigPath, ns.Name,
+				"create", "workspace",
+				"--name", "my-ws",
+				"--repo", "https://github.com/org/repo.git",
+				"--ref", "main",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the workspace exists in the cluster")
+			ws := &axonv1alpha1.Workspace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "my-ws", Namespace: ns.Name}, ws)).To(Succeed())
+			Expect(ws.Spec.Repo).To(Equal("https://github.com/org/repo.git"))
+			Expect(ws.Spec.Ref).To(Equal("main"))
+
+			By("Getting the workspace via CLI succeeds")
+			err = runCLI(kubeconfigPath, ns.Name, "get", "workspace", "my-ws")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Listing workspaces via CLI succeeds")
+			err = runCLI(kubeconfigPath, ns.Name, "get", "workspaces")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting workspace in YAML format succeeds")
+			err = runCLI(kubeconfigPath, ns.Name, "get", "workspace", "my-ws", "-o", "yaml")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting workspace in JSON format succeeds")
+			err = runCLI(kubeconfigPath, ns.Name, "get", "workspace", "my-ws", "-o", "json")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the workspace via CLI")
+			err = runCLI(kubeconfigPath, ns.Name, "delete", "workspace", "my-ws")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the workspace is deleted")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "my-ws", Namespace: ns.Name}, ws)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When creating a workspace with secret", func() {
+		It("Should create a workspace with secretRef", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-ws-secret",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Creating a workspace with --secret flag")
+			err := runCLI(kubeconfigPath, ns.Name,
+				"create", "workspace",
+				"--name", "secret-ws",
+				"--repo", "https://github.com/org/repo.git",
+				"--secret", "my-gh-secret",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the workspace has secretRef")
+			ws := &axonv1alpha1.Workspace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "secret-ws", Namespace: ns.Name}, ws)).To(Succeed())
+			Expect(ws.Spec.SecretRef).NotTo(BeNil())
+			Expect(ws.Spec.SecretRef.Name).To(Equal("my-gh-secret"))
+		})
+	})
+
+	Context("When using workspace aliases", func() {
+		It("Should support 'ws' alias for create, get, and delete", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-ws-alias",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Creating a workspace via CLI with 'ws' alias")
+			err := runCLI(kubeconfigPath, ns.Name,
+				"create", "ws",
+				"--name", "alias-ws",
+				"--repo", "https://github.com/org/repo.git",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying workspace exists")
+			ws := &axonv1alpha1.Workspace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alias-ws", Namespace: ns.Name}, ws)).To(Succeed())
+
+			By("Getting workspace using 'ws' alias succeeds")
+			err = runCLI(kubeconfigPath, ns.Name, "get", "ws", "alias-ws")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting workspace using 'ws' alias")
+			err = runCLI(kubeconfigPath, ns.Name, "delete", "ws", "alias-ws")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying workspace is deleted")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "alias-ws", Namespace: ns.Name}, ws)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When completing workspace names", func() {
+		It("Should return workspace names from the cluster", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-complete-workspace",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating workspaces")
+			for _, name := range []string{"ws-alpha", "ws-beta"} {
+				ws := &axonv1alpha1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: ns.Name,
+					},
+					Spec: axonv1alpha1.WorkspaceSpec{
+						Repo: "https://github.com/org/repo.git",
+					},
+				}
+				Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+			}
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+			output := runComplete(kubeconfigPath, ns.Name, "get", "workspace", "")
+			Expect(output).To(ContainSubstring("ws-alpha"))
+			Expect(output).To(ContainSubstring("ws-beta"))
+			Expect(output).To(ContainSubstring(":4"))
+		})
+	})
+})
+
+var _ = Describe("CLI Delete TaskSpawner Command", func() {
+	Context("When deleting a task spawner via CLI", func() {
+		It("Should delete the task spawner", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-delete-ts",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a TaskSpawner directly")
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-spawner",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: "claude-code",
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialTypeAPIKey,
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: "test-secret",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Deleting the task spawner via CLI")
+			err := runCLI(kubeconfigPath, ns.Name, "delete", "taskspawner", "my-spawner")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the task spawner is deleted")
+			Eventually(func() bool {
+				ts2 := &axonv1alpha1.TaskSpawner{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "my-spawner", Namespace: ns.Name}, ts2)
+				if err == nil {
+					return ts2.DeletionTimestamp != nil
+				}
+				return apierrors.IsNotFound(err)
+			}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+		})
+	})
+
+	Context("When using 'ts' alias", func() {
+		It("Should support 'ts' alias for delete", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cli-delete-ts-alias",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a TaskSpawner directly")
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "alias-spawner",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: "claude-code",
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialTypeAPIKey,
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: "test-secret",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+
+			By("Deleting using 'ts' alias")
+			err := runCLI(kubeconfigPath, ns.Name, "delete", "ts", "alias-spawner")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the task spawner is deleted")
+			Eventually(func() bool {
+				ts2 := &axonv1alpha1.TaskSpawner{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "alias-spawner", Namespace: ns.Name}, ts2)
+				if err == nil {
+					return ts2.DeletionTimestamp != nil
+				}
+				return apierrors.IsNotFound(err)
+			}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+		})
+	})
+
+	Context("When completing delete taskspawner names", func() {
+		It("Should return TaskSpawner names for delete command", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-complete-del-ts",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a TaskSpawner")
+			ts := &axonv1alpha1.TaskSpawner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spawner-del",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: axonv1alpha1.TaskTemplate{
+						Type: "claude-code",
+						Credentials: axonv1alpha1.Credentials{
+							Type: axonv1alpha1.CredentialTypeAPIKey,
+							SecretRef: axonv1alpha1.SecretReference{
+								Name: "test-secret",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+			output := runComplete(kubeconfigPath, ns.Name, "delete", "taskspawner", "")
+			Expect(output).To(ContainSubstring("spawner-del"))
+			Expect(output).To(ContainSubstring(":4"))
+		})
+	})
+
+	Context("When completing delete workspace names", func() {
+		It("Should return Workspace names for delete command", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-complete-del-ws",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Workspace")
+			ws := &axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ws-del",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/org/repo.git",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
+
+			kubeconfigPath := writeEnvtestKubeconfig()
+			output := runComplete(kubeconfigPath, ns.Name, "delete", "workspace", "")
+			Expect(output).To(ContainSubstring("ws-del"))
+			Expect(output).To(ContainSubstring(":4"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Adds `axon create workspace` command with `--secret` and `--token` flags for flexible authentication (secret references an existing Secret, token auto-creates one)
- Adds `axon create taskspawner` command with `--prompt-template` flag for custom Go text/template prompt rendering
- Adds `axon get workspace` command for listing and viewing workspace details (with yaml/json output)
- Adds `axon delete workspace` and `axon delete taskspawner` commands
- Adds shell completion support for workspace names across all relevant commands

## New Commands

```bash
# Create a workspace
axon create workspace --name my-workspace --repo https://github.com/org/repo.git --ref main
axon create workspace --name my-workspace --repo https://github.com/org/repo.git --secret my-secret
axon create workspace --name my-workspace --repo https://github.com/org/repo.git --token ghp_xxx

# Create a task spawner (GitHub issues source)
axon create taskspawner --name my-spawner --workspace my-workspace --secret my-secret
axon create taskspawner --name my-spawner --workspace my-workspace --secret my-secret --prompt-template '{{.Title}}\n{{.Body}}'

# Create a task spawner (cron source)
axon create taskspawner --name my-spawner --schedule "0 9 * * 1" --secret my-secret

# List/get workspaces
axon get workspaces
axon get workspace my-workspace -o yaml

# Delete workspaces and task spawners
axon delete workspace my-workspace
axon delete taskspawner my-spawner
```

## Test plan
- [x] Unit tests for workspace printer functions (table and detail)
- [x] Unit tests for completion wiring (get/delete workspace, delete taskspawner)
- [x] Unit tests for flag completions (create taskspawner credential-type, state)
- [x] Integration tests (envtest) for create/get/delete workspace
- [x] Integration tests for create workspace with secret
- [x] Integration tests for delete taskspawner
- [x] Integration tests for workspace completion
- [x] Integration tests for alias support (ws, ts)
- [x] E2E tests for workspace CRUD lifecycle
- [x] E2E tests for error cases (nonexistent resources)
- [x] E2E tests for workspace list output formats (yaml, json)
- [x] `go vet` passes
- [x] Build succeeds
- [x] All unit tests pass
- [x] All integration tests pass (33/33)

Closes #38