### PR TITLE
Support custom agent images via agent image interface

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -62,6 +62,12 @@ type TaskSpec struct {
 	// +optional
 	Model string `json:"model,omitempty"`
 
+	// Image optionally overrides the default agent container image.
+	// Custom images must implement the agent image interface
+	// (see docs/agent-image-interface.md).
+	// +optional
+	Image string `json:"image,omitempty"`
+
 	// WorkspaceRef optionally references a Workspace resource for the agent to work in.
 	// +optional
 	WorkspaceRef *WorkspaceReference `json:"workspaceRef,omitempty"`

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -78,6 +78,12 @@ type TaskTemplate struct {
 	// +optional
 	Model string `json:"model,omitempty"`
 
+	// Image optionally overrides the default agent container image.
+	// Custom images must implement the agent image interface
+	// (see docs/agent-image-interface.md).
+	// +optional
+	Image string `json:"image,omitempty"`
+
 	// PromptTemplate is a Go text/template for rendering the task prompt.
 	// Available variables: {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}.
 	// +optional

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -29,7 +29,10 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN npm install -g @anthropic-ai/claude-code
 
-RUN useradd -u 1100 -m -s /bin/bash claude
+COPY claude-code/axon_entrypoint.sh /axon_entrypoint.sh
+RUN chmod +x /axon_entrypoint.sh
+
+RUN useradd -u 61100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude
 
 USER claude

--- a/claude-code/axon_entrypoint.sh
+++ b/claude-code/axon_entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# axon_entrypoint.sh — reference implementation of the Axon agent image
+# interface for Claude Code.
+#
+# Interface contract:
+#   - First argument ($1): the task prompt
+#   - AXON_MODEL env var: model name (optional)
+#   - UID 61100: shared between git-clone init container and agent
+#   - Working directory: /workspace/repo when a workspace is configured
+
+set -euo pipefail
+
+PROMPT="${1:?Prompt argument is required}"
+
+ARGS=(
+    "--dangerously-skip-permissions"
+    "--output-format" "stream-json"
+    "--verbose"
+    "-p" "$PROMPT"
+)
+
+if [ -n "${AXON_MODEL:-}" ]; then
+    ARGS+=("--model" "$AXON_MODEL")
+fi
+
+exec claude "${ARGS[@]}"

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -181,6 +181,7 @@ func runCycleWithSource(ctx context.Context, cl client.Client, key types.Namespa
 				Prompt:                  prompt,
 				Credentials:             ts.Spec.TaskTemplate.Credentials,
 				Model:                   ts.Spec.TaskTemplate.Model,
+				Image:                   ts.Spec.TaskTemplate.Image,
 				TTLSecondsAfterFinished: ts.Spec.TaskTemplate.TTLSecondsAfterFinished,
 			},
 		}

--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -1,0 +1,59 @@
+# Agent Image Interface
+
+This document describes the interface that custom agent images must implement
+to be compatible with Axon.
+
+## Overview
+
+Axon runs agent tasks as Kubernetes Jobs. Each agent container is invoked using
+a standard interface so that any compatible image can be used as a drop-in
+replacement for the default `claude-code` image.
+
+## Requirements
+
+### 1. Entrypoint
+
+The image must provide an executable at `/axon_entrypoint.sh`. Axon sets
+`Command: ["/axon_entrypoint.sh"]` on the container, overriding any
+`ENTRYPOINT` in the Dockerfile.
+
+### 2. Prompt argument
+
+The task prompt is passed as the first positional argument (`$1`). Axon sets
+`Args: ["<prompt>"]` on the container.
+
+### 3. Environment variables
+
+Axon sets the following reserved environment variables on agent containers:
+
+| Variable | Description | Always set? |
+|---|---|---|
+| `AXON_MODEL` | The model name to use | Only when `model` is specified in the Task |
+| `ANTHROPIC_API_KEY` | API key for Anthropic (api-key credential type) | When credential type is `api-key` |
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (oauth credential type) | When credential type is `oauth` |
+| `GITHUB_TOKEN` | GitHub token for workspace access | When workspace has a `secretRef` |
+| `GH_TOKEN` | GitHub token (alias for GitHub CLI) | When workspace has a `secretRef` |
+
+### 4. User ID
+
+The agent image must be configured to run as **UID 61100**. This UID is shared
+between the `git-clone` init container and the agent container so that both can
+read and write workspace files without additional permission workarounds.
+
+Set this in your Dockerfile:
+
+```dockerfile
+RUN useradd -u 61100 -m -s /bin/bash agent
+USER agent
+```
+
+### 5. Working directory
+
+When a workspace is configured, Axon mounts the cloned repository at
+`/workspace/repo` and sets `WorkingDir` on the container accordingly. The
+entrypoint script does not need to handle directory changes.
+
+## Reference implementation
+
+See `claude-code/axon_entrypoint.sh` for a reference implementation that wraps
+the `claude` CLI.

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -71,6 +71,12 @@ spec:
                 - secretRef
                 - type
                 type: object
+              image:
+                description: |-
+                  Image optionally overrides the default agent container image.
+                  Custom images must implement the agent image interface
+                  (see docs/agent-image-interface.md).
+                type: string
               model:
                 description: Model optionally overrides the default model.
                 type: string
@@ -237,6 +243,12 @@ spec:
                     - secretRef
                     - type
                     type: object
+                  image:
+                    description: |-
+                      Image optionally overrides the default agent container image.
+                      Custom images must implement the agent image interface
+                      (see docs/agent-image-interface.md).
+                    type: string
                   model:
                     description: Model optionally overrides the default model.
                     type: string

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -23,6 +23,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		secret         string
 		credentialType string
 		model          string
+		image          string
 		name           string
 		watch          bool
 		workspace      string
@@ -134,6 +135,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 						},
 					},
 					Model: model,
+					Image: image,
 				},
 			}
 
@@ -161,6 +163,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
 	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key or oauth)")
 	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&image, "image", "", "custom agent image (must implement agent image interface)")
 	cmd.Flags().StringVar(&name, "name", "", "task name (auto-generated if omitted)")
 	cmd.Flags().StringVar(&workspace, "workspace", "", "name of Workspace resource to use")
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch task status after creation")

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -1,0 +1,320 @@
+package controller
+
+import (
+	"testing"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildClaudeCodeJob_DefaultImage(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Hello world",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+			Model: "claude-sonnet-4-20250514",
+		},
+	}
+
+	job, err := builder.Build(task, nil)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+
+	// Default image should be used.
+	if container.Image != ClaudeCodeImage {
+		t.Errorf("Expected image %q, got %q", ClaudeCodeImage, container.Image)
+	}
+
+	// Command should be /axon_entrypoint.sh (uniform interface).
+	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
+		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	}
+
+	// Args should be just the prompt.
+	if len(container.Args) != 1 || container.Args[0] != "Hello world" {
+		t.Errorf("Expected args [Hello world], got %v", container.Args)
+	}
+
+	// AXON_MODEL should be set with the correct value.
+	foundAxonModel := false
+	for _, env := range container.Env {
+		if env.Name == "AXON_MODEL" {
+			foundAxonModel = true
+			if env.Value != "claude-sonnet-4-20250514" {
+				t.Errorf("AXON_MODEL value: expected %q, got %q", "claude-sonnet-4-20250514", env.Value)
+			}
+		}
+	}
+	if !foundAxonModel {
+		t.Error("Expected AXON_MODEL env var to be set")
+	}
+}
+
+func TestBuildClaudeCodeJob_CustomImage(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-custom",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix the bug",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+			Model: "my-model",
+			Image: "my-custom-agent:latest",
+		},
+	}
+
+	job, err := builder.Build(task, nil)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+
+	// Custom image should be used.
+	if container.Image != "my-custom-agent:latest" {
+		t.Errorf("Expected image %q, got %q", "my-custom-agent:latest", container.Image)
+	}
+
+	// Command should be /axon_entrypoint.sh (same interface as default).
+	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
+		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	}
+
+	// Args should be just the prompt.
+	if len(container.Args) != 1 || container.Args[0] != "Fix the bug" {
+		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
+	}
+
+	// AXON_MODEL should be set with the correct value.
+	foundAxonModel := false
+	for _, env := range container.Env {
+		if env.Name == "AXON_MODEL" {
+			foundAxonModel = true
+			if env.Value != "my-model" {
+				t.Errorf("AXON_MODEL value: expected %q, got %q", "my-model", env.Value)
+			}
+		}
+	}
+	if !foundAxonModel {
+		t.Error("Expected AXON_MODEL env var to be set")
+	}
+}
+
+func TestBuildClaudeCodeJob_NoModel(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-no-model",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Hello",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+
+	job, err := builder.Build(task, nil)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+
+	// AXON_MODEL should NOT be set when model is empty.
+	for _, env := range container.Env {
+		if env.Name == "AXON_MODEL" {
+			t.Error("AXON_MODEL should not be set when model is empty")
+		}
+	}
+}
+
+func TestBuildClaudeCodeJob_WorkspaceWithRef(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workspace",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix the code",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+
+	workspace := &axonv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/example/repo.git",
+		Ref:  "main",
+	}
+
+	job, err := builder.Build(task, workspace)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	// Verify git clone args.
+	initContainer := job.Spec.Template.Spec.InitContainers[0]
+	expectedArgs := []string{
+		"clone",
+		"--branch", "main", "--no-single-branch", "--depth", "1",
+		"--", "https://github.com/example/repo.git", WorkspaceMountPath + "/repo",
+	}
+
+	if len(initContainer.Args) != len(expectedArgs) {
+		t.Fatalf("Expected %d clone args, got %d: %v", len(expectedArgs), len(initContainer.Args), initContainer.Args)
+	}
+	for i, arg := range expectedArgs {
+		if initContainer.Args[i] != arg {
+			t.Errorf("Clone args[%d]: expected %q, got %q", i, arg, initContainer.Args[i])
+		}
+	}
+
+	// Verify init container runs as ClaudeCodeUID.
+	if initContainer.SecurityContext == nil || initContainer.SecurityContext.RunAsUser == nil {
+		t.Fatal("Expected init container SecurityContext.RunAsUser to be set")
+	}
+	if *initContainer.SecurityContext.RunAsUser != ClaudeCodeUID {
+		t.Errorf("Expected RunAsUser %d, got %d", ClaudeCodeUID, *initContainer.SecurityContext.RunAsUser)
+	}
+
+	// Verify FSGroup.
+	if job.Spec.Template.Spec.SecurityContext == nil || job.Spec.Template.Spec.SecurityContext.FSGroup == nil {
+		t.Fatal("Expected pod SecurityContext.FSGroup to be set")
+	}
+	if *job.Spec.Template.Spec.SecurityContext.FSGroup != ClaudeCodeUID {
+		t.Errorf("Expected FSGroup %d, got %d", ClaudeCodeUID, *job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+
+	// Verify main container working dir.
+	container := job.Spec.Template.Spec.Containers[0]
+	if container.WorkingDir != WorkspaceMountPath+"/repo" {
+		t.Errorf("Expected workingDir %q, got %q", WorkspaceMountPath+"/repo", container.WorkingDir)
+	}
+}
+
+func TestBuildClaudeCodeJob_CustomImageWithWorkspace(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-custom-ws",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix the bug",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+			Image: "my-agent:v1",
+			Model: "gpt-4",
+		},
+	}
+
+	workspace := &axonv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/example/repo.git",
+		SecretRef: &axonv1alpha1.SecretReference{
+			Name: "github-token",
+		},
+	}
+
+	job, err := builder.Build(task, workspace)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+
+	// Custom image with workspace should still use /axon_entrypoint.sh.
+	if container.Image != "my-agent:v1" {
+		t.Errorf("Expected image %q, got %q", "my-agent:v1", container.Image)
+	}
+	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
+		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	}
+	if len(container.Args) != 1 || container.Args[0] != "Fix the bug" {
+		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
+	}
+
+	// Should have workspace volume mount and working dir.
+	if container.WorkingDir != WorkspaceMountPath+"/repo" {
+		t.Errorf("Expected workingDir %q, got %q", WorkspaceMountPath+"/repo", container.WorkingDir)
+	}
+	if len(container.VolumeMounts) != 1 {
+		t.Fatalf("Expected 1 volume mount, got %d", len(container.VolumeMounts))
+	}
+
+	// Verify FSGroup.
+	if job.Spec.Template.Spec.SecurityContext == nil || job.Spec.Template.Spec.SecurityContext.FSGroup == nil {
+		t.Fatal("Expected pod SecurityContext.FSGroup to be set")
+	}
+	if *job.Spec.Template.Spec.SecurityContext.FSGroup != ClaudeCodeUID {
+		t.Errorf("Expected FSGroup %d, got %d", ClaudeCodeUID, *job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+
+	// Should have AXON_MODEL with correct value, ANTHROPIC_API_KEY, GITHUB_TOKEN, GH_TOKEN.
+	envMap := map[string]string{}
+	for _, env := range container.Env {
+		if env.Value != "" {
+			envMap[env.Name] = env.Value
+		} else {
+			envMap[env.Name] = "(from-secret)"
+		}
+	}
+	for _, name := range []string{"AXON_MODEL", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
+		if _, ok := envMap[name]; !ok {
+			t.Errorf("Expected env var %q to be set", name)
+		}
+	}
+	if envMap["AXON_MODEL"] != "gpt-4" {
+		t.Errorf("AXON_MODEL value: expected %q, got %q", "gpt-4", envMap["AXON_MODEL"])
+	}
+}
+
+func TestBuildClaudeCodeJob_UnsupportedType(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-unsupported",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   "unsupported-agent",
+			Prompt: "Hello",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+
+	_, err := builder.Build(task, nil)
+	if err == nil {
+		t.Fatal("Expected error for unsupported agent type, got nil")
+	}
+}

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -71,6 +71,12 @@ spec:
                 - secretRef
                 - type
                 type: object
+              image:
+                description: |-
+                  Image optionally overrides the default agent container image.
+                  Custom images must implement the agent image interface
+                  (see docs/agent-image-interface.md).
+                type: string
               model:
                 description: Model optionally overrides the default model.
                 type: string
@@ -237,6 +243,12 @@ spec:
                     - secretRef
                     - type
                     type: object
+                  image:
+                    description: |-
+                      Image optionally overrides the default agent container image.
+                      Custom images must implement the agent image interface
+                      (see docs/agent-image-interface.md).
+                    type: string
                   model:
                     description: Model optionally overrides the default model.
                     type: string


### PR DESCRIPTION
## Summary

Implements the agent image interface from #86, allowing users to specify custom agent container images that follow a standard protocol:

- **Entrypoint**: `/axon_entrypoint.sh` receives the task prompt as `$1`
- **Model**: `AXON_MODEL` environment variable (replaces `--model` CLI flag)
- **UID**: 61100 shared between git-clone init container and agent container
- **Working directory**: `/workspace/repo` when a workspace is configured

Key changes:
- Add `image` field to `TaskSpec` and `TaskTemplate` API types
- Add `/axon_entrypoint.sh` to claude-code image as reference implementation
- Update job builder to use uniform interface (no branching for custom vs default images)
- Remove `umask` and `core.sharedRepository` workarounds (shared UID is sufficient)
- Change agent UID from 1100 to 61100 to avoid system UID conflicts
- Add `--image` flag to CLI `run` command
- Pass `Image` through TaskSpawner to spawned Tasks
- Add `docs/agent-image-interface.md` documenting the interface protocol

## Test plan

- [x] Unit tests for job builder (new `job_builder_test.go`)
- [x] Integration test for custom image with workspace
- [x] All existing Task Controller integration tests pass (34/34)
- [x] `make build` succeeds
- [x] `make test` passes
- [x] `make test-integration` passes

Closes #86