### PR TITLE
Add admin-only /reset-worker workflow to reset axon-worker task

### DIFF
--- a/.github/workflows/reset-axon-worker.yaml
+++ b/.github/workflows/reset-axon-worker.yaml
@@ -1,0 +1,168 @@
+name: Reset Axon Worker
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: reset-axon-worker-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reset-axon-worker:
+    if: contains(github.event.comment.body, '/reset-worker')
+    runs-on: ubuntu-latest
+    env:
+      AXON_NAMESPACE: ${{ vars.AXON_NAMESPACE || 'default' }}
+      GCP_PROJECT_ID: gjkim-400213
+      GKE_CLUSTER_NAME: gjkim
+      GKE_CLUSTER_LOCATION: asia-northeast3
+      GCP_SERVICE_ACCOUNT_EMAIL: axon-core-axon-gh-action@gjkim-400213.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/axon
+    steps:
+      - name: Determine if reset is requested
+        id: gate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function extractClosingIssueNumbers(text, owner, repo) {
+              const regex = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:https?:\/\/github\.com\/([^\/\s]+)\/([^\/\s]+)\/issues\/(\d+)|([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#(\d+)|#(\d+))/gim
+              const numbers = []
+              let match
+              while ((match = regex.exec(text || "")) !== null) {
+                if (match[7]) {
+                  numbers.push(Number(match[7]))
+                  continue
+                }
+                const fullOwner = (match[1] || match[4] || "").toLowerCase()
+                const fullRepo = (match[2] || match[5] || "").toLowerCase()
+                if (fullOwner === owner.toLowerCase() && fullRepo === repo.toLowerCase()) {
+                  numbers.push(Number(match[3] || match[6]))
+                }
+              }
+              return [...new Set(numbers)].filter((n) => Number.isInteger(n) && n > 0)
+            }
+
+            const commenter = context.payload.comment?.user?.login || ""
+            if (!commenter) {
+              core.info("Ignoring /reset-worker with unknown commenter")
+              core.setOutput("should_reset", "false")
+              return
+            }
+
+            let permission = ""
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: commenter,
+              })
+              permission = (data.permission || "").toLowerCase()
+            } catch (error) {
+              core.info(`Failed to resolve commenter permission for ${commenter}: ${error.message}`)
+              core.setOutput("should_reset", "false")
+              return
+            }
+
+            if (permission !== "admin") {
+              core.info(`Ignoring /reset-worker from non-admin user ${commenter} (permission=${permission || "unknown"})`)
+              core.setOutput("should_reset", "false")
+              return
+            }
+
+            const issue = context.payload.issue
+            if (!issue?.pull_request) {
+              core.info(`Reset requested on issue #${issue.number}`)
+              core.setOutput("should_reset", "true")
+              core.setOutput("target_issue_number", String(issue.number))
+              core.setOutput("target_pr_number", "")
+              return
+            }
+
+            const prNumber = issue.number
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            })
+
+            const referencedIssues = extractClosingIssueNumbers(pr.body || "", context.repo.owner, context.repo.repo)
+            if (referencedIssues.length === 0) {
+              core.info(`PR #${prNumber} does not declare a fixed issue in this repository`)
+              core.setOutput("should_reset", "false")
+              return
+            }
+
+            core.info(`Reset requested on PR #${prNumber} for issue #${referencedIssues[0]}`)
+            core.setOutput("should_reset", "true")
+            core.setOutput("target_issue_number", String(referencedIssues[0]))
+            core.setOutput("target_pr_number", String(prNumber))
+
+      - name: Authenticate to Google Cloud
+        if: steps.gate.outputs.should_reset == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Configure GKE credentials
+        if: steps.gate.outputs.should_reset == 'true'
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
+          location: ${{ env.GKE_CLUSTER_LOCATION }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Remove existing worker task
+        if: steps.gate.outputs.should_reset == 'true'
+        run: |
+          set -euo pipefail
+          task_name="axon-workers-${{ steps.gate.outputs.target_issue_number }}"
+          kubectl delete task.axon.io "${task_name}" -n "${AXON_NAMESPACE}" --ignore-not-found=true
+          echo "Removed task ${task_name} in namespace ${AXON_NAMESPACE} for target issue #${{ steps.gate.outputs.target_issue_number }}"
+
+      - name: Remove axon/needs-input label from issue and PR
+        if: steps.gate.outputs.should_reset == 'true'
+        uses: actions/github-script@v7
+        env:
+          TARGET_ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
+          TARGET_PR_NUMBER: ${{ steps.gate.outputs.target_pr_number }}
+        with:
+          script: |
+            const label = "axon/needs-input"
+            const targets = new Set()
+
+            const targetIssueNumber = Number(process.env.TARGET_ISSUE_NUMBER || "0")
+            const targetPrNumber = Number(process.env.TARGET_PR_NUMBER || "0")
+
+            if (Number.isInteger(targetIssueNumber) && targetIssueNumber > 0) {
+              targets.add(targetIssueNumber)
+            }
+            if (Number.isInteger(targetPrNumber) && targetPrNumber > 0) {
+              targets.add(targetPrNumber)
+            }
+
+            for (const issue_number of targets) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: label,
+                })
+                core.info(`Removed label ${label} from #${issue_number}`)
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Label ${label} not present on #${issue_number}`)
+                  continue
+                }
+                throw error
+              }
+            }

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -94,6 +94,9 @@ This TaskSpawner picks up open GitHub issues labeled with `actor/axon` and creat
 - Ensures CI passes before completion
 - Labels issues with `axon/needs-input` when human input is needed
 - Creates a feedback loop: remove the label to re-queue the issue
+- Supports manual reset via `/reset-worker` comment from a repository admin:
+  - Deletes `Task/axon-workers-<ISSUE-NUMBER>` so it can be recreated with the same name
+  - Removes `axon/needs-input` from the relevant issue and PR
 
 **Deploy:**
 ```bash


### PR DESCRIPTION
## Summary
- add a new issue_comment workflow that listens for /reset-worker
- allow reset only when commenter has admin permission on the repository
- support reset from issue comments and PR comments when the PR declares it fixes/closes/resolves an issue in this repo
- authenticate to GKE and delete Task/axon-worker so it can be recreated with the same name

## Verification
- make verify

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-only /reset-worker comment command to force-delete the axon worker Task for a specific issue and remove axon/needs-input labels, helping unstick workers quickly.

- **New Features**
  - Admin-only; triggers on /reset-worker in issue comments or PRs that close an issue in this repo.
  - Deletes Task axon-workers-<ISSUE-NUMBER> in $AXON_NAMESPACE via GKE (Workload Identity), with --ignore-not-found.
  - Removes axon/needs-input from the target issue and PR; docs added in README.

<sup>Written for commit 74fcd361fdab5873848e13c86e84540b604ae789. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

