### PR TITLE
Wait for terminating resources before server-side apply

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -10,8 +10,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -60,6 +58,8 @@ func deleteControllerResources() {
 // restoreCRDs re-applies CRDs by running install followed by cleanup of
 // non-CRD resources. This restores the envtest environment after uninstall
 // removes CRDs that were originally loaded by the BeforeSuite.
+// The install command itself waits for any terminating CRDs before applying,
+// so we only need to clear namespace finalizers here.
 func restoreCRDs(kubeconfigPath string) {
 	// Wait for namespace termination to complete before re-installing.
 	clearNamespaceFinalizers()
@@ -67,19 +67,6 @@ func restoreCRDs(kubeconfigPath string) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: "axon-system"}, &corev1.Namespace{})
 		return apierrors.IsNotFound(err)
 	}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
-
-	// Wait for all CRDs to be fully deleted before reinstalling. If install's
-	// server-side apply patches a CRD that still has a deletionTimestamp, the
-	// patch succeeds but the CRD is still deleted, leaving the API unavailable.
-	crdGVK := schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
-	for _, name := range []string{"tasks.axon.io", "taskspawners.axon.io", "workspaces.axon.io"} {
-		Eventually(func() bool {
-			crd := &unstructured.Unstructured{}
-			crd.SetGroupVersionKind(crdGVK)
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, crd)
-			return apierrors.IsNotFound(err)
-		}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
-	}
 
 	reinstall := cli.NewRootCommand()
 	reinstall.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})


### PR DESCRIPTION
## Summary
- Fix `axon install` to wait for resources that have a `deletionTimestamp` before applying via server-side apply
- When a CRD is being deleted (has a `deletionTimestamp`), server-side apply succeeds but the CRD continues to be garbage collected, leaving the API unavailable
- This caused CRDs to be removed when re-running `local-run.sh` shortly after an uninstall

## Changes
- Added `waitForDeletion()` helper that polls until a resource is fully deleted
- Updated `applyManifests()` to check each resource for a `deletionTimestamp` before applying, waiting for deletion to complete if found
- Simplified `restoreCRDs()` in integration tests since the install command now handles the CRD deletion race internally
- Added unit tests for `waitForDeletion`

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make test-integration`) - confirmed the fix is active (logs show "Waiting for CustomResourceDefinition taskspawners.axon.io to be deleted")
- [x] Verification checks pass (`make verify`)

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for terminating resources before server-side apply in axon install, preventing CRDs from being re-applied while still deleting and avoiding API downtime. Fixes Linear #185.

- **Bug Fixes**
  - Added waitForDeletion (500ms poll, 60s timeout) and updated applyManifests to GET and pause when a resource has a deletionTimestamp.
  - Logs “Waiting for … to be deleted” and only applies after deletion completes, avoiding CRD GC after reinstall.
  - Simplified integration CRD restore; added unit tests for already-gone and eventually-deleted cases.

<sup>Written for commit 4382ca9b9ab290388e2f96ea178dfa091436e310. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

