### PR TITLE
Update Docker Hub username in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: axoncore
+          username: gjkim42
           password: ${{ secrets.DOCKERHUB_AXON_TOKEN }}
 
       - name: Build images


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Docker Hub login in the release workflow to use gjkim42 instead of axoncore, ensuring image pushes authenticate with the correct account.

<sup>Written for commit 0047b7595fb11bce5ad30af70e36a57d0fd60759. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

