### PR TITLE
Add --dry-run flag for run, create, and install commands

### DIFF
--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -1,0 +1,324 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCommand_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("secret: my-secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	cmd := NewRootCommand()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--dry-run",
+		"--prompt", "hello world",
+		"--name", "test-task",
+		"--namespace", "test-ns",
+	})
+
+	// Capture stdout.
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	if !strings.Contains(output, "kind: Task") {
+		t.Errorf("expected YAML output to contain 'kind: Task', got:\n%s", output)
+	}
+	if !strings.Contains(output, "name: test-task") {
+		t.Errorf("expected YAML output to contain 'name: test-task', got:\n%s", output)
+	}
+	if !strings.Contains(output, "namespace: test-ns") {
+		t.Errorf("expected YAML output to contain 'namespace: test-ns', got:\n%s", output)
+	}
+	if !strings.Contains(output, "prompt: hello world") {
+		t.Errorf("expected YAML output to contain 'prompt: hello world', got:\n%s", output)
+	}
+	if !strings.Contains(output, "my-secret") {
+		t.Errorf("expected YAML output to contain secret name 'my-secret', got:\n%s", output)
+	}
+	// Ensure no "created" message is printed.
+	if strings.Contains(output, "created") {
+		t.Errorf("dry-run should not print 'created' message, got:\n%s", output)
+	}
+}
+
+func TestRunCommand_DryRun_WithWorkspaceConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `secret: my-secret
+workspace:
+  repo: https://github.com/org/repo.git
+  ref: main
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--dry-run",
+		"--prompt", "hello",
+		"--name", "ws-task",
+		"--namespace", "test-ns",
+	})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	if !strings.Contains(output, "axon-workspace") {
+		t.Errorf("expected workspace reference 'axon-workspace' in dry-run output, got:\n%s", output)
+	}
+}
+
+func TestCreateWorkspaceCommand_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"create", "workspace",
+		"--config", cfgPath,
+		"--dry-run",
+		"--name", "my-ws",
+		"--repo", "https://github.com/org/repo.git",
+		"--ref", "main",
+		"--secret", "gh-token",
+		"--namespace", "test-ns",
+	})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	if !strings.Contains(output, "kind: Workspace") {
+		t.Errorf("expected 'kind: Workspace' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "name: my-ws") {
+		t.Errorf("expected 'name: my-ws' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "namespace: test-ns") {
+		t.Errorf("expected 'namespace: test-ns' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "https://github.com/org/repo.git") {
+		t.Errorf("expected repo URL in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "gh-token") {
+		t.Errorf("expected secret name in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "created") {
+		t.Errorf("dry-run should not print 'created' message, got:\n%s", output)
+	}
+}
+
+func TestCreateWorkspaceCommand_DryRun_WithToken(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"create", "workspace",
+		"--config", cfgPath,
+		"--dry-run",
+		"--name", "my-ws",
+		"--repo", "https://github.com/org/repo.git",
+		"--token", "ghp_test123",
+		"--namespace", "test-ns",
+	})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	// Token should produce a secret reference in the output.
+	if !strings.Contains(output, "my-ws-credentials") {
+		t.Errorf("expected auto-generated secret name 'my-ws-credentials' in output, got:\n%s", output)
+	}
+}
+
+func TestCreateTaskSpawnerCommand_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("secret: my-secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"create", "taskspawner",
+		"--config", cfgPath,
+		"--dry-run",
+		"--name", "my-spawner",
+		"--workspace", "my-ws",
+		"--namespace", "test-ns",
+	})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	if !strings.Contains(output, "kind: TaskSpawner") {
+		t.Errorf("expected 'kind: TaskSpawner' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "name: my-spawner") {
+		t.Errorf("expected 'name: my-spawner' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "my-secret") {
+		t.Errorf("expected secret name in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "created") {
+		t.Errorf("dry-run should not print 'created' message, got:\n%s", output)
+	}
+}
+
+func TestCreateTaskSpawnerCommand_DryRun_Cron(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("secret: my-secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"create", "taskspawner",
+		"--config", cfgPath,
+		"--dry-run",
+		"--name", "cron-spawner",
+		"--schedule", "*/5 * * * *",
+		"--namespace", "test-ns",
+	})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	if !strings.Contains(output, "kind: TaskSpawner") {
+		t.Errorf("expected 'kind: TaskSpawner' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "*/5 * * * *") {
+		t.Errorf("expected cron schedule in output, got:\n%s", output)
+	}
+}
+
+func TestInstallCommand_DryRun(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--dry-run"})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = old
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	out.ReadFrom(r)
+	output := out.String()
+
+	if !strings.Contains(output, "CustomResourceDefinition") {
+		t.Errorf("expected CRD manifest in dry-run output, got:\n%s", output[:min(len(output), 500)])
+	}
+	if !strings.Contains(output, "Deployment") {
+		t.Errorf("expected Deployment manifest in dry-run output, got:\n%s", output[:min(len(output), 500)])
+	}
+	// Should not contain installation messages.
+	if strings.Contains(output, "Installing axon") {
+		t.Errorf("dry-run should not print installation messages, got:\n%s", output[:min(len(output), 500)])
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--dry-run` flag to `axon run`, `axon create workspace`, `axon create taskspawner`, and `axon install` commands
- In dry-run mode, resources are printed as YAML (or raw manifests for `install`) without making any Kubernetes API calls
- No client connection, secret creation, or resource application occurs during dry-run

## Test plan
- [x] Unit tests for all dry-run paths (`internal/cli/dryrun_test.go`)
- [x] `make verify` passes
- [x] `make test` passes
- [x] `make build` passes
- [ ] CI passes

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a --dry-run flag to run, create (workspace/taskspawner), and install so users can preview YAML/manifests without touching the cluster. Addresses Linear #186 by enabling safe previews and skipping client connections, secret creation, and resource application.

- **New Features**
  - axon run --dry-run: prints Task YAML, resolves inline workspace config to "axon-workspace", skips secret creation.
  - axon create workspace/taskspawner --dry-run: prints YAML for the resource, GVK set, no client calls.
  - axon install --dry-run: prints CRD and versioned controller manifests, no install actions.
  - Client helpers: newClientOrDryRun returns nil client in dry-run; ResolveNamespace falls back to "default".
  - Tests: added dry-run coverage for run, create workspace/taskspawner, and install.

<sup>Written for commit 7aa3ad9b858d359b297493a79223cc8b371f2f14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

