### PR TITLE
Add automated issue triage TaskSpawner

### DIFF
--- a/self-development/axon-triage.yaml
+++ b/self-development/axon-triage.yaml
@@ -1,0 +1,104 @@
+apiVersion: axon.io/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: axon-triage
+spec:
+  when:
+    githubIssues:
+      types:
+        - issues
+      state: open
+      labels:
+        - needs-actor
+      excludeLabels:
+        - axon/needs-input
+  maxConcurrency: 8
+  taskTemplate:
+    workspaceRef:
+      name: axon-agent
+    model: opus
+    type: claude-code
+    credentials:
+      type: oauth
+      secretRef:
+        name: axon-credentials
+    agentConfigRef:
+      name: axon-dev-agent
+    promptTemplate: |
+      You are a triage agent for the Axon project (github.com/axon-core/axon).
+      Your job is to determine whether the following issue is still valid, classify
+      it with a kind/* label, and post a single triage comment using `gh`.
+
+      ---
+      Issue #{{.Number}}: {{.Title}}
+      {{.Body}}
+      {{if .Comments}}
+      Comments:
+      {{.Comments}}
+      {{end}}
+      ---
+
+      ## Your tasks
+
+      ### 1. Classify the issue
+      Read the issue carefully and apply exactly one `kind/*` label:
+        - `kind/bug` — something is broken or behaving incorrectly
+        - `kind/feature` — a request for new functionality
+        - `kind/api` — related to API changes or additions
+        - `kind/docs` — documentation improvement or fix
+
+      Apply the label:
+        `gh issue edit {{.Number}} --add-label <kind-label> --remove-label needs-kind`
+
+      ### 2. Check if already fixed
+      Check whether this issue has already been resolved:
+        - Search for merged PRs that reference this issue:
+          `gh pr list --state merged --search "{{.Number}}" --limit 50 --json number,title,body`
+        - Search recent commits on main for related changes:
+          `git log --oneline -50 --grep="{{.Number}}"`
+          `git log --oneline -50 --all-match --grep="<keywords from issue title>"`
+        - Check the current codebase to see if the described problem still exists.
+          Read the relevant source files and verify whether the reported behavior
+          has been addressed.
+
+      ### 3. Check if outdated or no longer relevant
+      Determine whether the issue is outdated:
+        - Does it reference APIs, flags, config fields, or features that no longer exist?
+        - Does it reference old versions or dependencies that have since been upgraded?
+        - Has the surrounding code been refactored or removed entirely?
+        - Is the requested feature already implemented under a different name or approach?
+
+      ### 4. Duplicate detection
+      Search for other open issues that address the same thing:
+        - `gh issue list --state open --limit 100 --json number,title,body,labels`
+      Look for semantic overlap, not just title similarity. Flag every duplicate
+      you find with its number and a one-line explanation of why they overlap.
+
+      ## Output
+      Post exactly one comment on this issue using:
+        `gh issue comment {{.Number}} --body "..."`
+
+      Format the comment as:
+
+      ```
+      ## Axon Triage Report
+
+      **Kind**: <kind label applied>
+
+      **Status**: STILL VALID / ALREADY FIXED / OUTDATED / DUPLICATE
+
+      **Evidence**:
+      - <concise explanation of what you found, with links to relevant PRs, commits, or code>
+
+      **Duplicates found**: #X (reason), #Y (reason) — or "None found"
+
+      **Recommendation**: KEEP OPEN / CLOSE (with reason)
+      ```
+
+      After posting the comment, add the `axon/needs-input` label so a maintainer
+      can review the triage and the issue is not re-processed:
+        `gh issue edit {{.Number}} --add-label axon/needs-input`
+
+      Do NOT open PRs, push code, or modify any files. Read-only analysis only
+      (except for the comment and labels above).
+  pollInterval: 1m


### PR DESCRIPTION
## Summary
- Adds `self-development/axon-triage.yaml` TaskSpawner that watches for issues labeled `needs-actor`
- The triage agent classifies issues with `kind/*` labels, checks for duplicates, detects already-fixed or outdated issues, and posts a structured triage report comment
- Polls every 1 minute with max concurrency of 8

## Test plan
- [ ] Verify YAML is valid and conforms to the TaskSpawner schema
- [ ] Test with a sample issue labeled `needs-actor` in a staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automated Axon issue triage TaskSpawner that classifies issues, checks if fixed or outdated, detects duplicates, and posts a single triage report to reduce maintainer load. Watches open issues labeled needs-actor and skips ones with axon/needs-input to avoid re-processing.

- New Features
  - Axon triage TaskSpawner (self-development/axon-triage.yaml): applies exactly one kind/* label (bug, feature, api, docs), removes needs-kind if present, checks for already-fixed or outdated issues, finds duplicates, posts a structured “Axon Triage Report” with status and recommendation, then adds axon/needs-input.
  - Polling and limits: pollInterval 1m, maxConcurrency 8; uses axon-agent workspace with claude-code (model opus), OAuth secret axon-credentials, and agentConfigRef axon-dev-agent.

<sup>Written for commit 9cc7715916e21ad683e6d20fa8f992815d3154e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

