### PR TITLE
Fix typo: 'an coding agent' → 'a coding agent'

### DIFF
--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -18,7 +18,7 @@ spec:
       secretRef:
         name: axon-credentials
     promptTemplate: |
-      You are an coding agent that works within the ephemeral container environment.
+      You are a coding agent that works within the ephemeral container environment.
       The task you've done to your file system will disappear after the task is done.
       You either
       - create a PR to fix the issue


### PR DESCRIPTION
## Summary

Fixed a small grammar typo in the axon-workers.yaml prompt template.

## Changes

- Changed "an coding agent" to "a coding agent" in self-development/axon-workers.yaml:21

## Impact

Minor documentation/grammar fix. No functional changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a grammar typo in self-development/axon-workers.yaml prompt: “an coding agent” → “a coding agent”. Documentation-only change with no functional impact.

<sup>Written for commit a4adb570196904c94beef51276d0f8359cce4e54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

