### PR TITLE
fake-strategist: Remove unnecessary debug job

### DIFF
--- a/.github/workflows/run-fake-strategist.yaml
+++ b/.github/workflows/run-fake-strategist.yaml
@@ -42,10 +42,6 @@ jobs:
           location: ${{ env.GKE_CLUSTER_LOCATION }}
           project_id: ${{ env.GCP_PROJECT_ID }}
 
-      - name: Debug
-        run: |
-          kubectl get pods -n default
-
       - name: Create strategist task if none active
         id: create_task
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the temporary Debug step from the run-fake-strategist GitHub Actions workflow to reduce log noise and unnecessary cluster reads. The workflow no longer runs kubectl get pods and proceeds directly to creating the strategist task.

<sup>Written for commit 470f29a0454e39f3ddf258d8978dacc0ed833bf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

