### PR TITLE
Show table view by default for get-by-name, add --detail flag

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -34,11 +34,12 @@ func newGetCommand(cfg *ClientConfig) *cobra.Command {
 
 func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 	var output string
+	var detail bool
 
 	cmd := &cobra.Command{
 		Use:     "taskspawner [name]",
 		Aliases: []string{"taskspawners", "ts"},
-		Short:   "List task spawners or get details of a specific task spawner",
+		Short:   "List task spawners or get a specific task spawner",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if output != "" && output != "yaml" && output != "json" {
@@ -69,7 +70,11 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 				case "json":
 					return printJSON(os.Stdout, ts)
 				default:
-					printTaskSpawnerDetail(os.Stdout, ts)
+					if detail {
+						printTaskSpawnerDetail(os.Stdout, ts)
+					} else {
+						printTaskSpawnerTable(os.Stdout, []axonv1alpha1.TaskSpawner{*ts}, false)
+					}
 					return nil
 				}
 			}
@@ -97,6 +102,7 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 	}
 
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (yaml or json)")
+	cmd.Flags().BoolVarP(&detail, "detail", "d", false, "Show detailed information for a specific task spawner")
 
 	cmd.ValidArgsFunction = completeTaskSpawnerNames(cfg)
 	_ = cmd.RegisterFlagCompletionFunc("output", cobra.FixedCompletions([]string{"yaml", "json"}, cobra.ShellCompDirectiveNoFileComp))
@@ -106,11 +112,12 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 
 func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 	var output string
+	var detail bool
 
 	cmd := &cobra.Command{
 		Use:     "task [name]",
 		Aliases: []string{"tasks"},
-		Short:   "List tasks or get details of a specific task",
+		Short:   "List tasks or get a specific task",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if output != "" && output != "yaml" && output != "json" {
@@ -141,7 +148,11 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 				case "json":
 					return printJSON(os.Stdout, task)
 				default:
-					printTaskDetail(os.Stdout, task)
+					if detail {
+						printTaskDetail(os.Stdout, task)
+					} else {
+						printTaskTable(os.Stdout, []axonv1alpha1.Task{*task}, false)
+					}
 					return nil
 				}
 			}
@@ -169,6 +180,7 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (yaml or json)")
+	cmd.Flags().BoolVarP(&detail, "detail", "d", false, "Show detailed information for a specific task")
 
 	cmd.ValidArgsFunction = completeTaskNames(cfg)
 	_ = cmd.RegisterFlagCompletionFunc("output", cobra.FixedCompletions([]string{"yaml", "json"}, cobra.ShellCompDirectiveNoFileComp))
@@ -178,11 +190,12 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 
 func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 	var output string
+	var detail bool
 
 	cmd := &cobra.Command{
 		Use:     "workspace [name]",
 		Aliases: []string{"workspaces", "ws"},
-		Short:   "List workspaces or get details of a specific workspace",
+		Short:   "List workspaces or get a specific workspace",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if output != "" && output != "yaml" && output != "json" {
@@ -213,7 +226,11 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 				case "json":
 					return printJSON(os.Stdout, ws)
 				default:
-					printWorkspaceDetail(os.Stdout, ws)
+					if detail {
+						printWorkspaceDetail(os.Stdout, ws)
+					} else {
+						printWorkspaceTable(os.Stdout, []axonv1alpha1.Workspace{*ws}, false)
+					}
 					return nil
 				}
 			}
@@ -241,6 +258,7 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 	}
 
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (yaml or json)")
+	cmd.Flags().BoolVarP(&detail, "detail", "d", false, "Show detailed information for a specific workspace")
 
 	cmd.ValidArgsFunction = completeWorkspaceNames(cfg)
 	_ = cmd.RegisterFlagCompletionFunc("output", cobra.FixedCompletions([]string{"yaml", "json"}, cobra.ShellCompDirectiveNoFileComp))

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestDetailFlagRegistered(t *testing.T) {
+	root := NewRootCommand()
+
+	tests := []struct {
+		name string
+		path []string
+	}{
+		{"get task", []string{"get", "task"}},
+		{"get taskspawner", []string{"get", "taskspawner"}},
+		{"get workspace", []string{"get", "workspace"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := findSubcommand(t, root, tt.path)
+			f := cmd.Flags().Lookup("detail")
+			if f == nil {
+				t.Fatalf("expected --detail flag on %q", tt.name)
+			}
+			if f.Shorthand != "d" {
+				t.Errorf("expected shorthand -d, got %q", f.Shorthand)
+			}
+			if f.DefValue != "false" {
+				t.Errorf("expected default value false, got %q", f.DefValue)
+			}
+		})
+	}
+}

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -115,7 +115,7 @@ var _ = Describe("CLI", func() {
 		f.WaitForJobCompletion("cli-ws-task")
 
 		By("verifying task status via CLI get (detail)")
-		output := framework.AxonOutput("get", "task", "cli-ws-task", "-n", f.Namespace)
+		output := framework.AxonOutput("get", "task", "cli-ws-task", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("Succeeded"))
 		Expect(output).To(ContainSubstring("Workspace"))
 

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 		f.WaitForJobCompletion("config-task")
 
 		By("verifying task status via CLI get")
-		output := framework.AxonOutput("get", "task", "config-task", "-n", f.Namespace)
+		output := framework.AxonOutput("get", "task", "config-task", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("Succeeded"))
 		Expect(output).To(ContainSubstring("Workspace"))
 

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -124,7 +124,7 @@ var _ = Describe("TaskSpawner", func() {
 		Expect(output).To(ContainSubstring("spawner"))
 
 		By("verifying axon get taskspawner shows detail")
-		output = framework.AxonOutput("get", "taskspawner", "spawner", "-n", f.Namespace)
+		output = framework.AxonOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("spawner"))
 		Expect(output).To(ContainSubstring("GitHub Issues"))
 
@@ -224,7 +224,7 @@ var _ = Describe("Cron TaskSpawner", func() {
 		Expect(output).To(ContainSubstring("cron-spawner"))
 
 		By("verifying axon get taskspawner shows cron detail")
-		output = framework.AxonOutput("get", "taskspawner", "cron-spawner", "-n", f.Namespace)
+		output = framework.AxonOutput("get", "taskspawner", "cron-spawner", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("cron-spawner"))
 		Expect(output).To(ContainSubstring("Cron"))
 		Expect(output).To(ContainSubstring("0 9 * * 1"))


### PR DESCRIPTION
## Summary
- `axon get <resource> <name>` now shows the compact table view by default instead of the detail view
- Added `--detail` (`-d`) flag to show the full detail view when needed
- Applied consistently to `task`, `taskspawner`, and `workspace` subcommands

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] Verify `axon get task <name>` shows table row
- [ ] Verify `axon get task <name> --detail` shows detail view
- [ ] Verify `axon get taskspawner <name>` shows table row
- [ ] Verify `axon get workspace <name>` shows table row
- [ ] Verify `-o yaml` / `-o json` still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default to a compact table row when getting a single resource by name; use --detail (-d) for the full view. Updated unit and e2e tests to cover table output and use the new flag.

- **New Features**
  - Table view is now the default for get-by-name on task, taskspawner, and workspace.
  - Added --detail (-d) to show the full detail view.
  - -o yaml and -o json continue to work unchanged.

- **Migration**
  - If scripts relied on the previous detail output for get-by-name, add --detail or switch to -o json/yaml.

<sup>Written for commit de05e440ddcbbb8d5321bf494d54bd4f48521c77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

