### PR TITLE
Enrich `axon get task` table and detail output

### DIFF
--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -99,17 +99,28 @@ func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
 }
 
 func TestPrintTaskTable(t *testing.T) {
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-30 * time.Minute))
 	tasks := []axonv1alpha1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-one",
-				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
 			Spec: axonv1alpha1.TaskSpec{
-				Type: "claude-code",
+				Type:   "claude-code",
+				Model:  "claude-sonnet-4-20250514",
+				Branch: "feature/test",
+				WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+					Name: "my-ws",
+				},
+				AgentConfigRef: &axonv1alpha1.AgentConfigReference{
+					Name: "my-config",
+				},
 			},
 			Status: axonv1alpha1.TaskStatus{
-				Phase: axonv1alpha1.TaskPhaseRunning,
+				Phase:     axonv1alpha1.TaskPhaseRunning,
+				StartTime: &startTime,
 			},
 		},
 	}
@@ -118,27 +129,35 @@ func TestPrintTaskTable(t *testing.T) {
 	printTaskTable(&buf, tasks, false)
 	output := buf.String()
 
-	if !strings.Contains(output, "NAME") {
-		t.Errorf("expected header NAME in output, got %q", output)
+	for _, header := range []string{"NAME", "TYPE", "PHASE", "BRANCH", "WORKSPACE", "AGENT CONFIG", "DURATION", "AGE"} {
+		if !strings.Contains(output, header) {
+			t.Errorf("expected header %s in output, got %q", header, output)
+		}
 	}
 	if strings.Contains(output, "NAMESPACE") {
 		t.Errorf("expected no NAMESPACE header when allNamespaces is false, got %q", output)
 	}
-	if !strings.Contains(output, "task-one") {
-		t.Errorf("expected task-one in output, got %q", output)
+	for _, val := range []string{"task-one", "feature/test", "my-ws", "my-config"} {
+		if !strings.Contains(output, val) {
+			t.Errorf("expected %s in output, got %q", val, output)
+		}
 	}
 }
 
 func TestPrintTaskTableAllNamespaces(t *testing.T) {
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-90 * time.Minute))
+	completionTime := metav1.NewTime(now.Add(-60 * time.Minute))
 	tasks := []axonv1alpha1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-one",
 				Namespace:         "ns-a",
-				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
 			Spec: axonv1alpha1.TaskSpec{
-				Type: "claude-code",
+				Type:   "claude-code",
+				Branch: "feat/one",
 			},
 			Status: axonv1alpha1.TaskStatus{
 				Phase: axonv1alpha1.TaskPhaseRunning,
@@ -148,13 +167,15 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-two",
 				Namespace:         "ns-b",
-				CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+				CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
 			},
 			Spec: axonv1alpha1.TaskSpec{
 				Type: "codex",
 			},
 			Status: axonv1alpha1.TaskStatus{
-				Phase: axonv1alpha1.TaskPhaseSucceeded,
+				Phase:          axonv1alpha1.TaskPhaseSucceeded,
+				StartTime:      &startTime,
+				CompletionTime: &completionTime,
 			},
 		},
 	}
@@ -163,14 +184,15 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 	printTaskTable(&buf, tasks, true)
 	output := buf.String()
 
-	if !strings.Contains(output, "NAMESPACE") {
-		t.Errorf("expected NAMESPACE header when allNamespaces is true, got %q", output)
+	for _, header := range []string{"NAMESPACE", "NAME", "TYPE", "PHASE", "BRANCH", "WORKSPACE", "AGENT CONFIG", "DURATION", "AGE"} {
+		if !strings.Contains(output, header) {
+			t.Errorf("expected header %s in output, got %q", header, output)
+		}
 	}
-	if !strings.Contains(output, "ns-a") {
-		t.Errorf("expected namespace ns-a in output, got %q", output)
-	}
-	if !strings.Contains(output, "ns-b") {
-		t.Errorf("expected namespace ns-b in output, got %q", output)
+	for _, val := range []string{"ns-a", "ns-b", "feat/one"} {
+		if !strings.Contains(output, val) {
+			t.Errorf("expected %s in output, got %q", val, output)
+		}
 	}
 }
 
@@ -321,5 +343,175 @@ func TestPrintWorkspaceDetailWithoutOptionalFields(t *testing.T) {
 	}
 	if strings.Contains(output, "Secret:") {
 		t.Errorf("expected no Secret field when secretRef is nil, got %q", output)
+	}
+}
+
+func TestTaskDuration(t *testing.T) {
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-30 * time.Minute))
+	completionTime := metav1.NewTime(now.Add(-10 * time.Minute))
+
+	tests := []struct {
+		name   string
+		status axonv1alpha1.TaskStatus
+		want   string
+	}{
+		{
+			name:   "no start time",
+			status: axonv1alpha1.TaskStatus{},
+			want:   "-",
+		},
+		{
+			name: "completed task",
+			status: axonv1alpha1.TaskStatus{
+				StartTime:      &startTime,
+				CompletionTime: &completionTime,
+			},
+			want: "20m",
+		},
+		{
+			name: "running task",
+			status: axonv1alpha1.TaskStatus{
+				StartTime: &startTime,
+			},
+			want: "30m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := taskDuration(&tt.status)
+			if got != tt.want {
+				t.Errorf("taskDuration() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintTaskDetail(t *testing.T) {
+	now := time.Now()
+	startTime := metav1.NewTime(now.Add(-30 * time.Minute))
+	completionTime := metav1.NewTime(now.Add(-10 * time.Minute))
+	ttl := int32(3600)
+	timeout := int64(7200)
+
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "full-task",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "Fix the bug",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			},
+			Model:     "claude-sonnet-4-20250514",
+			Image:     "custom-image:latest",
+			Branch:    "feature/fix",
+			DependsOn: []string{"task-a", "task-b"},
+			WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+				Name: "my-ws",
+			},
+			AgentConfigRef: &axonv1alpha1.AgentConfigReference{
+				Name: "my-config",
+			},
+			TTLSecondsAfterFinished: &ttl,
+			PodOverrides: &axonv1alpha1.PodOverrides{
+				ActiveDeadlineSeconds: &timeout,
+			},
+		},
+		Status: axonv1alpha1.TaskStatus{
+			Phase:          axonv1alpha1.TaskPhaseSucceeded,
+			JobName:        "full-task-job",
+			PodName:        "full-task-pod",
+			StartTime:      &startTime,
+			CompletionTime: &completionTime,
+			Message:        "Task completed successfully",
+			Outputs:        []string{"https://github.com/org/repo/pull/1"},
+			Results:        map[string]string{"pr": "1"},
+		},
+	}
+
+	var buf bytes.Buffer
+	printTaskDetail(&buf, task)
+	output := buf.String()
+
+	for _, expected := range []string{
+		"full-task",
+		"claude-code",
+		"Succeeded",
+		"Fix the bug",
+		"my-secret",
+		"claude-sonnet-4-20250514",
+		"custom-image:latest",
+		"feature/fix",
+		"task-a, task-b",
+		"my-ws",
+		"my-config",
+		"3600s",
+		"7200s",
+		"full-task-job",
+		"full-task-pod",
+		"Duration:",
+		"Task completed successfully",
+		"https://github.com/org/repo/pull/1",
+		"pr=1",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected %q in output, got:\n%s", expected, output)
+		}
+	}
+}
+
+func TestPrintTaskDetailMinimal(t *testing.T) {
+	task := &axonv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "minimal-task",
+			Namespace: "default",
+		},
+		Spec: axonv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "Do something",
+			Credentials: axonv1alpha1.Credentials{
+				Type:      axonv1alpha1.CredentialTypeAPIKey,
+				SecretRef: axonv1alpha1.SecretReference{Name: "secret"},
+			},
+		},
+		Status: axonv1alpha1.TaskStatus{
+			Phase: axonv1alpha1.TaskPhasePending,
+		},
+	}
+
+	var buf bytes.Buffer
+	printTaskDetail(&buf, task)
+	output := buf.String()
+
+	if !strings.Contains(output, "minimal-task") {
+		t.Errorf("expected task name in output, got:\n%s", output)
+	}
+
+	for _, absent := range []string{
+		"Model:",
+		"Image:",
+		"Branch:",
+		"Depends On:",
+		"Workspace:",
+		"Agent Config:",
+		"TTL:",
+		"Timeout:",
+		"Job:",
+		"Pod:",
+		"Start Time:",
+		"Completion Time:",
+		"Duration:",
+		"Message:",
+		"Outputs:",
+		"Results:",
+	} {
+		if strings.Contains(output, absent) {
+			t.Errorf("expected no %s field for minimal task, got:\n%s", absent, output)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add 4 new columns to `axon get task` table view: **BRANCH**, **WORKSPACE**, **AGENT CONFIG**, **DURATION**
- Add 7 new fields to `axon get task <name>` detail view: **Image**, **Branch**, **Depends On**, **Agent Config**, **TTL**, **Timeout**, **Duration**
- Add `taskDuration` helper that computes human-readable duration from start/completion times

## Test plan
- [x] `make test` — all unit tests pass
- [x] `make verify` — lint/fmt/vet checks pass
- [x] `make build` — binary builds successfully
- [ ] Run `axon get task` against a cluster to verify table formatting
- [ ] Run `axon get task <name>` to verify detail view with all fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances `axon get task` table and detail outputs with Branch, Workspace, Agent Config, and Duration for better at-a-glance context. Adds a helper to show human-readable task duration.

- **New Features**
  - Table view: BRANCH, WORKSPACE, AGENT CONFIG, DURATION columns.
  - Detail view: Image, Branch, Depends On, Agent Config, TTL, Timeout, Duration fields.
  - New helper: taskDuration computes human-readable durations from start/completion times.

<sup>Written for commit 6aca02aa6f43b2c5d479921dee666173c1bfb98f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

