### PR TITLE
self-development: Update ttlSecondsAfterFinished to 86400

### DIFF
--- a/self-development/axon-fake-strategist.yaml
+++ b/self-development/axon-fake-strategist.yaml
@@ -12,7 +12,7 @@ spec:
       name: axon-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/axon-fake-user.yaml
+++ b/self-development/axon-fake-user.yaml
@@ -12,7 +12,7 @@ spec:
       name: axon-agent
     model: sonnet
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -9,7 +9,7 @@ spec:
     name: axon-agent
   model: opus
   type: claude-code
-  ttlSecondsAfterFinished: 3600
+  ttlSecondsAfterFinished: 864000
   credentials:
     type: oauth
     secretRef:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased ttlSecondsAfterFinished from 3600s (1h) to 864000s (10d) in self-development configs to keep finished resources longer for debugging and re-runs.

Updated in:
- axon-fake-strategist.yaml
- axon-fake-user.yaml
- tasks/fake-strategist-task.yaml

<sup>Written for commit c13b17315ea36f05fe98a963ad4558f95bcb49c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

