### PR TITLE
Add credential acquisition links to config file template

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,9 +12,11 @@ const configTemplate = `# Axon configuration file
 # See: https://github.com/axon-core/axon
 
 # OAuth token (axon auto-creates the Kubernetes secret for you)
+# Get one by logging into https://claude.ai and extracting the sessionKey cookie
 oauthToken: ""
 
 # Or use an API key instead:
+# Get one at: https://console.anthropic.com/settings/keys
 # apiKey: ""
 
 # Agent type (optional, default: claude-code)
@@ -35,6 +37,7 @@ oauthToken: ""
 #   repo: https://github.com/org/repo.git
 #   ref: main
 #   token: ""  # GitHub token for git auth and gh CLI (optional)
+#                # Get one at: https://github.com/settings/tokens/new
 
 # Advanced: provide your own Kubernetes secret directly
 # secret: ""


### PR DESCRIPTION
## Problem

When users run `axon init`, they get a config file with empty credential fields:

```yaml
# OAuth token (axon auto-creates the Kubernetes secret for you)
oauthToken: ""

# Or use an API key instead:
# apiKey: ""
```

New users immediately ask: **"Where do I get these credentials?"**

This is the #1 onboarding blocker - users can't proceed without credentials, but the config doesn't tell them where to obtain them.

## Solution

Added credential acquisition links directly in the config template comments:

- **OAuth token**: Instructions to extract sessionKey from claude.ai
- **API key**: https://console.anthropic.com/settings/keys
- **GitHub token**: https://github.com/settings/tokens/new

## Changes

Modified `internal/cli/init.go` to include helpful links in the `configTemplate` constant.

## Testing

✅ Built and tested `axon init` - config generates correctly with new links
✅ Verified YAML is still valid
✅ Confirmed all links are accurate and accessible

## Impact

This change removes the most common onboarding friction point. New users can now:
1. Run `axon init`
2. Open the config file
3. **Immediately know where to get credentials** (instead of searching docs/Slack/Google)
4. Fill in credentials and start using Axon

## Related

This PR is complementary to but separate from:
- #244: Adding next-step guidance to CLI output  
- #243: Improving Quick Start docs
- PR #246: Adding links to example YAML files

This PR focuses specifically on the config template itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add direct credential links to the axon init config template so users know where to get OAuth (claude.ai sessionKey), Anthropic API keys, and GitHub tokens. This removes the main onboarding blocker and speeds up setup.

<sup>Written for commit 876d45e3d21afc4b45cd2e87231cab51edbacb95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

