### PR TITLE
Replace build-essential with make in Dockerfile

### DIFF
--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 ARG GO_VERSION=1.25.0
 
 RUN apt-get update && apt-get install -y \
-    build-essential \
+    make \
     curl \
     ca-certificates \
     git \


### PR DESCRIPTION
## Summary
- Replace `build-essential` with `make` in the claude-code Dockerfile
- The project only needs golang and `make` for development; `build-essential` is unnecessarily heavy as it pulls in gcc, g++, libc-dev, and dpkg-dev which are not needed

## Test plan
- [ ] Verify the Docker image builds successfully with only `make` installed
- [ ] Verify `make build`, `make test`, and `make verify` work inside the container

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace build-essential with make in the claude-code Dockerfile to drop unnecessary compilers and slim the image. Satisfies #136 by keeping only what’s needed for make build/test/verify, reducing build time and image size.

<sup>Written for commit 7f1a2e6d675a4d0565ec6f20e51f143d041174b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

