### PR TITLE
Support Go template variables in TaskTemplate branch field

### DIFF
--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -100,6 +100,8 @@ type TaskTemplate struct {
 	DependsOn []string `json:"dependsOn,omitempty"`
 
 	// Branch is the git branch spawned Tasks should work on.
+	// Supports Go text/template variables from the work item, e.g. "axon-task-{{.Number}}".
+	// Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
 	// +optional
 	Branch string `json:"branch,omitempty"`
 

--- a/cmd/axon-spawner/main.go
+++ b/cmd/axon-spawner/main.go
@@ -247,7 +247,12 @@ func runCycleWithSource(ctx context.Context, cl client.Client, key types.Namespa
 			task.Spec.DependsOn = ts.Spec.TaskTemplate.DependsOn
 		}
 		if ts.Spec.TaskTemplate.Branch != "" {
-			task.Spec.Branch = ts.Spec.TaskTemplate.Branch
+			branch, err := source.RenderTemplate(ts.Spec.TaskTemplate.Branch, item)
+			if err != nil {
+				log.Error(err, "rendering branch template", "item", item.ID)
+				continue
+			}
+			task.Spec.Branch = branch
 		}
 
 		if err := cl.Create(ctx, task); err != nil {

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -645,8 +645,10 @@ spec:
                     - name
                     type: object
                   branch:
-                    description: Branch is the git branch spawned Tasks should work
-                      on.
+                    description: |-
+                      Branch is the git branch spawned Tasks should work on.
+                      Supports Go text/template variables from the work item, e.g. "axon-task-{{.Number}}".
+                      Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
                     type: string
                   credentials:
                     description: Credentials specifies how to authenticate with the

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -645,8 +645,10 @@ spec:
                     - name
                     type: object
                   branch:
-                    description: Branch is the git branch spawned Tasks should work
-                      on.
+                    description: |-
+                      Branch is the git branch spawned Tasks should work on.
+                      Supports Go text/template variables from the work item, e.g. "axon-task-{{.Number}}".
+                      Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
                     type: string
                   credentials:
                     description: Credentials specifies how to authenticate with the

--- a/internal/source/prompt.go
+++ b/internal/source/prompt.go
@@ -23,10 +23,16 @@ func RenderPrompt(promptTemplate string, item WorkItem) (string, error) {
 	if tmplStr == "" {
 		tmplStr = defaultPromptTemplate
 	}
+	return RenderTemplate(tmplStr, item)
+}
 
-	tmpl, err := template.New("prompt").Parse(tmplStr)
+// RenderTemplate renders a Go text/template string with the given work item's fields.
+// Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}},
+// {{.Labels}}, {{.Comments}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
+func RenderTemplate(tmplStr string, item WorkItem) (string, error) {
+	tmpl, err := template.New("tmpl").Parse(tmplStr)
 	if err != nil {
-		return "", fmt.Errorf("parsing prompt template: %w", err)
+		return "", fmt.Errorf("parsing template: %w", err)
 	}
 
 	kind := item.Kind
@@ -60,7 +66,7 @@ func RenderPrompt(promptTemplate string, item WorkItem) (string, error) {
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("executing prompt template: %w", err)
+		return "", fmt.Errorf("executing template: %w", err)
 	}
 
 	return buf.String(), nil

--- a/internal/source/prompt_test.go
+++ b/internal/source/prompt_test.go
@@ -150,3 +150,39 @@ func TestRenderPromptInvalidTemplate(t *testing.T) {
 		t.Fatal("expected error for invalid template")
 	}
 }
+
+func TestRenderTemplate(t *testing.T) {
+	item := WorkItem{
+		ID:     "42",
+		Number: 42,
+		Title:  "Fix the login bug",
+		Kind:   "Issue",
+	}
+
+	result, err := RenderTemplate("axon-task-{{.Number}}", item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "axon-task-42" {
+		t.Errorf("expected %q, got %q", "axon-task-42", result)
+	}
+}
+
+func TestRenderTemplateStaticString(t *testing.T) {
+	item := WorkItem{Number: 1}
+
+	result, err := RenderTemplate("my-branch", item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "my-branch" {
+		t.Errorf("expected %q, got %q", "my-branch", result)
+	}
+}
+
+func TestRenderTemplateInvalid(t *testing.T) {
+	_, err := RenderTemplate("{{.Bad", WorkItem{})
+	if err == nil {
+		t.Fatal("expected error for invalid template")
+	}
+}


### PR DESCRIPTION
## Summary
- The `branch` field in `TaskTemplate` now supports Go `text/template` variables (same as `promptTemplate`), allowing each spawned Task to get a unique branch name based on the work item
- Extracted a general-purpose `RenderTemplate` function from `RenderPrompt` for reuse across template fields
- Example: `branch: "axon-task-{{.Number}}"` produces `axon-task-326` for issue #326

## Test plan
- [x] Unit tests for `RenderTemplate` (static string, template with variables, invalid template)
- [x] Integration tests for branch template rendering in spawner (`BranchTemplateRendered`, `BranchStaticPassedThrough`)
- [x] All existing tests pass (`make test`)
- [x] `make verify` passes (generated CRD manifests updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Go template support to TaskTemplate.branch so spawned Tasks get unique branches per work item. Extracted a reusable RenderTemplate, updated CRD manifests/docs, and added unit/integration tests for env propagation, concurrency across different branches, and locking on the same branch.

- **New Features**
  - Branch accepts Go text/template variables from the work item (ID, Number, Title, Body, URL, Comments, Labels, Kind, Time, Schedule), e.g. axon-task-{{.Number}}; static strings pass through unchanged.
  - Spawner renders the branch per item using RenderTemplate; on render error it logs and skips the item.

<sup>Written for commit b7e8a67439da4cadd43098ffcc8b804e2d210d6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

