### PR TITLE
Increase axon-workers ephemeral storage request to 4Gi

### DIFF
--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -24,7 +24,7 @@ spec:
         requests:
           cpu: "250m"
           memory: "512Mi"
-          ephemeral-storage: "1Gi"
+          ephemeral-storage: "4Gi"
         limits:
           cpu: "1"
           memory: "2Gi"


### PR DESCRIPTION
## Summary
- update `self-development/axon-workers.yaml` to set `requests.ephemeral-storage` to `4Gi`
- keep `limits.ephemeral-storage` at `4Gi`

## Why
GKE Autopilot mutates ephemeral-storage limits down to the request value; setting request to `4Gi` preserves an effective `4Gi` limit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased axon-workers ephemeral-storage request from 1Gi to 4Gi in self-development/axon-workers.yaml. This prevents GKE Autopilot from lowering the limit to the request, keeping an effective 4Gi.

<sup>Written for commit 1282354f5ac978b519ae6accd9fe0c3c0bde2880. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

