### PR TITLE
Use local-only tagged image injection in local-run.sh

### DIFF
--- a/local-run.sh
+++ b/local-run.sh
@@ -4,10 +4,69 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-make image
-make push
-go install github.com/axon-core/axon/cmd/axon
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+REGISTRY="${REGISTRY:-gjkim42}"
+LOCAL_IMAGE_TAG="${LOCAL_IMAGE_TAG:-local-dev}"
+VERSION_PKG="github.com/axon-core/axon/internal/version.Version"
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "Kind CLI not found in PATH" >&2
+  exit 1
+fi
+
+if ! kind get clusters | grep -Fxq "${KIND_CLUSTER_NAME}"; then
+  echo "Kind cluster ${KIND_CLUSTER_NAME} not found" >&2
+  exit 1
+fi
+
+make image REGISTRY="${REGISTRY}" VERSION="${LOCAL_IMAGE_TAG}"
+
+images=(
+  "${REGISTRY}/axon-controller:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/axon-spawner:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/axon-token-refresher:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/claude-code:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/codex:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/gemini:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/opencode:${LOCAL_IMAGE_TAG}"
+)
+
+for image in "${images[@]}"; do
+  kind load docker-image --name "${KIND_CLUSTER_NAME}" "${image}"
+done
+
+go install -ldflags "-X ${VERSION_PKG}=${LOCAL_IMAGE_TAG}" github.com/axon-core/axon/cmd/axon
 
 axon install
+kubectl patch deployment/axon-controller-manager \
+  -n axon-system \
+  --type=strategic \
+  -p "$(
+    cat <<EOF
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "manager",
+            "imagePullPolicy": "IfNotPresent",
+            "args": [
+              "--leader-elect",
+              "--claude-code-image=${REGISTRY}/claude-code:${LOCAL_IMAGE_TAG}",
+              "--codex-image=${REGISTRY}/codex:${LOCAL_IMAGE_TAG}",
+              "--gemini-image=${REGISTRY}/gemini:${LOCAL_IMAGE_TAG}",
+              "--opencode-image=${REGISTRY}/opencode:${LOCAL_IMAGE_TAG}",
+              "--spawner-image=${REGISTRY}/axon-spawner:${LOCAL_IMAGE_TAG}",
+              "--token-refresher-image=${REGISTRY}/axon-token-refresher:${LOCAL_IMAGE_TAG}"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+  )"
 kubectl rollout restart deployment/axon-controller-manager -n axon-system
 kubectl rollout status deployment/axon-controller-manager -n axon-system


### PR DESCRIPTION
## Summary
- remove push from local workflow and use kind image loading
- build and load a dedicated local tag (default `local-dev`)
- include all local runtime images: controller, spawner, token-refresher, claude-code, codex, gemini, opencode
- install axon CLI with matching version tag so `axon install` renders the same image tag
- patch controller manager args to use local-tagged images and set manager pull policy to `IfNotPresent`

## Validation
- make verify
- make test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch local-run.sh to build and load local-tagged images directly into kind instead of pushing to a registry. This makes local runs faster and ensures all components use the same local images.

- **New Features**
  - Build all images with LOCAL_IMAGE_TAG (default: local-dev) and load into kind; no push required.
  - Covers controller, spawner, token-refresher, and model runtimes (claude-code, codex, gemini, opencode).
  - Install axon CLI with a matching version so axon install renders the same tag.
  - Patch axon-controller-manager to use local-tagged images and imagePullPolicy IfNotPresent; restart and wait for rollout.
  - Add checks for kind CLI and cluster; support overrides via KIND_CLUSTER_NAME, REGISTRY, LOCAL_IMAGE_TAG.

<sup>Written for commit 8d8a7435f7ad97bc4b4177d2a69ad921c7370495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

