### PR TITLE
CLI UX: Improve error messages for missing arguments

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -33,7 +33,15 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 		Use:     "task <name>",
 		Aliases: []string{"tasks"},
 		Short:   "Delete a task",
-		Args:    cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("task name is required\nUsage: %s", cmd.Use)
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("too many arguments: expected 1 task name, got %d\nUsage: %s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {
@@ -65,7 +73,15 @@ func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 		Use:     "workspace <name>",
 		Aliases: []string{"workspaces", "ws"},
 		Short:   "Delete a workspace",
-		Args:    cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("workspace name is required\nUsage: %s", cmd.Use)
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("too many arguments: expected 1 workspace name, got %d\nUsage: %s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {
@@ -97,7 +113,15 @@ func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 		Use:     "taskspawner <name>",
 		Aliases: []string{"taskspawners", "ts"},
 		Short:   "Delete a task spawner",
-		Args:    cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("task spawner name is required\nUsage: %s", cmd.Use)
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("too many arguments: expected 1 task spawner name, got %d\nUsage: %s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -22,7 +22,15 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs <name>",
 		Short: "View logs from a task's pod",
-		Args:  cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("task name is required\nUsage: %s", cmd.Use)
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("too many arguments: expected 1 task name, got %d\nUsage: %s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, ns, err := cfg.NewClient()
 			if err != nil {


### PR DESCRIPTION
## Summary
Replace generic "accepts 1 arg(s), received 0" error with descriptive messages that clearly state what argument is required.

## Changes
Before:
```
$ axon delete task
Error: accepts 1 arg(s), received 0
```

After:
```
$ axon delete task
Error: task name is required
Usage: task <name>
```

Updated commands:
- `axon delete task`
- `axon delete workspace`  
- `axon delete taskspawner`
- `axon logs`

Also improved "too many arguments" error to show expected vs actual count.

## Test plan
- [x] Tested `axon delete task` without arguments - shows "task name is required"
- [x] Tested `axon logs` without arguments - shows "task name is required"
- [x] Tested with too many arguments - shows "expected 1, got N"
- [x] Ran `make verify` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CLI errors clearer when you forget a required name or pass too many args. Each command now says which name is required and shows usage; “too many arguments” now reports expected vs actual.

- **Bug Fixes**
  - axon delete task: “task name is required”
  - axon delete workspace: “workspace name is required”
  - axon delete taskspawner: “task spawner name is required”
  - axon logs: “task name is required”

<sup>Written for commit f7018a8fffea74a40dc9f95abeb76a1e489ad5ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

