### PR TITLE
Fix incorrect delete command example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ axon get taskspawners
 axon logs my-task -f
 
 # Delete a task
-axon delete my-task
+axon delete task my-task
 
 # Uninstall axon from the cluster
 axon uninstall


### PR DESCRIPTION
## Summary
- Fix the delete command example on README line 452: `axon delete my-task` -> `axon delete task my-task`
- The `delete` command requires a resource type (`task`, `workspace`, or `taskspawner`) as a subcommand

Fixes #208

## Test plan
- [x] Verified the correct CLI syntax by inspecting `internal/cli/delete.go` — the delete command requires a resource type and returns an error without one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delete command example in the README to include the required resource type: use `axon delete task my-task` instead of `axon delete my-task`. Aligns docs with CLI behavior per issue #208.

<sup>Written for commit aff2714fbda3ac6fdb3858f3300ca8befd776f3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

