### PR TITLE
Prompt user before overriding existing config and credentials

### DIFF
--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// stdinReader is the reader used for confirmation prompts.
+// It defaults to os.Stdin but can be overridden in tests.
+var stdinReader io.Reader = os.Stdin
+
+// confirmOverride prompts the user to confirm overriding an existing resource.
+// It returns true if the user answers "y" or "yes" (case-insensitive).
+// If the input is empty or cannot be read, it returns false.
+func confirmOverride(resource string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "Resource %s already exists. Override? [y/N]: ", resource)
+
+	reader := bufio.NewReader(stdinReader)
+	answer, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, nil
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "y" || answer == "yes", nil
+}

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestConfirmOverride_AcceptsYes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"YES\n", true},
+		{"Yes\n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"N\n", false},
+		{"\n", false},
+		{"something\n", false},
+		// Piped input without trailing newline (EOF).
+		{"y", true},
+		{"yes", true},
+		{"n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			old := stdinReader
+			stdinReader = strings.NewReader(tt.input)
+			defer func() { stdinReader = old }()
+
+			got, err := confirmOverride("secret/test")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("confirmOverride() = %v, want %v for input %q", got, tt.want, tt.input)
+			}
+		})
+	}
+}
+
+func TestConfirmOverride_EmptyInput(t *testing.T) {
+	old := stdinReader
+	stdinReader = bytes.NewReader(nil)
+	defer func() { stdinReader = old }()
+
+	got, err := confirmOverride("workspace/test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Error("expected false for empty input")
+	}
+}
+
+func TestConfirmOverride_IncludesResourceName(t *testing.T) {
+	old := stdinReader
+	stdinReader = strings.NewReader("n\n")
+	defer func() { stdinReader = old }()
+
+	// This just verifies the function runs without error with a resource name.
+	_, err := confirmOverride("secret/axon-credentials")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -35,6 +35,7 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 		secret string
 		token  string
 		dryRun bool
+		yes    bool
 	)
 
 	cmd := &cobra.Command{
@@ -65,7 +66,7 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 			if token != "" {
 				secretName := name + "-credentials"
 				if !dryRun {
-					if err := ensureCredentialSecret(cfg, secretName, "GITHUB_TOKEN", token); err != nil {
+					if err := ensureCredentialSecret(cfg, secretName, "GITHUB_TOKEN", token, yes); err != nil {
 						return err
 					}
 				}
@@ -98,6 +99,7 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&secret, "secret", "", "secret name containing GITHUB_TOKEN for git authentication")
 	cmd.Flags().StringVar(&token, "token", "", "GitHub token (auto-creates a secret)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print the resource that would be created without submitting it")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompts")
 
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("repo")


### PR DESCRIPTION
## Summary
- Add interactive confirmation prompt before overriding existing Kubernetes secrets or workspace resources during `axon run` and `axon create workspace`
- Add `--yes`/`-y` flag to skip confirmation for non-interactive and scripted use
- Add `confirmOverride` utility with unit tests

Fixes #176

## Test plan
- [x] Unit tests for `confirmOverride` covering yes/no/empty input
- [x] `make test` passes
- [x] `make verify` passes
- [x] `make build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prompts users before overriding existing Kubernetes secrets or Workspace resources in axon run and axon create workspace. Adds a --yes/-y flag to skip prompts and only prompts when changes would be made, addressing Linear issue #176.

- **New Features**
  - Prompt only when a secret’s data or a workspace’s spec differs; skip update if unchanged.
  - --yes/-y flag on run and create workspace to skip confirmation.
  - confirmOverride utility with tests; accepts piped input without a trailing newline (handles EOF).

<sup>Written for commit f8e2a97e926e790b6271c86032a84a27b472e911. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

