### PR TITLE
Move pollInterval to GitHubIssues and validate When source

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ spec:
         name: my-workspace
       labels: [bug]
       state: open
+      pollInterval: 5m
   taskTemplate:
     type: claude-code
     credentials:
@@ -233,7 +234,6 @@ spec:
       secretRef:
         name: claude-credentials
     promptTemplate: "Fix: {{.Title}}\n{{.Body}}"
-  pollInterval: 5m
 ```
 
 ```bash
@@ -334,11 +334,12 @@ The key pattern here is `excludeLabels: [axon/needs-input]` — this creates a f
 | `spec.when.githubIssues.labels` | Filter issues by labels | No |
 | `spec.when.githubIssues.excludeLabels` | Exclude issues with these labels | No |
 | `spec.when.githubIssues.state` | Filter by state: `open`, `closed`, `all` (default: `open`) | No |
+| `spec.when.githubIssues.pollInterval` | How often to poll the GitHub API (default: `5m`) | No |
+| `spec.when.cron.schedule` | Cron expression (e.g., `0 9 * * 1`) | Yes (for cron) |
 | `spec.taskTemplate.type` | Agent type (`claude-code`) | Yes |
 | `spec.taskTemplate.credentials` | Credentials for the agent (same as Task) | Yes |
 | `spec.taskTemplate.model` | Model override | No |
 | `spec.taskTemplate.promptTemplate` | Go text/template for prompt (`{{.Title}}`, `{{.Body}}`, `{{.Number}}`, etc.) | No |
-| `spec.pollInterval` | How often to poll the source (default: `5m`) | No |
 
 </details>
 

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -18,6 +18,8 @@ const (
 
 // When defines the conditions that trigger task spawning.
 // Exactly one field must be set.
+// +kubebuilder:validation:MinProperties=1
+// +kubebuilder:validation:MaxProperties=1
 type When struct {
 	// GitHubIssues discovers issues from a GitHub repository.
 	// +optional
@@ -62,6 +64,11 @@ type GitHubIssues struct {
 	// +kubebuilder:default=open
 	// +optional
 	State string `json:"state,omitempty"`
+
+	// PollInterval is how often to poll the GitHub API for new items (e.g., "5m"). Defaults to "5m".
+	// +kubebuilder:default="5m"
+	// +optional
+	PollInterval string `json:"pollInterval,omitempty"`
 }
 
 // TaskTemplate defines the template for spawned Tasks.
@@ -104,11 +111,6 @@ type TaskSpawnerSpec struct {
 	// TaskTemplate defines the template for spawned Tasks.
 	// +kubebuilder:validation:Required
 	TaskTemplate TaskTemplate `json:"taskTemplate"`
-
-	// PollInterval is how often to poll the source for new items (e.g., "5m"). Defaults to "5m".
-	// +kubebuilder:default="5m"
-	// +optional
-	PollInterval string `json:"pollInterval,omitempty"`
 }
 
 // TaskSpawnerStatus defines the observed state of TaskSpawner.

--- a/cmd/axon-spawner/main_test.go
+++ b/cmd/axon-spawner/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+)
+
+func TestParsePollInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{name: "empty defaults to 5m", input: "", expected: 5 * time.Minute},
+		{name: "valid duration 5m", input: "5m", expected: 5 * time.Minute},
+		{name: "valid duration 30s", input: "30s", expected: 30 * time.Second},
+		{name: "valid duration 1h", input: "1h", expected: 1 * time.Hour},
+		{name: "plain number treated as seconds", input: "60", expected: 60 * time.Second},
+		{name: "invalid string defaults to 5m", input: "invalid", expected: 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePollInterval(tt.input)
+			if got != tt.expected {
+				t.Errorf("parsePollInterval(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPollIntervalFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		ts       *axonv1alpha1.TaskSpawner
+		expected time.Duration
+	}{
+		{
+			name: "GitHub source with pollInterval",
+			ts: &axonv1alpha1.TaskSpawner{
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{
+						GitHubIssues: &axonv1alpha1.GitHubIssues{
+							PollInterval: "10m",
+						},
+					},
+				},
+			},
+			expected: 10 * time.Minute,
+		},
+		{
+			name: "GitHub source with empty pollInterval defaults to 5m",
+			ts: &axonv1alpha1.TaskSpawner{
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{
+						GitHubIssues: &axonv1alpha1.GitHubIssues{},
+					},
+				},
+			},
+			expected: 5 * time.Minute,
+		},
+		{
+			name: "Cron source always returns 1m",
+			ts: &axonv1alpha1.TaskSpawner{
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{
+						Cron: &axonv1alpha1.Cron{
+							Schedule: "0 9 * * 1",
+						},
+					},
+				},
+			},
+			expected: 1 * time.Minute,
+		},
+		{
+			name: "No source configured returns 1m (cron fallback)",
+			ts: &axonv1alpha1.TaskSpawner{
+				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{},
+				},
+			},
+			expected: 1 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pollIntervalFor(tt.ts)
+			if got != tt.expected {
+				t.Errorf("pollIntervalFor() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -194,11 +194,6 @@ spec:
           spec:
             description: TaskSpawnerSpec defines the desired state of TaskSpawner.
             properties:
-              pollInterval:
-                default: 5m
-                description: PollInterval is how often to poll the source for new
-                  items (e.g., "5m"). Defaults to "5m".
-                type: string
               taskTemplate:
                 description: TaskTemplate defines the template for spawned Tasks.
                 properties:
@@ -255,6 +250,8 @@ spec:
                 type: object
               when:
                 description: When defines the conditions that trigger task spawning.
+                maxProperties: 1
+                minProperties: 1
                 properties:
                   cron:
                     description: Cron triggers task spawning on a cron schedule.
@@ -280,6 +277,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      pollInterval:
+                        default: 5m
+                        description: PollInterval is how often to poll the GitHub
+                          API for new items (e.g., "5m"). Defaults to "5m".
+                        type: string
                       state:
                         default: open
                         description: State filters issues by state (open, closed,

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -91,6 +91,9 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 		if len(gh.Labels) > 0 {
 			printField(w, "Labels", fmt.Sprintf("%v", gh.Labels))
 		}
+		if gh.PollInterval != "" {
+			printField(w, "Poll Interval", gh.PollInterval)
+		}
 	} else if ts.Spec.When.Cron != nil {
 		printField(w, "Source", "Cron")
 		printField(w, "Schedule", ts.Spec.When.Cron.Schedule)
@@ -99,7 +102,6 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 	if ts.Spec.TaskTemplate.Model != "" {
 		printField(w, "Model", ts.Spec.TaskTemplate.Model)
 	}
-	printField(w, "Poll Interval", ts.Spec.PollInterval)
 	if ts.Status.DeploymentName != "" {
 		printField(w, "Deployment", ts.Status.DeploymentName)
 	}

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -194,11 +194,6 @@ spec:
           spec:
             description: TaskSpawnerSpec defines the desired state of TaskSpawner.
             properties:
-              pollInterval:
-                default: 5m
-                description: PollInterval is how often to poll the source for new
-                  items (e.g., "5m"). Defaults to "5m".
-                type: string
               taskTemplate:
                 description: TaskTemplate defines the template for spawned Tasks.
                 properties:
@@ -255,6 +250,8 @@ spec:
                 type: object
               when:
                 description: When defines the conditions that trigger task spawning.
+                maxProperties: 1
+                minProperties: 1
                 properties:
                   cron:
                     description: Cron triggers task spawning on a cron schedule.
@@ -280,6 +277,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      pollInterval:
+                        default: 5m
+                        description: PollInterval is how often to poll the GitHub
+                          API for new items (e.g., "5m"). Defaults to "5m".
+                        type: string
                       state:
                         default: open
                         description: State filters issues by state (open, closed,

--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -9,6 +9,7 @@ spec:
         - axon/needs-input
       workspaceRef:
         name: axon-workspace
+      pollInterval: 1m
   taskTemplate:
     model: opus
     type: claude-code
@@ -50,4 +51,3 @@ spec:
         - You cannot make any progress on the issue, explain why.
       - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
         - gh issue create --title "<title>" --body "<description>" --label axon/needs-input
-  pollInterval: 1m

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -77,6 +77,7 @@ spec:
       labels: [do-not-remove/e2e-anchor]
       excludeLabels: [e2e-exclude-placeholder]
       state: open
+      pollInterval: 1m
   taskTemplate:
     type: claude-code
     credentials:
@@ -84,7 +85,6 @@ spec:
       secretRef:
         name: claude-credentials
     promptTemplate: "Fix: {{.Title}}\n{{.Body}}"
-  pollInterval: 1m
 `
 		Expect(kubectlWithInput(tsYAML, "apply", "-f", "-")).To(Succeed())
 
@@ -125,13 +125,13 @@ spec:
     githubIssues:
       workspaceRef:
         name: e2e-spawner-workspace
+      pollInterval: 5m
   taskTemplate:
     type: claude-code
     credentials:
       type: oauth
       secretRef:
         name: claude-credentials
-  pollInterval: 5m
 `
 		Expect(kubectlWithInput(tsYAML, "apply", "-f", "-")).To(Succeed())
 
@@ -213,7 +213,6 @@ spec:
       secretRef:
         name: claude-credentials
     promptTemplate: "Cron triggered at {{.Time}} (schedule: {{.Schedule}}). Print 'Hello from cron'"
-  pollInterval: 1m
 `
 		Expect(kubectlWithInput(tsYAML, "apply", "-f", "-")).To(Succeed())
 
@@ -249,7 +248,6 @@ spec:
       type: oauth
       secretRef:
         name: claude-credentials
-  pollInterval: 5m
 `
 		Expect(kubectlWithInput(tsYAML, "apply", "-f", "-")).To(Succeed())
 

--- a/test/integration/completion_test.go
+++ b/test/integration/completion_test.go
@@ -102,6 +102,11 @@ var _ = Describe("Completion", func() {
 					Namespace: ns.Name,
 				},
 				Spec: axonv1alpha1.TaskSpawnerSpec{
+					When: axonv1alpha1.When{
+						Cron: &axonv1alpha1.Cron{
+							Schedule: "0 9 * * 1",
+						},
+					},
 					TaskTemplate: axonv1alpha1.TaskTemplate{
 						Type: "claude-code",
 						Credentials: axonv1alpha1.Credentials{


### PR DESCRIPTION
## Summary
- Moves `pollInterval` from `TaskSpawnerSpec` to `GitHubIssues` where it semantically belongs, since it controls GitHub API polling frequency
- For cron sources, uses a fixed 1-minute poll interval (ticks are discovered retrospectively, so no ticks are missed regardless of interval)
- Adds `MinProperties=1` and `MaxProperties=1` validation on `When` to enforce exactly one source is configured
- Adds unit tests for `pollIntervalFor` and `parsePollInterval`, and integration tests for the new validation

Fixes #138

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make test-integration`) - 26/26 specs
- [x] Build succeeds (`make build`)
- [x] New validation tests verify both "no source" and "both sources" are rejected
- [x] New unit tests cover poll interval logic for GitHub and cron sources

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>