### PR TITLE
feat(taskspawner): Support GitHub fork workflow for issue polling

### DIFF
--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -42,10 +42,20 @@ type Cron struct {
 }
 
 // GitHubIssues discovers issues from a GitHub repository.
-// The repository owner and name are derived from the workspace's repo URL
-// specified in taskTemplate.workspaceRef.
+// By default the repository owner and name are derived from the workspace's
+// repo URL specified in taskTemplate.workspaceRef. Set the Repo field to
+// override this — useful for fork workflows where the workspace points to a
+// fork but issues should be discovered from the upstream repository.
 // If the workspace has a secretRef, it is used for GitHub API authentication.
 type GitHubIssues struct {
+	// Repo optionally overrides the repository to poll for issues, in
+	// "owner/repo" format or as a full URL. When empty, the repository
+	// is derived from the workspace repo URL in taskTemplate.workspaceRef.
+	// Use this for fork workflows where the workspace points to a fork
+	// but issues should be discovered from the upstream repository.
+	// +optional
+	Repo string `json:"repo,omitempty"`
+
 	// Types specifies which item types to discover: "issues", "pulls", or both.
 	// +kubebuilder:validation:Items:Enum=issues;pulls
 	// +kubebuilder:default={"issues"}

--- a/examples/06-fork-workflow/README.md
+++ b/examples/06-fork-workflow/README.md
@@ -1,0 +1,72 @@
+# 06 — Fork Workflow
+
+A TaskSpawner that discovers issues from an **upstream** repository but runs
+agents against a **fork**. This is the standard open-source contribution
+pattern where you don't have push access to the upstream repo.
+
+## Use Case
+
+You maintain a fork of an upstream project. When new issues are filed upstream,
+an AI agent clones your fork, creates a fix branch, and opens a PR from your
+fork back to the upstream repository.
+
+## Resources
+
+| File | Kind | Purpose |
+|------|------|---------|
+| `workspace.yaml` | Workspace | Points to your fork with an `upstream` remote |
+| `taskspawner.yaml` | TaskSpawner | Polls upstream for issues via `githubIssues.repo` |
+
+You also need Secrets for GitHub and agent credentials (see example 03).
+
+## How It Works
+
+```
+TaskSpawner polls upstream repo for issues (via githubIssues.repo)
+    │
+    ├── new issue found → creates Task
+    │       │
+    │       ├── clones fork (origin)
+    │       ├── adds upstream remote
+    │       ├── creates fix branch
+    │       ├── agent works on fix
+    │       └── opens PR from fork → upstream
+    └── ...
+```
+
+## Key Concepts
+
+- **`workspace.spec.repo`** — points to your fork (this is what gets cloned
+  as `origin`).
+- **`workspace.spec.remotes`** — adds the upstream repo as a named remote so
+  the agent can reference it.
+- **`taskspawner.spec.when.githubIssues.repo`** — tells the spawner to poll
+  the upstream repo for issues instead of the fork.
+- The same GitHub token (from `workspace.spec.secretRef`) is used for both
+  polling upstream issues and pushing to the fork.
+
+## Steps
+
+1. **Create secrets** for your GitHub token and agent credentials.
+
+2. **Edit `workspace.yaml`** — replace the fork and upstream URLs.
+
+3. **Edit `taskspawner.yaml`** — set `githubIssues.repo` to the upstream repo.
+
+4. **Apply the resources:**
+
+```bash
+kubectl apply -f examples/06-fork-workflow/
+```
+
+5. **Watch for spawned Tasks:**
+
+```bash
+kubectl get tasks -w
+```
+
+6. **Cleanup:**
+
+```bash
+kubectl delete -f examples/06-fork-workflow/
+```

--- a/examples/06-fork-workflow/taskspawner.yaml
+++ b/examples/06-fork-workflow/taskspawner.yaml
@@ -1,0 +1,32 @@
+apiVersion: axon.io/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: fork-issue-fixer
+spec:
+  when:
+    githubIssues:
+      # Poll the upstream repo for issues instead of the fork
+      # TODO: Replace with the upstream repository ("owner/repo" or full URL)
+      repo: https://github.com/upstream-org/upstream-repo.git
+      labels:
+        - bug
+      state: open
+  taskTemplate:
+    type: claude-code
+    workspaceRef:
+      name: my-fork
+    credentials:
+      type: oauth
+      secretRef:
+        name: claude-oauth-token
+    branch: "axon-task-{{.Number}}"
+    promptTemplate: |
+      Fix the following GitHub issue from the upstream repository and open a
+      PR from this fork back to upstream.
+
+      Issue #{{.Number}}: {{.Title}}
+
+      {{.Body}}
+    ttlSecondsAfterFinished: 3600
+  pollInterval: 5m
+  maxConcurrency: 3

--- a/examples/06-fork-workflow/workspace.yaml
+++ b/examples/06-fork-workflow/workspace.yaml
@@ -1,0 +1,14 @@
+apiVersion: axon.io/v1alpha1
+kind: Workspace
+metadata:
+  name: my-fork
+spec:
+  # TODO: Replace with your fork's repository URL
+  repo: https://github.com/your-user/upstream-repo.git
+  ref: main
+  secretRef:
+    name: github-token
+  remotes:
+    - name: upstream
+      # TODO: Replace with the upstream repository URL
+      url: https://github.com/upstream-org/upstream-repo.git

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -1055,6 +1055,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      repo:
+                        description: |-
+                          Repo optionally overrides the repository to poll for issues, in
+                          "owner/repo" format or as a full URL. When empty, the repository
+                          is derived from the workspace repo URL in taskTemplate.workspaceRef.
+                          Use this for fork workflows where the workspace points to a fork
+                          but issues should be discovered from the upstream repository.
+                        type: string
                       state:
                         default: open
                         description: State filters issues by state (open, closed,

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -216,6 +216,20 @@ func (b *JobBuilder) buildAgentJob(task *axonv1alpha1.Task, workspace *axonv1alp
 				Value: workspace.Ref,
 			})
 		}
+
+		// Inject AXON_UPSTREAM_REPO if an "upstream" remote is configured
+		for _, remote := range workspace.Remotes {
+			if remote.Name == "upstream" {
+				_, upstreamOwner, upstreamRepo := parseGitHubRepo(remote.URL)
+				if upstreamOwner != "" && upstreamRepo != "" {
+					envVars = append(envVars, corev1.EnvVar{
+						Name:  "AXON_UPSTREAM_REPO",
+						Value: fmt.Sprintf("%s/%s", upstreamOwner, upstreamRepo),
+					})
+				}
+				break
+			}
+		}
 	}
 
 	if workspace != nil && workspace.SecretRef != nil {

--- a/internal/controller/taskspawner_deployment_builder.go
+++ b/internal/controller/taskspawner_deployment_builder.go
@@ -63,6 +63,12 @@ func (b *DeploymentBuilder) Build(ts *axonv1alpha1.TaskSpawner, workspace *axonv
 
 	if workspace != nil {
 		host, owner, repo := parseGitHubRepo(workspace.Repo)
+
+		// Override with explicit GitHubIssues.Repo if set (fork workflow)
+		if ts.Spec.When.GitHubIssues != nil && ts.Spec.When.GitHubIssues.Repo != "" {
+			host, owner, repo = parseGitHubRepo(ts.Spec.When.GitHubIssues.Repo)
+		}
+
 		args = append(args,
 			"--github-owner="+owner,
 			"--github-repo="+repo,

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -1055,6 +1055,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      repo:
+                        description: |-
+                          Repo optionally overrides the repository to poll for issues, in
+                          "owner/repo" format or as a full URL. When empty, the repository
+                          is derived from the workspace repo URL in taskTemplate.workspaceRef.
+                          Use this for fork workflows where the workspace points to a fork
+                          but issues should be discovered from the upstream repository.
+                        type: string
                       state:
                         default: open
                         description: State filters issues by state (open, closed,


### PR DESCRIPTION
fixes #404
fixes #406 

## Summary
- Add optional `GitHubIssues.Repo` field to decouple issue discovery from the workspace clone source, enabling fork workflows where the spawner polls an upstream repo for issues while agents clone/push to a fork
- Fix cross-repo PR capture by querying the upstream repo (via `AXON_UPSTREAM_REPO` env var) in addition to origin, so PRs opened from a fork to upstream are correctly detected
- Auto-inject `AXON_UPSTREAM_REPO` env var when the workspace has a remote named `"upstream"`
- Add fork workflow example (`examples/06-fork-workflow/`)

## Test plan
- [x] Unit tests for deployment builder repo override (github.com + enterprise)
- [x] Unit tests for capture upstream PR detection (with/without PRs)
- [x] Unit tests for job builder `AXON_UPSTREAM_REPO` env var injection (upstream vs non-upstream remote)
- [x] Integration test: TaskSpawner with `githubIssues.repo` override verifies Deployment args
- [x] `make verify` passes
- [x] `make test` passes
- [x] `make test-integration` passes (81/81)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fork-friendly GitHub issue polling so the spawner can track upstream issues while agents work on a fork, and cross-repo PRs are correctly detected.

- **New Features**
  - Added spec.when.githubIssues.repo to override the issue source (owner/repo or URL); Deployment derives owner/repo from this instead of the workspace repo.
  - Auto-inject AXON_UPSTREAM_REPO when the workspace has an "upstream" remote.
  - Added example: examples/06-fork-workflow.

- **Bug Fixes**
  - Capture now finds PRs opened from a fork to upstream by also querying the upstream repo when AXON_UPSTREAM_REPO is set.

<sup>Written for commit c8e733a176ff05b164b8cbd39dd4d8153dd40275. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

