### PR TITLE
docs: improve Quick Start with workspace setup and ephemeral pod note

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,29 @@ go install github.com/axon-core/axon/cmd/axon@latest
 axon install
 ```
 
-### 3. Run Your First Task
+### 3. Initialize Your Config
 
 ```bash
 axon init
-# Edit ~/.axon/config.yaml with your token:
+# Edit ~/.axon/config.yaml with your token and workspace:
 #   oauthToken: <your-oauth-token>
+#   workspace:
+#     repo: https://github.com/your-org/your-repo.git
+#     ref: main
+#     token: <github-token>  # optional, for private repos and pushing changes
+```
 
-axon run -p "Create a hello world program in Python"
+### 4. Run Your First Task
+
+```bash
+axon run -p "Add a hello world program in Python"
 axon logs <task-name> -f
 ```
+
+The agent clones your repo, makes changes, and can push a branch or open a PR.
+
+> **Note:** Without a workspace, the agent runs in an ephemeral pod — any files it
+> creates are lost when the pod terminates. Set up a workspace to get persistent results.
 
 <details>
 <summary>Using kubectl and YAML instead of the CLI</summary>


### PR DESCRIPTION
## Summary
- Split Quick Start step 3 into separate "Initialize Your Config" (step 3) and "Run Your First Task" (step 4)
- Added workspace configuration (repo, ref, token) to the init step so new users get persistent results from their first task
- Added a note explaining that without a workspace, the agent runs in an ephemeral pod and files are lost on termination

Fixes #229

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Follow the updated Quick Start steps to confirm the flow is clear and logical
- [ ] Confirm the workspace config snippet matches the format documented in the Configuration reference section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Quick Start to include workspace setup and split the old step 3 into “Initialize Your Config” and “Run Your First Task,” so first runs produce persistent results. Adds a clear note that running without a workspace uses an ephemeral pod and files are lost, addressing #229.

<sup>Written for commit b5b87e865a2cac60439b7d443e1b6c2eb89489c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

