### PR TITLE
Support private GitHub Enterprise servers

### DIFF
--- a/cmd/axon-spawner/main_test.go
+++ b/cmd/axon-spawner/main_test.go
@@ -102,6 +102,46 @@ func newTask(name, namespace, spawnerName string, phase axonv1alpha1.TaskPhase) 
 	}
 }
 
+func TestBuildSource_GitHubIssuesWithBaseURL(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+
+	src, err := buildSource(ts, "my-org", "my-repo", "https://github.example.com/api/v3")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	ghSrc, ok := src.(*source.GitHubSource)
+	if !ok {
+		t.Fatalf("Expected *source.GitHubSource, got %T", src)
+	}
+	if ghSrc.BaseURL != "https://github.example.com/api/v3" {
+		t.Errorf("BaseURL = %q, want %q", ghSrc.BaseURL, "https://github.example.com/api/v3")
+	}
+	if ghSrc.Owner != "my-org" {
+		t.Errorf("Owner = %q, want %q", ghSrc.Owner, "my-org")
+	}
+	if ghSrc.Repo != "my-repo" {
+		t.Errorf("Repo = %q, want %q", ghSrc.Repo, "my-repo")
+	}
+}
+
+func TestBuildSource_GitHubIssuesDefaultBaseURL(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+
+	src, err := buildSource(ts, "axon-core", "axon", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	ghSrc, ok := src.(*source.GitHubSource)
+	if !ok {
+		t.Fatalf("Expected *source.GitHubSource, got %T", src)
+	}
+	if ghSrc.BaseURL != "" {
+		t.Errorf("BaseURL = %q, want empty (defaults to api.github.com)", ghSrc.BaseURL)
+	}
+}
+
 func TestRunCycleWithSource_NoMaxConcurrency(t *testing.T) {
 	ts := newTaskSpawner("spawner", "default", nil)
 	cl, key := setupTest(t, ts)

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -118,6 +118,16 @@ func (b *JobBuilder) buildClaudeCodeJob(task *axonv1alpha1.Task, workspace *axon
 		workspaceEnvVars = append(workspaceEnvVars, githubTokenEnv, ghTokenEnv)
 	}
 
+	// Set GH_HOST for GitHub Enterprise so that gh CLI targets the correct host.
+	if workspace != nil {
+		host, _, _ := parseGitHubRepo(workspace.Repo)
+		if host != "" && host != "github.com" {
+			ghHostEnv := corev1.EnvVar{Name: "GH_HOST", Value: host}
+			envVars = append(envVars, ghHostEnv)
+			workspaceEnvVars = append(workspaceEnvVars, ghHostEnv)
+		}
+	}
+
 	backoffLimit := int32(0)
 	claudeCodeUID := ClaudeCodeUID
 

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -1,6 +1,11 @@
 package controller
 
-import "testing"
+import (
+	"testing"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func TestParseGitHubOwnerRepo(t *testing.T) {
 	tests := []struct {
@@ -45,6 +50,18 @@ func TestParseGitHubOwnerRepo(t *testing.T) {
 			wantOwner: "my-org",
 			wantRepo:  "my-repo",
 		},
+		{
+			name:      "GitHub Enterprise HTTPS URL",
+			repoURL:   "https://github.example.com/my-org/my-repo.git",
+			wantOwner: "my-org",
+			wantRepo:  "my-repo",
+		},
+		{
+			name:      "GitHub Enterprise SSH URL",
+			repoURL:   "git@github.example.com:my-org/my-repo.git",
+			wantOwner: "my-org",
+			wantRepo:  "my-repo",
+		},
 	}
 
 	for _, tt := range tests {
@@ -55,6 +72,172 @@ func TestParseGitHubOwnerRepo(t *testing.T) {
 			}
 			if repo != tt.wantRepo {
 				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestParseGitHubRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoURL   string
+		wantHost  string
+		wantOwner string
+		wantRepo  string
+	}{
+		{
+			name:      "github.com HTTPS",
+			repoURL:   "https://github.com/axon-core/axon.git",
+			wantHost:  "github.com",
+			wantOwner: "axon-core",
+			wantRepo:  "axon",
+		},
+		{
+			name:      "github.com SSH",
+			repoURL:   "git@github.com:axon-core/axon.git",
+			wantHost:  "github.com",
+			wantOwner: "axon-core",
+			wantRepo:  "axon",
+		},
+		{
+			name:      "GitHub Enterprise HTTPS",
+			repoURL:   "https://github.example.com/my-org/my-repo.git",
+			wantHost:  "github.example.com",
+			wantOwner: "my-org",
+			wantRepo:  "my-repo",
+		},
+		{
+			name:      "GitHub Enterprise SSH",
+			repoURL:   "git@github.example.com:my-org/my-repo.git",
+			wantHost:  "github.example.com",
+			wantOwner: "my-org",
+			wantRepo:  "my-repo",
+		},
+		{
+			name:      "GitHub Enterprise HTTPS without .git",
+			repoURL:   "https://github.example.com/my-org/my-repo",
+			wantHost:  "github.example.com",
+			wantOwner: "my-org",
+			wantRepo:  "my-repo",
+		},
+		{
+			name:      "GitHub Enterprise with port",
+			repoURL:   "https://github.example.com:8443/my-org/my-repo.git",
+			wantHost:  "github.example.com:8443",
+			wantOwner: "my-org",
+			wantRepo:  "my-repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, owner, repo := parseGitHubRepo(tt.repoURL)
+			if host != tt.wantHost {
+				t.Errorf("host = %q, want %q", host, tt.wantHost)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestGitHubAPIBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "empty host returns empty",
+			host: "",
+			want: "",
+		},
+		{
+			name: "github.com returns empty",
+			host: "github.com",
+			want: "",
+		},
+		{
+			name: "enterprise host",
+			host: "github.example.com",
+			want: "https://github.example.com/api/v3",
+		},
+		{
+			name: "enterprise host with port",
+			host: "github.example.com:8443",
+			want: "https://github.example.com:8443/api/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gitHubAPIBaseURL(tt.host)
+			if got != tt.want {
+				t.Errorf("gitHubAPIBaseURL(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildDeploymentWithEnterpriseURL(t *testing.T) {
+	builder := NewDeploymentBuilder()
+
+	ts := &axonv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpawnerSpec{
+			When: axonv1alpha1.When{
+				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		repoURL           string
+		wantAPIBaseURLArg string
+	}{
+		{
+			name:              "github.com repo does not include api-base-url arg",
+			repoURL:           "https://github.com/axon-core/axon.git",
+			wantAPIBaseURLArg: "",
+		},
+		{
+			name:              "enterprise repo includes api-base-url arg",
+			repoURL:           "https://github.example.com/my-org/my-repo.git",
+			wantAPIBaseURLArg: "--github-api-base-url=https://github.example.com/api/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := &axonv1alpha1.WorkspaceSpec{
+				Repo: tt.repoURL,
+			}
+			dep := builder.Build(ts, workspace)
+			args := dep.Spec.Template.Spec.Containers[0].Args
+
+			found := ""
+			for _, arg := range args {
+				if len(arg) > len("--github-api-base-url=") && arg[:len("--github-api-base-url=")] == "--github-api-base-url=" {
+					found = arg
+				}
+			}
+
+			if tt.wantAPIBaseURLArg == "" {
+				if found != "" {
+					t.Errorf("Expected no --github-api-base-url arg, got %q", found)
+				}
+			} else {
+				if found != tt.wantAPIBaseURLArg {
+					t.Errorf("Got arg %q, want %q", found, tt.wantAPIBaseURLArg)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Generalize repository URL parsing to extract the host alongside owner and repo, supporting both `github.com` and GitHub Enterprise domains (HTTPS and SSH)
- When the workspace repo URL points to a non-`github.com` host, automatically derive and pass `--github-api-base-url=https://<host>/api/v3` to the spawner so it uses the correct GitHub Enterprise REST API endpoint
- Set `GH_HOST` environment variable in task Job containers for GitHub Enterprise hosts so the `gh` CLI targets the correct server

## Test plan
- [x] Unit tests for `parseGitHubRepo` with github.com and enterprise hosts (HTTPS, SSH, with/without `.git`, with port)
- [x] Unit tests for `gitHubAPIBaseURL` (empty, github.com, enterprise, enterprise with port)
- [x] Unit tests for `buildSource` with and without enterprise base URL
- [x] Unit tests for Job builder GH_HOST with enterprise workspace
- [x] Integration test for `DeploymentBuilder.Build` verifying `--github-api-base-url` arg is present for enterprise and absent for github.com
- [x] Integration test for GH_HOST env var with GitHub Enterprise workspace
- [x] Existing `parseGitHubOwnerRepo` tests extended with enterprise URL cases
- [x] All existing unit tests pass (`make test`)
- [x] All existing integration tests pass (`make test-integration`)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)