### PR TITLE
docs: sync self-development README schedules

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -106,18 +106,33 @@ kubectl logs -l job-name=<job-name> -f
 
 ### axon-fake-user.yaml
 
-This TaskSpawner runs hourly to test the developer experience as if you were a new user.
+This TaskSpawner runs daily to test the developer experience as if you were a new user.
 
 **Deploy:**
 ```bash
 kubectl apply -f self-development/axon-fake-user.yaml
 ```
 
-This spawner uses a cron schedule and will create a task every hour to:
+This spawner uses a daily cron schedule (`0 9 * * *`) and will create a task each day to:
 - Test documentation and onboarding flows
 - Check CLI help text and error messages
 - Review examples and identify gaps
 - Create GitHub issues for any problems found
+
+### axon-fake-strategist.yaml
+
+This TaskSpawner runs every 12 hours to strategically explore new ways to use and improve Axon.
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/axon-fake-strategist.yaml
+```
+
+This spawner uses a cron schedule (`0 */12 * * *`) and will create a task every 12 hours to focus on one of:
+- **New Use Cases** — explore what types of projects/teams could benefit from Axon, propose example TaskSpawner configs
+- **Workflow Improvements** — analyze existing self-development configs and suggest better patterns, prompts, or automation flows
+- **Integration Opportunities** — identify tools/platforms Axon could integrate with (CI systems, monitoring, chat ops, etc.)
+- **New CRDs & API Extensions** — propose new Custom Resource Definitions or extensions to existing CRDs that would expand Axon's capabilities
 
 ## Customizing for Your Repository
 

--- a/self-development/axon-fake-strategist.yaml
+++ b/self-development/axon-fake-strategist.yaml
@@ -1,0 +1,77 @@
+apiVersion: axon.io/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: axon-fake-strategist
+spec:
+  when:
+    cron:
+      schedule: "0 */12 * * *"
+  taskTemplate:
+    workspaceRef:
+      name: axon-workspace
+    model: opus
+    type: claude-code
+    credentials:
+      type: oauth
+      secretRef:
+        name: axon-credentials
+    promptTemplate: |
+      You are a strategic product thinker for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
+      You are running in an ephemeral container environment. The task you've done to your file system will disappear after the task is done.
+      You either create a PR, create an issue, or comment on an existing issue to persist your work.
+
+      Your goal is to find new and better ways to use Axon — expanding its reach, improving its workflows, and identifying opportunities for growth.
+
+      When commenting on issues or PRs, always start your comment with "🤖 **Axon Agent** @gjkim42\n\n" so it is clearly distinguishable from human comments and triggers a notification.
+
+      Pre-checklist:
+      - git config user.name "Gunju Kim"
+      - git config user.email "gjkim042@gmail.com"
+
+      Task:
+      Pick ONE of the following areas to focus on (choose the one most likely to produce valuable, actionable insights):
+
+      1. **New Use Cases**
+         - Explore what types of projects, teams, or industries could benefit from Axon
+         - Look at trending developer workflows and identify where autonomous agents could help
+         - Propose example TaskSpawner configs for new use cases
+         - Consider both technical and non-technical audiences
+
+      2. **Workflow Improvements**
+         - Analyze existing self-development configs in `self-development/`
+         - Suggest better patterns, prompts, or automation flows
+         - Identify inefficiencies or gaps in current autonomous workflows
+         - Propose improvements backed by concrete examples
+
+      3. **Integration Opportunities**
+         - Identify tools and platforms Axon could integrate with (CI systems, monitoring, chat ops, etc.)
+         - Evaluate how Axon could fit into existing developer toolchains
+         - Propose specific integration designs with example configs
+         - Consider ecosystem partners and complementary projects
+
+      4. **New CRDs & API Extensions**
+         - Review existing CRDs and identify limitations or missing features
+         - Propose new Custom Resource Definitions that would expand Axon's capabilities
+         - Suggest extensions to existing CRDs with concrete use cases
+         - Consider backward compatibility and incremental adoption
+
+      Actions:
+      - Create a GitHub issue with your findings and proposals:
+        ```
+        gh issue create --title "<title>" --body "<description>" --label generated-by-axon --label axon/needs-input
+        ```
+      - If you can propose a small, concrete change, create a PR:
+        ```
+        git checkout -b axon-fake-strategist-{{.ID}}
+        # ... make changes ...
+        git push -u origin axon-fake-strategist-{{.ID}}
+        gh pr create --title "<title>" --body "<description>" --label generated-by-axon --label ok-to-test
+        ```
+      - Prefer well-researched issues with clear proposals over broad, vague suggestions
+
+      Constraints:
+      - Focus on ONE area per run, do it thoroughly
+      - Do not create duplicate issues — check existing issues first with `gh issue list`
+      - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
+      - Keep changes minimal and focused
+  pollInterval: 1m

--- a/self-development/axon-fake-user.yaml
+++ b/self-development/axon-fake-user.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   when:
     cron:
-      schedule: "0 * * * *"
+      schedule: "0 9 * * *"
   taskTemplate:
     workspaceRef:
       name: axon-workspace


### PR DESCRIPTION
## Summary
- update self-development/README.md to reflect axon-fake-user.yaml schedule change to daily (0 9 * * *)
- add documentation for axon-fake-strategist.yaml
- correct strategist schedule docs to every 12 hours (0 */12 * * *)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added axon-fake-strategist TaskSpawner (self-development/axon-fake-strategist.yaml) and synced the README with accurate schedules and deploy info.
axon-fake-user now runs daily at 09:00 (0 9 * * *); axon-fake-strategist runs every 12 hours (0 */12 * * *).

<sup>Written for commit 24de4bff6a64df0d1517db10cf319396b32039d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

