### PR TITLE
test: prevent install/uninstall unit tests from using real kube context

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/axon-core/axon/internal/manifests"
@@ -160,20 +161,39 @@ func TestParseManifests_EmbeddedController(t *testing.T) {
 
 func TestInstallCommand_SkipsConfigLoading(t *testing.T) {
 	cmd := NewRootCommand()
-	cmd.SetArgs([]string{"install", "--config", "/nonexistent/path/config.yaml"})
+	cmd.SetArgs([]string{
+		"install",
+		"--config", "/nonexistent/path/config.yaml",
+		"--kubeconfig", "/nonexistent/path/kubeconfig",
+	})
 	err := cmd.Execute()
-	// We expect an error (no cluster), but not a config-loading error.
-	if err != nil && err.Error() == "loading config: open /nonexistent/path/config.yaml: no such file or directory" {
+	if err == nil {
+		t.Fatal("expected install to fail with invalid kubeconfig")
+	}
+	if err.Error() == "loading config: open /nonexistent/path/config.yaml: no such file or directory" {
 		t.Fatal("install should not fail on missing config file")
+	}
+	if !strings.Contains(err.Error(), "loading kubeconfig:") {
+		t.Fatalf("expected kubeconfig loading error, got %v", err)
 	}
 }
 
 func TestUninstallCommand_SkipsConfigLoading(t *testing.T) {
 	cmd := NewRootCommand()
-	cmd.SetArgs([]string{"uninstall", "--config", "/nonexistent/path/config.yaml"})
+	cmd.SetArgs([]string{
+		"uninstall",
+		"--config", "/nonexistent/path/config.yaml",
+		"--kubeconfig", "/nonexistent/path/kubeconfig",
+	})
 	err := cmd.Execute()
-	if err != nil && err.Error() == "loading config: open /nonexistent/path/config.yaml: no such file or directory" {
+	if err == nil {
+		t.Fatal("expected uninstall to fail with invalid kubeconfig")
+	}
+	if err.Error() == "loading config: open /nonexistent/path/config.yaml: no such file or directory" {
 		t.Fatal("uninstall should not fail on missing config file")
+	}
+	if !strings.Contains(err.Error(), "loading kubeconfig:") {
+		t.Fatalf("expected kubeconfig loading error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Update install/uninstall CLI unit tests to pass an explicit invalid --kubeconfig.
- Assert kubeconfig loading errors so tests fail before any API call to the current context.
- Keep behavior under test (config-loading skip for install/uninstall) without touching a live cluster.

Why:
make test runs internal/cli tests. The previous tests used only --config /nonexistent, but install/uninstall skip config loading and then fall back to default kubeconfig/context, which can execute against a real cluster.

Test:
- make test

fixes #185


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent install/uninstall CLI unit tests from touching the default kube context by passing an explicit invalid --kubeconfig and asserting kubeconfig load errors. This makes tests fail early and avoids any call to a real cluster while keeping the "skip config loading" behavior.

- **Bug Fixes**
  - Force invalid --kubeconfig in install/uninstall tests and expect "loading kubeconfig" errors.
  - Preserve config-loading skip and block accidental API calls to the current context.

<sup>Written for commit 9b82ae6e9b6174b78d607d59a10798a4d63e5cc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

