### PR TITLE
Enforce Task spec immutability

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -173,6 +173,7 @@ type Task struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Task spec is immutable after creation"
 	Spec   TaskSpec   `json:"spec,omitempty"`
 	Status TaskStatus `json:"status,omitempty"`
 }

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -480,6 +480,9 @@ spec:
             - prompt
             - type
             type: object
+            x-kubernetes-validations:
+            - message: Task spec is immutable after creation
+              rule: self == oldSelf
           status:
             description: TaskStatus defines the observed state of Task.
             properties:

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -480,6 +480,9 @@ spec:
             - prompt
             - type
             type: object
+            x-kubernetes-validations:
+            - message: Task spec is immutable after creation
+              rule: self == oldSelf
           status:
             description: TaskStatus defines the observed state of Task.
             properties:

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -2216,4 +2216,69 @@ var _ = Describe("Task Controller", func() {
 			Expect(mainContainer.Args[0]).To(Equal("Review branch feature-456"))
 		})
 	})
+
+	Context("When updating a Task spec after creation", func() {
+		It("Should reject the update because Task spec is immutable", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-task-immutable",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Secret with API key")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "anthropic-api-key",
+					Namespace: ns.Name,
+				},
+				StringData: map[string]string{
+					"ANTHROPIC_API_KEY": "test-api-key",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating a Task")
+			task := &axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-immutable",
+					Namespace: ns.Name,
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   "claude-code",
+					Prompt: "Original prompt",
+					Credentials: axonv1alpha1.Credentials{
+						Type: axonv1alpha1.CredentialTypeAPIKey,
+						SecretRef: axonv1alpha1.SecretReference{
+							Name: "anthropic-api-key",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
+
+			By("Waiting for the Task to be reconciled with a finalizer")
+			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
+			createdTask := &axonv1alpha1.Task{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
+				if err != nil {
+					return false
+				}
+				for _, f := range createdTask.Finalizers {
+					if f == "axon.io/finalizer" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Attempting to update the Task prompt")
+			createdTask.Spec.Prompt = "Updated prompt"
+			err := k8sClient.Update(ctx, createdTask)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("immutable"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- Add a CEL transition rule (`self == oldSelf`) on the Task `spec` field to make it immutable after creation
- Tasks spawn Jobs immediately on creation, so spec updates are misleading since they won't be reflected in the running Job
- The rule is enforced at the API server level with no webhook infrastructure needed

## Test plan
- [x] Added integration test that creates a Task, then attempts to update the prompt and verifies the update is rejected with "immutable" error
- [x] All existing integration tests pass (57/57)
- [x] `make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces immutability of Task.spec after creation to prevent misleading updates once a Job has started. Validation is handled by the API server using a CEL transition rule.

- **New Features**
  - Add CEL x-kubernetes-validations rule (self == oldSelf) on Task.spec; propagated to CRD manifests.
  - Add integration test that attempts to change the prompt and expects an “immutable” error; all existing tests and verify pass.

<sup>Written for commit 5877933b959bcb30200d06efefbae14014109691. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

