### PR TITLE
docs: reframe project as orchestration framework for AI agents

### DIFF
--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -1,13 +1,13 @@
-# Agent Image Interface
+# Standardized Agent Interface
 
 This document describes the interface that custom agent images must implement
-to be compatible with Axon.
+to be compatible with the Axon orchestration framework.
 
 ## Overview
 
-Axon runs agent tasks as Kubernetes Jobs. Each agent container is invoked using
-a standard interface so that any compatible image can be used as a drop-in
-replacement for the default `claude-code` image.
+Axon orchestrates agent tasks as Kubernetes Jobs. By providing a standardized
+execution interface, Axon allows any compatible image to be used as a drop-in
+replacement for the default agents.
 
 ## Requirements
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,6 @@
-# Axon Examples
+# Axon Orchestration Examples
 
-Copy-paste-ready YAML manifests for common Axon use cases. Each example is
-self-contained and includes all required resources (Secrets, Workspaces, Tasks).
+Ready-to-use patterns and YAML manifests for orchestrating AI agents with Axon. These examples demonstrate how to combine Tasks, Workspaces, and TaskSpawners into functional AI workflows.
 
 ## Prerequisites
 

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -1,10 +1,10 @@
-# Self-Development Examples
+# Self-Development Orchestration Patterns
 
-This directory contains real-world TaskSpawner configurations used by the Axon project itself for autonomous development.
+This directory contains real-world orchestration patterns used by the Axon project itself for autonomous development.
 
 ## Overview
 
-These TaskSpawners demonstrate how to set up fully autonomous AI agents that:
+These TaskSpawners demonstrate how to orchestrate fully autonomous AI workers that:
 - Monitor GitHub issues
 - Investigate and fix problems
 - Create or update pull requests


### PR DESCRIPTION
This PR updates the README and supporting documentation to reframe Axon as a Kubernetes-native orchestration framework for AI coding agents. It introduces the core orchestration primitives (Tasks, Workspaces, TaskSpawners) and highlights framework capabilities and patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframed Axon as a Kubernetes-native orchestration framework for autonomous AI coding agents. Clarifies core primitives (Tasks, Workspaces, TaskSpawners), event-driven workflows, and a standardized agent interface.

- **Refactors**
  - README: focuses on orchestration, lifecycle management, capabilities, and patterns; updated diagrams and positioning.
  - docs/agent-image-interface.md: renamed and clarified the standardized agent execution interface.
  - examples/README.md: shifted to orchestration-focused examples using Tasks, Workspaces, TaskSpawners.
  - self-development/README.md: updated language and patterns for autonomous orchestration.

<sup>Written for commit 4591db3126aff23e574c0cb1cd54dc20d3528722. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

