### PR TITLE
Add PR/issue triage example for high-volume repos

### DIFF
--- a/examples/06-openclaw-pr-triage/README.md
+++ b/examples/06-openclaw-pr-triage/README.md
@@ -1,0 +1,60 @@
+# 06 — PR & Issue Triage for High-Volume Repos
+
+A TaskSpawner that automatically triages every PR and issue on a fast-moving
+repo like [OpenClaw](https://github.com/openclaw/openclaw). Inspired by
+[@steipete's problem](https://x.com/steipete/status/2023057089346580828):
+hundreds of PRs per day, many duplicates, no way to keep up manually.
+
+## What It Does
+
+For every new PR or issue, an agent:
+
+1. **De-duplicates** — searches all open PRs/issues for semantic overlap and
+   flags duplicates with links.
+2. **Reviews quality** (PRs) — reads the diff and rates code quality, test
+   coverage, scope, and description.
+3. **Checks vision alignment** — flags PRs that stray from the project's
+   core principles (open-source, privacy-first, self-hosted).
+4. **Posts a triage comment** — a structured report with a clear
+   recommendation (MERGE / REVISE / CLOSE AS DUPLICATE / NEEDS MAINTAINER REVIEW).
+
+## Resources
+
+| File | Kind | Purpose |
+|------|------|---------|
+| `credentials-secret.yaml` | Secret | Claude OAuth token |
+| `github-token-secret.yaml` | Secret | GitHub token for repo access and commenting |
+| `workspace.yaml` | Workspace | Points to `openclaw/openclaw` |
+| `taskspawner.yaml` | TaskSpawner | Polls PRs + issues, spawns triage agents |
+
+## Steps
+
+1. **Edit the secrets** — replace placeholders in both secret files.
+
+2. **Apply:**
+
+```bash
+kubectl apply -f examples/06-openclaw-pr-triage/
+```
+
+3. **Watch it work:**
+
+```bash
+kubectl get taskspawners -w
+kubectl get tasks -w
+```
+
+4. **Cleanup:**
+
+```bash
+kubectl delete -f examples/06-openclaw-pr-triage/
+```
+
+## Tuning
+
+- `pollInterval: 3m` — how often to check for new PRs/issues.
+- `maxConcurrency: 5` — how many triage agents run in parallel.
+- `ttlSecondsAfterFinished: 600` — completed tasks are cleaned up after 10 min
+  so the spawner can re-process if new activity appears.
+- Edit the vision statement in `promptTemplate` to match your project's values.
+- Add `excludeLabels: ["triaged"]` to skip already-processed items.

--- a/examples/06-openclaw-pr-triage/credentials-secret.yaml
+++ b/examples/06-openclaw-pr-triage/credentials-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-claude-oauth
+type: Opaque
+stringData:
+  # TODO: Replace with your Claude OAuth token
+  CLAUDE_CODE_OAUTH_TOKEN: "REPLACE-ME"

--- a/examples/06-openclaw-pr-triage/github-token-secret.yaml
+++ b/examples/06-openclaw-pr-triage/github-token-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-github-token
+type: Opaque
+stringData:
+  # TODO: Replace with your GitHub token
+  # Required permissions: repo, pull_requests (read/write for comments)
+  GITHUB_TOKEN: "ghp_REPLACE-ME"

--- a/examples/06-openclaw-pr-triage/taskspawner.yaml
+++ b/examples/06-openclaw-pr-triage/taskspawner.yaml
@@ -1,0 +1,84 @@
+apiVersion: axon.io/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: openclaw-pr-triage
+spec:
+  when:
+    githubIssues:
+      types:
+        - pulls
+        - issues
+      state: open
+  taskTemplate:
+    type: claude-code
+    workspaceRef:
+      name: openclaw
+    credentials:
+      type: oauth
+      secretRef:
+        name: openclaw-claude-oauth
+    promptTemplate: |
+      You are a triage agent for the OpenClaw project (github.com/openclaw/openclaw).
+      Your job is to analyze the following {{.Kind}} and post a single triage comment using `gh`.
+
+      ---
+      {{.Kind}} #{{.Number}}: {{.Title}}
+      {{.Body}}
+      {{if .Comments}}
+      Comments:
+      {{.Comments}}
+      {{end}}
+      ---
+
+      ## Your tasks
+
+      ### 1. Duplicate detection
+      Search for other open PRs and issues that address the same thing:
+        - `gh pr list --state open --limit 100 --json number,title,body,labels`
+        - `gh issue list --state open --limit 100 --json number,title,body,labels`
+      Look for semantic overlap, not just title similarity. Two PRs that fix the
+      same bug in different ways are duplicates. Flag every duplicate you find with
+      its number and a one-line explanation of why they overlap.
+
+      ### 2. Quality signals (PRs only)
+      If this is a pull request, evaluate:
+        - **Code quality**: Read the diff with `gh pr diff {{.Number}}`. Look for
+          correctness, test coverage, error handling, and style consistency.
+        - **Description quality**: Is the problem clearly stated? Is the approach explained?
+        - **Scope**: Is it a focused change or does it bundle unrelated modifications?
+        - **Test coverage**: Does it add or update tests for the changed behavior?
+        - **Breaking changes**: Does it modify public APIs or config formats?
+      Rate the PR: STRONG / ACCEPTABLE / NEEDS WORK / REJECT.
+
+      ### 3. Vision alignment
+      OpenClaw's vision: a personal AI assistant that is open-source, privacy-first,
+      and runs on user-owned hardware. Any PR that undermines these principles
+      (e.g., adding telemetry, requiring a hosted service, removing self-host
+      capability) should be flagged as MISALIGNED with a clear explanation.
+
+      ## Output
+      Post exactly one comment on this {{.Kind}} using:
+        `gh {{if eq .Kind "pull_request"}}pr{{else}}issue{{end}} comment {{.Number}} --body "..."`
+
+      Format the comment as:
+
+      ```
+      ## Axon Triage Report
+
+      **Duplicates found**: #X (reason), #Y (reason) — or "None found"
+
+      **Quality** (PRs only): STRONG / ACCEPTABLE / NEEDS WORK / REJECT
+      - Code: ...
+      - Tests: ...
+      - Scope: ...
+
+      **Vision alignment**: ALIGNED / MISALIGNED
+      - ...
+
+      **Recommendation**: MERGE / REVISE / CLOSE AS DUPLICATE / NEEDS MAINTAINER REVIEW
+      ```
+
+      Do NOT open PRs, push code, or modify any files. Read-only analysis only.
+    ttlSecondsAfterFinished: 3600
+  pollInterval: 3m
+  maxConcurrency: 5

--- a/examples/06-openclaw-pr-triage/workspace.yaml
+++ b/examples/06-openclaw-pr-triage/workspace.yaml
@@ -1,0 +1,9 @@
+apiVersion: axon.io/v1alpha1
+kind: Workspace
+metadata:
+  name: openclaw
+spec:
+  repo: https://github.com/openclaw/openclaw.git
+  ref: main
+  secretRef:
+    name: openclaw-github-token

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ Ready-to-use patterns and YAML manifests for orchestrating AI agents with Axon. 
 | [03-taskspawner-github-issues](03-taskspawner-github-issues/) | Automatically create Tasks from labeled GitHub issues |
 | [04-taskspawner-cron](04-taskspawner-cron/) | Run agent tasks on a cron schedule |
 | [05-task-with-agentconfig](05-task-with-agentconfig/) | Inject reusable instructions and plugins via AgentConfig |
+| [06-openclaw-pr-triage](06-openclaw-pr-triage/) | Triage PRs and issues at scale: de-dupe, review, vision-check |
 
 ## How to Use
 


### PR DESCRIPTION
## Summary
- Adds example `06-openclaw-pr-triage` — a TaskSpawner that automatically triages every PR and issue on a high-volume repo
- Inspired by [@steipete's pain](https://x.com/steipete/status/2023057089346580828) with OpenClaw getting 400+ PRs/day
- The agent de-duplicates across open PRs/issues, reviews code quality, checks vision alignment, and posts a structured triage comment
- Uses a single TaskSpawner with `promptTemplate` — no AgentConfig needed

## Test plan
- [ ] Verify YAML is valid: `kubectl apply --dry-run=client -f examples/06-openclaw-pr-triage/`
- [ ] Review promptTemplate for completeness and correctness
- [ ] Confirm examples/README.md index is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds example 06: a TaskSpawner that auto-triages new PRs and issues for high-volume repos like OpenClaw, reducing maintainer load with de-dup, quality checks, and a structured triage comment.

- **New Features**
  - New example at examples/06-openclaw-pr-triage with TaskSpawner, Workspace, and Secret manifests.
  - De-duplicates across open PRs/issues and links overlaps.
  - For PRs: reviews diffs for code quality, tests, scope; rates quality and flags breaking changes.
  - Checks vision alignment and posts a single structured comment via gh with a clear recommendation.
  - Configurable pollInterval, maxConcurrency, TTL; uses a single promptTemplate (no AgentConfig). Index updated in examples/README.md.

- **Migration**
  - Add tokens to credentials-secret.yaml and github-token-secret.yaml.
  - Apply: kubectl apply -f examples/06-openclaw-pr-triage/.
  - Optional: tune pollInterval/maxConcurrency/TTL; add excludeLabels: ["triaged"] if needed.

<sup>Written for commit c54f2e0c699f3b042a26f32f4847ac8db549da69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

