### PR TITLE
Accept name as positional argument in create commands

### DIFF
--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -17,6 +17,8 @@ func TestValidArgsFunctionWired(t *testing.T) {
 		{"get task", []string{"get", "task"}},
 		{"get taskspawner", []string{"get", "taskspawner"}},
 		{"get workspace", []string{"get", "workspace"}},
+		{"create workspace", []string{"create", "workspace"}},
+		{"create taskspawner", []string{"create", "taskspawner"}},
 		{"delete task", []string{"delete", "task"}},
 		{"delete workspace", []string{"delete", "workspace"}},
 		{"delete taskspawner", []string{"delete", "taskspawner"}},

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -117,10 +117,9 @@ func TestCreateWorkspaceCommand_DryRun(t *testing.T) {
 
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{
-		"create", "workspace",
+		"create", "workspace", "my-ws",
 		"--config", cfgPath,
 		"--dry-run",
-		"--name", "my-ws",
 		"--repo", "https://github.com/org/repo.git",
 		"--ref", "main",
 		"--secret", "gh-token",
@@ -172,10 +171,9 @@ func TestCreateWorkspaceCommand_DryRun_WithToken(t *testing.T) {
 
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{
-		"create", "workspace",
+		"create", "workspace", "my-ws",
 		"--config", cfgPath,
 		"--dry-run",
-		"--name", "my-ws",
 		"--repo", "https://github.com/org/repo.git",
 		"--token", "ghp_test123",
 		"--namespace", "test-ns",
@@ -212,10 +210,9 @@ func TestCreateTaskSpawnerCommand_DryRun(t *testing.T) {
 
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{
-		"create", "taskspawner",
+		"create", "taskspawner", "my-spawner",
 		"--config", cfgPath,
 		"--dry-run",
-		"--name", "my-spawner",
 		"--workspace", "my-ws",
 		"--namespace", "test-ns",
 	})
@@ -259,10 +256,9 @@ func TestCreateTaskSpawnerCommand_DryRun_Cron(t *testing.T) {
 
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{
-		"create", "taskspawner",
+		"create", "taskspawner", "cron-spawner",
 		"--config", cfgPath,
 		"--dry-run",
-		"--name", "cron-spawner",
 		"--schedule", "*/5 * * * *",
 		"--namespace", "test-ns",
 	})
@@ -288,6 +284,52 @@ func TestCreateTaskSpawnerCommand_DryRun_Cron(t *testing.T) {
 	}
 	if !strings.Contains(output, "*/5 * * * *") {
 		t.Errorf("expected cron schedule in output, got:\n%s", output)
+	}
+}
+
+func TestCreateWorkspaceCommand_MissingName(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"create", "workspace",
+		"--config", cfgPath,
+		"--repo", "https://github.com/org/repo.git",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+	if !strings.Contains(err.Error(), "workspace name is required") {
+		t.Errorf("expected 'workspace name is required' error, got: %v", err)
+	}
+}
+
+func TestCreateTaskSpawnerCommand_MissingName(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("secret: my-secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"create", "taskspawner",
+		"--config", cfgPath,
+		"--workspace", "my-ws",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+	if !strings.Contains(err.Error(), "task spawner name is required") {
+		t.Errorf("expected 'task spawner name is required' error, got: %v", err)
 	}
 }
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -255,8 +255,7 @@ var _ = Describe("workspace CRUD", func() {
 
 	It("should create, get, and delete a workspace", func() {
 		By("creating a workspace via CLI")
-		axon("create", "workspace",
-			"--name", wsName,
+		axon("create", "workspace", wsName,
 			"--repo", "https://github.com/axon-core/axon.git",
 			"--ref", "main",
 		)

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -36,8 +36,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 
 			By("Creating a workspace via CLI")
 			err := runCLI(kubeconfigPath, ns.Name,
-				"create", "workspace",
-				"--name", "my-ws",
+				"create", "workspace", "my-ws",
 				"--repo", "https://github.com/org/repo.git",
 				"--ref", "main",
 			)
@@ -89,8 +88,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 
 			By("Creating a workspace with --secret flag")
 			err := runCLI(kubeconfigPath, ns.Name,
-				"create", "workspace",
-				"--name", "secret-ws",
+				"create", "workspace", "secret-ws",
 				"--repo", "https://github.com/org/repo.git",
 				"--secret", "my-gh-secret",
 			)
@@ -118,8 +116,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 
 			By("Creating a workspace via CLI with 'ws' alias")
 			err := runCLI(kubeconfigPath, ns.Name,
-				"create", "ws",
-				"--name", "alias-ws",
+				"create", "ws", "alias-ws",
 				"--repo", "https://github.com/org/repo.git",
 			)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- Changed `axon create workspace` and `axon create taskspawner` to accept the resource name as the first positional argument instead of a `--name` flag
- Added argument validation (exactly 1 name required) consistent with delete commands
- Added shell completion (`ValidArgsFunction`) for both create subcommands
- Updated all unit, integration, and e2e tests

**Before:** `axon create workspace --name my-ws --repo ...`
**After:** `axon create workspace my-ws --repo ...`

## Test plan
- [x] `make verify` passes
- [x] `make test` passes (unit tests)
- [x] New tests for missing name argument error cases added
- [x] Existing dry-run tests updated for positional argument syntax
- [x] Integration and e2e tests updated
- [ ] `make test-integration` passes
- [ ] `make test-e2e` passes

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch create workspace and create taskspawner to accept the resource name as the first positional argument. Adds strict argument validation and shell completion to meet Linear #238 and align with delete and common CLI conventions.

- **New Features**
  - workspace and taskspawner now use positional <name>; --name is removed
  - Validate exactly one name is provided; clear error messages
  - Added shell completion for both create subcommands

- **Migration**
  - Replace --name with a positional argument in scripts and docs
  - Before: axon create workspace --name my-ws --repo ...
  - After: axon create workspace my-ws --repo ...

<sup>Written for commit ac97aa1c128e89242dc24a87938e94a5b60fc775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

