### PR TITLE
cli: remove `create taskspawner` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,6 @@ The `axon` CLI lets you manage the full lifecycle without writing YAML.
 |---------|-------------|
 | `axon run` | Create and run a new Task |
 | `axon create workspace` | Create a Workspace resource |
-| `axon create taskspawner` | Create a TaskSpawner resource |
 | `axon get <resource>` | List resources (`tasks`, `taskspawners`, `workspaces`) |
 | `axon delete <resource> <name>` | Delete a resource |
 | `axon logs <task-name> [-f]` | View or stream logs from a task |

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -18,7 +18,6 @@ func TestValidArgsFunctionWired(t *testing.T) {
 		{"get taskspawner", []string{"get", "taskspawner"}},
 		{"get workspace", []string{"get", "workspace"}},
 		{"create workspace", []string{"create", "workspace"}},
-		{"create taskspawner", []string{"create", "taskspawner"}},
 		{"delete task", []string{"delete", "task"}},
 		{"delete workspace", []string{"delete", "workspace"}},
 		{"delete taskspawner", []string{"delete", "taskspawner"}},
@@ -119,49 +118,6 @@ func TestFlagCompletionCredentialType(t *testing.T) {
 	}
 	if !strings.Contains(output, "oauth") {
 		t.Errorf("expected oauth in credential-type completions, got %q", output)
-	}
-	if !strings.Contains(output, ":4") {
-		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in output, got %q", output)
-	}
-}
-
-func TestFlagCompletionCreateTaskSpawnerCredentialType(t *testing.T) {
-	root := NewRootCommand()
-
-	root.SetArgs([]string{"__complete", "create", "taskspawner", "--credential-type", ""})
-	out := &strings.Builder{}
-	root.SetOut(out)
-	root.Execute()
-
-	output := out.String()
-	if !strings.Contains(output, "api-key") {
-		t.Errorf("expected api-key in credential-type completions, got %q", output)
-	}
-	if !strings.Contains(output, "oauth") {
-		t.Errorf("expected oauth in credential-type completions, got %q", output)
-	}
-	if !strings.Contains(output, ":4") {
-		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in output, got %q", output)
-	}
-}
-
-func TestFlagCompletionCreateTaskSpawnerState(t *testing.T) {
-	root := NewRootCommand()
-
-	root.SetArgs([]string{"__complete", "create", "taskspawner", "--state", ""})
-	out := &strings.Builder{}
-	root.SetOut(out)
-	root.Execute()
-
-	output := out.String()
-	if !strings.Contains(output, "open") {
-		t.Errorf("expected open in state completions, got %q", output)
-	}
-	if !strings.Contains(output, "closed") {
-		t.Errorf("expected closed in state completions, got %q", output)
-	}
-	if !strings.Contains(output, "all") {
-		t.Errorf("expected all in state completions, got %q", output)
 	}
 	if !strings.Contains(output, ":4") {
 		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in output, got %q", output)


### PR DESCRIPTION
## Summary
- Remove the `axon create taskspawner` (and `axon create ts`) CLI subcommand as requested in #223
- TaskSpawners are complex resources better suited for YAML-based creation via `kubectl apply` rather than CLI flags
- Remove associated dry-run and completion tests, add a test verifying the subcommand no longer exists
- Remove `axon create taskspawner` entry from the README CLI reference table

Fixes #223

## Test plan
- [x] `make verify` passes (lint, fmt, vet)
- [x] `make test` passes (all unit tests)
- [x] New test `TestCreateCommand_NoTaskSpawnerSubcommand` verifies the subcommand is removed
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "axon create taskspawner" (alias "ts") CLI subcommand per #223. TaskSpawners should now be created via YAML with kubectl; related tests and the README entry were removed.

- **Migration**
  - Use kubectl apply with a TaskSpawner YAML manifest (see Quick Start).
  - The CLI no longer includes the taskspawner subcommand or its flag completions.

<sup>Written for commit 71c6beba7c9a57712a7f2716a584f0ce3796dec7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

