### PR TITLE
Auto-reopen issues with do-not-remove/ label prefix

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -2,7 +2,7 @@ name: Label
 
 on:
   issues:
-    types: [opened, labeled, unlabeled]
+    types: [opened, closed, labeled, unlabeled]
   pull_request_target:
     types: [opened, labeled, unlabeled]
 
@@ -64,5 +64,31 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: item.number,
                 name: 'needs-kind',
+              });
+            }
+
+  reopen-protected-issues:
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reopen issues with do-not-remove labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const isProtected = issue.labels.some(l => l.name.startsWith('do-not-remove/'));
+
+            if (isProtected) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'open',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'Reopening this issue because it has a `do-not-remove/` label. Issues with this label prefix are protected and must remain open.',
               });
             }


### PR DESCRIPTION
## Summary
- Added a `reopen-protected-issues` job to the Label workflow that automatically reopens issues with a `do-not-remove/` label prefix when they are closed
- This prevents the e2e anchor issue (#117) from being accidentally closed (e.g., by PRs using "Fixes #117"), which would break the TaskSpawner e2e test

Relates-to: #117

## Test plan
- [ ] Verify `make test` passes
- [ ] Verify the workflow triggers correctly when an issue with `do-not-remove/e2e-anchor` label is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically reopens issues with a do-not-remove/ label when they’re closed to protect the e2e anchor issue (#117) and keep TaskSpawner tests stable.

- **New Features**
  - Run Label workflow on issue.closed events.
  - New reopen-protected-issues job reopens and comments on issues with do-not-remove/ labels (e.g., do-not-remove/e2e-anchor).

<sup>Written for commit d0796a0ade2da5e9f7243e2ae7457880ff0d6152. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

