### PR TITLE
Add codex OAuth credential support and parameterized e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,7 @@ jobs:
       - name: E2E Test
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           GITHUB_TOKEN: ${{ github.token }}
           AXON_BIN: ${{ github.workspace }}/bin/axon
         run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ test-integration: envtest ## Run integration tests (envtest).
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./test/integration/... -v
 
 .PHONY: test-e2e
-test-e2e: ginkgo ## Run e2e tests (requires cluster and CLAUDE_CODE_OAUTH_TOKEN).
-	$(GINKGO) -v --timeout 10m ./test/e2e/...
+test-e2e: ginkgo ## Run e2e tests (requires cluster and agent credentials).
+	$(GINKGO) -v --timeout 20m ./test/e2e/...
 
 .PHONY: update
 update: controller-gen yamlfmt shfmt ## Run all generators and formatters.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,16 @@ workspace:
 **Claude OAuth token** (recommended for Claude Code):
 Run `claude auth login` locally, then copy the token from `~/.claude/credentials.json`.
 
-**Anthropic API key** (alternative):
+**Anthropic API key** (alternative for Claude Code):
 Create one at [console.anthropic.com](https://console.anthropic.com). Set `apiKey` instead of `oauthToken` in your config.
+
+**Codex OAuth credentials** (for OpenAI Codex):
+Run `codex auth login` locally, then reference the auth file in your config:
+```yaml
+oauthToken: "@~/.codex/auth.json"
+type: codex
+```
+Or set `apiKey` with an OpenAI API key instead.
 
 **GitHub token** (for pushing branches and creating PRs):
 Create a [Personal Access Token](https://github.com/settings/tokens) with `repo` scope (and `workflow` if your repo uses GitHub Actions).

--- a/codex/axon_entrypoint.sh
+++ b/codex/axon_entrypoint.sh
@@ -12,6 +12,14 @@ set -uo pipefail
 
 PROMPT="${1:?Prompt argument is required}"
 
+# Write auth.json from env var for OAuth/ChatGPT credential flow.
+# Strip control characters so serde_json's strict parser accepts
+# the file (the env var value may contain raw newlines).
+if [ -n "${CODEX_AUTH_JSON:-}" ]; then
+  mkdir -p ~/.codex
+  printf '%s' "$CODEX_AUTH_JSON" | tr -d '\n\r' >~/.codex/auth.json
+fi
+
 ARGS=(
   "exec"
   "--dangerously-bypass-approvals-and-sandbox"

--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -30,7 +30,8 @@ Axon sets the following reserved environment variables on agent containers:
 |---|---|---|
 | `AXON_MODEL` | The model name to use | Only when `model` is specified in the Task |
 | `ANTHROPIC_API_KEY` | API key for Anthropic (`claude-code` agent, api-key credential type) | When credential type is `api-key` and agent type is `claude-code` |
-| `CODEX_API_KEY` | API key for OpenAI Codex (`codex` agent, api-key or oauth credential type) | When agent type is `codex` |
+| `CODEX_API_KEY` | API key for OpenAI Codex (`codex` agent, `api-key` credential type) | When credential type is `api-key` and agent type is `codex` |
+| `CODEX_AUTH_JSON` | Contents of `~/.codex/auth.json` (`codex` agent, `oauth` credential type) | When credential type is `oauth` and agent type is `codex` |
 | `GEMINI_API_KEY` | API key for Google Gemini (`gemini` agent, api-key or oauth credential type) | When agent type is `gemini` |
 | `OPENCODE_API_KEY` | API key for OpenCode (`opencode` agent, api-key or oauth credential type) | When agent type is `opencode` |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token (`claude-code` agent, oauth credential type) | When credential type is `oauth` and agent type is `claude-code` |

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -20,7 +20,7 @@ func resolveContent(s string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("reading file %s: %w", s[1:], err)
 		}
-		return string(data), nil
+		return strings.TrimRight(string(data), "\n"), nil
 	}
 	return s, nil
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -18,6 +18,8 @@ oauthToken: ""
 # apiKey: ""
 
 # Agent type (optional, default: claude-code)
+# For codex with oauth: set oauthToken to auth.json content or @filepath
+#   oauthToken: "@~/.codex/auth.json"
 # type: claude-code
 
 # Model override (optional)

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -129,7 +129,7 @@ func apiKeyEnvVar(agentType string) string {
 func oauthEnvVar(agentType string) string {
 	switch agentType {
 	case AgentTypeCodex:
-		return "CODEX_API_KEY"
+		return "CODEX_AUTH_JSON"
 	case AgentTypeGemini:
 		return "GEMINI_API_KEY"
 	case AgentTypeOpenCode:

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -802,28 +802,31 @@ func TestBuildCodexJob_OAuthCredentials(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 
-	// CODEX_API_KEY should be set for codex oauth.
-	foundCodexKey := false
+	// CODEX_AUTH_JSON should be set for codex oauth.
+	foundCodexAuthJSON := false
 	for _, env := range container.Env {
-		if env.Name == "CODEX_API_KEY" {
-			foundCodexKey = true
+		if env.Name == "CODEX_AUTH_JSON" {
+			foundCodexAuthJSON = true
 			if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
-				t.Error("Expected CODEX_API_KEY to reference a secret")
+				t.Error("Expected CODEX_AUTH_JSON to reference a secret")
 			} else {
 				if env.ValueFrom.SecretKeyRef.Name != "codex-oauth" {
 					t.Errorf("Expected secret name %q, got %q", "codex-oauth", env.ValueFrom.SecretKeyRef.Name)
 				}
-				if env.ValueFrom.SecretKeyRef.Key != "CODEX_API_KEY" {
-					t.Errorf("Expected secret key %q, got %q", "CODEX_API_KEY", env.ValueFrom.SecretKeyRef.Key)
+				if env.ValueFrom.SecretKeyRef.Key != "CODEX_AUTH_JSON" {
+					t.Errorf("Expected secret key %q, got %q", "CODEX_AUTH_JSON", env.ValueFrom.SecretKeyRef.Key)
 				}
 			}
+		}
+		if env.Name == "CODEX_API_KEY" {
+			t.Error("CODEX_API_KEY should not be set for codex oauth credential type")
 		}
 		if env.Name == "CLAUDE_CODE_OAUTH_TOKEN" {
 			t.Error("CLAUDE_CODE_OAUTH_TOKEN should not be set for codex agent type")
 		}
 	}
-	if !foundCodexKey {
-		t.Error("Expected CODEX_API_KEY env var to be set")
+	if !foundCodexAuthJSON {
+		t.Error("Expected CODEX_AUTH_JSON env var to be set")
 	}
 }
 

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -16,6 +16,12 @@ import (
 var _ = Describe("Config", func() {
 	f := framework.NewFramework("config")
 
+	BeforeEach(func() {
+		if oauthToken == "" {
+			Skip("CLAUDE_CODE_OAUTH_TOKEN not set")
+		}
+	})
+
 	It("should run a Task using config file defaults", func() {
 		By("writing a temp config file with oauthToken and inline workspace")
 		dir := GinkgoT().TempDir()
@@ -103,6 +109,12 @@ var _ = Describe("Config", func() {
 
 var _ = Describe("Config with namespace", func() {
 	f := framework.NewFramework("config-ns")
+
+	BeforeEach(func() {
+		if oauthToken == "" {
+			Skip("CLAUDE_CODE_OAUTH_TOKEN not set")
+		}
+	})
 
 	It("should use namespace from config file", func() {
 		By("creating OAuth credentials secret")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -6,14 +6,48 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
 )
 
 const testModel = "haiku"
 
 var (
-	oauthToken  string
-	githubToken string
+	oauthToken    string
+	codexAuthJSON string
+	githubToken   string
 )
+
+type agentTestConfig struct {
+	AgentType      string
+	CredentialType axonv1alpha1.CredentialType
+	SecretName     string
+	SecretKey      string
+	SecretValue    *string
+	Model          string
+	SkipMessage    string
+}
+
+var agentConfigs = []agentTestConfig{
+	{
+		AgentType:      "claude-code",
+		CredentialType: axonv1alpha1.CredentialTypeOAuth,
+		SecretName:     "claude-credentials",
+		SecretKey:      "CLAUDE_CODE_OAUTH_TOKEN",
+		SecretValue:    &oauthToken,
+		Model:          testModel,
+		SkipMessage:    "CLAUDE_CODE_OAUTH_TOKEN not set",
+	},
+	{
+		AgentType:      "codex",
+		CredentialType: axonv1alpha1.CredentialTypeOAuth,
+		SecretName:     "codex-credentials",
+		SecretKey:      "CODEX_AUTH_JSON",
+		SecretValue:    &codexAuthJSON,
+		Model:          "gpt-5.1-codex-mini",
+		SkipMessage:    "CODEX_AUTH_JSON not set",
+	},
+}
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -22,8 +56,10 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	oauthToken = os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")
-	if oauthToken == "" {
-		Skip("CLAUDE_CODE_OAUTH_TOKEN not set, skipping e2e tests")
-	}
+	codexAuthJSON = os.Getenv("CODEX_AUTH_JSON")
 	githubToken = os.Getenv("GITHUB_TOKEN")
+
+	if oauthToken == "" && codexAuthJSON == "" {
+		Skip("Neither CLAUDE_CODE_OAUTH_TOKEN nor CODEX_AUTH_JSON set, skipping e2e tests")
+	}
 })

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,47 +12,313 @@ import (
 	"github.com/axon-core/axon/test/e2e/framework"
 )
 
-var _ = Describe("Task", func() {
-	f := framework.NewFramework("task")
+func describeAgentTests(cfg agentTestConfig) {
+	Describe(fmt.Sprintf("Task [%s]", cfg.AgentType), func() {
+		f := framework.NewFramework(fmt.Sprintf("task-%s", cfg.AgentType))
 
-	It("should run a Task to completion", func() {
-		By("creating OAuth credentials secret")
-		f.CreateSecret("claude-credentials",
-			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
-
-		By("creating a Task")
-		f.CreateTask(&axonv1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "basic-task",
-			},
-			Spec: axonv1alpha1.TaskSpec{
-				Type:   "claude-code",
-				Model:  testModel,
-				Prompt: "Print 'Hello from Axon e2e test' to stdout",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
-				},
-			},
+		BeforeEach(func() {
+			if *cfg.SecretValue == "" {
+				Skip(cfg.SkipMessage)
+			}
 		})
 
-		By("waiting for Job to be created")
-		f.WaitForJobCreation("basic-task")
+		It("should run a Task to completion", func() {
+			By("creating credentials secret")
+			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
-		By("waiting for Job to complete")
-		f.WaitForJobCompletion("basic-task")
+			By("creating a Task")
+			f.CreateTask(&axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "basic-task",
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   cfg.AgentType,
+					Model:  cfg.Model,
+					Prompt: "Print 'Hello from Axon e2e test' to stdout",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      cfg.CredentialType,
+						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+					},
+				},
+			})
 
-		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("basic-task")).To(Equal("Succeeded"))
+			By("waiting for Job to be created")
+			f.WaitForJobCreation("basic-task")
 
-		By("getting Job logs")
-		logs := f.GetJobLogs("basic-task")
-		GinkgoWriter.Printf("Job logs:\n%s\n", logs)
+			By("waiting for Job to complete")
+			f.WaitForJobCompletion("basic-task")
+
+			By("verifying Task status is Succeeded")
+			Expect(f.GetTaskPhase("basic-task")).To(Equal("Succeeded"))
+
+			By("getting Job logs")
+			logs := f.GetJobLogs("basic-task")
+			GinkgoWriter.Printf("Job logs:\n%s\n", logs)
+		})
 	})
-})
+
+	Describe(fmt.Sprintf("Task with workspace [%s]", cfg.AgentType), func() {
+		f := framework.NewFramework(fmt.Sprintf("ws-%s", cfg.AgentType))
+
+		BeforeEach(func() {
+			if *cfg.SecretValue == "" {
+				Skip(cfg.SkipMessage)
+			}
+		})
+
+		It("should run a Task with workspace to completion", func() {
+			By("creating credentials secret")
+			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
+
+			By("creating a Workspace resource")
+			f.CreateWorkspace(&axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "e2e-workspace",
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/axon-core/axon.git",
+					Ref:  "main",
+				},
+			})
+
+			By("creating a Task with workspace ref")
+			f.CreateTask(&axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ws-task",
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   cfg.AgentType,
+					Model:  cfg.Model,
+					Prompt: "Create a file called 'test.txt' with the content 'hello' in the current directory and print 'done'",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      cfg.CredentialType,
+						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+					},
+					WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-workspace"},
+				},
+			})
+
+			By("waiting for Job to be created")
+			f.WaitForJobCreation("ws-task")
+
+			By("waiting for Job to complete")
+			f.WaitForJobCompletion("ws-task")
+
+			By("verifying Task status is Succeeded")
+			Expect(f.GetTaskPhase("ws-task")).To(Equal("Succeeded"))
+
+			By("getting Job logs")
+			logs := f.GetJobLogs("ws-task")
+			GinkgoWriter.Printf("Job logs:\n%s\n", logs)
+
+			By("verifying no permission errors in logs")
+			Expect(logs).NotTo(ContainSubstring("permission denied"))
+			Expect(logs).NotTo(ContainSubstring("Permission denied"))
+			Expect(logs).NotTo(ContainSubstring("EACCES"))
+		})
+	})
+
+	Describe(fmt.Sprintf("Task output capture [%s]", cfg.AgentType), func() {
+		f := framework.NewFramework(fmt.Sprintf("output-%s", cfg.AgentType))
+
+		BeforeEach(func() {
+			if *cfg.SecretValue == "" {
+				Skip(cfg.SkipMessage)
+			}
+		})
+
+		It("should populate Outputs and Results after task completes", func() {
+			By("creating credentials secret")
+			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
+
+			By("creating a Workspace resource")
+			f.CreateWorkspace(&axonv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "e2e-outputs-workspace",
+				},
+				Spec: axonv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/axon-core/axon.git",
+					Ref:  "main",
+				},
+			})
+
+			By("creating a Task with workspace ref")
+			f.CreateTask(&axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "outputs-task",
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   cfg.AgentType,
+					Model:  cfg.Model,
+					Prompt: "Print 'hello' to stdout",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      cfg.CredentialType,
+						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+					},
+					WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-outputs-workspace"},
+				},
+			})
+
+			By("waiting for Job to be created")
+			f.WaitForJobCreation("outputs-task")
+
+			By("waiting for Job to complete")
+			f.WaitForJobCompletion("outputs-task")
+
+			By("verifying Task status is Succeeded")
+			Expect(f.GetTaskPhase("outputs-task")).To(Equal("Succeeded"))
+
+			By("verifying output markers appear in Pod logs")
+			logs := f.GetJobLogs("outputs-task")
+			GinkgoWriter.Printf("Job logs:\n%s\n", logs)
+			Expect(logs).To(ContainSubstring("---AXON_OUTPUTS_START---"))
+			Expect(logs).To(ContainSubstring("---AXON_OUTPUTS_END---"))
+
+			By("verifying Outputs field contains branch, commit, base-branch, and usage")
+			outputs := f.GetTaskOutputs("outputs-task")
+			Expect(outputs).To(ContainSubstring("branch: main"))
+			Expect(outputs).To(MatchRegexp(`commit: [0-9a-f]{40}`))
+			Expect(outputs).To(ContainSubstring("base-branch: main"))
+			Expect(outputs).To(MatchRegexp(`input-tokens: \d+`))
+			Expect(outputs).To(MatchRegexp(`output-tokens: \d+`))
+
+			if cfg.AgentType == "claude-code" {
+				Expect(outputs).To(MatchRegexp(`cost-usd: [\d.]+`))
+			}
+
+			By("verifying Results map has structured entries")
+			results := f.GetTaskResults("outputs-task")
+			Expect(results).To(HaveKeyWithValue("branch", "main"))
+			Expect(results).To(HaveKey("commit"))
+			Expect(results["commit"]).To(MatchRegexp(`^[0-9a-f]{40}$`))
+			Expect(results).To(HaveKeyWithValue("base-branch", "main"))
+			Expect(results).To(HaveKey("input-tokens"))
+			Expect(results).To(HaveKey("output-tokens"))
+
+			if cfg.AgentType == "claude-code" {
+				Expect(results).To(HaveKey("cost-usd"))
+			}
+		})
+	})
+
+	Describe(fmt.Sprintf("Task dependency chain [%s]", cfg.AgentType), func() {
+		f := framework.NewFramework(fmt.Sprintf("deps-%s", cfg.AgentType))
+
+		BeforeEach(func() {
+			if *cfg.SecretValue == "" {
+				Skip(cfg.SkipMessage)
+			}
+		})
+
+		It("should start dependent task only after dependency succeeds", func() {
+			By("creating credentials secret")
+			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
+
+			By("creating Task A")
+			f.CreateTask(&axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dep-chain-a",
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   cfg.AgentType,
+					Model:  cfg.Model,
+					Prompt: "Print 'Task A done' to stdout",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      cfg.CredentialType,
+						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+					},
+				},
+			})
+
+			By("creating Task B that depends on Task A")
+			f.CreateTask(&axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dep-chain-b",
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:      cfg.AgentType,
+					Model:     cfg.Model,
+					Prompt:    "Print 'Task B done' to stdout",
+					DependsOn: []string{"dep-chain-a"},
+					Credentials: axonv1alpha1.Credentials{
+						Type:      cfg.CredentialType,
+						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+					},
+				},
+			})
+
+			By("verifying Task B enters Waiting phase while Task A runs")
+			Eventually(func() string {
+				return f.GetTaskPhase("dep-chain-b")
+			}, 30*time.Second, time.Second).Should(Equal("Waiting"))
+
+			By("waiting for Task A to complete")
+			f.WaitForJobCreation("dep-chain-a")
+			f.WaitForJobCompletion("dep-chain-a")
+			Expect(f.GetTaskPhase("dep-chain-a")).To(Equal("Succeeded"))
+
+			By("waiting for Task B to start and complete after Task A succeeds")
+			f.WaitForJobCreation("dep-chain-b")
+			f.WaitForJobCompletion("dep-chain-b")
+			Expect(f.GetTaskPhase("dep-chain-b")).To(Equal("Succeeded"))
+		})
+	})
+
+	Describe(fmt.Sprintf("Task cleanup on failure [%s]", cfg.AgentType), func() {
+		f := framework.NewFramework(fmt.Sprintf("cleanup-%s", cfg.AgentType))
+
+		BeforeEach(func() {
+			if *cfg.SecretValue == "" {
+				Skip(cfg.SkipMessage)
+			}
+		})
+
+		It("should clean up namespace resources automatically", func() {
+			By("creating credentials secret")
+			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
+
+			By("creating a Task")
+			f.CreateTask(&axonv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cleanup-task",
+				},
+				Spec: axonv1alpha1.TaskSpec{
+					Type:   cfg.AgentType,
+					Model:  cfg.Model,
+					Prompt: "Print 'Hello' to stdout",
+					Credentials: axonv1alpha1.Credentials{
+						Type:      cfg.CredentialType,
+						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+					},
+				},
+			})
+
+			By("verifying resources exist in the namespace")
+			Eventually(func() []string {
+				return f.ListTaskNames("")
+			}, 30*time.Second, time.Second).Should(ContainElement("cleanup-task"))
+		})
+	})
+}
+
+// Register shared tests for each agent type.
+var _ = func() bool {
+	for _, cfg := range agentConfigs {
+		describeAgentTests(cfg)
+	}
+	return true
+}()
+
+// Claude-code-only tests below.
 
 var _ = Describe("Task with make available", func() {
 	f := framework.NewFramework("make")
+
+	BeforeEach(func() {
+		if oauthToken == "" {
+			Skip("CLAUDE_CODE_OAUTH_TOKEN not set")
+		}
+	})
 
 	It("should have make command available in claude-code container", func() {
 		By("creating OAuth credentials secret")
@@ -89,138 +356,13 @@ var _ = Describe("Task with make available", func() {
 	})
 })
 
-var _ = Describe("Task with workspace", func() {
-	f := framework.NewFramework("ws")
-
-	It("should run a Task with workspace to completion", func() {
-		By("creating OAuth credentials secret")
-		f.CreateSecret("claude-credentials",
-			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
-
-		By("creating a Workspace resource")
-		f.CreateWorkspace(&axonv1alpha1.Workspace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "e2e-workspace",
-			},
-			Spec: axonv1alpha1.WorkspaceSpec{
-				Repo: "https://github.com/axon-core/axon.git",
-				Ref:  "main",
-			},
-		})
-
-		By("creating a Task with workspace ref")
-		f.CreateTask(&axonv1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ws-task",
-			},
-			Spec: axonv1alpha1.TaskSpec{
-				Type:   "claude-code",
-				Model:  testModel,
-				Prompt: "Create a file called 'test.txt' with the content 'hello' in the current directory and print 'done'",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
-				},
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-workspace"},
-			},
-		})
-
-		By("waiting for Job to be created")
-		f.WaitForJobCreation("ws-task")
-
-		By("waiting for Job to complete")
-		f.WaitForJobCompletion("ws-task")
-
-		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("ws-task")).To(Equal("Succeeded"))
-
-		By("getting Job logs")
-		logs := f.GetJobLogs("ws-task")
-		GinkgoWriter.Printf("Job logs:\n%s\n", logs)
-
-		By("verifying no permission errors in logs")
-		Expect(logs).NotTo(ContainSubstring("permission denied"))
-		Expect(logs).NotTo(ContainSubstring("Permission denied"))
-		Expect(logs).NotTo(ContainSubstring("EACCES"))
-	})
-})
-
-var _ = Describe("Task output capture", func() {
-	f := framework.NewFramework("output")
-
-	It("should populate Outputs and Results after task completes", func() {
-		By("creating OAuth credentials secret")
-		f.CreateSecret("claude-credentials",
-			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
-
-		By("creating a Workspace resource")
-		f.CreateWorkspace(&axonv1alpha1.Workspace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "e2e-outputs-workspace",
-			},
-			Spec: axonv1alpha1.WorkspaceSpec{
-				Repo: "https://github.com/axon-core/axon.git",
-				Ref:  "main",
-			},
-		})
-
-		By("creating a Task with workspace ref")
-		f.CreateTask(&axonv1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "outputs-task",
-			},
-			Spec: axonv1alpha1.TaskSpec{
-				Type:   "claude-code",
-				Model:  testModel,
-				Prompt: "Print 'hello' to stdout",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
-				},
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-outputs-workspace"},
-			},
-		})
-
-		By("waiting for Job to be created")
-		f.WaitForJobCreation("outputs-task")
-
-		By("waiting for Job to complete")
-		f.WaitForJobCompletion("outputs-task")
-
-		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("outputs-task")).To(Equal("Succeeded"))
-
-		By("verifying output markers appear in Pod logs")
-		logs := f.GetJobLogs("outputs-task")
-		GinkgoWriter.Printf("Job logs:\n%s\n", logs)
-		Expect(logs).To(ContainSubstring("---AXON_OUTPUTS_START---"))
-		Expect(logs).To(ContainSubstring("---AXON_OUTPUTS_END---"))
-
-		By("verifying Outputs field contains branch, commit, base-branch, and usage")
-		outputs := f.GetTaskOutputs("outputs-task")
-		Expect(outputs).To(ContainSubstring("branch: main"))
-		Expect(outputs).To(MatchRegexp(`commit: [0-9a-f]{40}`))
-		Expect(outputs).To(ContainSubstring("base-branch: main"))
-		Expect(outputs).To(MatchRegexp(`input-tokens: \d+`))
-		Expect(outputs).To(MatchRegexp(`output-tokens: \d+`))
-		Expect(outputs).To(MatchRegexp(`cost-usd: [\d.]+`))
-
-		By("verifying Results map has structured entries")
-		results := f.GetTaskResults("outputs-task")
-		Expect(results).To(HaveKeyWithValue("branch", "main"))
-		Expect(results).To(HaveKey("commit"))
-		Expect(results["commit"]).To(MatchRegexp(`^[0-9a-f]{40}$`))
-		Expect(results).To(HaveKeyWithValue("base-branch", "main"))
-		Expect(results).To(HaveKey("input-tokens"))
-		Expect(results).To(HaveKey("output-tokens"))
-		Expect(results).To(HaveKey("cost-usd"))
-	})
-})
-
 var _ = Describe("Task with workspace and secretRef", func() {
 	f := framework.NewFramework("github")
 
 	BeforeEach(func() {
+		if oauthToken == "" {
+			Skip("CLAUDE_CODE_OAUTH_TOKEN not set")
+		}
 		if githubToken == "" {
 			Skip("GITHUB_TOKEN not set, skipping GitHub e2e tests")
 		}
@@ -276,94 +418,5 @@ var _ = Describe("Task with workspace and secretRef", func() {
 		By("getting Job logs")
 		logs := f.GetJobLogs("github-task")
 		GinkgoWriter.Printf("Job logs:\n%s\n", logs)
-	})
-})
-
-var _ = Describe("Task dependency chain", func() {
-	f := framework.NewFramework("deps")
-
-	It("should start dependent task only after dependency succeeds", func() {
-		By("creating OAuth credentials secret")
-		f.CreateSecret("claude-credentials",
-			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
-
-		By("creating Task A")
-		f.CreateTask(&axonv1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "dep-chain-a",
-			},
-			Spec: axonv1alpha1.TaskSpec{
-				Type:   "claude-code",
-				Model:  testModel,
-				Prompt: "Print 'Task A done' to stdout",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
-				},
-			},
-		})
-
-		By("creating Task B that depends on Task A")
-		f.CreateTask(&axonv1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "dep-chain-b",
-			},
-			Spec: axonv1alpha1.TaskSpec{
-				Type:      "claude-code",
-				Model:     testModel,
-				Prompt:    "Print 'Task B done' to stdout",
-				DependsOn: []string{"dep-chain-a"},
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
-				},
-			},
-		})
-
-		By("verifying Task B enters Waiting phase while Task A runs")
-		Eventually(func() string {
-			return f.GetTaskPhase("dep-chain-b")
-		}, 30*time.Second, time.Second).Should(Equal("Waiting"))
-
-		By("waiting for Task A to complete")
-		f.WaitForJobCreation("dep-chain-a")
-		f.WaitForJobCompletion("dep-chain-a")
-		Expect(f.GetTaskPhase("dep-chain-a")).To(Equal("Succeeded"))
-
-		By("waiting for Task B to start and complete after Task A succeeds")
-		f.WaitForJobCreation("dep-chain-b")
-		f.WaitForJobCompletion("dep-chain-b")
-		Expect(f.GetTaskPhase("dep-chain-b")).To(Equal("Succeeded"))
-	})
-})
-
-var _ = Describe("Task cleanup on failure", func() {
-	f := framework.NewFramework("cleanup")
-
-	It("should clean up namespace resources automatically", func() {
-		By("creating OAuth credentials secret")
-		f.CreateSecret("claude-credentials",
-			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
-
-		By("creating a Task")
-		f.CreateTask(&axonv1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cleanup-task",
-			},
-			Spec: axonv1alpha1.TaskSpec{
-				Type:   "claude-code",
-				Model:  testModel,
-				Prompt: "Print 'Hello' to stdout",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
-				},
-			},
-		})
-
-		By("verifying resources exist in the namespace")
-		Eventually(func() []string {
-			return f.ListTaskNames("")
-		}, 30*time.Second, time.Second).Should(ContainElement("cleanup-task"))
 	})
 })


### PR DESCRIPTION
## Summary
- Change codex OAuth env var from `CODEX_API_KEY` to `CODEX_AUTH_JSON` so the entrypoint writes `auth.json` to `~/.codex/` for the ChatGPT credential flow
- Strip control characters from `CODEX_AUTH_JSON` before writing `auth.json` to avoid serde_json parse failures
- Add `@filepath` resolution for `oauthToken`/`apiKey` in config (e.g. `oauthToken: "@~/.codex/auth.json"`)
- Parameterize e2e tests so both claude-code and codex run the same suite (basic task, workspace, output capture, dependency chain, cleanup), skipping when credentials are not set
- Use `gpt-5.1-codex-mini` model for codex e2e tests
- Add `CODEX_AUTH_JSON` to CI workflow and document codex credentials in README
- Collect failed pod container logs in e2e debug info
- Increase e2e suite timeout to 20m for dual-agent suites

## Test plan
- [x] `make verify` passes
- [x] `make test` passes (unit tests including new dryrun + resolveContent tests)
- [x] `make test-integration` passes (74/74, including new codex OAuth integration test)
- [ ] `make test-e2e` with `CLAUDE_CODE_OAUTH_TOKEN` set runs claude-code tests, codex skipped
- [ ] `make test-e2e` with `CODEX_AUTH_JSON` set runs codex tests, claude-code skipped
- [ ] Both env vars set runs both suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)