### PR TITLE
Add opencode agent type support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,8 @@ jobs:
           kind load docker-image gjkim42/axon-spawner:e2e
           kind load docker-image gjkim42/claude-code:e2e
           kind load docker-image gjkim42/codex:e2e
+          kind load docker-image gjkim42/gemini:e2e
+          kind load docker-image gjkim42/opencode:e2e
 
       - name: Build CLI
         run: make build WHAT=cmd/axon
@@ -88,7 +90,7 @@ jobs:
         run: |
           bin/axon install
           kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
-          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never","--codex-image=gjkim42/codex:e2e","--codex-image-pull-policy=Never"]}]}}}}'
+          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never","--codex-image=gjkim42/codex:e2e","--codex-image-pull-policy=Never","--gemini-image=gjkim42/gemini:e2e","--gemini-image-pull-policy=Never","--opencode-image=gjkim42/opencode:e2e","--opencode-image-pull-policy=Never"]}]}}}}'
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
       - name: E2E Test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image configuration
 REGISTRY ?= gjkim42
 VERSION ?= latest
-IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner cmd/axon-token-refresher claude-code codex gemini
+IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner cmd/axon-token-refresher claude-code codex gemini opencode
 
 # Version injection for the axon CLI – only set ldflags when an explicit
 # version is given so that dev builds fall through to runtime/debug info.

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ The [`examples/`](examples/) directory contains self-contained, ready-to-apply Y
 
 | Field | Description | Required |
 |-------|-------------|----------|
-| `spec.type` | Agent type (`claude-code`, `codex`, or `gemini`) | Yes |
+| `spec.type` | Agent type (`claude-code`, `codex`, `gemini`, or `opencode`) | Yes |
 | `spec.prompt` | Task prompt for the agent | Yes |
 | `spec.credentials.type` | `api-key` or `oauth` | Yes |
 | `spec.credentials.secretRef.name` | Secret name with credentials | Yes |
@@ -446,7 +446,7 @@ The [`examples/`](examples/) directory contains self-contained, ready-to-apply Y
 | `spec.when.githubIssues.state` | Filter by state: `open`, `closed`, `all` (default: `open`) | No |
 | `spec.when.githubIssues.types` | Filter by type: `issues`, `pulls` (default: `issues`) | No |
 | `spec.when.cron.schedule` | Cron schedule expression (e.g., `"0 * * * *"`) | Yes (when using cron) |
-| `spec.taskTemplate.type` | Agent type (`claude-code`, `codex`, or `gemini`) | Yes |
+| `spec.taskTemplate.type` | Agent type (`claude-code`, `codex`, `gemini`, or `opencode`) | Yes |
 | `spec.taskTemplate.credentials` | Credentials for the agent (same as Task) | Yes |
 | `spec.taskTemplate.model` | Model override | No |
 | `spec.taskTemplate.image` | Custom agent image override (see [Agent Image Interface](docs/agent-image-interface.md)) | No |
@@ -525,8 +525,8 @@ namespace: my-namespace
 
 | Field | Description |
 |-------|-------------|
-| `oauthToken` | OAuth token — Axon auto-creates the Kubernetes secret |
-| `apiKey` | API key — Axon auto-creates the Kubernetes secret |
+| `oauthToken` | OAuth token — Axon auto-creates the Kubernetes secret. Use `none` for an empty credential |
+| `apiKey` | API key — Axon auto-creates the Kubernetes secret. Use `none` for an empty credential (e.g., free-tier OpenCode models) |
 | `secret` | (Advanced) Use a pre-created Kubernetes secret |
 | `credentialType` | Credential type when using `secret` (`api-key` or `oauth`) |
 
@@ -565,7 +565,7 @@ If both `name` and `repo` are set, `name` takes precedence. The `--workspace` CL
 
 | Field | Description |
 |-------|-------------|
-| `type` | Default agent type (`claude-code`, `codex`, or `gemini`) |
+| `type` | Default agent type (`claude-code`, `codex`, `gemini`, or `opencode`) |
 | `model` | Default model override |
 | `namespace` | Default Kubernetes namespace |
 

--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -73,7 +73,7 @@ type PodOverrides struct {
 type TaskSpec struct {
 	// Type specifies the agent type (e.g., claude-code).
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=claude-code;codex;gemini
+	// +kubebuilder:validation:Enum=claude-code;codex;gemini;opencode
 	Type string `json:"type"`
 
 	// Prompt is the task prompt to send to the agent.

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -65,7 +65,7 @@ type GitHubIssues struct {
 type TaskTemplate struct {
 	// Type specifies the agent type (e.g., claude-code).
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=claude-code;codex;gemini
+	// +kubebuilder:validation:Enum=claude-code;codex;gemini;opencode
 	Type string `json:"type"`
 
 	// Credentials specifies how to authenticate with the agent.

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -38,6 +38,8 @@ func main() {
 	var codexImagePullPolicy string
 	var geminiImage string
 	var geminiImagePullPolicy string
+	var openCodeImage string
+	var openCodeImagePullPolicy string
 	var spawnerImage string
 	var spawnerImagePullPolicy string
 	var tokenRefresherImage string
@@ -54,6 +56,8 @@ func main() {
 	flag.StringVar(&codexImagePullPolicy, "codex-image-pull-policy", "", "The image pull policy for Codex agent containers (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&geminiImage, "gemini-image", controller.GeminiImage, "The image to use for Gemini CLI agent containers.")
 	flag.StringVar(&geminiImagePullPolicy, "gemini-image-pull-policy", "", "The image pull policy for Gemini CLI agent containers (e.g., Always, Never, IfNotPresent).")
+	flag.StringVar(&openCodeImage, "opencode-image", controller.OpenCodeImage, "The image to use for OpenCode agent containers.")
+	flag.StringVar(&openCodeImagePullPolicy, "opencode-image-pull-policy", "", "The image pull policy for OpenCode agent containers (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&spawnerImage, "spawner-image", controller.DefaultSpawnerImage, "The image to use for spawner Deployments.")
 	flag.StringVar(&spawnerImagePullPolicy, "spawner-image-pull-policy", "", "The image pull policy for spawner Deployments (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&tokenRefresherImage, "token-refresher-image", controller.DefaultTokenRefresherImage, "The image to use for the token refresher sidecar.")
@@ -91,6 +95,8 @@ func main() {
 	jobBuilder.CodexImagePullPolicy = corev1.PullPolicy(codexImagePullPolicy)
 	jobBuilder.GeminiImage = geminiImage
 	jobBuilder.GeminiImagePullPolicy = corev1.PullPolicy(geminiImagePullPolicy)
+	jobBuilder.OpenCodeImage = openCodeImage
+	jobBuilder.OpenCodeImagePullPolicy = corev1.PullPolicy(openCodeImagePullPolicy)
 	if err = (&controller.TaskReconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),

--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -32,6 +32,7 @@ Axon sets the following reserved environment variables on agent containers:
 | `ANTHROPIC_API_KEY` | API key for Anthropic (`claude-code` agent, api-key credential type) | When credential type is `api-key` and agent type is `claude-code` |
 | `CODEX_API_KEY` | API key for OpenAI Codex (`codex` agent, api-key or oauth credential type) | When agent type is `codex` |
 | `GEMINI_API_KEY` | API key for Google Gemini (`gemini` agent, api-key or oauth credential type) | When agent type is `gemini` |
+| `OPENCODE_API_KEY` | API key for OpenCode (`opencode` agent, api-key or oauth credential type) | When agent type is `opencode` |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (`claude-code` agent, oauth credential type) | When credential type is `oauth` and agent type is `claude-code` |
 | `GITHUB_TOKEN` | GitHub token for workspace access | When workspace has a `secretRef` |
 | `GH_TOKEN` | GitHub token for `gh` CLI (github.com) | When workspace has a `secretRef` and repo is on github.com |
@@ -100,3 +101,4 @@ Captured outputs are stored in `TaskStatus.Outputs` and displayed by the CLI.
 - `claude-code/axon_entrypoint.sh` — wraps the `claude` CLI (Anthropic Claude Code).
 - `codex/axon_entrypoint.sh` — wraps the `codex` CLI (OpenAI Codex).
 - `gemini/axon_entrypoint.sh` — wraps the `gemini` CLI (Google Gemini).
+- `opencode/axon_entrypoint.sh` — wraps the `opencode` CLI (OpenCode).

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -453,6 +453,7 @@ spec:
                 - claude-code
                 - codex
                 - gemini
+                - opencode
                 type: string
               workspaceRef:
                 description: WorkspaceRef optionally references a Workspace resource
@@ -889,6 +890,7 @@ spec:
                     - claude-code
                     - codex
                     - gemini
+                    - opencode
                     type: string
                   workspaceRef:
                     description: |-

--- a/internal/cli/logparser_opencode.go
+++ b/internal/cli/logparser_opencode.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// OpenCodeEvent represents a single NDJSON event from opencode run --format json.
+type OpenCodeEvent struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	SessionID string          `json:"sessionID,omitempty"`
+	Part      json.RawMessage `json:"part,omitempty"`
+}
+
+// openCodePart represents the nested part field in an OpenCode event.
+type openCodePart struct {
+	Type   string          `json:"type,omitempty"`
+	Text   string          `json:"text,omitempty"`
+	Tokens *openCodeTokens `json:"tokens,omitempty"`
+}
+
+// openCodeTokens holds token usage from step_finish events.
+type openCodeTokens struct {
+	Input  int `json:"input,omitempty"`
+	Output int `json:"output,omitempty"`
+}
+
+// ParseAndFormatOpenCodeLogs reads NDJSON lines from opencode run --format json
+// and writes formatted output: text content goes to stdout, status info goes
+// to stderr. Non-JSON lines are passed through to stdout as-is.
+func ParseAndFormatOpenCodeLogs(r io.Reader, stdout, stderr io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event OpenCodeEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			// Not valid JSON; pass through as-is.
+			fmt.Fprintf(stdout, "%s\n", line)
+			continue
+		}
+
+		switch event.Type {
+		case "text":
+			if event.Text != "" {
+				fmt.Fprint(stdout, event.Text)
+			} else if len(event.Part) > 0 {
+				var part openCodePart
+				if err := json.Unmarshal(event.Part, &part); err == nil && part.Text != "" {
+					fmt.Fprint(stdout, part.Text)
+				}
+			}
+		case "step_start":
+			// Step boundaries are not displayed by default.
+		case "step_finish":
+			if len(event.Part) > 0 {
+				var part openCodePart
+				if err := json.Unmarshal(event.Part, &part); err == nil && part.Tokens != nil {
+					fmt.Fprintf(stderr, "\n[result] completed (input=%d, output=%d)\n",
+						part.Tokens.Input, part.Tokens.Output)
+				} else {
+					fmt.Fprintf(stderr, "\n[result] completed\n")
+				}
+			} else {
+				fmt.Fprintf(stderr, "\n[result] completed\n")
+			}
+		}
+	}
+
+	return scanner.Err()
+}

--- a/internal/cli/logparser_opencode_test.go
+++ b/internal/cli/logparser_opencode_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseAndFormatOpenCodeLogs(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "text event with top-level text field",
+			input:      `{"type":"text","text":"Here is the explanation of context in Go."}`,
+			wantStdout: "Here is the explanation of context in Go.",
+			wantStderr: "",
+		},
+		{
+			name:       "text event with nested part text",
+			input:      `{"type":"text","part":{"type":"text","text":"Hello world"}}`,
+			wantStdout: "Hello world",
+			wantStderr: "",
+		},
+		{
+			name:       "step_finish event with tokens",
+			input:      `{"type":"step_finish","part":{"tokens":{"input":100,"output":50}}}`,
+			wantStdout: "",
+			wantStderr: "\n[result] completed (input=100, output=50)\n",
+		},
+		{
+			name:       "step_finish event without tokens",
+			input:      `{"type":"step_finish","part":{"type":"step_finish"}}`,
+			wantStdout: "",
+			wantStderr: "\n[result] completed\n",
+		},
+		{
+			name:       "step_finish event without part",
+			input:      `{"type":"step_finish"}`,
+			wantStdout: "",
+			wantStderr: "\n[result] completed\n",
+		},
+		{
+			name:       "step_start event is silent",
+			input:      `{"type":"step_start","sessionID":"abc123"}`,
+			wantStdout: "",
+			wantStderr: "",
+		},
+		{
+			name:       "non-JSON passthrough",
+			input:      "this is plain text output",
+			wantStdout: "this is plain text output\n",
+			wantStderr: "",
+		},
+		{
+			name:       "empty input",
+			input:      "",
+			wantStdout: "",
+			wantStderr: "",
+		},
+		{
+			name: "multiple NDJSON events",
+			input: `{"type":"step_start","sessionID":"s1"}
+{"type":"text","text":"Line one."}
+{"type":"text","text":"\nLine two."}
+{"type":"step_finish","part":{"tokens":{"input":200,"output":75}}}`,
+			wantStdout: "Line one.\nLine two.",
+			wantStderr: "\n[result] completed (input=200, output=75)\n",
+		},
+		{
+			name:       "unknown event type is ignored",
+			input:      `{"type":"unknown_event","data":"something"}`,
+			wantStdout: "",
+			wantStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			err := ParseAndFormatOpenCodeLogs(strings.NewReader(tt.input), &stdout, &stderr)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got := stdout.String(); got != tt.wantStdout {
+				t.Errorf("stdout:\n got: %q\nwant: %q", got, tt.wantStdout)
+			}
+			if got := stderr.String(); got != tt.wantStderr {
+				t.Errorf("stderr:\n got: %q\nwant: %q", got, tt.wantStderr)
+			}
+		})
+	}
+}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -158,6 +158,8 @@ func streamAgentLogs(ctx context.Context, cs *kubernetes.Clientset, namespace, p
 			return ParseAndFormatCodexLogs(stream, os.Stdout, os.Stderr)
 		case "gemini":
 			return ParseAndFormatGeminiLogs(stream, os.Stdout, os.Stderr)
+		case "opencode":
+			return ParseAndFormatOpenCodeLogs(stream, os.Stdout, os.Stderr)
 		default:
 			return ParseAndFormatLogs(stream, os.Stdout, os.Stderr)
 		}

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -23,6 +23,9 @@ const (
 	// GeminiImage is the default image for Google Gemini CLI agent.
 	GeminiImage = "gjkim42/gemini:latest"
 
+	// OpenCodeImage is the default image for OpenCode agent.
+	OpenCodeImage = "gjkim42/opencode:latest"
+
 	// AgentTypeClaudeCode is the agent type for Claude Code.
 	AgentTypeClaudeCode = "claude-code"
 
@@ -31,6 +34,9 @@ const (
 
 	// AgentTypeGemini is the agent type for Google Gemini CLI.
 	AgentTypeGemini = "gemini"
+
+	// AgentTypeOpenCode is the agent type for OpenCode.
+	AgentTypeOpenCode = "opencode"
 
 	// GitCloneImage is the image used for cloning git repositories.
 	GitCloneImage = "alpine/git:v2.47.2"
@@ -65,6 +71,8 @@ type JobBuilder struct {
 	CodexImagePullPolicy      corev1.PullPolicy
 	GeminiImage               string
 	GeminiImagePullPolicy     corev1.PullPolicy
+	OpenCodeImage             string
+	OpenCodeImagePullPolicy   corev1.PullPolicy
 }
 
 // NewJobBuilder creates a new JobBuilder.
@@ -73,6 +81,7 @@ func NewJobBuilder() *JobBuilder {
 		ClaudeCodeImage: ClaudeCodeImage,
 		CodexImage:      CodexImage,
 		GeminiImage:     GeminiImage,
+		OpenCodeImage:   OpenCodeImage,
 	}
 }
 
@@ -85,6 +94,8 @@ func (b *JobBuilder) Build(task *axonv1alpha1.Task, workspace *axonv1alpha1.Work
 		return b.buildAgentJob(task, workspace, agentConfig, b.CodexImage, b.CodexImagePullPolicy)
 	case AgentTypeGemini:
 		return b.buildAgentJob(task, workspace, agentConfig, b.GeminiImage, b.GeminiImagePullPolicy)
+	case AgentTypeOpenCode:
+		return b.buildAgentJob(task, workspace, agentConfig, b.OpenCodeImage, b.OpenCodeImagePullPolicy)
 	default:
 		return nil, fmt.Errorf("unsupported agent type: %s", task.Spec.Type)
 	}
@@ -102,6 +113,10 @@ func apiKeyEnvVar(agentType string) string {
 		// GEMINI_API_KEY is the environment variable that the gemini CLI
 		// reads for API key authentication.
 		return "GEMINI_API_KEY"
+	case AgentTypeOpenCode:
+		// OPENCODE_API_KEY is the environment variable that the opencode
+		// entrypoint reads for API key authentication.
+		return "OPENCODE_API_KEY"
 	default:
 		return "ANTHROPIC_API_KEY"
 	}
@@ -115,6 +130,8 @@ func oauthEnvVar(agentType string) string {
 		return "CODEX_API_KEY"
 	case AgentTypeGemini:
 		return "GEMINI_API_KEY"
+	case AgentTypeOpenCode:
+		return "OPENCODE_API_KEY"
 	default:
 		return "CLAUDE_CODE_OAUTH_TOKEN"
 	}

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -453,6 +453,7 @@ spec:
                 - claude-code
                 - codex
                 - gemini
+                - opencode
                 type: string
               workspaceRef:
                 description: WorkspaceRef optionally references a Workspace resource
@@ -889,6 +890,7 @@ spec:
                     - claude-code
                     - codex
                     - gemini
+                    - opencode
                     type: string
                   workspaceRef:
                     description: |-

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:24.04
+
+ARG GO_VERSION=1.25.0
+
+RUN apt-get update && apt-get install -y \
+    make \
+    curl \
+    ca-certificates \
+    git \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ARCH=$(dpkg --print-architecture) \
+    && TARBALL="go${GO_VERSION}.linux-${ARCH}.tar.gz" \
+    && curl -fsSL -o "/tmp/${TARBALL}" "https://dl.google.com/go/${TARBALL}" \
+    && curl -fsSL -o "/tmp/${TARBALL}.sha256" "https://dl.google.com/go/${TARBALL}.sha256" \
+    && echo "$(cat /tmp/${TARBALL}.sha256)  /tmp/${TARBALL}" | sha256sum -c - \
+    && tar -C /usr/local -xzf "/tmp/${TARBALL}" \
+    && rm "/tmp/${TARBALL}" "/tmp/${TARBALL}.sha256"
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN npm install -g opencode-ai
+
+COPY opencode/axon_entrypoint.sh /axon_entrypoint.sh
+RUN chmod +x /axon_entrypoint.sh
+
+COPY axon/capture-outputs.sh /axon/capture-outputs.sh
+RUN chmod +x /axon/capture-outputs.sh
+
+RUN useradd -u 61100 -m -s /bin/bash agent
+RUN mkdir -p /home/agent/.opencode && chown -R agent:agent /home/agent
+
+USER agent
+
+ENV GOPATH="/home/agent/go"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+WORKDIR /workspace
+
+ENTRYPOINT ["opencode"]

--- a/opencode/axon_entrypoint.sh
+++ b/opencode/axon_entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# axon_entrypoint.sh — Axon agent image interface implementation for
+# OpenCode CLI.
+#
+# Interface contract:
+#   - First argument ($1): the task prompt
+#   - AXON_MODEL env var: model name (optional, provider/model format)
+#   - OPENCODE_API_KEY env var: API key forwarded to the provider
+#   - UID 61100: shared between git-clone init container and agent
+#   - Working directory: /workspace/repo when a workspace is configured
+
+set -uo pipefail
+
+PROMPT="${1:?Prompt argument is required}"
+
+# Map OPENCODE_API_KEY to the correct provider environment variable
+# based on the provider prefix in AXON_MODEL.
+if [ -n "${OPENCODE_API_KEY:-}" ] && [ -n "${AXON_MODEL:-}" ]; then
+  PROVIDER="${AXON_MODEL%%/*}"
+  case "$PROVIDER" in
+    anthropic) export ANTHROPIC_API_KEY="$OPENCODE_API_KEY" ;;
+    openai) export OPENAI_API_KEY="$OPENCODE_API_KEY" ;;
+    google) export GEMINI_API_KEY="$OPENCODE_API_KEY" ;;
+    groq) export GROQ_API_KEY="$OPENCODE_API_KEY" ;;
+    xai) export XAI_API_KEY="$OPENCODE_API_KEY" ;;
+    opencode | zen)
+      # Zen/OpenCode models: no provider-specific key mapping needed.
+      ;;
+    *)
+      echo "Warning: Unrecognized provider prefix '$PROVIDER' in AXON_MODEL, defaulting to Anthropic" >&2
+      export ANTHROPIC_API_KEY="$OPENCODE_API_KEY"
+      ;;
+  esac
+elif [ -n "${OPENCODE_API_KEY:-}" ]; then
+  # Default to Anthropic when no model is specified.
+  export ANTHROPIC_API_KEY="$OPENCODE_API_KEY"
+fi
+
+ARGS=(
+  "run"
+  "--format" "json"
+  "$PROMPT"
+)
+
+if [ -n "${AXON_MODEL:-}" ]; then
+  ARGS+=("--model" "$AXON_MODEL")
+fi
+
+opencode "${ARGS[@]}"
+AGENT_EXIT_CODE=$?
+
+/axon/capture-outputs.sh
+
+exit $AGENT_EXIT_CODE

--- a/test/e2e/opencode_test.go
+++ b/test/e2e/opencode_test.go
@@ -1,0 +1,72 @@
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const openCodeTaskName = "e2e-opencode-task"
+
+// openCodeTestModel uses a free OpenCode model so e2e tests require no authentication.
+const openCodeTestModel = "opencode/big-pickle"
+
+var _ = Describe("OpenCode Task", func() {
+	BeforeEach(func() {
+		By("cleaning up existing resources")
+		kubectl("delete", "secret", "opencode-credentials", "--ignore-not-found")
+		kubectl("delete", "task", openCodeTaskName, "--ignore-not-found")
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			By("collecting debug info on failure")
+			debugTask(openCodeTaskName)
+		}
+
+		By("cleaning up test resources")
+		kubectl("delete", "task", openCodeTaskName, "--ignore-not-found")
+		kubectl("delete", "secret", "opencode-credentials", "--ignore-not-found")
+	})
+
+	It("should run an OpenCode Task to completion", func() {
+		By("creating credentials secret (empty key for free OpenCode model)")
+		Expect(kubectlWithInput("", "create", "secret", "generic", "opencode-credentials",
+			"--from-literal=OPENCODE_API_KEY=")).To(Succeed())
+
+		By("creating an OpenCode Task")
+		taskYAML := `apiVersion: axon.io/v1alpha1
+kind: Task
+metadata:
+  name: ` + openCodeTaskName + `
+spec:
+  type: opencode
+  model: ` + openCodeTestModel + `
+  prompt: "Print 'Hello from OpenCode e2e test' to stdout"
+  credentials:
+    type: api-key
+    secretRef:
+      name: opencode-credentials
+`
+		Expect(kubectlWithInput(taskYAML, "apply", "-f", "-")).To(Succeed())
+
+		By("waiting for Job to be created")
+		Eventually(func() error {
+			return kubectlWithInput("", "get", "job", openCodeTaskName)
+		}, 30*time.Second, time.Second).Should(Succeed())
+
+		By("waiting for Job to complete")
+		Eventually(func() error {
+			return kubectlWithInput("", "wait", "--for=condition=complete", "job/"+openCodeTaskName, "--timeout=10s")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("verifying Task status is Succeeded")
+		output := kubectlOutput("get", "task", openCodeTaskName, "-o", "jsonpath={.status.phase}")
+		Expect(output).To(Equal("Succeeded"))
+
+		By("getting Job logs")
+		logs := kubectlOutput("logs", "job/"+openCodeTaskName)
+		GinkgoWriter.Printf("Job logs:\n%s\n", logs)
+	})
+})


### PR DESCRIPTION
## Summary
- Add `opencode` as a new agent type, joining `claude-code`, `codex`, and `gemini`
- OpenCode is a multi-provider AI coding agent (opencode-ai/opencode) that supports Anthropic, OpenAI, Google Gemini, Groq, xAI, and other LLM providers
- The entrypoint maps `OPENCODE_API_KEY` to the correct provider-specific environment variable (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) based on the provider prefix in `AXON_MODEL`

### Changes
- **Controller**: Add `AgentTypeOpenCode` constant, `OpenCodeImage` default, and `JobBuilder` configuration with `--opencode-image` / `--opencode-image-pull-policy` flags
- **Agent image**: Add `opencode/Dockerfile` and `opencode/axon_entrypoint.sh` implementing the agent image interface
- **Credentials**: Add `OPENCODE_API_KEY` env var for both API key and OAuth credential types
- **CLI**: Add `opencode` to `--type` flag completions and credential key mappings in `run.go`
- **Log parser**: Add `ParseAndFormatOpenCodeLogs` for OpenCode's `{"response": "..."}` JSON output format
- **Docs**: Update `agent-image-interface.md` with `OPENCODE_API_KEY` and reference implementation
- **Build**: Add `opencode` to `IMAGE_DIRS` in Makefile

## Test plan
- [x] All existing unit tests pass (`make test`)
- [x] All verification checks pass (`make verify`)
- [x] Build succeeds (`make build`)
- [x] Added unit tests for OpenCode job builder (default image, custom image, workspace, OAuth)
- [x] Added unit tests for OpenCode log parser (JSON response, empty, non-JSON passthrough)
- [ ] CI tests pass

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode as a new agent type to meet axon-task-184, enabling multi-provider coding models with NDJSON log streaming. Supports free-tier models by allowing an empty OPENCODE_API_KEY via a "none" config value.

- **New Features**
  - Controller/CLI: added OpenCode type, --opencode-image/--opencode-image-pull-policy flags, type completion, OPENCODE_API_KEY mapping for api-key and oauth, "none" mapped to an empty secret, and wired OpenCode logs to a new NDJSON parser.
  - Agent image: new opencode Dockerfile and entrypoint run "opencode run --format json", mapping OPENCODE_API_KEY to provider vars from AXON_MODEL (anthropic/openai/google/groq/xai/opencode/zen) with an Anthropic fallback.
  - Schema/Build/CI/Docs: CRDs include "opencode"; Makefile builds opencode; CI loads gemini/opencode images and sets controller flags; docs list OPENCODE_API_KEY and README documents "none".
  - Tests: unit (job builder, OpenCode parser, resolveCredentialValue/dry-run), integration (Task), and e2e using opencode/big-pickle with an empty key.

- **Migration**
  - Set Task/TaskSpawner type to "opencode" and provide an OPENCODE_API_KEY secret (use "none" in config for empty keys).
  - Optionally set --opencode-image and --opencode-image-pull-policy on the controller.
  - Set AXON_MODEL with a provider prefix (e.g., anthropic/..., openai/..., google/...); defaults to Anthropic if unset.

<sup>Written for commit a8a1597b0226645a2b9ce7a8fd37efccba2fd9fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

