### PR TITLE
Use branch field in axon-workers TaskSpawner

### DIFF
--- a/self-development/axon-workers.yaml
+++ b/self-development/axon-workers.yaml
@@ -29,6 +29,7 @@ spec:
           cpu: "1"
           memory: "2Gi"
           ephemeral-storage: "4Gi"
+    branch: "axon-task-{{.Number}}"
     agentConfigRef:
       name: axon-dev-agent
     promptTemplate: |
@@ -42,9 +43,9 @@ spec:
         - gh pr edit <number> --add-label generated-by-axon --add-label ok-to-test
 
       Task:
-      - 0. Set up your working branch axon-task-{{.Number}}. Run this exactly:
+      - 0. Set up your working branch. Run this exactly:
         ```
-        git fetch --unshallow; git fetch origin axon-task-{{.Number}} && git checkout -B axon-task-{{.Number}} origin/axon-task-{{.Number}} && git rebase main || git checkout -b axon-task-{{.Number}} main
+        git fetch --unshallow || true; git rebase main
         ```
       - 1. Check if a PR already exists for branch axon-task-{{.Number}}.
 


### PR DESCRIPTION
## Summary
- Add `branch: "axon-task-{{.Number}}"` to the axon-workers TaskTemplate so the controller's `branch-setup` init container handles branch checkout and locking
- Simplify Step 0 in the prompt from a complex checkout one-liner to just `git fetch --unshallow && git rebase main`
- Other manifests (axon-fake-strategist, axon-fake-user, squash-commits-task) are intentionally unchanged since they use optional/conditional branch creation

## Test plan
- [ ] `make verify` passes
- [ ] Deploy and verify that the init container checks out the correct branch
- [ ] Verify branch locking prevents concurrent tasks on the same branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the TaskSpawner branch field (axon-task-{{.Number}}) so the controller’s branch-setup init container handles checkout and branch locking. Simplifies Step 0 to "git fetch --unshallow || true; git rebase main"; other manifests remain unchanged.

<sup>Written for commit 74bd3cb70ec14dff763fa94e8e0956037ffb356f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

