### PR TITLE
Generate controller RBAC from kubebuilder markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,7 @@ test-e2e: ginkgo ## Run e2e tests (requires cluster and CLAUDE_CODE_OAUTH_TOKEN)
 .PHONY: update
 update: controller-gen ## Run all generators and formatters.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
-	$(CONTROLLER_GEN) crd paths="./..." output:crd:stdout > install-crd.yaml
-	cp install-crd.yaml internal/manifests/install-crd.yaml
-	cp install.yaml internal/manifests/install.yaml
+	hack/update-install-manifest.sh $(CONTROLLER_GEN)
 	go fmt ./...
 	go mod tidy
 

--- a/hack/update-install-manifest.sh
+++ b/hack/update-install-manifest.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONTROLLER_GEN="${1:?Usage: update-install-manifest.sh <controller-gen-binary>}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+START_MARKER="# BEGIN GENERATED: controller-rbac"
+END_MARKER="# END GENERATED: controller-rbac"
+
+has_resource() {
+  local file="$1"
+  local kind="$2"
+  local name="$3"
+
+  awk -v want_kind="${kind}" -v want_name="${name}" '
+function reset_doc() {
+  doc_kind = ""
+  meta_name = ""
+  in_metadata = 0
+}
+BEGIN {
+  reset_doc()
+  found = 0
+}
+$0 == "---" {
+  if (doc_kind == want_kind && meta_name == want_name) {
+    found = 1
+    exit
+  }
+  reset_doc()
+  next
+}
+$0 ~ /^kind:[[:space:]]+/ {
+  doc_kind = $2
+  next
+}
+$0 ~ /^metadata:[[:space:]]*$/ {
+  in_metadata = 1
+  next
+}
+in_metadata {
+  if ($0 ~ /^[^[:space:]]/) {
+    in_metadata = 0
+    next
+  }
+  if ($0 ~ /^[[:space:]]+name:[[:space:]]+/) {
+    meta_name = $2
+    gsub(/"/, "", meta_name)
+    in_metadata = 0
+  }
+}
+END {
+  if (doc_kind == want_kind && meta_name == want_name) {
+    found = 1
+  }
+  exit(found ? 0 : 1)
+}
+' "${file}"
+}
+
+validate_manifest_resources() {
+  local file="$1"
+  local -a required=(
+    "Namespace axon-system"
+    "ServiceAccount axon-controller"
+    "ClusterRole axon-controller-role"
+    "ClusterRole axon-spawner-role"
+    "ClusterRoleBinding axon-controller-rolebinding"
+    "Role axon-leader-election-role"
+    "RoleBinding axon-leader-election-rolebinding"
+    "Deployment axon-controller-manager"
+  )
+
+  local entry
+  for entry in "${required[@]}"; do
+    local kind="${entry%% *}"
+    local name="${entry#* }"
+    if ! has_resource "${file}" "${kind}" "${name}"; then
+      echo "ERROR: install.yaml missing required resource ${kind}/${name}"
+      exit 1
+    fi
+  done
+}
+
+if [[ "$(grep -Fxc "${START_MARKER}" install.yaml)" -ne 1 ]]; then
+  echo "ERROR: install.yaml must contain exactly one '${START_MARKER}' marker"
+  exit 1
+fi
+
+if [[ "$(grep -Fxc "${END_MARKER}" install.yaml)" -ne 1 ]]; then
+  echo "ERROR: install.yaml must contain exactly one '${END_MARKER}' marker"
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+# Regenerate CRDs before syncing manifests.
+"${CONTROLLER_GEN}" crd paths="./..." output:crd:stdout > install-crd.yaml
+
+RBAC_FILE="${TMPDIR}/rbac.yaml"
+GOCACHE="${TMPDIR}/go-build-cache" "${CONTROLLER_GEN}" \
+  rbac:roleName=axon-controller-role \
+  paths="./..." \
+  output:rbac:stdout > "${RBAC_FILE}"
+
+awk -v start="${START_MARKER}" -v end="${END_MARKER}" -v rbac="${RBAC_FILE}" '
+$0 == start {
+  print
+  while ((getline line < rbac) > 0) {
+    print line
+  }
+  close(rbac)
+  in_generated_block = 1
+  next
+}
+$0 == end {
+  in_generated_block = 0
+  print
+  next
+}
+!in_generated_block {
+  print
+}
+' install.yaml > "${TMPDIR}/install.yaml"
+
+validate_manifest_resources "${TMPDIR}/install.yaml"
+
+mv "${TMPDIR}/install.yaml" install.yaml
+cp install-crd.yaml internal/manifests/install-crd.yaml
+cp install.yaml internal/manifests/install.yaml

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -15,6 +15,7 @@ cd "${REPO_ROOT}"
 # Files explicitly written by the update / verify pipeline.
 GENERATED_FILES=(
   install-crd.yaml
+  install.yaml
   internal/manifests/install-crd.yaml
   internal/manifests/install.yaml
   api/v1alpha1/zz_generated.deepcopy.go
@@ -37,9 +38,7 @@ done
 # 2. Run the generators (same commands as `make update`).
 # ---------------------------------------------------------------------------
 ${CONTROLLER_GEN} object:headerFile="hack/boilerplate.go.txt" paths="./..."
-${CONTROLLER_GEN} crd paths="./..." output:crd:stdout > install-crd.yaml
-cp install-crd.yaml internal/manifests/install-crd.yaml
-cp install.yaml internal/manifests/install.yaml
+hack/update-install-manifest.sh "${CONTROLLER_GEN}"
 
 # ---------------------------------------------------------------------------
 # 3. Compare generated files and restore originals.

--- a/install.yaml
+++ b/install.yaml
@@ -12,145 +12,108 @@ kind: ServiceAccount
 metadata:
   name: axon-controller
   namespace: axon-system
+# BEGIN GENERATED: controller-rbac
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: axon-controller-role
 rules:
-  # Tasks
-  - apiGroups:
-      - axon.io
-    resources:
-      - tasks
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - axon.io
-    resources:
-      - tasks/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - axon.io
-    resources:
-      - tasks/finalizers
-    verbs:
-      - update
-  # TaskSpawners
-  - apiGroups:
-      - axon.io
-    resources:
-      - taskspawners
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - axon.io
-    resources:
-      - taskspawners/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - axon.io
-    resources:
-      - taskspawners/finalizers
-    verbs:
-      - update
-  # Workspaces
-  - apiGroups:
-      - axon.io
-    resources:
-      - workspaces
-    verbs:
-      - get
-      - list
-      - watch
-  # Jobs
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # Deployments
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # Pods (for status and log reading)
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
-  # Secrets (for token mounting)
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  # ServiceAccounts (for spawner RBAC setup)
-  - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-  # RoleBindings (for spawner RBAC setup)
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-      - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - axon.io
+  resources:
+  - tasks
+  - taskspawners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - axon.io
+  resources:
+  - tasks/finalizers
+  - taskspawners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - axon.io
+  resources:
+  - tasks/status
+  - taskspawners/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - axon.io
+  resources:
+  - workspaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+# END GENERATED: controller-rbac
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -359,6 +359,12 @@ func TestInstallCommand_DryRun(t *testing.T) {
 	if !strings.Contains(output, "Deployment") {
 		t.Errorf("expected Deployment manifest in dry-run output, got:\n%s", output[:min(len(output), 500)])
 	}
+	if !strings.Contains(output, "name: axon-controller-role") {
+		t.Errorf("expected controller ClusterRole in dry-run output, got:\n%s", output[:min(len(output), 500)])
+	}
+	if !strings.Contains(output, "- rolebindings") {
+		t.Errorf("expected rolebindings RBAC rule in dry-run output, got:\n%s", output[:min(len(output), 500)])
+	}
 	// Should not contain installation messages.
 	if strings.Contains(output, "Installing axon") {
 		t.Errorf("dry-run should not print installation messages, got:\n%s", output[:min(len(output), 500)])

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -12,145 +12,108 @@ kind: ServiceAccount
 metadata:
   name: axon-controller
   namespace: axon-system
+# BEGIN GENERATED: controller-rbac
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: axon-controller-role
 rules:
-  # Tasks
-  - apiGroups:
-      - axon.io
-    resources:
-      - tasks
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - axon.io
-    resources:
-      - tasks/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - axon.io
-    resources:
-      - tasks/finalizers
-    verbs:
-      - update
-  # TaskSpawners
-  - apiGroups:
-      - axon.io
-    resources:
-      - taskspawners
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - axon.io
-    resources:
-      - taskspawners/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - axon.io
-    resources:
-      - taskspawners/finalizers
-    verbs:
-      - update
-  # Workspaces
-  - apiGroups:
-      - axon.io
-    resources:
-      - workspaces
-    verbs:
-      - get
-      - list
-      - watch
-  # Jobs
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # Deployments
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  # Pods (for status and log reading)
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
-  # Secrets (for token mounting)
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  # ServiceAccounts (for spawner RBAC setup)
-  - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-  # RoleBindings (for spawner RBAC setup)
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-      - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - axon.io
+  resources:
+  - tasks
+  - taskspawners
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - axon.io
+  resources:
+  - tasks/finalizers
+  - taskspawners/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - axon.io
+  resources:
+  - tasks/status
+  - taskspawners/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - axon.io
+  resources:
+  - workspaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+# END GENERATED: controller-rbac
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
## Summary
- Generate the controller ClusterRole in install.yaml from +kubebuilder:rbac markers
- Add hack/update-install-manifest.sh to update only a marked RBAC block in the install manifest
- Wire the script into both make update and make verify
- Keep static RBAC resources (spawner role/binding and leader-election RBAC) outside the generated block
- Add a dry-run install test assertion for controller RBAC presence

## Validation
- GOCACHE=/tmp/axon-gocache make update
- GOCACHE=/tmp/axon-gocache make verify
- GOCACHE=/tmp/axon-gocache make test (fails in sandbox: internal/source/github_test.go cannot bind httptest listener due operation not permitted)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates controller RBAC generation from kubebuilder markers and wires it into make update/verify. Consolidates manifest and CRD syncing with validations to prevent drift and missing install resources.

- **Refactors**
  - Generate axon-controller-role via controller-gen and replace content inside “BEGIN/END GENERATED: controller-rbac”.
  - Keep static RBAC (spawner role/binding, leader-election) outside the generated block.
  - Add hack/update-install-manifest.sh to regen CRDs, inject RBAC, enforce single-marker presence, verify required resources, and sync install.yaml and install-crd.yaml to internal/manifests/.
  - Update hack/verify.sh to include install.yaml in generated files and run the update script.
  - Strengthen dry-run tests to assert controller ClusterRole and rolebindings rule appear.

- **Bug Fixes**
  - Isolate install/uninstall unit tests from real cluster by expecting kubeconfig loading errors.

<sup>Written for commit 01b4b0ee6f62223b5add0bad0138105c9e4dfe4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

