### PR TITLE
docs: add table of contents to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,35 @@ https://github.com/user-attachments/assets/837cd8d5-4071-42dd-be32-114c649386ff
 
 See [Examples](#examples) for a full autonomous self-development pipeline.
 
+## Table of Contents
+
+- [Framework Core](#framework-core)
+- [Demo](#demo)
+- [Why Axon?](#why-axon)
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+  - [Prerequisites](#prerequisites)
+  - [1. Install the CLI](#1-install-the-cli)
+  - [2. Install Axon](#2-install-axon)
+  - [3. Initialize Your Config](#3-initialize-your-config)
+  - [4. Run Your First Task](#4-run-your-first-task)
+- [Examples](#examples)
+  - [Run against a git repo](#run-against-a-git-repo)
+  - [Create PRs automatically](#create-prs-automatically)
+  - [Inject agent instructions and plugins](#inject-agent-instructions-and-plugins)
+  - [Auto-fix GitHub issues with TaskSpawner](#auto-fix-github-issues-with-taskspawner)
+  - [Run tasks on a schedule (Cron)](#run-tasks-on-a-schedule-cron)
+  - [Autonomous self-development pipeline](#autonomous-self-development-pipeline)
+  - [Copy-paste YAML manifests](#copy-paste-yaml-manifests)
+- [Framework Capabilities](#framework-capabilities)
+- [Orchestration Patterns](#orchestration-patterns)
+- [Reference](#reference)
+- [Uninstall](#uninstall)
+- [Development](#development)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+- [License](#license)
+
 ## Why Axon?
 
 AI coding agents are evolving from interactive CLI tools into autonomous background workers. Axon provides the necessary infrastructure to manage this transition at scale.


### PR DESCRIPTION
This PR adds a Table of Contents to the README.md for better navigability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a linked Table of Contents to README.md for easier navigation, positioned after the Demo section.
It links to all major sections and nested items (Quick Start steps, Examples, Framework Capabilities, Orchestration Patterns, Reference, etc.).

<sup>Written for commit eac3404eb383357f59c6e6e3fd7e9791c67a4ff0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

