### PR TITLE
Add actor labels to differentiate actors

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -106,3 +106,35 @@ jobs:
                 if (e.status !== 404) throw e;
               }
             }
+
+  actor-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove needs-actor label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const item = context.payload.issue || context.payload.pull_request;
+            const labels = item.labels.map(l => l.name);
+            const hasActor = labels.some(l => l.startsWith('actor/'));
+            const hasNeedsActor = labels.includes('needs-actor');
+
+            if (!hasActor && !hasNeedsActor) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                labels: ['needs-actor'],
+              });
+            } else if (hasActor && hasNeedsActor) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  name: 'needs-actor',
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }

--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   when:
     githubIssues:
+      labels:
+        - actor/axon
       excludeLabels:
         - axon/needs-input
   taskTemplate:


### PR DESCRIPTION
## Summary
- Add `needs-actor` / `actor/*` label automation to the Label workflow, following the same pattern as `needs-triage`, `needs-kind`, and `needs-priority`
- When an issue/PR has no `actor/*` label, `needs-actor` is auto-added; when an `actor/*` label is added, `needs-actor` is auto-removed
- Update the axon-workers prompt template to have the agent label issues with `actor/axon` in the pre-checklist

## Test plan
- [ ] Verify the `actor-label` workflow job triggers correctly on issue/PR open, label, and unlabel events
- [ ] Verify `needs-actor` is added automatically when no `actor/*` label is present
- [ ] Verify `needs-actor` is removed when an `actor/*` label (e.g., `actor/axon`) is added
- [ ] Verify the axon agent adds `actor/axon` to issues it works on via the updated prompt template

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates actor labeling on issues and PRs: adds needs-actor when no actor/* label exists and removes it when an actor/* is set. Updates Axon worker config to handle issues labeled actor/axon (fixes #189).

<sup>Written for commit 641400f5f9673c865b7fd2d408731e1eaf4f7588. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

