### PR TITLE
feat: add --all-namespaces (-A) flag to get commands

### DIFF
--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -13,12 +13,20 @@ import (
 	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
-func printTaskTable(w io.Writer, tasks []axonv1alpha1.Task) {
+func printTaskTable(w io.Writer, tasks []axonv1alpha1.Task, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tTYPE\tPHASE\tAGE")
+	if allNamespaces {
+		fmt.Fprintln(tw, "NAMESPACE\tNAME\tTYPE\tPHASE\tAGE")
+	} else {
+		fmt.Fprintln(tw, "NAME\tTYPE\tPHASE\tAGE")
+	}
 	for _, t := range tasks {
 		age := duration.HumanDuration(time.Since(t.CreationTimestamp.Time))
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", t.Name, t.Spec.Type, t.Status.Phase, age)
+		if allNamespaces {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", t.Namespace, t.Name, t.Spec.Type, t.Status.Phase, age)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", t.Name, t.Spec.Type, t.Status.Phase, age)
+		}
 	}
 	tw.Flush()
 }
@@ -60,9 +68,13 @@ func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
 	}
 }
 
-func printTaskSpawnerTable(w io.Writer, spawners []axonv1alpha1.TaskSpawner) {
+func printTaskSpawnerTable(w io.Writer, spawners []axonv1alpha1.TaskSpawner, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tSOURCE\tPHASE\tDISCOVERED\tTASKS\tAGE")
+	if allNamespaces {
+		fmt.Fprintln(tw, "NAMESPACE\tNAME\tSOURCE\tPHASE\tDISCOVERED\tTASKS\tAGE")
+	} else {
+		fmt.Fprintln(tw, "NAME\tSOURCE\tPHASE\tDISCOVERED\tTASKS\tAGE")
+	}
 	for _, s := range spawners {
 		age := duration.HumanDuration(time.Since(s.CreationTimestamp.Time))
 		source := ""
@@ -75,9 +87,15 @@ func printTaskSpawnerTable(w io.Writer, spawners []axonv1alpha1.TaskSpawner) {
 		} else if s.Spec.When.Cron != nil {
 			source = "cron: " + s.Spec.When.Cron.Schedule
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%d\t%s\n",
-			s.Name, source, s.Status.Phase,
-			s.Status.TotalDiscovered, s.Status.TotalTasksCreated, age)
+		if allNamespaces {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
+				s.Namespace, s.Name, source, s.Status.Phase,
+				s.Status.TotalDiscovered, s.Status.TotalTasksCreated, age)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%d\t%s\n",
+				s.Name, source, s.Status.Phase,
+				s.Status.TotalDiscovered, s.Status.TotalTasksCreated, age)
+		}
 	}
 	tw.Flush()
 }
@@ -123,12 +141,20 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 	}
 }
 
-func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace) {
+func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tREPO\tREF\tAGE")
+	if allNamespaces {
+		fmt.Fprintln(tw, "NAMESPACE\tNAME\tREPO\tREF\tAGE")
+	} else {
+		fmt.Fprintln(tw, "NAME\tREPO\tREF\tAGE")
+	}
 	for _, ws := range workspaces {
 		age := duration.HumanDuration(time.Since(ws.CreationTimestamp.Time))
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ws.Name, ws.Spec.Repo, ws.Spec.Ref, age)
+		if allNamespaces {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", ws.Namespace, ws.Name, ws.Spec.Repo, ws.Spec.Ref, age)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ws.Name, ws.Spec.Repo, ws.Spec.Ref, age)
+		}
 	}
 	tw.Flush()
 }

--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -35,7 +35,7 @@ func TestPrintWorkspaceTable(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	printWorkspaceTable(&buf, workspaces)
+	printWorkspaceTable(&buf, workspaces, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -43,6 +43,9 @@ func TestPrintWorkspaceTable(t *testing.T) {
 	}
 	if !strings.Contains(output, "REPO") {
 		t.Errorf("expected header REPO in output, got %q", output)
+	}
+	if strings.Contains(output, "NAMESPACE") {
+		t.Errorf("expected no NAMESPACE header when allNamespaces is false, got %q", output)
 	}
 	if !strings.Contains(output, "ws-one") {
 		t.Errorf("expected ws-one in output, got %q", output)
@@ -52,6 +55,213 @@ func TestPrintWorkspaceTable(t *testing.T) {
 	}
 	if !strings.Contains(output, "https://github.com/org/repo.git") {
 		t.Errorf("expected repo URL in output, got %q", output)
+	}
+}
+
+func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
+	workspaces := []axonv1alpha1.Workspace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "ws-one",
+				Namespace:         "ns-a",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/org/repo.git",
+				Ref:  "main",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "ws-two",
+				Namespace:         "ns-b",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
+			},
+			Spec: axonv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/org/other.git",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWorkspaceTable(&buf, workspaces, true)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAMESPACE") {
+		t.Errorf("expected NAMESPACE header when allNamespaces is true, got %q", output)
+	}
+	if !strings.Contains(output, "ns-a") {
+		t.Errorf("expected namespace ns-a in output, got %q", output)
+	}
+	if !strings.Contains(output, "ns-b") {
+		t.Errorf("expected namespace ns-b in output, got %q", output)
+	}
+}
+
+func TestPrintTaskTable(t *testing.T) {
+	tasks := []axonv1alpha1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "task-one",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type: "claude-code",
+			},
+			Status: axonv1alpha1.TaskStatus{
+				Phase: axonv1alpha1.TaskPhaseRunning,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printTaskTable(&buf, tasks, false)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("expected header NAME in output, got %q", output)
+	}
+	if strings.Contains(output, "NAMESPACE") {
+		t.Errorf("expected no NAMESPACE header when allNamespaces is false, got %q", output)
+	}
+	if !strings.Contains(output, "task-one") {
+		t.Errorf("expected task-one in output, got %q", output)
+	}
+}
+
+func TestPrintTaskTableAllNamespaces(t *testing.T) {
+	tasks := []axonv1alpha1.Task{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "task-one",
+				Namespace:         "ns-a",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type: "claude-code",
+			},
+			Status: axonv1alpha1.TaskStatus{
+				Phase: axonv1alpha1.TaskPhaseRunning,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "task-two",
+				Namespace:         "ns-b",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+			},
+			Spec: axonv1alpha1.TaskSpec{
+				Type: "codex",
+			},
+			Status: axonv1alpha1.TaskStatus{
+				Phase: axonv1alpha1.TaskPhaseSucceeded,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printTaskTable(&buf, tasks, true)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAMESPACE") {
+		t.Errorf("expected NAMESPACE header when allNamespaces is true, got %q", output)
+	}
+	if !strings.Contains(output, "ns-a") {
+		t.Errorf("expected namespace ns-a in output, got %q", output)
+	}
+	if !strings.Contains(output, "ns-b") {
+		t.Errorf("expected namespace ns-b in output, got %q", output)
+	}
+}
+
+func TestPrintTaskSpawnerTable(t *testing.T) {
+	spawners := []axonv1alpha1.TaskSpawner{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "spawner-one",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+			Spec: axonv1alpha1.TaskSpawnerSpec{
+				When: axonv1alpha1.When{
+					Cron: &axonv1alpha1.Cron{
+						Schedule: "*/5 * * * *",
+					},
+				},
+			},
+			Status: axonv1alpha1.TaskSpawnerStatus{
+				Phase: axonv1alpha1.TaskSpawnerPhaseRunning,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printTaskSpawnerTable(&buf, spawners, false)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("expected header NAME in output, got %q", output)
+	}
+	if strings.Contains(output, "NAMESPACE") {
+		t.Errorf("expected no NAMESPACE header when allNamespaces is false, got %q", output)
+	}
+	if !strings.Contains(output, "spawner-one") {
+		t.Errorf("expected spawner-one in output, got %q", output)
+	}
+}
+
+func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
+	spawners := []axonv1alpha1.TaskSpawner{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "spawner-one",
+				Namespace:         "ns-a",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+			Spec: axonv1alpha1.TaskSpawnerSpec{
+				When: axonv1alpha1.When{
+					Cron: &axonv1alpha1.Cron{
+						Schedule: "*/5 * * * *",
+					},
+				},
+			},
+			Status: axonv1alpha1.TaskSpawnerStatus{
+				Phase: axonv1alpha1.TaskSpawnerPhaseRunning,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "spawner-two",
+				Namespace:         "ns-b",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+			},
+			Spec: axonv1alpha1.TaskSpawnerSpec{
+				When: axonv1alpha1.When{
+					GitHubIssues: &axonv1alpha1.GitHubIssues{},
+				},
+				TaskTemplate: axonv1alpha1.TaskTemplate{
+					WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+						Name: "my-ws",
+					},
+				},
+			},
+			Status: axonv1alpha1.TaskSpawnerStatus{
+				Phase: axonv1alpha1.TaskSpawnerPhaseRunning,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printTaskSpawnerTable(&buf, spawners, true)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAMESPACE") {
+		t.Errorf("expected NAMESPACE header when allNamespaces is true, got %q", output)
+	}
+	if !strings.Contains(output, "ns-a") {
+		t.Errorf("expected namespace ns-a in output, got %q", output)
+	}
+	if !strings.Contains(output, "ns-b") {
+		t.Errorf("expected namespace ns-b in output, got %q", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `-A`/`--all-namespaces` persistent flag to `axon get` subcommands (`task`, `taskspawner`, `workspace`)
- When the flag is set, resources are listed across all namespaces and a `NAMESPACE` column is prepended to the table output
- Returns an error when `-A` is combined with a resource name argument (getting a specific resource by name across all namespaces is not supported)

## Test plan
- [x] Unit tests for all three table printers with `allNamespaces=true` and `allNamespaces=false`
- [x] Unit tests for task spawner table printer with both cron and GitHub Issues sources
- [x] `make build` passes
- [x] `make test` passes
- [x] `make verify` passes

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds --all-namespaces (-A) to axon get commands (task, taskspawner, workspace) to list resources across all namespaces. Output includes a NAMESPACE column; using -A with a resource name returns an error, fulfilling Linear #265.

<sup>Written for commit c85ed9dd92f5157404ad16ba7f64df4feaa31bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

