### PR TITLE
Fix Demo section config comment to match Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Here is an example of running a task and streaming the logs:
 ```bash
 # 1. Initialize your config
 $ axon init
-# Edit ~/.axon/config.yaml with your token and workspace
+# Edit ~/.axon/config.yaml with your token and workspace:
+#   oauthToken: <your-oauth-token>
+#   workspace:
+#     repo: https://github.com/your-org/your-repo.git
+#     ref: main
+#     token: <github-token>
 
 # 2. Run a task against your repo
 $ axon run -p "Fix the bug described in issue #42 and open a PR with the fix"


### PR DESCRIPTION
## Summary
- Replace the vague Demo section comment (`# Edit ~/.axon/config.yaml with your token and workspace`) with specific config fields (`oauthToken`, `workspace` with `repo`/`ref`/`token`)
- Workspace config is kept in the Demo section since the prompt ("Fix the bug ... and open a PR") requires a connected git repository
- Matches the detailed format used in the Quick Start and Examples sections

Fixes #232

## Test plan
- [x] Verify the Demo section comment now shows specific config fields
- [x] Verify the config fields match the format used in the Quick Start and Examples sections
- [x] Verify workspace config is included (needed for the Demo prompt)