### PR TITLE
Update self-development/axon-workers.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ kubectl apply -f taskspawner.yaml
 
 TaskSpawner polls for new issues matching your filters and creates a Task for each one.
 
-### Autonomous issue-fixing pipeline
+### Autonomous self-development pipeline
 
 This is a real-world TaskSpawner that picks up every open issue, investigates it, opens (or updates) a PR, self-reviews, and ensures CI passes — fully autonomously. When the agent can't make progress, it labels the issue `axon/needs-input` and stops. Remove the label to re-queue it.
 

--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -38,10 +38,20 @@ spec:
         ```
         git fetch origin axon-task-{{.Number}} 2>/dev/null && git checkout -B axon-task-{{.Number}} origin/axon-task-{{.Number}} && git rebase main || git checkout -b axon-task-{{.Number}} main
         ```
-      - 1. Investigate the issue #{{.Number}} and its PR if exists.
-      - 3. Create a commit that fixes the issue.
-      - 4. /review the PR and get feedbacks from the PR to refine the patch.
-      - 5. Make sure the PR passes all CI tests.
+      - 1. Check if a PR already exists for branch axon-task-{{.Number}}.
+
+      If a PR already exists:
+      - 2a. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments).
+      - 3a. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
+      - 4a. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work.
+      - 5a. /review the PR to verify your changes address the feedback, then iterate if needed.
+      - 6a. Make sure the PR passes all CI tests.
+
+      If no PR exists:
+      - 2b. Investigate the issue #{{.Number}}.
+      - 3b. Create a commit that fixes the issue.
+      - 4b. Create a PR and /review it to get feedback, then iterate to address the feedback.
+      - 5b. Make sure the PR passes all CI tests.
 
       Post-checklist:
       - Add axon/needs-input label to the issue (gh issue edit {{.Number}} --add-label axon/needs-input) and leave a comment for the reason if any of the following applies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the README section name and updated the Axon worker checklist to handle existing PRs with incremental, review-driven changes that preserve prior work and ensure CI passes.

- **Refactors**
  - Split workflow into two paths: PR exists vs no PR.
  - When a PR exists, read all review comments and the current diff, then make only incremental fixes; do not rewrite.
  - Use /review to iterate and confirm feedback is addressed, and ensure CI passes.

<sup>Written for commit 77f08083e99503bd813e7c6db9dc61c4a6a340c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

