### PR TITLE
Use GH_ENTERPRISE_TOKEN for GitHub Enterprise workspaces

### DIFF
--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -33,7 +33,8 @@ Axon sets the following reserved environment variables on agent containers:
 | `CODEX_API_KEY` | API key for OpenAI Codex (`codex` agent, api-key or oauth credential type) | When agent type is `codex` |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (`claude-code` agent, oauth credential type) | When credential type is `oauth` and agent type is `claude-code` |
 | `GITHUB_TOKEN` | GitHub token for workspace access | When workspace has a `secretRef` |
-| `GH_TOKEN` | GitHub token (alias for GitHub CLI) | When workspace has a `secretRef` |
+| `GH_TOKEN` | GitHub token for `gh` CLI (github.com) | When workspace has a `secretRef` and repo is on github.com |
+| `GH_ENTERPRISE_TOKEN` | GitHub token for `gh` CLI (GitHub Enterprise) | When workspace has a `secretRef` and repo is on a GitHub Enterprise host |
 
 ### 4. User ID
 


### PR DESCRIPTION
## Summary
- The `gh` CLI uses `GH_TOKEN` for github.com but requires `GH_ENTERPRISE_TOKEN` for GitHub Enterprise Server hosts
- Previously, the job builder always set `GH_TOKEN` regardless of the target host, preventing `gh` from authenticating against enterprise instances
- Now the job builder sets `GH_ENTERPRISE_TOKEN` (instead of `GH_TOKEN`) when the workspace repository is hosted on a GitHub Enterprise Server

## Changes
- `internal/controller/job_builder.go`: Conditionally set `GH_TOKEN` or `GH_ENTERPRISE_TOKEN` based on whether the host is enterprise
- `internal/controller/job_builder_test.go`: Updated and expanded unit tests for both github.com and enterprise cases
- `test/integration/task_test.go`: Updated integration test to verify `GH_ENTERPRISE_TOKEN` is set for enterprise workspaces
- `docs/agent-image-interface.md`: Updated docs to reflect the new env var behavior

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make test-integration`)
- [x] Verification checks pass (`make verify`)
- [x] Build succeeds (`make build`)

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix gh CLI auth for GitHub Enterprise workspaces by setting GH_ENTERPRISE_TOKEN and GH_HOST; keep GH_TOKEN for github.com. Addresses axon-task-174 by enabling jobs to authenticate with both GitHub.com and GHE.

- **Bug Fixes**
  - Conditionally set GH_TOKEN (github.com) or GH_ENTERPRISE_TOKEN (GHE) in the job builder; set GH_HOST for enterprise hosts.
  - Updated unit and integration tests to verify the correct env vars for both cases.
  - Updated docs to clarify GH_TOKEN vs GH_ENTERPRISE_TOKEN behavior.

<sup>Written for commit dea798d9b3585cb9ae63b37b978c9b1f907baf61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

