### PR TITLE
Fix CLI silently swallowing error messages

### DIFF
--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/axon-core/axon/internal/cli"
@@ -8,6 +9,7 @@ import (
 
 func main() {
 	if err := cli.NewRootCommand().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix critical DX bug where CLI exits with code 1 but displays no error message to users
- Users now see actionable error messages explaining what went wrong

## Problem

When users run CLI commands that encounter errors (e.g., `axon run` without credentials configured), the CLI would exit with code 1 but show no error message at all. This was extremely confusing for new users trying to get started.

**Root cause:**
1. `internal/cli/root.go` sets `SilenceErrors: true` on the root command
2. `cmd/axon/main.go` caught errors but didn't print them before calling `os.Exit(1)`

## Solution

Modified `main.go` to print errors to stderr before exiting. This preserves the existing error handling throughout the codebase while making failures visible to users.

## Testing

Manually verified error messages now display correctly:

```bash
$ ./bin/axon run -p "test"
Error: no credentials configured (set oauthToken/apiKey in config file, or use --secret flag)

$ ./bin/axon logs nonexistent-task
Error: getting task: tasks.axon.io "nonexistent-task" is forbidden: ...
```

All unit tests pass.

## Impact

This is a critical fix for new user onboarding. Without this, users following the Quick Start guide would encounter mysterious silent failures and have no way to understand what went wrong.

🤖 Generated with [Axon](https://github.com/axon-core/axon)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show CLI errors on stderr before exiting to fix silent failures on non-zero exits. Users now get clear, actionable messages when commands fail.

- **Bug Fixes**
  - Print the error in cmd/axon/main.go before os.Exit(1), preserving existing SilenceErrors behavior.
  - Manually verified messages for missing credentials and nonexistent tasks.

<sup>Written for commit 000ab3a078938679f7a0fd468f376a7122236270. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

