### PR TITLE
Handle needs-priority label

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -66,3 +66,31 @@ jobs:
                 name: 'needs-kind',
               });
             }
+
+  priority-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove needs-priority label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const item = context.payload.issue || context.payload.pull_request;
+            const labels = item.labels.map(l => l.name);
+            const hasPriority = labels.some(l => l.startsWith('priority/'));
+            const hasNeedsPriority = labels.includes('needs-priority');
+
+            if (!hasPriority && !hasNeedsPriority) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                labels: ['needs-priority'],
+              });
+            } else if (hasPriority && hasNeedsPriority) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                name: 'needs-priority',
+              });
+            }


### PR DESCRIPTION
## Summary
- Add a `priority-label` job to the Label workflow that automatically manages the `needs-priority` label
- Adds `needs-priority` when no `priority/*` label exists on an issue or PR
- Removes `needs-priority` when a `priority/*` label is added

Follows the same pattern as the existing `needs-kind` and `needs-triage` label handling.

Fixes #145

## Test plan
- [ ] Verify the workflow triggers correctly on issue/PR opened, labeled, and unlabeled events
- [ ] Verify `needs-priority` is added when an issue/PR is opened without a `priority/*` label
- [ ] Verify `needs-priority` is removed when a `priority/*` label is added to an issue/PR
- [ ] Verify `needs-priority` is re-added when all `priority/*` labels are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates needs-priority label handling in the Label workflow so issues and PRs without a priority are flagged, and the flag is cleared once a priority/* label is added. Aligns with Linear task 145 to enforce priority labeling.

- **New Features**
  - Adds a priority-label job in .github/workflows/label.yaml using actions/github-script.
  - Adds needs-priority when no priority/* label exists; removes it when a priority/* label is applied.
  - Mirrors the existing needs-kind and needs-triage behavior.

<sup>Written for commit 49d9ec40c7957408273775f75902c5e0bd73bb0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

