### PR TITLE
Add branch field for branch management

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -27,7 +27,7 @@ const (
 	TaskPhaseSucceeded TaskPhase = "Succeeded"
 	// TaskPhaseFailed means the Task has failed.
 	TaskPhaseFailed TaskPhase = "Failed"
-	// TaskPhaseWaiting means the Task is waiting for dependencies.
+	// TaskPhaseWaiting means the Task is waiting for dependencies or branch lock.
 	TaskPhaseWaiting TaskPhase = "Waiting"
 )
 
@@ -108,6 +108,12 @@ type TaskSpec struct {
 	// +optional
 	DependsOn []string `json:"dependsOn,omitempty"`
 
+	// Branch is the git branch this Task works on.
+	// The controller ensures only one Task with the same Branch value
+	// runs at a time. Overrides workspace ref for checkout.
+	// +optional
+	Branch string `json:"branch,omitempty"`
+
 	// TTLSecondsAfterFinished limits the lifetime of a Task that has finished
 	// execution (either Succeeded or Failed). If set, the Task will be
 	// automatically deleted after the given number of seconds once it reaches
@@ -165,6 +171,7 @@ type TaskStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Branch",type=string,JSONPath=`.spec.branch`,priority=1
 // +kubebuilder:printcolumn:name="Depends On",type=string,JSONPath=`.spec.dependsOn`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -97,6 +97,10 @@ type TaskTemplate struct {
 	// +optional
 	DependsOn []string `json:"dependsOn,omitempty"`
 
+	// Branch is the git branch spawned Tasks should work on.
+	// +optional
+	Branch string `json:"branch,omitempty"`
+
 	// PromptTemplate is a Go text/template for rendering the task prompt.
 	// Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
 	// +optional

--- a/cmd/axon-controller/main.go
+++ b/cmd/axon-controller/main.go
@@ -98,12 +98,13 @@ func main() {
 	jobBuilder.OpenCodeImage = openCodeImage
 	jobBuilder.OpenCodeImagePullPolicy = corev1.PullPolicy(openCodeImagePullPolicy)
 	if err = (&controller.TaskReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		JobBuilder:  jobBuilder,
-		Clientset:   clientset,
-		TokenClient: githubapp.NewTokenClient(),
-		Recorder:    mgr.GetEventRecorderFor("axon-controller"),
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		JobBuilder:   jobBuilder,
+		Clientset:    clientset,
+		TokenClient:  githubapp.NewTokenClient(),
+		Recorder:     mgr.GetEventRecorderFor("axon-controller"),
+		BranchLocker: controller.NewBranchLocker(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Task")
 		os.Exit(1)

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -203,6 +203,9 @@ func runCycleWithSource(ctx context.Context, cl client.Client, key types.Namespa
 		if len(ts.Spec.TaskTemplate.DependsOn) > 0 {
 			task.Spec.DependsOn = ts.Spec.TaskTemplate.DependsOn
 		}
+		if ts.Spec.TaskTemplate.Branch != "" {
+			task.Spec.Branch = ts.Spec.TaskTemplate.Branch
+		}
 
 		if err := cl.Create(ctx, task); err != nil {
 			if apierrors.IsAlreadyExists(err) {

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -125,6 +125,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .spec.branch
+      name: Branch
+      priority: 1
+      type: string
     - jsonPath: .spec.dependsOn
       name: Depends On
       priority: 1
@@ -166,6 +170,12 @@ spec:
                 required:
                 - name
                 type: object
+              branch:
+                description: |-
+                  Branch is the git branch this Task works on.
+                  The controller ensures only one Task with the same Branch value
+                  runs at a time. Overrides workspace ref for checkout.
+                type: string
               credentials:
                 description: Credentials specifies how to authenticate with the agent.
                 properties:
@@ -610,6 +620,10 @@ spec:
                     required:
                     - name
                     type: object
+                  branch:
+                    description: Branch is the git branch spawned Tasks should work
+                      on.
+                    type: string
                   credentials:
                     description: Credentials specifies how to authenticate with the
                       agent.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -49,6 +49,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		envFlags       []string
 		agentConfigRef string
 		dependsOn      []string
+		branch         string
 	)
 
 	cmd := &cobra.Command{
@@ -206,6 +207,10 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 			if len(dependsOn) > 0 {
 				task.Spec.DependsOn = dependsOn
 			}
+			if branch != "" {
+				task.Spec.Branch = branch
+			}
+
 			if workspace != "" {
 				task.Spec.WorkspaceRef = &axonv1alpha1.WorkspaceReference{
 					Name: workspace,
@@ -287,6 +292,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().StringArrayVar(&envFlags, "env", nil, "additional environment variables for the agent (NAME=VALUE)")
 	cmd.Flags().StringVar(&agentConfigRef, "agent-config", "", "name of AgentConfig resource to use")
 	cmd.Flags().StringArrayVar(&dependsOn, "depends-on", nil, "Task names this task depends on (repeatable)")
+	cmd.Flags().StringVar(&branch, "branch", "", "Git branch to work on")
 
 	cmd.MarkFlagRequired("prompt")
 

--- a/internal/controller/branch_locker.go
+++ b/internal/controller/branch_locker.go
@@ -1,0 +1,48 @@
+package controller
+
+import "sync"
+
+// BranchLocker tracks which task owns each workspace+branch combination.
+// TryAcquire atomically checks availability and claims ownership, so the
+// hot path does not depend on the informer cache being up-to-date.
+// The status-based check (checkBranchLock) is kept as a fallback to
+// reconstruct ownership after a controller restart.
+type BranchLocker struct {
+	mu     sync.Mutex
+	owners map[string]string // lock key -> owning task name
+}
+
+// NewBranchLocker creates a new BranchLocker.
+func NewBranchLocker() *BranchLocker {
+	return &BranchLocker{owners: make(map[string]string)}
+}
+
+// TryAcquire attempts to claim the branch lock for the given task.
+// Returns (true, "") if acquired, or (false, holder) if another task holds it.
+// Calling TryAcquire again with the same key and taskName is idempotent.
+func (bl *BranchLocker) TryAcquire(key, taskName string) (bool, string) {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	if holder, ok := bl.owners[key]; ok && holder != taskName {
+		return false, holder
+	}
+	bl.owners[key] = taskName
+	return true, ""
+}
+
+// Release releases the branch lock if held by the given task.
+// It is safe to call Release even if the task does not hold the lock.
+func (bl *BranchLocker) Release(key, taskName string) {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	if bl.owners[key] == taskName {
+		delete(bl.owners, key)
+	}
+}
+
+// Holder returns the task name holding the given key, or "" if unheld.
+func (bl *BranchLocker) Holder(key string) string {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	return bl.owners[key]
+}

--- a/internal/controller/branch_locker_test.go
+++ b/internal/controller/branch_locker_test.go
@@ -1,0 +1,82 @@
+package controller
+
+import "testing"
+
+func TestBranchLocker_TryAcquireAndRelease(t *testing.T) {
+	bl := NewBranchLocker()
+
+	ok, holder := bl.TryAcquire("ws:feature-1", "task-a")
+	if !ok {
+		t.Fatalf("Expected TryAcquire to succeed, got held by %q", holder)
+	}
+
+	// Same task re-acquiring is idempotent.
+	ok, _ = bl.TryAcquire("ws:feature-1", "task-a")
+	if !ok {
+		t.Fatal("Expected idempotent TryAcquire to succeed")
+	}
+
+	// Different task should be rejected.
+	ok, holder = bl.TryAcquire("ws:feature-1", "task-b")
+	if ok {
+		t.Fatal("Expected TryAcquire to fail for different task")
+	}
+	if holder != "task-a" {
+		t.Errorf("Expected holder %q, got %q", "task-a", holder)
+	}
+
+	// Release and re-acquire by different task.
+	bl.Release("ws:feature-1", "task-a")
+	ok, _ = bl.TryAcquire("ws:feature-1", "task-b")
+	if !ok {
+		t.Fatal("Expected TryAcquire to succeed after release")
+	}
+}
+
+func TestBranchLocker_DifferentKeysIndependent(t *testing.T) {
+	bl := NewBranchLocker()
+
+	ok, _ := bl.TryAcquire("ws-a:feature-1", "task-a")
+	if !ok {
+		t.Fatal("Expected TryAcquire to succeed")
+	}
+
+	// Different key should succeed independently.
+	ok, _ = bl.TryAcquire("ws-b:feature-1", "task-b")
+	if !ok {
+		t.Fatal("Expected TryAcquire on different key to succeed")
+	}
+}
+
+func TestBranchLocker_ReleaseWrongTask(t *testing.T) {
+	bl := NewBranchLocker()
+
+	bl.TryAcquire("ws:feature-1", "task-a")
+
+	// Releasing with wrong task name should be a no-op.
+	bl.Release("ws:feature-1", "task-b")
+
+	if h := bl.Holder("ws:feature-1"); h != "task-a" {
+		t.Errorf("Expected holder %q after wrong release, got %q", "task-a", h)
+	}
+}
+
+func TestBranchLocker_ReleaseUnheldKey(t *testing.T) {
+	bl := NewBranchLocker()
+
+	// Should not panic.
+	bl.Release("ws:nonexistent", "task-a")
+}
+
+func TestBranchLocker_Holder(t *testing.T) {
+	bl := NewBranchLocker()
+
+	if h := bl.Holder("ws:feature-1"); h != "" {
+		t.Errorf("Expected empty holder, got %q", h)
+	}
+
+	bl.TryAcquire("ws:feature-1", "task-a")
+	if h := bl.Holder("ws:feature-1"); h != "task-a" {
+		t.Errorf("Expected holder %q, got %q", "task-a", h)
+	}
+}

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -125,6 +125,10 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .spec.branch
+      name: Branch
+      priority: 1
+      type: string
     - jsonPath: .spec.dependsOn
       name: Depends On
       priority: 1
@@ -166,6 +170,12 @@ spec:
                 required:
                 - name
                 type: object
+              branch:
+                description: |-
+                  Branch is the git branch this Task works on.
+                  The controller ensures only one Task with the same Branch value
+                  runs at a time. Overrides workspace ref for checkout.
+                type: string
               credentials:
                 description: Credentials specifies how to authenticate with the agent.
                 properties:
@@ -610,6 +620,10 @@ spec:
                     required:
                     - name
                     type: object
+                  branch:
+                    description: Branch is the git branch spawned Tasks should work
+                      on.
+                    type: string
                   credentials:
                     description: Credentials specifies how to authenticate with the
                       agent.

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -81,11 +81,12 @@ var _ = BeforeSuite(func() {
 	tokenClient.Client = mockGitHubServer.Client()
 
 	err = (&controller.TaskReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		JobBuilder:  controller.NewJobBuilder(),
-		TokenClient: tokenClient,
-		Recorder:    mgr.GetEventRecorderFor("axon-controller"),
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		JobBuilder:   controller.NewJobBuilder(),
+		TokenClient:  tokenClient,
+		Recorder:     mgr.GetEventRecorderFor("axon-controller"),
+		BranchLocker: controller.NewBranchLocker(),
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Summary
- Add `branch` field to `TaskSpec` and `TaskTemplate` for explicit git branch targeting
- Implement branch mutex lock: controller ensures only one Task with the same branch runs at a time (tasks queue in `Waiting` phase)
- Add `branch-setup` init container that checks out or creates the specified branch before the agent runs
- Pass `AXON_BRANCH` env var to both init container and main agent container
- Wire branch support through CLI (`--branch` flag), spawner, and CRD manifests

Also includes prior features rebased from main:
- Task dependencies with `dependsOn` field, cycle detection, and prompt templates
- Structured `Results` field parsed from `key: value` output lines
- Various docs, README, and example improvements

## Test plan
- [x] Unit tests for job builder with branch field
- [x] Integration tests for branch lock (concurrent tasks on same branch)
- [x] Integration tests for branch init container creation
- [x] Integration tests for dependency chain, failure propagation, cycle detection
- [x] Integration tests for prompt template resolution with dependency results
- [x] E2e test for task dependency chain
- [ ] Manual: verify `axon run --branch feature-x` creates task with branch field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds branch-aware task execution so a Task can target a git branch, with a per-workspace branch lock and an init container that fetches/checks out the branch. Prevents concurrent runs on the same workspace+branch and surfaces the branch in CRDs and kubectl columns.

- **New Features**
  - TaskSpec/TaskTemplate: new branch field for explicit git branch targeting.
  - Controller enforces one Task per workspace+branch using an in-memory BranchLocker (TryAcquire/Release) with status-based recovery after restarts.
  - Branch-setup init container checks out or creates the branch; AXON_BRANCH env is set on init and main containers.
  - CLI adds --branch; spawner propagates template branch; CRDs/manifests updated with schema and Branch printcolumn.

- **Bug Fixes**
  - Prevent env slice mutation by copying workspace env before appending AXON_BRANCH (keeps git-clone env clean).
  - Add credential helper to branch-setup fetch for private repos when workspace SecretRef is set.
  - Improve branch lock: include earlier Waiting tasks for FIFO ordering, re-enqueue same-branch Waiting tasks on completion, and warn if branch is set without workspaceRef (checkout skipped).

<sup>Written for commit de933fc9b106896375291a80258733e900a98fc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

