### PR TITLE
Pin agent and spawner image tags in install manifest

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -238,6 +238,10 @@ spec:
           image: gjkim42/axon-controller:latest
           args:
             - --leader-elect
+            - --claude-code-image=gjkim42/claude-code:latest
+            - --codex-image=gjkim42/codex:latest
+            - --gemini-image=gjkim42/gemini:latest
+            - --spawner-image=gjkim42/axon-spawner:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -270,6 +270,39 @@ func TestVersionedManifest_EmbeddedController(t *testing.T) {
 	}
 }
 
+func TestVersionedManifest_EmbeddedControllerImageArgs(t *testing.T) {
+	original := version.Version
+	defer func() { version.Version = original }()
+
+	// Verify the embedded manifest contains image flags that will be versioned.
+	expectedArgs := []string{
+		"--claude-code-image=gjkim42/claude-code:",
+		"--codex-image=gjkim42/codex:",
+		"--gemini-image=gjkim42/gemini:",
+		"--spawner-image=gjkim42/axon-spawner:",
+	}
+	for _, arg := range expectedArgs {
+		if !bytes.Contains(manifests.InstallController, []byte(arg)) {
+			t.Errorf("expected embedded controller manifest to contain %q", arg)
+		}
+	}
+
+	// Verify all image args get the pinned version after substitution.
+	version.Version = "v0.3.0"
+	result := versionedManifest(manifests.InstallController)
+	versionedArgs := []string{
+		"--claude-code-image=gjkim42/claude-code:v0.3.0",
+		"--codex-image=gjkim42/codex:v0.3.0",
+		"--gemini-image=gjkim42/gemini:v0.3.0",
+		"--spawner-image=gjkim42/axon-spawner:v0.3.0",
+	}
+	for _, arg := range versionedArgs {
+		if !bytes.Contains(result, []byte(arg)) {
+			t.Errorf("expected versioned manifest to contain %q", arg)
+		}
+	}
+}
+
 func TestVersionCommand(t *testing.T) {
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{"version"})

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -238,6 +238,10 @@ spec:
           image: gjkim42/axon-controller:latest
           args:
             - --leader-elect
+            - --claude-code-image=gjkim42/claude-code:latest
+            - --codex-image=gjkim42/codex:latest
+            - --gemini-image=gjkim42/gemini:latest
+            - --spawner-image=gjkim42/axon-spawner:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary
- Adds explicit `--claude-code-image`, `--codex-image`, `--gemini-image`, and `--spawner-image` flags to the controller Deployment args in `install.yaml`
- These flags use `:latest` tags in the manifest so that the existing `versionedManifest()` function replaces them with the release version at install time
- Ensures all images (controller, agents, spawner) are pinned to the same release version, not just the controller image

## Details

Previously, `install.yaml` only set the controller image (`gjkim42/axon-controller:latest`). The `versionedManifest()` function in `internal/cli/install.go` replaces all `:latest` tags with the binary's version at install time, but the controller args did not include image flags for agent and spawner images. This meant the controller fell back to the hardcoded `:latest` defaults in `job_builder.go` and `taskspawner_deployment_builder.go`.

By adding the image flags as args in the Deployment spec, `versionedManifest()` now replaces them all consistently. For example, installing `v0.6.0` results in:
- `image: gjkim42/axon-controller:v0.6.0`
- `--claude-code-image=gjkim42/claude-code:v0.6.0`
- `--codex-image=gjkim42/codex:v0.6.0`
- `--gemini-image=gjkim42/gemini:v0.6.0`
- `--spawner-image=gjkim42/axon-spawner:v0.6.0`

## Test plan
- [x] `make verify` passes
- [x] `make test` passes (all unit tests)
- [x] `make build` succeeds
- [x] Added `TestVersionedManifest_EmbeddedControllerImageArgs` test to verify all image args are present in the embedded manifest and get properly versioned

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins agent and spawner image tags in the install manifest so controller, agent, and spawner images are all pinned to the release version at install. Addresses Linear #225.

- **Bug Fixes**
  - Added --claude-code-image, --codex-image, --gemini-image, and --spawner-image args to the controller Deployment in install.yaml and internal/manifests/install.yaml.
  - versionedManifest replaces :latest with the release tag for all images.
  - Added a unit test to confirm the flags exist in the embedded manifest and get versioned correctly.

<sup>Written for commit 4f1351a40b44cce9e4c8772787e18b48aac641e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

