### PR TITLE
docs: Update reference documentation with missing fields and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ The key pattern here is `excludeLabels: [axon/needs-input]` — this creates a f
 | `spec.credentials.type` | `api-key` or `oauth` | Yes |
 | `spec.credentials.secretRef.name` | Secret name with credentials | Yes |
 | `spec.model` | Model override (e.g., `claude-sonnet-4-20250514`) | No |
+| `spec.image` | Custom agent image override | No |
 | `spec.workspaceRef.name` | Name of a Workspace resource to use | No |
+| `spec.ttlSecondsAfterFinished` | Auto-delete task after N seconds (0 for immediate) | No |
 
 </details>
 
@@ -337,8 +339,11 @@ The key pattern here is `excludeLabels: [axon/needs-input]` — this creates a f
 | `spec.taskTemplate.type` | Agent type (`claude-code`, `codex`, or `gemini`) | Yes |
 | `spec.taskTemplate.credentials` | Credentials for the agent (same as Task) | Yes |
 | `spec.taskTemplate.model` | Model override | No |
+| `spec.taskTemplate.image` | Custom agent image override | No |
 | `spec.taskTemplate.promptTemplate` | Go text/template for prompt (`{{.Title}}`, `{{.Body}}`, `{{.Number}}`, etc.) | No |
+| `spec.taskTemplate.ttlSecondsAfterFinished` | Auto-delete spawned tasks after N seconds | No |
 | `spec.pollInterval` | How often to poll the source (default: `5m`) | No |
+| `spec.maxConcurrency` | Limit max concurrent running tasks | No |
 
 </details>
 
@@ -352,6 +357,21 @@ The key pattern here is `excludeLabels: [axon/needs-input]` — this creates a f
 | `status.podName` | Name of the Pod running the Task |
 | `status.startTime` | When the Task started running |
 | `status.completionTime` | When the Task completed |
+| `status.message` | Additional information about the current status |
+
+</details>
+
+<details>
+<summary><strong>TaskSpawner Status</strong></summary>
+
+| Field | Description |
+|-------|-------------|
+| `status.phase` | Current phase: `Pending`, `Running`, or `Failed` |
+| `status.deploymentName` | Name of the Deployment running the spawner |
+| `status.totalDiscovered` | Total number of items discovered from the source |
+| `status.totalTasksCreated` | Total number of Tasks created by this spawner |
+| `status.activeTasks` | Number of currently active (non-terminal) Tasks |
+| `status.lastDiscoveryTime` | Last time the source was polled |
 | `status.message` | Additional information about the current status |
 
 </details>
@@ -413,6 +433,7 @@ If both `name` and `repo` are set, `name` takes precedence. The `--workspace` CL
 
 | Field | Description |
 |-------|-------------|
+| `type` | Default agent type (`claude-code`, `codex`, or `gemini`) |
 | `model` | Default model override |
 | `namespace` | Default Kubernetes namespace |
 

--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -36,6 +36,7 @@ Axon sets the following reserved environment variables on agent containers:
 | `GITHUB_TOKEN` | GitHub token for workspace access | When workspace has a `secretRef` |
 | `GH_TOKEN` | GitHub token for `gh` CLI (github.com) | When workspace has a `secretRef` and repo is on github.com |
 | `GH_ENTERPRISE_TOKEN` | GitHub token for `gh` CLI (GitHub Enterprise) | When workspace has a `secretRef` and repo is on a GitHub Enterprise host |
+| `GH_HOST` | Hostname for GitHub Enterprise | When repo is on a GitHub Enterprise host |
 
 ### 4. User ID
 

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -139,7 +139,7 @@ To adapt these examples for your own repository:
 
 3. **Customize the prompt:**
    - Edit `spec.taskTemplate.promptTemplate` to match your workflow
-   - Available template variables: `{{.Number}}`, `{{.Title}}`, `{{.Body}}`, `{{.URL}}`
+   - Available template variables: `{{.Number}}`, `{{.Title}}`, `{{.Body}}`, `{{.URL}}`, `{{.Comments}}`, `{{.Labels}}`, `{{.Kind}}`
 
 4. **Set the polling interval:**
    ```yaml


### PR DESCRIPTION
This PR updates the reference documentation in README.md, docs/agent-image-interface.md, and self-development/README.md to include missing fields, environment variables, and template variables that were recently added to the codebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated reference docs to include newly supported fields and variables. Covers agent image overrides, task TTLs, max concurrency, TaskSpawner status fields, GH_HOST for GitHub Enterprise, new prompt template variables (Comments, Labels, Kind), and the default agent type in CLI config.

<sup>Written for commit 9dab7153318ff87915574bf4922ef9e608213282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

