### PR TITLE
Add task dependencies with dependsOn field

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -27,6 +27,8 @@ const (
 	TaskPhaseSucceeded TaskPhase = "Succeeded"
 	// TaskPhaseFailed means the Task has failed.
 	TaskPhaseFailed TaskPhase = "Failed"
+	// TaskPhaseWaiting means the Task is waiting for dependencies.
+	TaskPhaseWaiting TaskPhase = "Waiting"
 )
 
 // SecretReference refers to a Secret containing credentials.
@@ -102,6 +104,10 @@ type TaskSpec struct {
 	// +optional
 	AgentConfigRef *AgentConfigReference `json:"agentConfigRef,omitempty"`
 
+	// DependsOn lists Task names that must succeed before this Task starts.
+	// +optional
+	DependsOn []string `json:"dependsOn,omitempty"`
+
 	// TTLSecondsAfterFinished limits the lifetime of a Task that has finished
 	// execution (either Succeeded or Failed). If set, the Task will be
 	// automatically deleted after the given number of seconds once it reaches
@@ -155,6 +161,7 @@ type TaskStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Depends On",type=string,JSONPath=`.spec.dependsOn`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Task is the Schema for the tasks API.

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -93,6 +93,10 @@ type TaskTemplate struct {
 	// +optional
 	AgentConfigRef *AgentConfigReference `json:"agentConfigRef,omitempty"`
 
+	// DependsOn lists Task names that spawned Tasks depend on.
+	// +optional
+	DependsOn []string `json:"dependsOn,omitempty"`
+
 	// PromptTemplate is a Go text/template for rendering the task prompt.
 	// Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -463,6 +463,11 @@ func (in *TaskSpec) DeepCopyInto(out *TaskSpec) {
 		*out = new(AgentConfigReference)
 		**out = **in
 	}
+	if in.DependsOn != nil {
+		in, out := &in.DependsOn, &out.DependsOn
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)
@@ -526,6 +531,11 @@ func (in *TaskTemplate) DeepCopyInto(out *TaskTemplate) {
 		in, out := &in.AgentConfigRef, &out.AgentConfigRef
 		*out = new(AgentConfigReference)
 		**out = **in
+	}
+	if in.DependsOn != nil {
+		in, out := &in.DependsOn, &out.DependsOn
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -200,6 +200,10 @@ func runCycleWithSource(ctx context.Context, cl client.Client, key types.Namespa
 			task.Spec.AgentConfigRef = ts.Spec.TaskTemplate.AgentConfigRef
 		}
 
+		if len(ts.Spec.TaskTemplate.DependsOn) > 0 {
+			task.Spec.DependsOn = ts.Spec.TaskTemplate.DependsOn
+		}
+
 		if err := cl.Create(ctx, task); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				log.Info("Task already exists, skipping", "task", taskName)

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -125,6 +125,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .spec.dependsOn
+      name: Depends On
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -184,6 +188,12 @@ spec:
                 - secretRef
                 - type
                 type: object
+              dependsOn:
+                description: DependsOn lists Task names that must succeed before this
+                  Task starts.
+                items:
+                  type: string
+                type: array
               image:
                 description: |-
                   Image optionally overrides the default agent container image.
@@ -618,6 +628,12 @@ spec:
                     - secretRef
                     - type
                     type: object
+                  dependsOn:
+                    description: DependsOn lists Task names that spawned Tasks depend
+                      on.
+                    items:
+                      type: string
+                    type: array
                   image:
                     description: |-
                       Image optionally overrides the default agent container image.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -51,6 +51,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		skillFlags     []string
 		agentFlags     []string
 		agentConfigRef string
+		dependsOn      []string
 	)
 
 	cmd := &cobra.Command{
@@ -259,6 +260,9 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				},
 			}
 
+			if len(dependsOn) > 0 {
+				task.Spec.DependsOn = dependsOn
+			}
 			if workspace != "" {
 				task.Spec.WorkspaceRef = &axonv1alpha1.WorkspaceReference{
 					Name: workspace,
@@ -342,6 +346,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().StringArrayVar(&skillFlags, "skill", nil, "skill definition as name=content or name=@file")
 	cmd.Flags().StringArrayVar(&agentFlags, "agent", nil, "agent definition as name=content or name=@file")
 	cmd.Flags().StringVar(&agentConfigRef, "agent-config", "", "name of AgentConfig resource to use")
+	cmd.Flags().StringArrayVar(&dependsOn, "depends-on", nil, "Task names this task depends on (repeatable)")
 
 	cmd.MarkFlagRequired("prompt")
 

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -29,7 +29,7 @@ func TestBuildClaudeCodeJob_DefaultImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestBuildClaudeCodeJob_CustomImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestBuildClaudeCodeJob_NoModel(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestBuildClaudeCodeJob_WorkspaceWithRef(t *testing.T) {
 		Ref:  "main",
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestBuildClaudeCodeJob_WorkspaceWithInjectedFiles(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -320,7 +320,7 @@ func TestBuildClaudeCodeJob_WorkspaceWithInjectedFilesInvalidPath(t *testing.T) 
 		},
 	}
 
-	_, err := builder.Build(task, workspace, nil)
+	_, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err == nil {
 		t.Fatal("Expected Build() to fail for invalid workspace file path")
 	}
@@ -355,7 +355,7 @@ func TestBuildClaudeCodeJob_CustomImageWithWorkspace(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestBuildClaudeCodeJob_WorkspaceWithSecretRefPersistsCredentialHelper(t *te
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestBuildClaudeCodeJob_EnterpriseWorkspaceSetsGHHostAndEnterpriseToken(t *t
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -556,7 +556,7 @@ func TestBuildClaudeCodeJob_GithubComWorkspaceUsesGHToken(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -603,7 +603,7 @@ func TestBuildCodexJob_DefaultImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -687,7 +687,7 @@ func TestBuildCodexJob_CustomImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -731,7 +731,7 @@ func TestBuildCodexJob_WithWorkspace(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -794,7 +794,7 @@ func TestBuildCodexJob_OAuthCredentials(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -844,7 +844,7 @@ func TestBuildGeminiJob_DefaultImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -931,7 +931,7 @@ func TestBuildGeminiJob_CustomImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -975,7 +975,7 @@ func TestBuildGeminiJob_WithWorkspace(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1041,7 +1041,7 @@ func TestBuildGeminiJob_OAuthCredentials(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1094,7 +1094,7 @@ func TestBuildOpenCodeJob_DefaultImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1184,7 +1184,7 @@ func TestBuildOpenCodeJob_CustomImage(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1228,7 +1228,7 @@ func TestBuildOpenCodeJob_WithWorkspace(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, nil)
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1297,7 +1297,7 @@ func TestBuildOpenCodeJob_OAuthCredentials(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1352,7 +1352,7 @@ func TestBuildClaudeCodeJob_UnsupportedType(t *testing.T) {
 		},
 	}
 
-	_, err := builder.Build(task, nil, nil)
+	_, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err == nil {
 		t.Fatal("Expected error for unsupported agent type, got nil")
 	}
@@ -1389,7 +1389,7 @@ func TestBuildJob_PodOverridesResources(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1434,7 +1434,7 @@ func TestBuildJob_PodOverridesActiveDeadlineSeconds(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1471,7 +1471,7 @@ func TestBuildJob_PodOverridesEnv(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1522,7 +1522,7 @@ func TestBuildJob_PodOverridesEnvBuiltinPrecedence(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1568,7 +1568,7 @@ func TestBuildJob_PodOverridesNodeSelector(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1616,7 +1616,7 @@ func TestBuildJob_PodOverridesAllFields(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1668,7 +1668,7 @@ func TestBuildJob_NoPodOverrides(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, nil)
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1712,7 +1712,7 @@ func TestBuildJob_AgentConfigAgentsMD(t *testing.T) {
 		AgentsMD: "Follow TDD. Always write tests first.",
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1773,7 +1773,7 @@ func TestBuildJob_AgentConfigPlugins(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1876,7 +1876,7 @@ func TestBuildJob_AgentConfigFull(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1940,7 +1940,7 @@ func TestBuildJob_AgentConfigWithWorkspace(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, workspace, agentConfig)
+	job, err := builder.Build(task, workspace, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -1988,7 +1988,7 @@ func TestBuildJob_AgentConfigWithoutWorkspace(t *testing.T) {
 		AgentsMD: "Follow TDD",
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -2049,7 +2049,7 @@ func TestBuildJob_AgentConfigCodex(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -2115,7 +2115,7 @@ func TestBuildJob_AgentConfigGemini(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -2184,7 +2184,7 @@ func TestBuildJob_AgentConfigOpenCode(t *testing.T) {
 		},
 	}
 
-	job, err := builder.Build(task, nil, agentConfig)
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
 	if err != nil {
 		t.Fatalf("Build() returned error: %v", err)
 	}
@@ -2283,7 +2283,7 @@ func TestBuildJob_AgentConfigPluginNamePathTraversal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := builder.Build(task, nil, tt.config)
+			_, err := builder.Build(task, nil, tt.config, task.Spec.Prompt)
 			if err == nil {
 				t.Fatal("Expected Build() to fail for path traversal, got nil")
 			}

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -125,6 +125,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .spec.dependsOn
+      name: Depends On
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -184,6 +188,12 @@ spec:
                 - secretRef
                 - type
                 type: object
+              dependsOn:
+                description: DependsOn lists Task names that must succeed before this
+                  Task starts.
+                items:
+                  type: string
+                type: array
               image:
                 description: |-
                   Image optionally overrides the default agent container image.
@@ -618,6 +628,12 @@ spec:
                     - secretRef
                     - type
                     type: object
+                  dependsOn:
+                    description: DependsOn lists Task names that spawned Tasks depend
+                      on.
+                    items:
+                      type: string
+                    type: array
                   image:
                     description: |-
                       Image optionally overrides the default agent container image.


### PR DESCRIPTION
## Summary
- Add `dependsOn` field to TaskSpec: tasks wait for listed dependencies to succeed before starting; if any dependency fails, the task fails immediately
- Support Go template expansion in prompts referencing dependency outputs (e.g. `{{ index .Deps "task-a" "Outputs" }}`)
- Add `--depends-on` CLI flag, propagate the field through TaskSpawner

## Test plan
- [x] `make verify` passes (lint, fmt, vet)
- [x] `make test` passes (all unit tests)
- [x] `make test-integration` passes (including new: dependency waiting, dependency failure, cycle detection, prompt template resolution)
- [ ] `make test-e2e` — new dependency chain e2e test (uses cheapest model)
- [ ] Manual: `axon run --prompt "echo hello" --depends-on task-a --dry-run` produces correct YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)