### PR TITLE
Handle 404 errors when removing labels in label workflow

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -31,12 +31,16 @@ jobs:
                 labels: ['needs-triage'],
               });
             } else if (hasTriageAccepted && hasNeedsTriage) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: item.number,
-                name: 'needs-triage',
-              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  name: 'needs-triage',
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
             }
 
   kind-label:
@@ -59,12 +63,16 @@ jobs:
                 labels: ['needs-kind'],
               });
             } else if (hasKind && hasNeedsKind) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: item.number,
-                name: 'needs-kind',
-              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  name: 'needs-kind',
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
             }
 
   priority-label:
@@ -87,10 +95,14 @@ jobs:
                 labels: ['needs-priority'],
               });
             } else if (hasPriority && hasNeedsPriority) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: item.number,
-                name: 'needs-priority',
-              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  name: 'needs-priority',
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
             }


### PR DESCRIPTION
## Summary
- The `kind-label` job fails with `HttpError: Label does not exist` (404) when trying to remove a `needs-kind` label that was already removed by a concurrent workflow run
- Wrapped all `removeLabel` API calls in all three label jobs (`triage-label`, `kind-label`, `priority-label`) with try-catch blocks that ignore 404 errors
- A 404 on label removal means the label is already gone, which is the desired state

## Root Cause
When multiple label events fire in quick succession (e.g., adding `kind/bug` to an issue that already has `needs-kind`), multiple workflow runs execute concurrently. The first run successfully removes `needs-kind`, but the second run fails because the label no longer exists on the issue.

Fixes #156

## Test plan
- [ ] Verify the workflow YAML is syntactically valid
- [ ] Trigger label events on an issue/PR to confirm the workflow runs without failures
- [ ] Confirm rapid label additions no longer cause job failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 404 "Label does not exist" failures in label workflows by ignoring 404s when removing needs-* labels during concurrent runs. Makes label removal idempotent and keeps jobs green. Fixes #156.

- **Bug Fixes**
  - Wrapped removeLabel calls in triage-label, kind-label, and priority-label with try/catch; ignore 404, rethrow others.
  - Handles race conditions when another run already removed the label.
  - No behavior change: a missing label already matches the desired state.

<sup>Written for commit c27e2b8a06092535dc6c3d6bf0a439efb32c97ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

