### PR TITLE
Display custom image in CLI detail views

### DIFF
--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -42,6 +42,9 @@ func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
 	if t.Spec.Model != "" {
 		printField(w, "Model", t.Spec.Model)
 	}
+	if t.Spec.Image != "" {
+		printField(w, "Image", t.Spec.Image)
+	}
 	if t.Spec.WorkspaceRef != nil {
 		printField(w, "Workspace", t.Spec.WorkspaceRef.Name)
 	}
@@ -126,6 +129,9 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 	printField(w, "Task Type", ts.Spec.TaskTemplate.Type)
 	if ts.Spec.TaskTemplate.Model != "" {
 		printField(w, "Model", ts.Spec.TaskTemplate.Model)
+	}
+	if ts.Spec.TaskTemplate.Image != "" {
+		printField(w, "Image", ts.Spec.TaskTemplate.Image)
 	}
 	printField(w, "Poll Interval", ts.Spec.PollInterval)
 	if ts.Status.DeploymentName != "" {


### PR DESCRIPTION
## Summary
- Show the `Image` field in `printTaskDetail` and `printTaskSpawnerDetail` CLI output when a custom agent image is configured
- Add unit tests for `printTaskDetail` and `printTaskSpawnerDetail` covering all fields including optional field omission
- Add spawner integration test verifying that `Image` is forwarded from `TaskTemplate` to spawned Tasks

## Context
The custom image support (API types, job builder, CLI `--image` flag, spawner forwarding) was already implemented. This PR completes the integration by:
1. Making the image visible in CLI detail views (`axon get task <name>`, `axon get taskspawner <name>`)
2. Adding comprehensive test coverage for the detail view printers and image forwarding

Closes #271

## Test plan
- [x] `make test` — all unit tests pass
- [x] `make verify` — lint, fmt, vet all pass
- [x] `make build` — builds successfully
- [x] New printer tests verify Image field is displayed when set and omitted when empty
- [x] New spawner test verifies Image field propagation from TaskTemplate to Task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the custom agent Image in axon get task <name> and axon get taskspawner <name> so users can confirm the container image that will run. Completes #271 by finishing image visibility in the CLI and verifying image forwarding from TaskTemplate to spawned Tasks.

<sup>Written for commit e6cac5a445f5f90dc9f5cc0df91cbe75f4c7f581. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

