### PR TITLE
Persist git credential helper for agent container

### DIFF
--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -251,8 +251,12 @@ func (b *JobBuilder) buildAgentJob(task *axonv1alpha1.Task, workspace *axonv1alp
 		}
 
 		if workspace.SecretRef != nil {
+			credentialHelper := `!f() { echo "username=x-access-token"; echo "password=$GITHUB_TOKEN"; }; f`
 			initContainer.Command = []string{"sh", "-c",
-				`exec git -c credential.helper='!f() { echo "username=x-access-token"; echo "password=$GITHUB_TOKEN"; }; f' "$@"`,
+				fmt.Sprintf(
+					`git -c credential.helper='%s' "$@" && git -C %s/repo config credential.helper '%s'`,
+					credentialHelper, WorkspaceMountPath, credentialHelper,
+				),
 			}
 			initContainer.Args = append([]string{"--"}, cloneArgs...)
 		}

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -467,6 +467,8 @@ var _ = Describe("Task Controller", func() {
 			By("Verifying the init container uses credential helper for git auth")
 			Expect(initContainer.Command).To(HaveLen(3))
 			Expect(initContainer.Command[0]).To(Equal("sh"))
+			Expect(initContainer.Command[2]).To(ContainSubstring("git -c credential.helper="))
+			Expect(initContainer.Command[2]).To(ContainSubstring("git -C /workspace/repo config credential.helper"))
 			Expect(initContainer.Args).To(Equal([]string{
 				"--", "clone", "--branch", "main", "--no-single-branch", "--depth", "1",
 				"--", "https://github.com/example/repo.git", "/workspace/repo",


### PR DESCRIPTION
## Summary
- The git clone init container previously configured the credential helper inline with `git -c credential.helper=...`, which only applied for that single clone command
- After cloning, the init container now also writes the credential helper to the repo's git config using `git -C /workspace/repo config credential.helper ...`
- This allows the agent container to use git (fetch, push, etc.) with the same authentication

## Test plan
- [x] Unit test added: `TestBuildClaudeCodeJob_WorkspaceWithSecretRefPersistsCredentialHelper`
- [x] Integration test updated to verify persistent credential helper in init container script
- [x] All existing unit tests pass (`make test`)
- [x] All verification checks pass (`make verify`)

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted the git credential helper to the repo’s config during clone so the agent container can fetch and push with the same authentication. Addresses Task #257 by ensuring authenticated git operations continue after init.

- **Bug Fixes**
  - After cloning, write the credential helper to /workspace/repo via git config.
  - Added unit and integration tests to confirm the init script includes both inline and persisted helpers.

<sup>Written for commit f5b27be858f344373d826b818da8ffbc6c08d2d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

