### PR TITLE
Fix: Print error messages to stderr when commands fail

### DIFF
--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/axon-core/axon/internal/cli"
@@ -8,6 +9,7 @@ import (
 
 func main() {
 	if err := cli.NewRootCommand().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where all CLI errors were silently swallowed, making the CLI completely unusable for new users.

## Problem

When trying to follow the Quick Start guide as a new user, running `axon run -p "test"` without credentials would fail with exit code 1 but print no error message:

```bash
$ axon run -p "test"
$ echo $?
1
```

This happened because:
1. The root command has `SilenceErrors: true` (internal/cli/root.go:17)
2. main.go exited without printing the error (cmd/axon/main.go:10-12)

## Solution

Print errors to stderr in main.go before exiting with non-zero code.

## After this fix

```bash
$ axon run -p "test"
Error: no credentials configured (set oauthToken/apiKey in config file, or use --secret flag)
$ echo $?
1
```

## Test plan

- [x] Built and tested the CLI manually
- [x] Verified error messages are shown for missing credentials
- [x] Verified error messages are shown for missing required flags
- [x] Verified help command still works correctly
- [x] All unit tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Print CLI command errors to stderr before exiting so failures are visible to users. Fixes silent failures where commands exited with code 1 but no message (e.g., missing credentials).

<sup>Written for commit 09d588043eb959e98357af155cd331f468e7ad6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

