### PR TITLE
Add conservative resources to self-development taskspawners

### DIFF
--- a/self-development/axon-fake-strategist.yaml
+++ b/self-development/axon-fake-strategist.yaml
@@ -15,6 +15,16 @@ spec:
       type: oauth
       secretRef:
         name: axon-credentials
+    podOverrides:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+          ephemeral-storage: "4Gi"
     promptTemplate: |
       You are a strategic product thinker for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       You are running in an ephemeral container environment. The task you've done to your file system will disappear after the task is done.

--- a/self-development/axon-fake-user.yaml
+++ b/self-development/axon-fake-user.yaml
@@ -15,6 +15,16 @@ spec:
       type: oauth
       secretRef:
         name: axon-credentials
+    podOverrides:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+          ephemeral-storage: "4Gi"
     promptTemplate: |
       You are a developer experience tester for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       You are running in an ephemeral container environment. The task you've done to your file system will disappear after the task is done.

--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -19,6 +19,16 @@ spec:
       type: oauth
       secretRef:
         name: axon-credentials
+    podOverrides:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+          ephemeral-storage: "4Gi"
     promptTemplate: |
       You are a coding agent that works within the ephemeral container environment.
       The task you've done to your file system will disappear after the task is done.


### PR DESCRIPTION
## Summary
- add `spec.taskTemplate.podOverrides.resources` to all self-development TaskSpawner manifests
- set conservative requests/limits for cpu, memory, and ephemeral-storage
- keep schedules, prompts, and workflow behavior unchanged

## Changed files
- self-development/axon-workers.yaml
- self-development/axon-fake-user.yaml
- self-development/axon-fake-strategist.yaml

## Validation
- make verify
- make test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set conservative CPU, memory, and ephemeral-storage requests/limits on all self-development TaskSpawner pods to improve scheduling stability. No changes to schedules, prompts, or workflow behavior.

- **Refactors**
  - Added spec.taskTemplate.podOverrides.resources to axon-workers, axon-fake-user, and axon-fake-strategist.
  - Requests: 250m CPU, 512Mi memory, 1Gi ephemeral-storage; Limits: 1 CPU, 2Gi memory, 4Gi ephemeral-storage.

<sup>Written for commit 9c1c107271840d1484a2d2d47b72a402c2c5aa84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

