### PR TITLE
Add --version and --image-pull-policy flags to axon install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,9 +88,7 @@ jobs:
 
       - name: Deploy controller
         run: |
-          bin/axon install
-          kubectl set image deployment/axon-controller-manager manager=gjkim42/axon-controller:e2e -n axon-system
-          kubectl patch deployment axon-controller-manager -n axon-system -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Never","args":["--leader-elect","--spawner-image=gjkim42/axon-spawner:e2e","--spawner-image-pull-policy=Never","--claude-code-image=gjkim42/claude-code:e2e","--claude-code-image-pull-policy=Never","--codex-image=gjkim42/codex:e2e","--codex-image-pull-policy=Never","--gemini-image=gjkim42/gemini:e2e","--gemini-image-pull-policy=Never","--opencode-image=gjkim42/opencode:e2e","--opencode-image-pull-policy=Never"]}]}}}}'
+          bin/axon install --version e2e --image-pull-policy Never
           kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
 
       - name: E2E Test

--- a/install.yaml
+++ b/install.yaml
@@ -258,7 +258,9 @@ spec:
             - --claude-code-image=gjkim42/claude-code:latest
             - --codex-image=gjkim42/codex:latest
             - --gemini-image=gjkim42/gemini:latest
+            - --opencode-image=gjkim42/opencode:latest
             - --spawner-image=gjkim42/axon-spawner:latest
+            - --token-refresher-image=gjkim42/axon-token-refresher:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -258,7 +258,9 @@ spec:
             - --claude-code-image=gjkim42/claude-code:latest
             - --codex-image=gjkim42/codex:latest
             - --gemini-image=gjkim42/gemini:latest
+            - --opencode-image=gjkim42/opencode:latest
             - --spawner-image=gjkim42/axon-spawner:latest
+            - --token-refresher-image=gjkim42/axon-token-refresher:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/local-run.sh
+++ b/local-run.sh
@@ -7,8 +7,6 @@ set -o pipefail
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 REGISTRY="${REGISTRY:-gjkim42}"
 LOCAL_IMAGE_TAG="${LOCAL_IMAGE_TAG:-local-dev}"
-VERSION_PKG="github.com/axon-core/axon/internal/version.Version"
-
 if ! command -v kind >/dev/null 2>&1; then
   echo "Kind CLI not found in PATH" >&2
   exit 1
@@ -35,38 +33,7 @@ for image in "${images[@]}"; do
   kind load docker-image --name "${KIND_CLUSTER_NAME}" "${image}"
 done
 
-go install -ldflags "-X ${VERSION_PKG}=${LOCAL_IMAGE_TAG}" github.com/axon-core/axon/cmd/axon
+go install github.com/axon-core/axon/cmd/axon
 
-axon install
-kubectl patch deployment/axon-controller-manager \
-  -n axon-system \
-  --type=strategic \
-  -p "$(
-    cat <<EOF
-{
-  "spec": {
-    "template": {
-      "spec": {
-        "containers": [
-          {
-            "name": "manager",
-            "imagePullPolicy": "IfNotPresent",
-            "args": [
-              "--leader-elect",
-              "--claude-code-image=${REGISTRY}/claude-code:${LOCAL_IMAGE_TAG}",
-              "--codex-image=${REGISTRY}/codex:${LOCAL_IMAGE_TAG}",
-              "--gemini-image=${REGISTRY}/gemini:${LOCAL_IMAGE_TAG}",
-              "--opencode-image=${REGISTRY}/opencode:${LOCAL_IMAGE_TAG}",
-              "--spawner-image=${REGISTRY}/axon-spawner:${LOCAL_IMAGE_TAG}",
-              "--token-refresher-image=${REGISTRY}/axon-token-refresher:${LOCAL_IMAGE_TAG}"
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
-EOF
-  )"
-kubectl rollout restart deployment/axon-controller-manager -n axon-system
+axon install --version "${LOCAL_IMAGE_TAG}" --image-pull-policy IfNotPresent
 kubectl rollout status deployment/axon-controller-manager -n axon-system


### PR DESCRIPTION
## Summary
- Add `--version` flag to `axon install` to override image tags independently of the binary version (e.g., `axon install --version v0.2.0`)
- Add `--image-pull-policy` flag to set pull policy on the controller container and propagate it to all spawned pods via `--*-image-pull-policy` controller args
- Add `--opencode-image` and `--token-refresher-image` to the embedded manifest so all image args are managed by `axon install`
- Simplify CI and `local-run.sh` by removing kubectl patches

## Test plan
- [x] `make test` passes
- [x] `make verify` passes
- [ ] Verify `axon install --dry-run --version v0.5.0` outputs manifests with `:v0.5.0` tags
- [ ] Verify `axon install --dry-run --image-pull-policy Always` outputs manifests with `imagePullPolicy: Always` and `--*-image-pull-policy=Always` args
- [ ] Verify `axon install --dry-run` without flags still uses the binary version as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)