### PR TITLE
Remove kubectl from prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,20 @@ Get running in 5 minutes (most of the time is gathering credentials).
 
 ### Prerequisites
 
-- Kubernetes cluster (1.28+) — don't have one? Create a local cluster with [kind](https://kind.sigs.k8s.io/): `kind create cluster`
-- kubectl configured
+- Kubernetes cluster (1.28+)
+
+<details>
+<summary>Don't have a cluster? Create one locally with kind</summary>
+
+1. [Install kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (requires Docker)
+2. Create a cluster:
+   ```bash
+   kind create cluster
+   ```
+
+This creates a single-node cluster and configures your kubeconfig automatically.
+
+</details>
 
 ### 1. Install the CLI
 


### PR DESCRIPTION
## Summary
- Remove kubectl from the Quick Start prerequisites since the axon CLI uses client-go directly and does not require the kubectl binary
- Expand the kind local cluster setup into a collapsible step-by-step guide for easier onboarding

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm kind instructions link is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed kubectl from the Quick Start prerequisites because the axon CLI uses client-go and doesn’t need the kubectl binary. Expanded the local setup into a collapsible, step-by-step kind guide to make onboarding easier.

<sup>Written for commit ff85260e10418d92475908c9d2223c9841525309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

