### PR TITLE
Update axon-workers prompt to checkout existing branch correctly

### DIFF
--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -36,7 +36,7 @@ spec:
       Task:
       - 0. Set up your working branch axon-task-{{.Number}}. Run this exactly:
         ```
-        git fetch origin axon-task-{{.Number}} 2>/dev/null && git checkout -B axon-task-{{.Number}} origin/axon-task-{{.Number}} && git rebase main || git checkout -b axon-task-{{.Number}} main
+        git fetch --unshallow; git fetch origin axon-task-{{.Number}} && git checkout -B axon-task-{{.Number}} origin/axon-task-{{.Number}} && git rebase main || git checkout -b axon-task-{{.Number}} main
         ```
       - 1. Check if a PR already exists for branch axon-task-{{.Number}}.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure axon-workers can check out an existing axon-task-{{.Number}} branch on shallow clones. Add git fetch --unshallow before fetching so checkout and rebase onto main work reliably.

<sup>Written for commit 437e2f0e8726f498076af9f8a98ac09df6fa183e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

