### PR TITLE
Add workflow to protect e2e anchor issue from being closed

### DIFF
--- a/.github/workflows/e2e-anchor.yaml
+++ b/.github/workflows/e2e-anchor.yaml
@@ -1,0 +1,30 @@
+name: Protect e2e anchor issue
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  reopen-anchor:
+    runs-on: ubuntu-latest
+    if: github.event.issue.number == 117
+    steps:
+      - name: Reopen e2e anchor issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 117,
+              state: 'open',
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 117,
+              body: 'Automatically reopened: this issue is required by the e2e test suite (TaskSpawner GitHub Issues discovery test). Please do not close it.',
+            });


### PR DESCRIPTION
## Summary
- The e2e test `should create a spawner Deployment and discover issues` depends on issue #117 being open with the `do-not-remove/e2e-anchor` label
- Issue #117 was accidentally closed, causing the TaskSpawner's GitHub Issues source to find no open matching issues, which made the test time out after 3 minutes waiting for Tasks to be created
- All recent CI runs have been failing with this single test failure
- Reopened issue #117 and added a GitHub Actions workflow that automatically reopens it whenever it gets closed

## Root cause
The `TaskSpawner` e2e test creates a spawner with `state: open` and `labels: [do-not-remove/e2e-anchor]`. When the spawner queries the GitHub API for open issues with that label, it found zero results because issue #117 was closed. With no discovered items, no Tasks were created, and the test timed out at `taskspawner_test.go:104`.

## Test plan
- [x] Reopened issue #117 so the e2e test can discover it again
- [ ] Verify the e2e CI job passes on this PR
- [ ] Verify the anchor protection workflow triggers correctly if #117 is closed again

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that auto-reopens the e2e anchor issue (#117) if it’s closed, preventing TaskSpawner e2e timeouts and stabilizing CI. Addresses Linear task #144 by protecting the required anchor issue.

- **New Features**
  - Runs on issues.closed and only targets issue #117.
  - Reopens the issue and posts a reminder comment.

<sup>Written for commit 6abfbc62f6db6c8c3c75e74406f04fb1f8d59751. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

