### PR TITLE
Rename axon-core/axon to kelos-dev/kelos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,25 +84,25 @@ jobs:
 
       - name: Load images into kind
         run: |
-          kind load docker-image gjkim42/axon-controller:e2e
-          kind load docker-image gjkim42/axon-spawner:e2e
+          kind load docker-image gjkim42/kelos-controller:e2e
+          kind load docker-image gjkim42/kelos-spawner:e2e
           kind load docker-image gjkim42/claude-code:e2e
           kind load docker-image gjkim42/codex:e2e
           kind load docker-image gjkim42/gemini:e2e
           kind load docker-image gjkim42/opencode:e2e
 
       - name: Build CLI
-        run: make build WHAT=cmd/axon
+        run: make build WHAT=cmd/kelos
 
       - name: Deploy controller
         run: |
-          bin/axon install --version e2e --image-pull-policy Never
-          kubectl wait --for=condition=available deployment/axon-controller-manager -n axon-system --timeout=120s
+          bin/kelos install --version e2e --image-pull-policy Never
+          kubectl wait --for=condition=available deployment/kelos-controller-manager -n kelos-system --timeout=120s
 
       - name: E2E Test
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           GITHUB_TOKEN: ${{ github.token }}
-          AXON_BIN: ${{ github.workspace }}/bin/axon
+          KELOS_BIN: ${{ github.workspace }}/bin/kelos
         run: make test-e2e

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -20,7 +20,7 @@ jobs:
     if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
-      AXON_NAMESPACE: ${{ vars.AXON_NAMESPACE || 'default' }}
+      KELOS_NAMESPACE: ${{ vars.KELOS_NAMESPACE || 'default' }}
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
@@ -34,7 +34,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Build CLI
-        run: make build WHAT=cmd/axon
+        run: make build WHAT=cmd/kelos
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -49,13 +49,13 @@ jobs:
           location: ${{ env.GKE_CLUSTER_LOCATION }}
           project_id: ${{ env.GCP_PROJECT_ID }}
 
-      - name: Install axon
+      - name: Install kelos
         run: |
-          bin/axon install --version main --image-pull-policy Always
-          kubectl rollout restart deployment/axon-controller-manager -n axon-system
-          kubectl rollout status deployment/axon-controller-manager -n axon-system --timeout=120s
-          kubectl rollout restart deployment -l app.kubernetes.io/component=spawner -n "${AXON_NAMESPACE}"
-          kubectl rollout status deployment -l app.kubernetes.io/component=spawner -n "${AXON_NAMESPACE}" --timeout=120s
+          bin/kelos install --version main --image-pull-policy Always
+          kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
+          kubectl rollout status deployment/kelos-controller-manager -n kelos-system --timeout=120s
+          kubectl rollout restart deployment -l app.kubernetes.io/component=spawner -n "${KELOS_NAMESPACE}"
+          kubectl rollout status deployment -l app.kubernetes.io/component=spawner -n "${KELOS_NAMESPACE}" --timeout=120s
 
       - name: Apply self-development resources
-        run: kubectl apply -f self-development/ -n "${AXON_NAMESPACE}"
+        run: kubectl apply -f self-development/ -n "${KELOS_NAMESPACE}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: gjkim42
-          password: ${{ secrets.DOCKERHUB_AXON_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_KELOS_TOKEN }}
 
       - name: Determine version
         id: version
@@ -62,5 +62,5 @@ jobs:
         run: |
           gh release create "$VERSION" --verify-tag --generate-notes || true
           gh release upload "$VERSION" --clobber \
-            bin/axon-* \
+            bin/kelos-* \
             bin/checksums.txt

--- a/.github/workflows/reset-kelos-worker.yaml
+++ b/.github/workflows/reset-kelos-worker.yaml
@@ -1,4 +1,4 @@
-name: Squash Axon Worker Commits
+name: Reset Kelos Worker
 
 on:
   issue_comment:
@@ -18,15 +18,15 @@ permissions:
   id-token: write
 
 concurrency:
-  group: squash-axon-worker-commits-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: reset-kelos-worker-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  squash-axon-worker-commits:
-    if: contains(github.event.comment.body || github.event.review.body || '', '/squash-commits')
+  reset-kelos-worker:
+    if: contains(github.event.comment.body || github.event.review.body || '', '/reset-worker')
     runs-on: ubuntu-latest
     env:
-      AXON_NAMESPACE: ${{ vars.AXON_NAMESPACE || 'default' }}
+      KELOS_NAMESPACE: ${{ vars.KELOS_NAMESPACE || 'default' }}
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
@@ -56,9 +56,11 @@ jobs:
               return [...new Set(numbers)].filter((n) => Number.isInteger(n) && n > 0)
             }
 
+            // For pull_request_review events, the commenter is in review.user
+            // For issue_comment and pull_request_review_comment events, it is in comment.user
             const commenter = context.payload.comment?.user?.login || context.payload.review?.user?.login || ""
             if (!commenter) {
-              core.info("Ignoring /squash-commits with unknown commenter")
+              core.info("Ignoring /reset-worker with unknown commenter")
               core.setOutput("should_reset", "false")
               return
             }
@@ -78,18 +80,22 @@ jobs:
             }
 
             if (permission !== "admin") {
-              core.info(`Ignoring /squash-commits from non-admin user ${commenter} (permission=${permission || "unknown"})`)
+              core.info(`Ignoring /reset-worker from non-admin user ${commenter} (permission=${permission || "unknown"})`)
               core.setOutput("should_reset", "false")
               return
             }
 
+            // For issue_comment events, context.payload.issue is available.
+            // For pull_request_review_comment and pull_request_review events,
+            // only context.payload.pull_request is available.
             const issue = context.payload.issue
             const pullRequest = context.payload.pull_request
 
-            // This command only makes sense on a PR (it squashes commits on a branch)
             if (issue && !issue.pull_request) {
-              core.info("This command must be used on a pull request, not an issue")
-              core.setOutput("should_reset", "false")
+              core.info(`Reset requested on issue #${issue.number}`)
+              core.setOutput("should_reset", "true")
+              core.setOutput("target_issue_number", String(issue.number))
+              core.setOutput("target_pr_number", "")
               return
             }
 
@@ -112,30 +118,10 @@ jobs:
               return
             }
 
-            core.info(`Squash requested on PR #${prNumber} (branch: ${pr.head.ref}) for issue #${referencedIssues[0]}`)
+            core.info(`Reset requested on PR #${prNumber} for issue #${referencedIssues[0]}`)
             core.setOutput("should_reset", "true")
             core.setOutput("target_issue_number", String(referencedIssues[0]))
             core.setOutput("target_pr_number", String(prNumber))
-            core.setOutput("target_branch", pr.head.ref)
-
-      - name: Checkout repository
-        if: steps.gate.outputs.should_reset == 'true'
-        uses: actions/checkout@v4
-
-      - name: Generate task manifest from template
-        id: manifest
-        if: steps.gate.outputs.should_reset == 'true'
-        env:
-          BRANCH: ${{ steps.gate.outputs.target_branch }}
-          PR_NUMBER: ${{ steps.gate.outputs.target_pr_number }}
-          ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
-        run: |
-          set -euo pipefail
-          MANIFEST_PATH="${RUNNER_TEMP}/squash-task.yaml"
-          export BRANCH PR_NUMBER ISSUE_NUMBER
-          envsubst '${BRANCH} ${PR_NUMBER} ${ISSUE_NUMBER}' \
-            < self-development/tasks/squash-commits-task.yaml > "${MANIFEST_PATH}"
-          echo "manifest_path=${MANIFEST_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Authenticate to Google Cloud
         if: steps.gate.outputs.should_reset == 'true'
@@ -154,46 +140,47 @@ jobs:
 
       - name: Remove existing worker task
         if: steps.gate.outputs.should_reset == 'true'
-        env:
-          TARGET_ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
         run: |
           set -euo pipefail
-          task_name="axon-workers-${TARGET_ISSUE_NUMBER}"
-          kubectl delete task.axon.io "${task_name}" -n "${AXON_NAMESPACE}" --ignore-not-found=true
-          echo "Removed task ${task_name} in namespace ${AXON_NAMESPACE} for target issue #${TARGET_ISSUE_NUMBER}"
+          task_name="kelos-workers-${{ steps.gate.outputs.target_issue_number }}"
+          kubectl delete task.kelos.dev "${task_name}" -n "${KELOS_NAMESPACE}" --ignore-not-found=true
+          echo "Removed task ${task_name} in namespace ${KELOS_NAMESPACE} for target issue #${{ steps.gate.outputs.target_issue_number }}"
 
-      - name: Add axon/needs-input label to issue
+      - name: Remove kelos/needs-input label from issue and PR
         if: steps.gate.outputs.should_reset == 'true'
         uses: actions/github-script@v7
         env:
           TARGET_ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
+          TARGET_PR_NUMBER: ${{ steps.gate.outputs.target_pr_number }}
         with:
           script: |
-            const label = "axon/needs-input"
+            const label = "kelos/needs-input"
+            const targets = new Set()
+
             const targetIssueNumber = Number(process.env.TARGET_ISSUE_NUMBER || "0")
+            const targetPrNumber = Number(process.env.TARGET_PR_NUMBER || "0")
 
-            if (!Number.isInteger(targetIssueNumber) || targetIssueNumber <= 0) {
-              core.info("No valid target issue number, skipping label addition")
-              return
+            if (Number.isInteger(targetIssueNumber) && targetIssueNumber > 0) {
+              targets.add(targetIssueNumber)
+            }
+            if (Number.isInteger(targetPrNumber) && targetPrNumber > 0) {
+              targets.add(targetPrNumber)
             }
 
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: targetIssueNumber,
-                labels: [label],
-              })
-              core.info(`Added label ${label} to issue #${targetIssueNumber}`)
-            } catch (error) {
-              core.warning(`Failed to add label ${label} to issue #${targetIssueNumber}: ${error.message}`)
+            for (const issue_number of targets) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: label,
+                })
+                core.info(`Removed label ${label} from #${issue_number}`)
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Label ${label} not present on #${issue_number}`)
+                  continue
+                }
+                throw error
+              }
             }
-
-      - name: Create squash task
-        if: steps.gate.outputs.should_reset == 'true'
-        env:
-          MANIFEST_PATH: ${{ steps.manifest.outputs.manifest_path }}
-        run: |
-          set -euo pipefail
-          task_name="$(kubectl create -n "${AXON_NAMESPACE}" -f "${MANIFEST_PATH}" -o jsonpath='{.metadata.name}')"
-          echo "Created squash task: ${task_name} in namespace ${AXON_NAMESPACE}"

--- a/.github/workflows/run-fake-strategist.yaml
+++ b/.github/workflows/run-fake-strategist.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       namespace:
-        description: Kubernetes namespace for Axon resources
+        description: Kubernetes namespace for Kelos resources
         required: false
         default: ""
 
@@ -20,7 +20,7 @@ jobs:
   run-fake-strategist:
     runs-on: ubuntu-latest
     env:
-      AXON_NAMESPACE: ${{ inputs.namespace || vars.AXON_NAMESPACE || 'default' }}
+      KELOS_NAMESPACE: ${{ inputs.namespace || vars.KELOS_NAMESPACE || 'default' }}
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
@@ -48,7 +48,7 @@ jobs:
           set -euo pipefail
 
           existing_task="$(
-            kubectl get tasks.axon.io -n "${AXON_NAMESPACE}" -l axon.run/type=fake-strategist-manual -o json \
+            kubectl get tasks.kelos.dev -n "${KELOS_NAMESPACE}" -l kelos.dev/type=fake-strategist-manual -o json \
               | jq -r '.items[] | select(.status.phase == "Pending" or .status.phase == "Running") | .metadata.name' \
               | head -n1
           )"
@@ -60,7 +60,7 @@ jobs:
           fi
 
           task_name="$(
-            kubectl create -n "${AXON_NAMESPACE}" -f self-development/tasks/fake-strategist-task.yaml -o jsonpath='{.metadata.name}'
+            kubectl create -n "${KELOS_NAMESPACE}" -f self-development/tasks/fake-strategist-task.yaml -o jsonpath='{.metadata.name}'
           )"
 
           echo "action=created" >> "$GITHUB_OUTPUT"
@@ -73,8 +73,8 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${TASK_ACTION}" == "skipped" ]]; then
-            echo "Fake strategist task already active: ${TASK_NAME} in namespace ${AXON_NAMESPACE}"
+            echo "Fake strategist task already active: ${TASK_NAME} in namespace ${KELOS_NAMESPACE}"
           else
-            echo "Created fake strategist task: ${TASK_NAME} in namespace ${AXON_NAMESPACE}"
-            echo "Check status with: kubectl get task ${TASK_NAME} -n ${AXON_NAMESPACE} -o yaml"
+            echo "Created fake strategist task: ${TASK_NAME} in namespace ${KELOS_NAMESPACE}"
+            echo "Check status with: kubectl get task ${TASK_NAME} -n ${KELOS_NAMESPACE} -o yaml"
           fi

--- a/.github/workflows/squash-kelos-worker-commits.yaml
+++ b/.github/workflows/squash-kelos-worker-commits.yaml
@@ -1,4 +1,4 @@
-name: Reset Axon Worker
+name: Squash Kelos Worker Commits
 
 on:
   issue_comment:
@@ -18,15 +18,15 @@ permissions:
   id-token: write
 
 concurrency:
-  group: reset-axon-worker-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: squash-kelos-worker-commits-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  reset-axon-worker:
-    if: contains(github.event.comment.body || github.event.review.body || '', '/reset-worker')
+  squash-kelos-worker-commits:
+    if: contains(github.event.comment.body || github.event.review.body || '', '/squash-commits')
     runs-on: ubuntu-latest
     env:
-      AXON_NAMESPACE: ${{ vars.AXON_NAMESPACE || 'default' }}
+      KELOS_NAMESPACE: ${{ vars.KELOS_NAMESPACE || 'default' }}
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
@@ -56,11 +56,9 @@ jobs:
               return [...new Set(numbers)].filter((n) => Number.isInteger(n) && n > 0)
             }
 
-            // For pull_request_review events, the commenter is in review.user
-            // For issue_comment and pull_request_review_comment events, it is in comment.user
             const commenter = context.payload.comment?.user?.login || context.payload.review?.user?.login || ""
             if (!commenter) {
-              core.info("Ignoring /reset-worker with unknown commenter")
+              core.info("Ignoring /squash-commits with unknown commenter")
               core.setOutput("should_reset", "false")
               return
             }
@@ -80,22 +78,18 @@ jobs:
             }
 
             if (permission !== "admin") {
-              core.info(`Ignoring /reset-worker from non-admin user ${commenter} (permission=${permission || "unknown"})`)
+              core.info(`Ignoring /squash-commits from non-admin user ${commenter} (permission=${permission || "unknown"})`)
               core.setOutput("should_reset", "false")
               return
             }
 
-            // For issue_comment events, context.payload.issue is available.
-            // For pull_request_review_comment and pull_request_review events,
-            // only context.payload.pull_request is available.
             const issue = context.payload.issue
             const pullRequest = context.payload.pull_request
 
+            // This command only makes sense on a PR (it squashes commits on a branch)
             if (issue && !issue.pull_request) {
-              core.info(`Reset requested on issue #${issue.number}`)
-              core.setOutput("should_reset", "true")
-              core.setOutput("target_issue_number", String(issue.number))
-              core.setOutput("target_pr_number", "")
+              core.info("This command must be used on a pull request, not an issue")
+              core.setOutput("should_reset", "false")
               return
             }
 
@@ -118,10 +112,30 @@ jobs:
               return
             }
 
-            core.info(`Reset requested on PR #${prNumber} for issue #${referencedIssues[0]}`)
+            core.info(`Squash requested on PR #${prNumber} (branch: ${pr.head.ref}) for issue #${referencedIssues[0]}`)
             core.setOutput("should_reset", "true")
             core.setOutput("target_issue_number", String(referencedIssues[0]))
             core.setOutput("target_pr_number", String(prNumber))
+            core.setOutput("target_branch", pr.head.ref)
+
+      - name: Checkout repository
+        if: steps.gate.outputs.should_reset == 'true'
+        uses: actions/checkout@v4
+
+      - name: Generate task manifest from template
+        id: manifest
+        if: steps.gate.outputs.should_reset == 'true'
+        env:
+          BRANCH: ${{ steps.gate.outputs.target_branch }}
+          PR_NUMBER: ${{ steps.gate.outputs.target_pr_number }}
+          ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
+        run: |
+          set -euo pipefail
+          MANIFEST_PATH="${RUNNER_TEMP}/squash-task.yaml"
+          export BRANCH PR_NUMBER ISSUE_NUMBER
+          envsubst '${BRANCH} ${PR_NUMBER} ${ISSUE_NUMBER}' \
+            < self-development/tasks/squash-commits-task.yaml > "${MANIFEST_PATH}"
+          echo "manifest_path=${MANIFEST_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Authenticate to Google Cloud
         if: steps.gate.outputs.should_reset == 'true'
@@ -140,47 +154,46 @@ jobs:
 
       - name: Remove existing worker task
         if: steps.gate.outputs.should_reset == 'true'
+        env:
+          TARGET_ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
         run: |
           set -euo pipefail
-          task_name="axon-workers-${{ steps.gate.outputs.target_issue_number }}"
-          kubectl delete task.axon.io "${task_name}" -n "${AXON_NAMESPACE}" --ignore-not-found=true
-          echo "Removed task ${task_name} in namespace ${AXON_NAMESPACE} for target issue #${{ steps.gate.outputs.target_issue_number }}"
+          task_name="kelos-workers-${TARGET_ISSUE_NUMBER}"
+          kubectl delete task.kelos.dev "${task_name}" -n "${KELOS_NAMESPACE}" --ignore-not-found=true
+          echo "Removed task ${task_name} in namespace ${KELOS_NAMESPACE} for target issue #${TARGET_ISSUE_NUMBER}"
 
-      - name: Remove axon/needs-input label from issue and PR
+      - name: Add kelos/needs-input label to issue
         if: steps.gate.outputs.should_reset == 'true'
         uses: actions/github-script@v7
         env:
           TARGET_ISSUE_NUMBER: ${{ steps.gate.outputs.target_issue_number }}
-          TARGET_PR_NUMBER: ${{ steps.gate.outputs.target_pr_number }}
         with:
           script: |
-            const label = "axon/needs-input"
-            const targets = new Set()
-
+            const label = "kelos/needs-input"
             const targetIssueNumber = Number(process.env.TARGET_ISSUE_NUMBER || "0")
-            const targetPrNumber = Number(process.env.TARGET_PR_NUMBER || "0")
 
-            if (Number.isInteger(targetIssueNumber) && targetIssueNumber > 0) {
-              targets.add(targetIssueNumber)
-            }
-            if (Number.isInteger(targetPrNumber) && targetPrNumber > 0) {
-              targets.add(targetPrNumber)
+            if (!Number.isInteger(targetIssueNumber) || targetIssueNumber <= 0) {
+              core.info("No valid target issue number, skipping label addition")
+              return
             }
 
-            for (const issue_number of targets) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number,
-                  name: label,
-                })
-                core.info(`Removed label ${label} from #${issue_number}`)
-              } catch (error) {
-                if (error.status === 404) {
-                  core.info(`Label ${label} not present on #${issue_number}`)
-                  continue
-                }
-                throw error
-              }
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: targetIssueNumber,
+                labels: [label],
+              })
+              core.info(`Added label ${label} to issue #${targetIssueNumber}`)
+            } catch (error) {
+              core.warning(`Failed to add label ${label} to issue #${targetIssueNumber}: ${error.message}`)
             }
+
+      - name: Create squash task
+        if: steps.gate.outputs.should_reset == 'true'
+        env:
+          MANIFEST_PATH: ${{ steps.manifest.outputs.manifest_path }}
+        run: |
+          set -euo pipefail
+          task_name="$(kubectl create -n "${KELOS_NAMESPACE}" -f "${MANIFEST_PATH}" -o jsonpath='{.metadata.name}')"
+          echo "Created squash task: ${task_name} in namespace ${KELOS_NAMESPACE}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,24 @@
-AGENTS.md
+# Project Conventions for AI Assistants
+
+## Rules for AI Assistants
+- **Use Makefile targets** instead of discovering build/test commands yourself.
+- **Keep changes minimal.** Do not refactor, reorganize, or 'improve' code beyond what was explicitly requested.
+- **For CI/release workflows**, always use existing Makefile targets rather than reimplementing build logic in YAML.
+- **Better tests.** Always try to add or improve tests(including integration, e2e) when modifying code.
+- **Logging conventions.** Start log messages with capital letters and do not end with punctuation.
+- **Commit messages.** Do not include PR links in commit messages.
+
+## Key Makefile Targets
+- `make verify` — run all verification checks (lint, fmt, vet, etc.).
+- `make update` — update all generated files
+- tests:
+  - `make test` — run all unit tests
+  - `make test-integration` — run integration tests
+  - e2e tests are hard to run locally. Push changes and use the PR's CI jobs to run them instead.
+- `make build` — build binary
+
+## Directory Structure
+- `cmd/` — CLI entrypoints
+- `test/e2e/` — end-to-end tests
+- `.github/workflows/` — CI workflows
+

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Image configuration
 REGISTRY ?= gjkim42
 VERSION ?= latest
-IMAGE_DIRS ?= cmd/axon-controller cmd/axon-spawner cmd/axon-token-refresher claude-code codex gemini opencode
+IMAGE_DIRS ?= cmd/kelos-controller cmd/kelos-spawner cmd/kelos-token-refresher claude-code codex gemini opencode
 
-# Version injection for the axon CLI – only set ldflags when an explicit
+# Version injection for the kelos CLI – only set ldflags when an explicit
 # version is given so that dev builds fall through to runtime/debug info.
-VERSION_PKG = github.com/axon-core/axon/internal/version
+VERSION_PKG = github.com/kelos-dev/kelos/internal/version
 ifneq ($(VERSION),latest)
 LDFLAGS ?= -X $(VERSION_PKG).Version=$(VERSION)
 endif
@@ -69,7 +69,7 @@ verify: controller-gen yamlfmt shfmt ## Verify everything is up-to-date and corr
 ##@ Build
 
 .PHONY: build
-build: ## Build binaries (use WHAT=cmd/axon to build specific binary).
+build: ## Build binaries (use WHAT=cmd/kelos to build specific binary).
 	@for dir in $$(go list ./$(or $(WHAT),cmd/...)); do \
 		bin_name=$$(basename $$dir); \
 		CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/$$bin_name $$dir; \
@@ -77,14 +77,14 @@ build: ## Build binaries (use WHAT=cmd/axon to build specific binary).
 
 .PHONY: run
 run: ## Run a controller from your host.
-	go run ./cmd/axon-controller
+	go run ./cmd/kelos-controller
 
 .PHONY: image
 image: ## Build docker images (use WHAT to build specific image).
 	@for dir in $(filter cmd/%,$(or $(WHAT),$(IMAGE_DIRS))); do \
 		GOOS=linux GOARCH=amd64 $(MAKE) build WHAT=$$dir; \
 	done
-	@GOOS=linux GOARCH=amd64 $(MAKE) build WHAT=cmd/axon-capture
+	@GOOS=linux GOARCH=amd64 $(MAKE) build WHAT=cmd/kelos-capture
 	@for dir in $(or $(WHAT),$(IMAGE_DIRS)); do \
 		docker build -t $(REGISTRY)/$$(basename $$dir):$(VERSION) -f $$dir/Dockerfile .; \
 	done
@@ -102,10 +102,10 @@ release-binaries: ## Cross-compile CLI binaries for release and generate checksu
 	@for platform in $(RELEASE_PLATFORMS); do \
 		os=$${platform%/*}; \
 		arch=$${platform#*/}; \
-		GOOS=$$os GOARCH=$$arch $(MAKE) build WHAT=cmd/axon; \
-		mv bin/axon "bin/axon-$${os}-$${arch}"; \
+		GOOS=$$os GOARCH=$$arch $(MAKE) build WHAT=cmd/kelos; \
+		mv bin/kelos "bin/kelos-$${os}-$${arch}"; \
 	done
-	@cd bin && sha256sum axon-* > checksums.txt
+	@cd bin && sha256sum kelos-* > checksums.txt
 
 .PHONY: clean
 clean: ## Clean build artifacts.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-<h1 align="center">Axon</h1>
+<h1 align="center">Kelos</h1>
 
 <p align="center"><strong>The Kubernetes-native framework for orchestrating autonomous AI coding agents.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/axon-core/axon/actions/workflows/ci.yaml"><img src="https://github.com/axon-core/axon/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/axon-core/axon/releases/latest"><img src="https://img.shields.io/github/v/release/axon-core/axon" alt="Release"></a>
-  <a href="https://github.com/axon-core/axon"><img src="https://img.shields.io/github/stars/axon-core/axon?style=flat" alt="GitHub Stars"></a>
-  <a href="https://github.com/axon-core/axon"><img src="https://img.shields.io/github/go-mod/go-version/axon-core/axon" alt="Go Version"></a>
+  <a href="https://github.com/kelos-dev/kelos/actions/workflows/ci.yaml"><img src="https://github.com/kelos-dev/kelos/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/kelos-dev/kelos/releases/latest"><img src="https://img.shields.io/github/v/release/kelos-dev/kelos" alt="Release"></a>
+  <a href="https://github.com/kelos-dev/kelos"><img src="https://img.shields.io/github/stars/kelos-dev/kelos?style=flat" alt="GitHub Stars"></a>
+  <a href="https://github.com/kelos-dev/kelos"><img src="https://img.shields.io/github/go-mod/go-version/kelos-dev/kelos" alt="Go Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
 </p>
 
@@ -17,7 +17,7 @@
   <a href="examples/">YAML Manifests</a>
 </p>
 
-Point Axon at a GitHub issue and get a PR back — fully autonomous, running in Kubernetes. Each agent runs in an isolated, ephemeral Pod with a freshly cloned git workspace. Fan out across repositories, chain tasks into pipelines, and react to events automatically.
+Point Kelos at a GitHub issue and get a PR back — fully autonomous, running in Kubernetes. Each agent runs in an isolated, ephemeral Pod with a freshly cloned git workspace. Fan out across repositories, chain tasks into pipelines, and react to events automatically.
 
 Supports **Claude Code**, **OpenAI Codex**, **Google Gemini**, **OpenCode**, and [custom agent images](docs/agent-image-interface.md).
 
@@ -25,31 +25,31 @@ Supports **Claude Code**, **OpenAI Codex**, **Google Gemini**, **OpenCode**, and
 
 ```bash
 # Run multiple tasks in parallel across your repo
-$ axon run -p "Fix the bug described in issue #42 and open a PR" --name fix-42
-$ axon run -p "Add unit tests for the auth module" --name add-tests
-$ axon run -p "Update API docs for v2 endpoints" --name update-docs
+$ kelos run -p "Fix the bug described in issue #42 and open a PR" --name fix-42
+$ kelos run -p "Add unit tests for the auth module" --name add-tests
+$ kelos run -p "Update API docs for v2 endpoints" --name update-docs
 
 # Watch all tasks progress simultaneously
-$ axon get tasks
+$ kelos get tasks
 NAME          TYPE          PHASE     BRANCH                WORKSPACE   AGENT CONFIG   DURATION   AGE
-fix-42        claude-code   Running   axon-task-fix-42      my-repo     my-config      2m         2m
-add-tests     claude-code   Running   axon-task-add-tests   my-repo     my-config      1m         1m
-update-docs   claude-code   Running   axon-task-update-docs my-repo     my-config      45s        45s
+fix-42        claude-code   Running   kelos-task-fix-42      my-repo     my-config      2m         2m
+add-tests     claude-code   Running   kelos-task-add-tests   my-repo     my-config      1m         1m
+update-docs   claude-code   Running   kelos-task-update-docs my-repo     my-config      45s        45s
 ```
 
 https://github.com/user-attachments/assets/0ea57071-15d8-4b3b-a546-d00429b76f8d
 
 See [Autonomous self-development pipeline](#autonomous-self-development-pipeline) for a full end-to-end example.
 
-## Why Axon?
+## Why Kelos?
 
-AI coding agents are evolving from interactive CLI tools into autonomous background workers. Axon provides the infrastructure to manage this transition at scale.
+AI coding agents are evolving from interactive CLI tools into autonomous background workers. Kelos provides the infrastructure to manage this transition at scale.
 
 - **Orchestration, not just execution** — Don't just run an agent; manage its entire lifecycle. Chain tasks with `dependsOn` and pass results (branch names, PR URLs, token usage) between pipeline stages. Use `TaskSpawner` to build event-driven workers that react to GitHub issues, PRs, or schedules.
 - **Host-isolated autonomy** — Each task runs in an isolated, ephemeral Pod with a freshly cloned git workspace. Agents have no access to your host machine — use [scoped tokens and branch protection](#security-considerations) to control repository access.
-- **Standardized interface** — Plug in any agent (Claude, Codex, Gemini, OpenCode, or your own) using a simple [container interface](docs/agent-image-interface.md). Axon handles credential injection, workspace management, and Kubernetes plumbing.
+- **Standardized interface** — Plug in any agent (Claude, Codex, Gemini, OpenCode, or your own) using a simple [container interface](docs/agent-image-interface.md). Kelos handles credential injection, workspace management, and Kubernetes plumbing.
 - **Scalable parallelism** — Fan out agents across multiple repositories. Kubernetes handles scheduling, resource management, and queueing — scale is limited by your cluster capacity and API provider quotas.
-- **Observable & CI-native** — Every agent run is a first-class Kubernetes resource with deterministic outputs (branch names, PR URLs, commit SHAs, token usage) captured into status. Monitor via `kubectl`, manage via the `axon` CLI or declarative YAML (GitOps-ready), and integrate with ArgoCD or GitHub Actions.
+- **Observable & CI-native** — Every agent run is a first-class Kubernetes resource with deterministic outputs (branch names, PR URLs, commit SHAs, token usage) captured into status. Monitor via `kubectl`, manage via the `kelos` CLI or declarative YAML (GitOps-ready), and integrate with ArgoCD or GitHub Actions.
 
 ## Quick Start
 
@@ -75,40 +75,40 @@ This creates a single-node cluster and configures your kubeconfig automatically.
 ### 1. Install the CLI
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/axon-core/axon/main/hack/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kelos-dev/kelos/main/hack/install.sh | bash
 ```
 
 <details>
 <summary>Alternative: install from source</summary>
 
 ```bash
-go install github.com/axon-core/axon/cmd/axon@latest
+go install github.com/kelos-dev/kelos/cmd/kelos@latest
 ```
 
 </details>
 
-### 2. Install Axon
+### 2. Install Kelos
 
 ```bash
-axon install
+kelos install
 ```
 
-This installs the Axon controller and CRDs into the `axon-system` namespace.
+This installs the Kelos controller and CRDs into the `kelos-system` namespace.
 
 Verify the installation:
 
 ```bash
-kubectl get pods -n axon-system
-kubectl get crds | grep axon.io
+kubectl get pods -n kelos-system
+kubectl get crds | grep kelos.dev
 ```
 
 ### 3. Initialize Your Config
 
 ```bash
-axon init
+kelos init
 ```
 
-Edit `~/.axon/config.yaml`:
+Edit `~/.kelos/config.yaml`:
 
 ```yaml
 oauthToken: <your-oauth-token>
@@ -145,10 +145,10 @@ Create a [Personal Access Token](https://github.com/settings/tokens) with `repo`
 ### 4. Run Your First Task
 
 ```bash
-$ axon run -p "Add a hello world program in Python"
+$ kelos run -p "Add a hello world program in Python"
 task/task-r8x2q created
 
-$ axon logs task-r8x2q -f
+$ kelos logs task-r8x2q -f
 ```
 
 The task name (e.g. `task-r8x2q`) is auto-generated. Use `--name` to set a custom name, or `-w` to automatically watch task logs.
@@ -156,7 +156,7 @@ The task name (e.g. `task-r8x2q`) is auto-generated. Use `--name` to set a custo
 The agent clones your repo, makes changes, and can push a branch or open a PR.
 
 > **Tip:** If something goes wrong, check the controller logs with
-> `kubectl logs deployment/axon-controller-manager -n axon-system`.
+> `kubectl logs deployment/kelos-controller-manager -n kelos-system`.
 
 <details>
 <summary>Using kubectl and YAML instead of the CLI</summary>
@@ -164,7 +164,7 @@ The agent clones your repo, makes changes, and can push a branch or open a PR.
 Create a `Workspace` resource to define a git repository:
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-workspace
@@ -176,7 +176,7 @@ spec:
 Then reference it from a `Task`:
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: hello-world
@@ -202,19 +202,19 @@ kubectl get tasks -w
 <details>
 <summary>Using an API key instead of OAuth</summary>
 
-Set `apiKey` instead of `oauthToken` in `~/.axon/config.yaml`:
+Set `apiKey` instead of `oauthToken` in `~/.kelos/config.yaml`:
 
 ```yaml
 apiKey: <your-api-key>
 ```
 
-Or pass `--secret` to `axon run` with a pre-created secret (api-key is the default credential type), or set `spec.credentials.type: api-key` in YAML.
+Or pass `--secret` to `kelos run` with a pre-created secret (api-key is the default credential type), or set `spec.credentials.type: api-key` in YAML.
 
 </details>
 
 ## How It Works
 
-Axon orchestrates the flow from external events to autonomous execution:
+Kelos orchestrates the flow from external events to autonomous execution:
 
 ```
   Triggers (GitHub, Cron) ──┐
@@ -224,11 +224,11 @@ Axon orchestrates the flow from external events to autonomous execution:
   API (CI/CD, Webhooks) ────┘          └─(Lifecycle)──┴─(Execution)─┴─(Success/Fail)
 ```
 
-You define what needs to be done, and Axon handles the "how" — from cloning the right repo and injecting credentials to running the agent and capturing its outputs (branch names, commit SHAs, PR URLs, and token usage).
+You define what needs to be done, and Kelos handles the "how" — from cloning the right repo and injecting credentials to running the agent and capturing its outputs (branch names, commit SHAs, PR URLs, and token usage).
 
 ### Core Primitives
 
-Axon is built on four resources:
+Kelos is built on four resources:
 
 1. **Tasks** — Ephemeral units of work that wrap an AI agent run.
 2. **Workspaces** — Persistent or ephemeral environments (git repos) where agents operate.
@@ -265,7 +265,7 @@ workspace:
 ```
 
 ```bash
-axon run -p "Fix the bug described in issue #42 and open a PR with the fix"
+kelos run -p "Fix the bug described in issue #42 and open a PR with the fix"
 ```
 
 The `gh` CLI and `GITHUB_TOKEN` are available inside the agent container, so the agent can push branches and create PRs autonomously.
@@ -275,7 +275,7 @@ The `gh` CLI and `GITHUB_TOKEN` are available inside the agent container, so the
 Create a TaskSpawner to automatically turn GitHub issues into agent tasks:
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
   name: fix-bugs
@@ -307,8 +307,8 @@ TaskSpawner polls for new issues matching your filters and creates a Task for ea
 Use `dependsOn` to chain tasks into pipelines. A task in `Waiting` phase stays paused until all its dependencies succeed:
 
 ```bash
-axon run -p "Scaffold a new user service" --name scaffold --branch feature/user-service
-axon run -p "Write tests for the user service" --depends-on scaffold --branch feature/user-service
+kelos run -p "Scaffold a new user service" --name scaffold --branch feature/user-service
+kelos run -p "Write tests for the user service" --depends-on scaffold --branch feature/user-service
 ```
 
 Tasks sharing the same `branch` are serialized automatically — only one runs at a time.
@@ -317,7 +317,7 @@ Tasks sharing the same `branch` are serialized automatically — only one runs a
 <summary>YAML equivalent</summary>
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: scaffold
@@ -332,7 +332,7 @@ spec:
     name: my-workspace
   branch: feature/user-service
 ---
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: write-tests
@@ -354,7 +354,7 @@ spec:
 Downstream tasks can reference upstream results in their prompt using `{{.Deps}}`:
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: open-pr
@@ -379,7 +379,7 @@ The `.Deps` map is keyed by dependency Task name. Each entry has `Results` (key-
 Use `AgentConfig` to bundle project-wide instructions, plugins, and MCP servers:
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: AgentConfig
 metadata:
   name: my-config
@@ -396,7 +396,7 @@ spec:
 ```
 
 ```bash
-axon run -p "Fix the bug" --agent-config my-config
+kelos run -p "Fix the bug" --agent-config my-config
 ```
 
 - `agentsMD` is written to `~/.claude/CLAUDE.md` (user-level, additive with the repo's own instructions).
@@ -407,7 +407,7 @@ See the [full AgentConfig spec](docs/reference.md#agentconfig) for plugins, skil
 
 ### Autonomous self-development pipeline
 
-This is a real-world TaskSpawner that picks up every open issue, investigates it, opens (or updates) a PR, self-reviews, and ensures CI passes — fully autonomously. When the agent can't make progress, it labels the issue `axon/needs-input` and stops. Remove the label to re-queue it.
+This is a real-world TaskSpawner that picks up every open issue, investigates it, opens (or updates) a PR, self-reviews, and ensures CI passes — fully autonomously. When the agent can't make progress, it labels the issue `kelos/needs-input` and stops. Remove the label to re-queue it.
 
 ```
  ┌────────────────────────────────────────────────────────────────┐
@@ -429,9 +429,9 @@ This is a real-world TaskSpawner that picks up every open issue, investigates it
  └────────────────────────────────────────────────────────────────┘
 ```
 
-See [`self-development/axon-workers.yaml`](self-development/axon-workers.yaml) for the full manifest and the [`self-development/` README](self-development/README.md) for setup instructions.
+See [`self-development/kelos-workers.yaml`](self-development/kelos-workers.yaml) for the full manifest and the [`self-development/` README](self-development/README.md) for setup instructions.
 
-The key pattern is `excludeLabels: [axon/needs-input]` — this creates a feedback loop where the agent works autonomously until it needs human input, then pauses. Removing the label re-queues the issue on the next poll.
+The key pattern is `excludeLabels: [kelos/needs-input]` — this creates a feedback loop where the agent works autonomously until it needs human input, then pauses. Removing the label re-queues the issue on the next poll.
 
 > Browse all ready-to-apply YAML manifests in the [`examples/`](examples/) directory.
 
@@ -457,15 +457,15 @@ The key pattern is `excludeLabels: [axon/needs-input]` — this creates a feedba
 
 | Command | Description |
 |---------|-------------|
-| `axon install` | Install Axon CRDs and controller into the cluster |
-| `axon uninstall` | Uninstall Axon from the cluster |
-| `axon init` | Initialize `~/.axon/config.yaml` |
-| `axon run` | Create and run a new Task |
-| `axon get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`) |
-| `axon delete <resource> <name>` | Delete a resource |
-| `axon logs <task-name> [-f]` | View or stream logs from a task |
-| `axon suspend taskspawner <name>` | Pause a TaskSpawner |
-| `axon resume taskspawner <name>` | Resume a paused TaskSpawner |
+| `kelos install` | Install Kelos CRDs and controller into the cluster |
+| `kelos uninstall` | Uninstall Kelos from the cluster |
+| `kelos init` | Initialize `~/.kelos/config.yaml` |
+| `kelos run` | Create and run a new Task |
+| `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`) |
+| `kelos delete <resource> <name>` | Delete a resource |
+| `kelos logs <task-name> [-f]` | View or stream logs from a task |
+| `kelos suspend taskspawner <name>` | Pause a TaskSpawner |
+| `kelos resume taskspawner <name>` | Resume a paused TaskSpawner |
 
 See [full CLI reference](docs/reference.md#cli-reference) for all flags and options.
 
@@ -473,7 +473,7 @@ See [full CLI reference](docs/reference.md#cli-reference) for all flags and opti
 
 ## Security Considerations
 
-Axon runs agents in isolated, ephemeral Pods with no access to your host machine, SSH keys, or other processes. The risk surface is limited to what the injected credentials allow.
+Kelos runs agents in isolated, ephemeral Pods with no access to your host machine, SSH keys, or other processes. The risk surface is limited to what the injected credentials allow.
 
 **What agents CAN do:** Push branches, create PRs, and call the GitHub API using the injected `GITHUB_TOKEN`.
 
@@ -489,7 +489,7 @@ Best practices:
 
 > **About `--dangerously-skip-permissions`:** Claude Code uses this flag for non-interactive operation. Despite the name, the actual risk is minimal — agents run inside ephemeral containers with no host access. The flag simply disables interactive approval prompts, which is necessary for autonomous execution.
 
-Axon uses standard Kubernetes RBAC — use namespace isolation to separate teams. Each TaskSpawner automatically creates a scoped ServiceAccount and RoleBinding.
+Kelos uses standard Kubernetes RBAC — use namespace isolation to separate teams. Each TaskSpawner automatically creates a scoped ServiceAccount and RoleBinding.
 
 ## Cost and Limits
 
@@ -516,15 +516,15 @@ spec:
 Or via the CLI:
 
 ```bash
-axon run -p "Fix the bug" --timeout 30m
+kelos run -p "Fix the bug" --timeout 30m
 ```
 
 **Use `suspend` for emergencies.** If costs are spiraling, pause a spawner immediately:
 
 ```bash
-axon suspend taskspawner my-spawner
+kelos suspend taskspawner my-spawner
 # ... investigate ...
-axon resume taskspawner my-spawner
+kelos resume taskspawner my-spawner
 ```
 
 **Rate limits.** API providers enforce concurrency and token limits. If a task hits a rate limit mid-execution, it will likely fail. Use `maxConcurrency` to stay within your provider's limits.
@@ -532,16 +532,16 @@ axon resume taskspawner my-spawner
 ## FAQ
 
 <details>
-<summary><strong>What agents does Axon support?</strong></summary>
+<summary><strong>What agents does Kelos support?</strong></summary>
 
-Axon supports **Claude Code**, **OpenAI Codex**, **Google Gemini**, and **OpenCode** out of the box. You can also bring your own agent image using the [container interface](docs/agent-image-interface.md).
+Kelos supports **Claude Code**, **OpenAI Codex**, **Google Gemini**, and **OpenCode** out of the box. You can also bring your own agent image using the [container interface](docs/agent-image-interface.md).
 
 </details>
 
 <details>
-<summary><strong>Can I use Axon without Kubernetes?</strong></summary>
+<summary><strong>Can I use Kelos without Kubernetes?</strong></summary>
 
-No. Axon is built on Kubernetes Custom Resources and requires a Kubernetes cluster. For local development, use [kind](https://kind.sigs.k8s.io/) (`kind create cluster`) to create a single-node cluster on your machine.
+No. Kelos is built on Kubernetes Custom Resources and requires a Kubernetes cluster. For local development, use [kind](https://kind.sigs.k8s.io/) (`kind create cluster`) to create a single-node cluster on your machine.
 
 </details>
 
@@ -562,7 +562,7 @@ Costs depend on the model and task complexity. Check the [API pricing](https://d
 ## Uninstall
 
 ```bash
-axon uninstall
+kelos uninstall
 ```
 
 ## Development
@@ -587,7 +587,7 @@ make image              # build docker image
 
 For significant changes, please open an issue first to discuss the approach.
 
-We welcome contributions of all kinds — see [good first issues](https://github.com/axon-core/axon/labels/good%20first%20issue) for places to start.
+We welcome contributions of all kinds — see [good first issues](https://github.com/kelos-dev/kelos/labels/good%20first%20issue) for places to start.
 
 ## License
 

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,6 +1,6 @@
-// Package v1alpha1 contains API Schema definitions for the axon v1alpha1 API group.
+// Package v1alpha1 contains API Schema definitions for the kelos v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=axon.io
+// +groupName=kelos.dev
 package v1alpha1
 
 import (
@@ -10,7 +10,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "axon.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "kelos.dev", Version: "v1alpha1"}
 
 	// SchemeGroupVersion is an alias for GroupVersion, required by the
 	// generated clientset code (client-gen / lister-gen).

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -77,7 +77,7 @@ type GitHubIssues struct {
 	State string `json:"state,omitempty"`
 
 	// TriggerComment enables comment-based discovery. When set, only issues
-	// that have a comment matching this string (e.g., "/axon pick-up") are
+	// that have a comment matching this string (e.g., "/kelos pick-up") are
 	// included. This is useful for repos where you lack label permissions.
 	// If ExcludeComments is also set, TriggerComment doubles as a resume
 	// command — the most recent match between TriggerComment and
@@ -87,7 +87,7 @@ type GitHubIssues struct {
 	TriggerComment string `json:"triggerComment,omitempty"`
 
 	// ExcludeComments enables comment-based exclusion. When set, issues that
-	// have a comment matching any of these strings (e.g., "/axon needs-input")
+	// have a comment matching any of these strings (e.g., "/kelos needs-input")
 	// are excluded unless a subsequent TriggerComment overrides it. Comments
 	// are scanned in reverse chronological order — the most recent matching
 	// command wins.
@@ -182,7 +182,7 @@ type TaskTemplate struct {
 	DependsOn []string `json:"dependsOn,omitempty"`
 
 	// Branch is the git branch spawned Tasks should work on.
-	// Supports Go text/template variables from the work item, e.g. "axon-task-{{.Number}}".
+	// Supports Go text/template variables from the work item, e.g. "kelos-task-{{.Number}}".
 	// Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
 	// +optional
 	Branch string `json:"branch,omitempty"`

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -30,10 +30,10 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ARG CLAUDE_CODE_VERSION=2.1.45
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
-COPY claude-code/axon_entrypoint.sh /axon_entrypoint.sh
-RUN chmod +x /axon_entrypoint.sh
+COPY claude-code/kelos_entrypoint.sh /kelos_entrypoint.sh
+RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/axon-capture /axon/axon-capture
+COPY bin/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude

--- a/claude-code/kelos_entrypoint.sh
+++ b/claude-code/kelos_entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# axon_entrypoint.sh — reference implementation of the Axon agent image
+# kelos_entrypoint.sh — reference implementation of the Kelos agent image
 # interface for Claude Code.
 #
 # Interface contract:
 #   - First argument ($1): the task prompt
-#   - AXON_MODEL env var: model name (optional)
+#   - KELOS_MODEL env var: model name (optional)
 #   - UID 61100: shared between git-clone init container and agent
 #   - Working directory: /workspace/repo when a workspace is configured
 
@@ -19,19 +19,19 @@ ARGS=(
   "-p" "$PROMPT"
 )
 
-if [ -n "${AXON_MODEL:-}" ]; then
-  ARGS+=("--model" "$AXON_MODEL")
+if [ -n "${KELOS_MODEL:-}" ]; then
+  ARGS+=("--model" "$KELOS_MODEL")
 fi
 
 # Write user-level instructions (additive, no conflict with repo)
-if [ -n "${AXON_AGENTS_MD:-}" ]; then
+if [ -n "${KELOS_AGENTS_MD:-}" ]; then
   mkdir -p ~/.claude
-  printf '%s' "$AXON_AGENTS_MD" >~/.claude/CLAUDE.md
+  printf '%s' "$KELOS_AGENTS_MD" >~/.claude/CLAUDE.md
 fi
 
 # Pass each plugin directory via --plugin-dir
-if [ -n "${AXON_PLUGIN_DIR:-}" ] && [ -d "${AXON_PLUGIN_DIR}" ]; then
-  for dir in "${AXON_PLUGIN_DIR}"/*/; do
+if [ -n "${KELOS_PLUGIN_DIR:-}" ] && [ -d "${KELOS_PLUGIN_DIR}" ]; then
+  for dir in "${KELOS_PLUGIN_DIR}"/*/; do
     [ -d "$dir" ] && ARGS+=("--plugin-dir" "$dir")
   done
 fi
@@ -39,13 +39,13 @@ fi
 # Write MCP server configuration to user-scoped ~/.claude.json.
 # This avoids overwriting the repository's own .mcp.json while
 # still making the servers available to Claude Code.
-if [ -n "${AXON_MCP_SERVERS:-}" ]; then
+if [ -n "${KELOS_MCP_SERVERS:-}" ]; then
   node -e '
 const fs = require("fs");
 const cfgPath = require("os").homedir() + "/.claude.json";
 let existing = {};
 try { existing = JSON.parse(fs.readFileSync(cfgPath, "utf8")); } catch {}
-const mcp = JSON.parse(process.env.AXON_MCP_SERVERS);
+const mcp = JSON.parse(process.env.KELOS_MCP_SERVERS);
 existing.mcpServers = Object.assign(existing.mcpServers || {}, mcp.mcpServers || {});
 fs.writeFileSync(cfgPath, JSON.stringify(existing, null, 2));
 '
@@ -54,6 +54,6 @@ fi
 claude "${ARGS[@]}" | tee /tmp/agent-output.jsonl
 AGENT_EXIT_CODE=${PIPESTATUS[0]}
 
-/axon/axon-capture
+/kelos/kelos-capture
 
 exit $AGENT_EXIT_CODE

--- a/cmd/kelos-capture/main.go
+++ b/cmd/kelos-capture/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/axon-core/axon/internal/capture"
+	"github.com/kelos-dev/kelos/internal/capture"
 )
 
 func main() {

--- a/cmd/kelos-controller/Dockerfile
+++ b/cmd/kelos-controller/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY bin/axon-spawner .
+COPY bin/kelos-controller .
 USER 65532:65532
-ENTRYPOINT ["/axon-spawner"]
+ENTRYPOINT ["/kelos-controller"]

--- a/cmd/kelos-controller/main.go
+++ b/cmd/kelos-controller/main.go
@@ -13,9 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/internal/controller"
-	"github.com/axon-core/axon/internal/githubapp"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/internal/controller"
+	"github.com/kelos-dev/kelos/internal/githubapp"
 )
 
 var (
@@ -25,7 +25,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 }
 
 func main() {
@@ -75,7 +75,7 @@ func main() {
 		Scheme:                 scheme,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "axon-controller-leader-election",
+		LeaderElectionID:       "kelos-controller-leader-election",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -103,7 +103,7 @@ func main() {
 		JobBuilder:   jobBuilder,
 		Clientset:    clientset,
 		TokenClient:  githubapp.NewTokenClient(),
-		Recorder:     mgr.GetEventRecorderFor("axon-controller"),
+		Recorder:     mgr.GetEventRecorderFor("kelos-controller"),
 		BranchLocker: controller.NewBranchLocker(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Task")
@@ -119,7 +119,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		DeploymentBuilder: deploymentBuilder,
-		Recorder:          mgr.GetEventRecorderFor("axon-controller"),
+		Recorder:          mgr.GetEventRecorderFor("kelos-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TaskSpawner")
 		os.Exit(1)

--- a/cmd/kelos-spawner/Dockerfile
+++ b/cmd/kelos-spawner/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY bin/axon-controller .
+COPY bin/kelos-spawner .
 USER 65532:65532
-ENTRYPOINT ["/axon-controller"]
+ENTRYPOINT ["/kelos-spawner"]

--- a/cmd/kelos-token-refresher/Dockerfile
+++ b/cmd/kelos-token-refresher/Dockerfile
@@ -11,15 +11,15 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN make build WHAT=cmd/axon-token-refresher
+RUN make build WHAT=cmd/kelos-token-refresher
 
 # Runtime stage
 FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /
 
-COPY --from=builder /workspace/bin/axon-token-refresher .
+COPY --from=builder /workspace/bin/kelos-token-refresher .
 
 USER 65532:65532
 
-ENTRYPOINT ["/axon-token-refresher"]
+ENTRYPOINT ["/kelos-token-refresher"]

--- a/cmd/kelos-token-refresher/main.go
+++ b/cmd/kelos-token-refresher/main.go
@@ -25,7 +25,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/axon-core/axon/internal/githubapp"
+	"github.com/kelos-dev/kelos/internal/githubapp"
 )
 
 const (

--- a/cmd/kelos/main.go
+++ b/cmd/kelos/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/axon-core/axon/internal/cli"
+	"github.com/kelos-dev/kelos/internal/cli"
 )
 
 func main() {

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -30,10 +30,10 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ARG CODEX_VERSION=0.103.0
 RUN npm install -g @openai/codex@${CODEX_VERSION}
 
-COPY codex/axon_entrypoint.sh /axon_entrypoint.sh
-RUN chmod +x /axon_entrypoint.sh
+COPY codex/kelos_entrypoint.sh /kelos_entrypoint.sh
+RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/axon-capture /axon/axon-capture
+COPY bin/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.codex && chown -R agent:agent /home/agent

--- a/codex/kelos_entrypoint.sh
+++ b/codex/kelos_entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# axon_entrypoint.sh — Axon agent image interface implementation for
+# kelos_entrypoint.sh — Kelos agent image interface implementation for
 # OpenAI Codex CLI.
 #
 # Interface contract:
 #   - First argument ($1): the task prompt
-#   - AXON_MODEL env var: model name (optional)
+#   - KELOS_MODEL env var: model name (optional)
 #   - UID 61100: shared between git-clone init container and agent
 #   - Working directory: /workspace/repo when a workspace is configured
 
@@ -27,19 +27,19 @@ ARGS=(
   "$PROMPT"
 )
 
-if [ -n "${AXON_MODEL:-}" ]; then
-  ARGS+=("--model" "$AXON_MODEL")
+if [ -n "${KELOS_MODEL:-}" ]; then
+  ARGS+=("--model" "$KELOS_MODEL")
 fi
 
 # Write user-level instructions (global scope read by Codex CLI)
-if [ -n "${AXON_AGENTS_MD:-}" ]; then
+if [ -n "${KELOS_AGENTS_MD:-}" ]; then
   mkdir -p ~/.codex
-  printf '%s' "$AXON_AGENTS_MD" >~/.codex/AGENTS.md
+  printf '%s' "$KELOS_AGENTS_MD" >~/.codex/AGENTS.md
 fi
 
 # Install each plugin as a Codex skill directory under ~/.codex/skills
-if [ -n "${AXON_PLUGIN_DIR:-}" ] && [ -d "${AXON_PLUGIN_DIR}" ]; then
-  for plugindir in "${AXON_PLUGIN_DIR}"/*/; do
+if [ -n "${KELOS_PLUGIN_DIR:-}" ] && [ -d "${KELOS_PLUGIN_DIR}" ]; then
+  for plugindir in "${KELOS_PLUGIN_DIR}"/*/; do
     [ -d "$plugindir" ] || continue
     # Copy skills into ~/.codex/skills/<plugin>/<skill>/SKILL.md
     if [ -d "${plugindir}skills" ]; then
@@ -59,12 +59,12 @@ if [ -n "${AXON_PLUGIN_DIR:-}" ] && [ -d "${AXON_PLUGIN_DIR}" ]; then
 fi
 
 # Write MCP server configuration to project-scoped config.
-# AXON_MCP_SERVERS contains JSON in .mcp.json format; convert to
+# KELOS_MCP_SERVERS contains JSON in .mcp.json format; convert to
 # Codex TOML via a small Node.js helper that is available in the image.
-if [ -n "${AXON_MCP_SERVERS:-}" ]; then
+if [ -n "${KELOS_MCP_SERVERS:-}" ]; then
   mkdir -p ~/.codex
   node -e '
-const cfg = JSON.parse(process.env.AXON_MCP_SERVERS);
+const cfg = JSON.parse(process.env.KELOS_MCP_SERVERS);
 const servers = cfg.mcpServers || {};
 let toml = "";
 for (const [name, s] of Object.entries(servers)) {
@@ -89,6 +89,6 @@ fi
 codex "${ARGS[@]}" | tee /tmp/agent-output.jsonl
 AGENT_EXIT_CODE=${PIPESTATUS[0]}
 
-/axon/axon-capture
+/kelos/kelos-capture
 
 exit $AGENT_EXIT_CODE

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -85,7 +85,7 @@ If template rendering fails (e.g., missing key), the raw prompt string is used a
 | `spec.taskTemplate.agentConfigRef.name` | Name of an AgentConfig resource for spawned Tasks | No |
 | `spec.taskTemplate.promptTemplate` | Go text/template for prompt (see [template variables](#prompttemplate-variables) below) | No |
 | `spec.taskTemplate.dependsOn` | Task names that spawned Tasks depend on | No |
-| `spec.taskTemplate.branch` | Git branch template for spawned Tasks (supports Go template variables, e.g., `axon-task-{{.Number}}`) | No |
+| `spec.taskTemplate.branch` | Git branch template for spawned Tasks (supports Go template variables, e.g., `kelos-task-{{.Number}}`) | No |
 | `spec.taskTemplate.ttlSecondsAfterFinished` | Auto-delete spawned tasks after N seconds | No |
 | `spec.taskTemplate.podOverrides` | Pod customization for spawned Tasks (resources, timeout, env, nodeSelector) | No |
 | `spec.pollInterval` | How often to poll the source (default: `5m`) | No |
@@ -140,10 +140,10 @@ The `promptTemplate` field uses Go `text/template` syntax. Available variables d
 
 ## Configuration
 
-Axon reads defaults from `~/.axon/config.yaml` (override with `--config`). CLI flags always take precedence over config file values.
+Kelos reads defaults from `~/.kelos/config.yaml` (override with `--config`). CLI flags always take precedence over config file values.
 
 ```yaml
-# ~/.axon/config.yaml
+# ~/.kelos/config.yaml
 oauthToken: <your-oauth-token>
 # or: apiKey: <your-api-key>
 model: claude-sonnet-4-5-20250929
@@ -154,8 +154,8 @@ namespace: my-namespace
 
 | Field | Description |
 |-------|-------------|
-| `oauthToken` | OAuth token — Axon auto-creates the Kubernetes secret. Use `none` for an empty credential |
-| `apiKey` | API key — Axon auto-creates the Kubernetes secret. Use `none` for an empty credential (e.g., free-tier OpenCode models) |
+| `oauthToken` | OAuth token — Kelos auto-creates the Kubernetes secret. Use `none` for an empty credential |
+| `apiKey` | API key — Kelos auto-creates the Kubernetes secret. Use `none` for an empty credential (e.g., free-tier OpenCode models) |
 | `secret` | (Advanced) Use a pre-created Kubernetes secret |
 | `credentialType` | Credential type when using `secret` (`api-key` or `oauth`) |
 
@@ -172,7 +172,7 @@ workspace:
   name: my-workspace
 ```
 
-**Specify inline — Axon auto-creates the Workspace resource and secret:**
+**Specify inline — Kelos auto-creates the Workspace resource and secret:**
 
 ```yaml
 workspace:
@@ -184,9 +184,9 @@ workspace:
 | Field | Description |
 |-------|-------------|
 | `workspace.name` | Name of an existing Workspace resource |
-| `workspace.repo` | Git repository URL — Axon auto-creates a Workspace resource |
+| `workspace.repo` | Git repository URL — Kelos auto-creates a Workspace resource |
 | `workspace.ref` | Git reference (branch, tag, or commit SHA) |
-| `workspace.token` | GitHub token — Axon auto-creates the secret and injects `GITHUB_TOKEN` |
+| `workspace.token` | GitHub token — Kelos auto-creates the secret and injects `GITHUB_TOKEN` |
 
 If both `name` and `repo` are set, `name` takes precedence. The `--workspace` CLI flag overrides all config values.
 
@@ -201,31 +201,31 @@ If both `name` and `repo` are set, `name` takes precedence. The `--workspace` CL
 
 ## CLI Reference
 
-The `axon` CLI lets you manage the full lifecycle without writing YAML.
+The `kelos` CLI lets you manage the full lifecycle without writing YAML.
 
 ### Core Commands
 
 | Command | Description |
 |---------|-------------|
-| `axon install` | Install Axon CRDs and controller into the cluster |
-| `axon uninstall` | Uninstall Axon from the cluster |
-| `axon init` | Initialize `~/.axon/config.yaml` |
-| `axon version` | Print version information |
+| `kelos install` | Install Kelos CRDs and controller into the cluster |
+| `kelos uninstall` | Uninstall Kelos from the cluster |
+| `kelos init` | Initialize `~/.kelos/config.yaml` |
+| `kelos version` | Print version information |
 
 ### Resource Management
 
 | Command | Description |
 |---------|-------------|
-| `axon run` | Create and run a new Task |
-| `axon create workspace` | Create a Workspace resource |
-| `axon create agentconfig` | Create an AgentConfig resource |
-| `axon get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`) |
-| `axon delete <resource> <name>` | Delete a resource |
-| `axon logs <task-name> [-f]` | View or stream logs from a task |
-| `axon suspend taskspawner <name>` | Pause a TaskSpawner (stops polling, running tasks continue) |
-| `axon resume taskspawner <name>` | Resume a paused TaskSpawner |
+| `kelos run` | Create and run a new Task |
+| `kelos create workspace` | Create a Workspace resource |
+| `kelos create agentconfig` | Create an AgentConfig resource |
+| `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`) |
+| `kelos delete <resource> <name>` | Delete a resource |
+| `kelos logs <task-name> [-f]` | View or stream logs from a task |
+| `kelos suspend taskspawner <name>` | Pause a TaskSpawner (stops polling, running tasks continue) |
+| `kelos resume taskspawner <name>` | Resume a paused TaskSpawner |
 
-### `axon run` Flags
+### `kelos run` Flags
 
 - `--prompt, -p`: Task prompt (required)
 - `--type, -t`: Agent type (default: `claude-code`)
@@ -242,7 +242,7 @@ The `axon` CLI lets you manage the full lifecycle without writing YAML.
 - `--secret`: Pre-created secret name
 - `--credential-type`: Credential type when using `--secret` (default: `api-key`)
 
-### `axon get` Flags
+### `kelos get` Flags
 
 - `--output, -o`: Output format (`yaml` or `json`)
 - `--detail, -d`: Show detailed information for a specific resource
@@ -250,7 +250,7 @@ The `axon` CLI lets you manage the full lifecycle without writing YAML.
 
 ### Common Flags
 
-- `--config`: Path to config file (default `~/.axon/config.yaml`)
+- `--config`: Path to config file (default `~/.kelos/config.yaml`)
 - `--namespace, -n`: Kubernetes namespace
 - `--kubeconfig`: Path to kubeconfig file
 - `--dry-run`: Print resources without creating them (supported by `run`, `create`, `install`)

--- a/examples/01-simple-task/README.md
+++ b/examples/01-simple-task/README.md
@@ -34,7 +34,7 @@ kubectl get tasks -w
 4. **Stream the agent logs:**
 
 ```bash
-axon logs simple-task -f
+kelos logs simple-task -f
 ```
 
 > **Tip:** You can also use `kubectl logs -l job-name=simple-task -f` for direct

--- a/examples/01-simple-task/task.yaml
+++ b/examples/01-simple-task/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: simple-task

--- a/examples/02-task-with-workspace/README.md
+++ b/examples/02-task-with-workspace/README.md
@@ -39,7 +39,7 @@ kubectl get tasks -w
 5. **Stream the agent logs:**
 
 ```bash
-axon logs add-tests -f
+kelos logs add-tests -f
 ```
 
 > **Tip:** You can also use `kubectl logs -l job-name=add-tests -f` for direct

--- a/examples/02-task-with-workspace/task.yaml
+++ b/examples/02-task-with-workspace/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: add-tests

--- a/examples/02-task-with-workspace/workspace.yaml
+++ b/examples/02-task-with-workspace/workspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-workspace

--- a/examples/03-taskspawner-github-issues/taskspawner.yaml
+++ b/examples/03-taskspawner-github-issues/taskspawner.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
   name: fix-bugs

--- a/examples/03-taskspawner-github-issues/workspace.yaml
+++ b/examples/03-taskspawner-github-issues/workspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-workspace

--- a/examples/04-taskspawner-cron/taskspawner.yaml
+++ b/examples/04-taskspawner-cron/taskspawner.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
   name: weekly-dependency-update

--- a/examples/04-taskspawner-cron/workspace.yaml
+++ b/examples/04-taskspawner-cron/workspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-workspace

--- a/examples/05-task-with-agentconfig/README.md
+++ b/examples/05-task-with-agentconfig/README.md
@@ -54,7 +54,7 @@ kubectl get tasks -w
 6. **Stream the agent logs:**
 
 ```bash
-axon logs review-pr -f
+kelos logs review-pr -f
 ```
 
 7. **Cleanup:**

--- a/examples/05-task-with-agentconfig/agentconfig.yaml
+++ b/examples/05-task-with-agentconfig/agentconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: AgentConfig
 metadata:
   name: code-reviewer

--- a/examples/05-task-with-agentconfig/task.yaml
+++ b/examples/05-task-with-agentconfig/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: review-pr

--- a/examples/05-task-with-agentconfig/workspace.yaml
+++ b/examples/05-task-with-agentconfig/workspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-workspace

--- a/examples/06-fork-workflow/taskspawner.yaml
+++ b/examples/06-fork-workflow/taskspawner.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
   name: fork-issue-fixer
@@ -19,7 +19,7 @@ spec:
       type: oauth
       secretRef:
         name: claude-oauth-token
-    branch: "axon-task-{{.Number}}"
+    branch: "kelos-task-{{.Number}}"
     promptTemplate: |
       Fix the following GitHub issue from the upstream repository and open a
       PR from this fork back to upstream.

--- a/examples/06-fork-workflow/workspace.yaml
+++ b/examples/06-fork-workflow/workspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-fork

--- a/examples/07-task-pipeline/README.md
+++ b/examples/07-task-pipeline/README.md
@@ -91,15 +91,15 @@ to `Running`, and finally `open-pr`.
 5. **View results from a completed Task:**
 
 ```bash
-axon get task scaffold -o yaml | grep -A 10 results:
+kelos get task scaffold -o yaml | grep -A 10 results:
 ```
 
 6. **Stream logs from any stage:**
 
 ```bash
-axon logs scaffold -f
-axon logs write-tests -f
-axon logs open-pr -f
+kelos logs scaffold -f
+kelos logs write-tests -f
+kelos logs open-pr -f
 ```
 
 7. **Cleanup:**
@@ -113,13 +113,13 @@ kubectl delete -f examples/07-task-pipeline/
 You can create the same pipeline with the CLI:
 
 ```bash
-axon run -p "Scaffold a user authentication module" \
+kelos run -p "Scaffold a user authentication module" \
   --name scaffold --branch feature/auth --workspace my-workspace -w
 
-axon run -p 'Write tests for the auth module on branch {{index .Deps "scaffold" "Results" "branch"}}' \
+kelos run -p 'Write tests for the auth module on branch {{index .Deps "scaffold" "Results" "branch"}}' \
   --name write-tests --depends-on scaffold --branch feature/auth --workspace my-workspace -w
 
-axon run -p 'Open a PR for branch {{index .Deps "write-tests" "Results" "branch"}}' \
+kelos run -p 'Open a PR for branch {{index .Deps "write-tests" "Results" "branch"}}' \
   --name open-pr --depends-on write-tests --branch feature/auth --workspace my-workspace -w
 ```
 

--- a/examples/07-task-pipeline/pipeline.yaml
+++ b/examples/07-task-pipeline/pipeline.yaml
@@ -1,5 +1,5 @@
 # Stage 1: Scaffold the feature
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: scaffold
@@ -22,7 +22,7 @@ spec:
     Create the code, commit your changes, and push the branch.
 ---
 # Stage 2: Write tests (waits for scaffold to succeed)
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: write-tests
@@ -48,7 +48,7 @@ spec:
     Run the tests to make sure they pass. Commit and push.
 ---
 # Stage 3: Open a pull request (waits for write-tests to succeed)
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
   name: open-pr

--- a/examples/07-task-pipeline/workspace.yaml
+++ b/examples/07-task-pipeline/workspace.yaml
@@ -1,4 +1,4 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
   name: my-workspace

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,10 @@
-# Axon Orchestration Examples
+# Kelos Orchestration Examples
 
-Ready-to-use patterns and YAML manifests for orchestrating AI agents with Axon. These examples demonstrate how to combine Tasks, Workspaces, and TaskSpawners into functional AI workflows.
+Ready-to-use patterns and YAML manifests for orchestrating AI agents with Kelos. These examples demonstrate how to combine Tasks, Workspaces, and TaskSpawners into functional AI workflows.
 
 ## Prerequisites
 
-- Kubernetes cluster (1.28+) with Axon installed (`axon install`)
+- Kubernetes cluster (1.28+) with Kelos installed (`kelos install`)
 - `kubectl` configured
 
 ## Examples

--- a/gemini/Dockerfile
+++ b/gemini/Dockerfile
@@ -30,10 +30,10 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ARG GEMINI_CLI_VERSION=0.29.6
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION}
 
-COPY gemini/axon_entrypoint.sh /axon_entrypoint.sh
-RUN chmod +x /axon_entrypoint.sh
+COPY gemini/kelos_entrypoint.sh /kelos_entrypoint.sh
+RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/axon-capture /axon/axon-capture
+COPY bin/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/axon-core/axon
+module github.com/kelos-dev/kelos
 
 go 1.25.0
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Download and install the axon CLI binary.
-# Usage: curl -fsSL https://raw.githubusercontent.com/axon-core/axon/main/hack/install.sh | bash
+# Download and install the kelos CLI binary.
+# Usage: curl -fsSL https://raw.githubusercontent.com/kelos-dev/kelos/main/hack/install.sh | bash
 
 set -euo pipefail
 
-REPO="axon-core/axon"
+REPO="kelos-dev/kelos"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -27,8 +27,8 @@ case "$OS" in
     ;;
 esac
 
-BINARY="axon-${OS}-${ARCH}"
-BASE_URL="${AXON_RELEASE_URL:-https://github.com/${REPO}/releases/latest/download}"
+BINARY="kelos-${OS}-${ARCH}"
+BASE_URL="${KELOS_RELEASE_URL:-https://github.com/${REPO}/releases/latest/download}"
 URL="${BASE_URL}/${BINARY}"
 
 echo "Downloading ${BINARY}..."
@@ -49,7 +49,7 @@ if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
 fi
 
 if [ -w "$INSTALL_DIR" ]; then
-  mv "$TMP" "${INSTALL_DIR}/axon"
+  mv "$TMP" "${INSTALL_DIR}/kelos"
 else
   echo "Error: ${INSTALL_DIR} is not writable" >&2
   echo "Set INSTALL_DIR to a writable path and try again" >&2
@@ -57,10 +57,10 @@ else
   exit 1
 fi
 
-echo "axon installed to ${INSTALL_DIR}/axon"
+echo "kelos installed to ${INSTALL_DIR}/kelos"
 
 if ! echo "$PATH" | tr ':' '\n' | grep -Fqx "$INSTALL_DIR"; then
   echo ""
-  echo "Add axon to your PATH by adding the following to your shell profile:"
+  echo "Add kelos to your PATH by adding the following to your shell profile:"
   echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
 fi

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -27,6 +27,6 @@ source "${CODEGEN_PKG}/kube_codegen.sh"
 kube::codegen::gen_client \
   --with-watch \
   --output-dir "${SCRIPT_ROOT}/pkg/generated" \
-  --output-pkg "github.com/axon-core/axon/pkg/generated" \
+  --output-pkg "github.com/kelos-dev/kelos/pkg/generated" \
   --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
   "${SCRIPT_ROOT}"

--- a/hack/update-install-manifest.sh
+++ b/hack/update-install-manifest.sh
@@ -63,14 +63,14 @@ END {
 validate_manifest_resources() {
   local file="$1"
   local -a required=(
-    "Namespace axon-system"
-    "ServiceAccount axon-controller"
-    "ClusterRole axon-controller-role"
-    "ClusterRole axon-spawner-role"
-    "ClusterRoleBinding axon-controller-rolebinding"
-    "Role axon-leader-election-role"
-    "RoleBinding axon-leader-election-rolebinding"
-    "Deployment axon-controller-manager"
+    "Namespace kelos-system"
+    "ServiceAccount kelos-controller"
+    "ClusterRole kelos-controller-role"
+    "ClusterRole kelos-spawner-role"
+    "ClusterRoleBinding kelos-controller-rolebinding"
+    "Role kelos-leader-election-role"
+    "RoleBinding kelos-leader-election-rolebinding"
+    "Deployment kelos-controller-manager"
   )
 
   local entry
@@ -102,7 +102,7 @@ trap 'rm -rf "${TMPDIR}"' EXIT
 
 RBAC_FILE="${TMPDIR}/rbac.yaml"
 GOCACHE="${TMPDIR}/go-build-cache" "${CONTROLLER_GEN}" \
-  rbac:roleName=axon-controller-role \
+  rbac:roleName=kelos-controller-role \
   paths="./..." \
   output:rbac:stdout >"${RBAC_FILE}"
 

--- a/install-crd.yaml
+++ b/install-crd.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: agentconfigs.axon.io
+  name: agentconfigs.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: AgentConfig
     listKind: AgentConfigList
@@ -166,9 +166,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: tasks.axon.io
+  name: tasks.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: Task
     listKind: TaskList
@@ -600,9 +600,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: taskspawners.axon.io
+  name: taskspawners.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: TaskSpawner
     listKind: TaskSpawnerList
@@ -705,7 +705,7 @@ spec:
                   branch:
                     description: |-
                       Branch is the git branch spawned Tasks should work on.
-                      Supports Go text/template variables from the work item, e.g. "axon-task-{{.Number}}".
+                      Supports Go text/template variables from the work item, e.g. "kelos-task-{{.Number}}".
                       Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
                     type: string
                   credentials:
@@ -1059,7 +1059,7 @@ spec:
                       excludeComments:
                         description: |-
                           ExcludeComments enables comment-based exclusion. When set, issues that
-                          have a comment matching any of these strings (e.g., "/axon needs-input")
+                          have a comment matching any of these strings (e.g., "/kelos needs-input")
                           are excluded unless a subsequent TriggerComment overrides it. Comments
                           are scanned in reverse chronological order — the most recent matching
                           command wins.
@@ -1107,7 +1107,7 @@ spec:
                       triggerComment:
                         description: |-
                           TriggerComment enables comment-based discovery. When set, only issues
-                          that have a comment matching this string (e.g., "/axon pick-up") are
+                          that have a comment matching this string (e.g., "/kelos pick-up") are
                           included. This is useful for repos where you lack label permissions.
                           If ExcludeComments is also set, TriggerComment doubles as a resume
                           command — the most recent match between TriggerComment and
@@ -1266,9 +1266,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: workspaces.axon.io
+  name: workspaces.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: Workspace
     listKind: WorkspaceList

--- a/install.yaml
+++ b/install.yaml
@@ -2,22 +2,22 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: axon-system
+  name: kelos-system
   labels:
-    app.kubernetes.io/name: axon
+    app.kubernetes.io/name: kelos
     app.kubernetes.io/component: manager
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: axon-controller
-  namespace: axon-system
+  name: kelos-controller
+  namespace: kelos-system
 # BEGIN GENERATED: controller-rbac
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: axon-controller-role
+  name: kelos-controller-role
 rules:
 - apiGroups:
   - ""
@@ -72,7 +72,19 @@ rules:
   - update
   - watch
 - apiGroups:
-  - axon.io
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kelos.dev
   resources:
   - agentconfigs
   - workspaces
@@ -81,7 +93,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - axon.io
+  - kelos.dev
   resources:
   - tasks
   - taskspawners
@@ -94,14 +106,14 @@ rules:
   - update
   - watch
 - apiGroups:
-  - axon.io
+  - kelos.dev
   resources:
   - tasks/finalizers
   - taskspawners/finalizers
   verbs:
   - update
 - apiGroups:
-  - axon.io
+  - kelos.dev
   resources:
   - tasks/status
   - taskspawners/status
@@ -109,18 +121,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -135,10 +135,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: axon-spawner-role
+  name: kelos-spawner-role
 rules:
   - apiGroups:
-      - axon.io
+      - kelos.dev
     resources:
       - taskspawners
     verbs:
@@ -146,7 +146,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - axon.io
+      - kelos.dev
     resources:
       - taskspawners/status
     verbs:
@@ -154,7 +154,7 @@ rules:
       - update
       - patch
   - apiGroups:
-      - axon.io
+      - kelos.dev
     resources:
       - tasks
     verbs:
@@ -165,21 +165,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: axon-controller-rolebinding
+  name: kelos-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: axon-controller-role
+  name: kelos-controller-role
 subjects:
   - kind: ServiceAccount
-    name: axon-controller
-    namespace: axon-system
+    name: kelos-controller
+    namespace: kelos-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: axon-leader-election-role
-  namespace: axon-system
+  name: kelos-leader-election-role
+  namespace: kelos-system
 rules:
   - apiGroups:
       - ""
@@ -216,51 +216,51 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: axon-leader-election-rolebinding
-  namespace: axon-system
+  name: kelos-leader-election-rolebinding
+  namespace: kelos-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: axon-leader-election-role
+  name: kelos-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: axon-controller
-    namespace: axon-system
+    name: kelos-controller
+    namespace: kelos-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: axon-controller-manager
-  namespace: axon-system
+  name: kelos-controller-manager
+  namespace: kelos-system
   labels:
-    app.kubernetes.io/name: axon
+    app.kubernetes.io/name: kelos
     app.kubernetes.io/component: manager
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: axon
+      app.kubernetes.io/name: kelos
       app.kubernetes.io/component: manager
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: axon
+        app.kubernetes.io/name: kelos
         app.kubernetes.io/component: manager
     spec:
-      serviceAccountName: axon-controller
+      serviceAccountName: kelos-controller
       securityContext:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: gjkim42/axon-controller:latest
+          image: gjkim42/kelos-controller:latest
           args:
             - --leader-elect
             - --claude-code-image=gjkim42/claude-code:latest
             - --codex-image=gjkim42/codex:latest
             - --gemini-image=gjkim42/gemini:latest
             - --opencode-image=gjkim42/opencode:latest
-            - --spawner-image=gjkim42/axon-spawner:latest
-            - --token-refresher-image=gjkim42/axon-token-refresher:latest
+            - --spawner-image=gjkim42/kelos-spawner:latest
+            - --token-refresher-image=gjkim42/kelos-token-refresher:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	markerStart     = "---AXON_OUTPUTS_START---"
-	markerEnd       = "---AXON_OUTPUTS_END---"
+	markerStart     = "---KELOS_OUTPUTS_START---"
+	markerEnd       = "---KELOS_OUTPUTS_END---"
 	agentOutputFile = "/tmp/agent-output.jsonl"
 	commandTimeout  = 30 * time.Second
 )
@@ -70,7 +70,7 @@ func captureOutputs(r runner, usageFile string) []string {
 		}
 	}
 
-	if base := os.Getenv("AXON_BASE_BRANCH"); base != "" {
+	if base := os.Getenv("KELOS_BASE_BRANCH"); base != "" {
 		outputs = append(outputs, "base-branch: "+base)
 	} else if inGitRepo {
 		ref, err := r.run("git", "symbolic-ref", "refs/remotes/origin/HEAD")
@@ -82,7 +82,7 @@ func captureOutputs(r runner, usageFile string) []string {
 		}
 	}
 
-	agentType := os.Getenv("AXON_AGENT_TYPE")
+	agentType := os.Getenv("KELOS_AGENT_TYPE")
 	usage := ParseUsage(agentType, usageFile)
 	for _, key := range []string{"cost-usd", "input-tokens", "output-tokens"} {
 		if v, ok := usage[key]; ok {
@@ -103,7 +103,7 @@ func capturePRs(r runner, branch string) []string {
 	lines := queryPRs(r, branch, "")
 
 	// Also check upstream repo if set (fork workflow)
-	if upstreamRepo := os.Getenv("AXON_UPSTREAM_REPO"); upstreamRepo != "" {
+	if upstreamRepo := os.Getenv("KELOS_UPSTREAM_REPO"); upstreamRepo != "" {
 		lines = append(lines, queryPRs(r, branch, upstreamRepo)...)
 	}
 

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -37,8 +37,8 @@ func TestCaptureOutputsFullFlow(t *testing.T) {
 	}}
 
 	usageFile := writeTempFile(t, `{"type":"result","total_cost_usd":0.05,"usage":{"input_tokens":1000,"output_tokens":500}}`)
-	t.Setenv("AXON_AGENT_TYPE", "claude-code")
-	t.Setenv("AXON_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "claude-code")
+	t.Setenv("KELOS_BASE_BRANCH", "")
 
 	outputs := captureOutputs(r, usageFile)
 
@@ -64,8 +64,8 @@ func TestCaptureOutputsBaseBranchFromEnv(t *testing.T) {
 		"git rev-parse HEAD": {output: "deadbeef"},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "develop")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "develop")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -82,8 +82,8 @@ func TestCaptureOutputsNotGitRepo(t *testing.T) {
 		"git rev-parse --is-inside-work-tree": {err: fmt.Errorf("not a git repo")},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -103,8 +103,8 @@ func TestCaptureOutputsMultiplePRs(t *testing.T) {
 		"git symbolic-ref refs/remotes/origin/HEAD": {output: "refs/remotes/origin/main"},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -126,8 +126,8 @@ func TestCaptureOutputsDetachedHead(t *testing.T) {
 		"git symbolic-ref refs/remotes/origin/HEAD": {output: "refs/remotes/origin/main"},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -147,8 +147,8 @@ func TestCaptureOutputsGhFails(t *testing.T) {
 		"git symbolic-ref refs/remotes/origin/HEAD": {output: "refs/remotes/origin/main"},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -170,8 +170,8 @@ func TestCaptureOutputsMarkers(t *testing.T) {
 		"git symbolic-ref refs/remotes/origin/HEAD": {err: fmt.Errorf("no remote")},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -180,7 +180,7 @@ func TestCaptureOutputsMarkers(t *testing.T) {
 	}
 	// Markers should NOT be in the output slice; Run() adds them when printing.
 	for _, line := range outputs {
-		if strings.Contains(line, "AXON_OUTPUTS") {
+		if strings.Contains(line, "KELOS_OUTPUTS") {
 			t.Errorf("markers should not be in output slice: %s", line)
 		}
 	}
@@ -191,8 +191,8 @@ func TestCaptureOutputsNoMarkersWhenEmpty(t *testing.T) {
 		"git rev-parse --is-inside-work-tree": {err: fmt.Errorf("not a git repo")},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -240,9 +240,9 @@ func TestCaptureOutputsWithUpstreamRepo(t *testing.T) {
 		"git symbolic-ref refs/remotes/origin/HEAD": {output: "refs/remotes/origin/main"},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
-	t.Setenv("AXON_UPSTREAM_REPO", "upstream-org/repo")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
+	t.Setenv("KELOS_UPSTREAM_REPO", "upstream-org/repo")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -270,9 +270,9 @@ func TestCaptureOutputsUpstreamRepoNoPRs(t *testing.T) {
 		"git symbolic-ref refs/remotes/origin/HEAD": {output: "refs/remotes/origin/main"},
 	}}
 
-	t.Setenv("AXON_BASE_BRANCH", "")
-	t.Setenv("AXON_AGENT_TYPE", "")
-	t.Setenv("AXON_UPSTREAM_REPO", "upstream-org/repo")
+	t.Setenv("KELOS_BASE_BRANCH", "")
+	t.Setenv("KELOS_AGENT_TYPE", "")
+	t.Setenv("KELOS_UPSTREAM_REPO", "upstream-org/repo")
 
 	outputs := captureOutputs(r, "/nonexistent")
 
@@ -286,8 +286,8 @@ func TestCaptureOutputsUpstreamRepoNoPRs(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	// Ensure env vars don't leak between tests by clearing them.
-	os.Unsetenv("AXON_BASE_BRANCH")
-	os.Unsetenv("AXON_AGENT_TYPE")
-	os.Unsetenv("AXON_UPSTREAM_REPO")
+	os.Unsetenv("KELOS_BASE_BRANCH")
+	os.Unsetenv("KELOS_AGENT_TYPE")
+	os.Unsetenv("KELOS_UPSTREAM_REPO")
 	os.Exit(m.Run())
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -11,14 +11,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 }
 
 // ClientConfig holds configuration for Kubernetes client creation.

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {
@@ -24,7 +24,7 @@ func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		taskList := &axonv1alpha1.TaskList{}
+		taskList := &kelosv1alpha1.TaskList{}
 		if err := cl.List(ctx, taskList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -51,7 +51,7 @@ func completeTaskSpawnerNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		tsList := &axonv1alpha1.TaskSpawnerList{}
+		tsList := &kelosv1alpha1.TaskSpawnerList{}
 		if err := cl.List(ctx, tsList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -78,7 +78,7 @@ func completeAgentConfigNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		acList := &axonv1alpha1.AgentConfigList{}
+		acList := &kelosv1alpha1.AgentConfigList{}
 		if err := cl.List(ctx, acList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -105,7 +105,7 @@ func completeWorkspaceNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		wsList := &axonv1alpha1.WorkspaceList{}
+		wsList := &kelosv1alpha1.WorkspaceList{}
 		if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// Config holds configuration loaded from the axon config file.
+// Config holds configuration loaded from the kelos config file.
 type Config struct {
 	OAuthToken     string          `json:"oauthToken,omitempty"`
 	APIKey         string          `json:"apiKey,omitempty"`
@@ -39,17 +39,17 @@ type GitHubAppConfig struct {
 	PrivateKeyPath string `json:"privateKeyPath"`
 }
 
-// DefaultConfigPath returns the default config file path (~/.axon/config.yaml).
+// DefaultConfigPath returns the default config file path (~/.kelos/config.yaml).
 func DefaultConfigPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("getting home directory: %w", err)
 	}
-	return filepath.Join(home, ".axon", "config.yaml"), nil
+	return filepath.Join(home, ".kelos", "config.yaml"), nil
 }
 
 // LoadConfig reads and parses the config file at the given path.
-// If path is empty, the default path (~/.axon/config.yaml) is used.
+// If path is empty, the default path (~/.kelos/config.yaml) is used.
 // If the file does not exist, an empty Config is returned without error.
 func LoadConfig(path string) (*Config, error) {
 	if path == "" {

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -64,7 +64,7 @@ func TestConfirmOverride_IncludesResourceName(t *testing.T) {
 	defer func() { stdinReader = old }()
 
 	// This just verifies the function runs without error with a resource name.
-	_, err := confirmOverride("secret/axon-credentials")
+	_, err := confirmOverride("secret/kelos-credentials")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newCreateCommand(cfg *ClientConfig) *cobra.Command {
@@ -62,12 +62,12 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 				return err
 			}
 
-			ws := &axonv1alpha1.Workspace{
+			ws := &kelosv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: ns,
 				},
-				Spec: axonv1alpha1.WorkspaceSpec{
+				Spec: kelosv1alpha1.WorkspaceSpec{
 					Repo: repo,
 					Ref:  ref,
 				},
@@ -80,16 +80,16 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 						return err
 					}
 				}
-				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+				ws.Spec.SecretRef = &kelosv1alpha1.SecretReference{
 					Name: secretName,
 				}
 			} else if secret != "" {
-				ws.Spec.SecretRef = &axonv1alpha1.SecretReference{
+				ws.Spec.SecretRef = &kelosv1alpha1.SecretReference{
 					Name: secret,
 				}
 			}
 
-			ws.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("Workspace"))
+			ws.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Workspace"))
 
 			if dryRun {
 				return printYAML(os.Stdout, ws)

--- a/internal/cli/create_agentconfig.go
+++ b/internal/cli/create_agentconfig.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newCreateAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
@@ -41,7 +41,7 @@ func newCreateAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 				return err
 			}
 
-			acSpec := axonv1alpha1.AgentConfigSpec{}
+			acSpec := kelosv1alpha1.AgentConfigSpec{}
 
 			resolvedMD, err := resolveContent(agentsMD)
 			if err != nil {
@@ -50,14 +50,14 @@ func newCreateAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 			acSpec.AgentsMD = resolvedMD
 
 			if len(skillFlags) > 0 || len(agentFlags) > 0 {
-				plugin := axonv1alpha1.PluginSpec{Name: "axon"}
+				plugin := kelosv1alpha1.PluginSpec{Name: "kelos"}
 
 				for _, s := range skillFlags {
 					sn, sc, err := parseNameContent(s, "skill")
 					if err != nil {
 						return err
 					}
-					plugin.Skills = append(plugin.Skills, axonv1alpha1.SkillDefinition{
+					plugin.Skills = append(plugin.Skills, kelosv1alpha1.SkillDefinition{
 						Name: sn, Content: sc,
 					})
 				}
@@ -67,12 +67,12 @@ func newCreateAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					plugin.Agents = append(plugin.Agents, axonv1alpha1.AgentDefinition{
+					plugin.Agents = append(plugin.Agents, kelosv1alpha1.AgentDefinition{
 						Name: an, Content: ac,
 					})
 				}
 
-				acSpec.Plugins = []axonv1alpha1.PluginSpec{plugin}
+				acSpec.Plugins = []kelosv1alpha1.PluginSpec{plugin}
 			}
 
 			mcpSeen := make(map[string]bool, len(mcpFlags))
@@ -88,7 +88,7 @@ func newCreateAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 				acSpec.MCPServers = append(acSpec.MCPServers, mcpSpec)
 			}
 
-			acObj := &axonv1alpha1.AgentConfig{
+			acObj := &kelosv1alpha1.AgentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: ns,
@@ -96,7 +96,7 @@ func newCreateAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 				Spec: acSpec,
 			}
 
-			acObj.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("AgentConfig"))
+			acObj.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("AgentConfig"))
 
 			if dryRun {
 				return printYAML(os.Stdout, acObj)

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
@@ -60,7 +60,7 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				taskList := &axonv1alpha1.TaskList{}
+				taskList := &kelosv1alpha1.TaskList{}
 				if err := cl.List(ctx, taskList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing tasks: %w", err)
 				}
@@ -77,7 +77,7 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			task := &axonv1alpha1.Task{
+			task := &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,
@@ -128,7 +128,7 @@ func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				wsList := &axonv1alpha1.WorkspaceList{}
+				wsList := &kelosv1alpha1.WorkspaceList{}
 				if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing workspaces: %w", err)
 				}
@@ -145,7 +145,7 @@ func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			ws := &axonv1alpha1.Workspace{
+			ws := &kelosv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,
@@ -196,7 +196,7 @@ func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				tsList := &axonv1alpha1.TaskSpawnerList{}
+				tsList := &kelosv1alpha1.TaskSpawnerList{}
 				if err := cl.List(ctx, tsList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing task spawners: %w", err)
 				}
@@ -213,7 +213,7 @@ func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,

--- a/internal/cli/delete_agentconfig.go
+++ b/internal/cli/delete_agentconfig.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newDeleteAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
@@ -42,7 +42,7 @@ func newDeleteAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				acList := &axonv1alpha1.AgentConfigList{}
+				acList := &kelosv1alpha1.AgentConfigList{}
 				if err := cl.List(ctx, acList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing agent configs: %w", err)
 				}
@@ -59,7 +59,7 @@ func newDeleteAgentConfigCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			ac := &axonv1alpha1.AgentConfig{
+			ac := &kelosv1alpha1.AgentConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -147,8 +147,8 @@ func TestRunCommand_DryRun_OpenCodeNoneAPIKey(t *testing.T) {
 	if !strings.Contains(output, "type: opencode") {
 		t.Errorf("expected 'type: opencode' in output, got:\n%s", output)
 	}
-	if !strings.Contains(output, "axon-credentials") {
-		t.Errorf("expected 'axon-credentials' secret reference in output, got:\n%s", output)
+	if !strings.Contains(output, "kelos-credentials") {
+		t.Errorf("expected 'kelos-credentials' secret reference in output, got:\n%s", output)
 	}
 }
 
@@ -233,8 +233,8 @@ workspace:
 	out.ReadFrom(r)
 	output := out.String()
 
-	if !strings.Contains(output, "axon-workspace") {
-		t.Errorf("expected workspace reference 'axon-workspace' in dry-run output, got:\n%s", output)
+	if !strings.Contains(output, "kelos-workspace") {
+		t.Errorf("expected workspace reference 'kelos-workspace' in dry-run output, got:\n%s", output)
 	}
 }
 
@@ -587,14 +587,14 @@ func TestInstallCommand_DryRun(t *testing.T) {
 	if !strings.Contains(output, "Deployment") {
 		t.Errorf("expected Deployment manifest in dry-run output, got:\n%s", output[:min(len(output), 500)])
 	}
-	if !strings.Contains(output, "name: axon-controller-role") {
+	if !strings.Contains(output, "name: kelos-controller-role") {
 		t.Errorf("expected controller ClusterRole in dry-run output, got:\n%s", output[:min(len(output), 500)])
 	}
 	if !strings.Contains(output, "- rolebindings") {
 		t.Errorf("expected rolebindings RBAC rule in dry-run output, got:\n%s", output[:min(len(output), 500)])
 	}
 	// Should not contain installation messages.
-	if strings.Contains(output, "Installing axon") {
+	if strings.Contains(output, "Installing kelos") {
 		t.Errorf("dry-run should not print installation messages, got:\n%s", output[:min(len(output), 500)])
 	}
 }
@@ -675,8 +675,8 @@ func TestRunCommand_DryRun_CodexOAuthToken(t *testing.T) {
 	if !strings.Contains(output, "type: oauth") {
 		t.Errorf("expected credential 'type: oauth' in output, got:\n%s", output)
 	}
-	if !strings.Contains(output, "axon-credentials") {
-		t.Errorf("expected 'axon-credentials' secret reference in output, got:\n%s", output)
+	if !strings.Contains(output, "kelos-credentials") {
+		t.Errorf("expected 'kelos-credentials' secret reference in output, got:\n%s", output)
 	}
 }
 
@@ -723,8 +723,8 @@ func TestRunCommand_DryRun_CodexOAuthToken_FileRef(t *testing.T) {
 	if !strings.Contains(output, "type: oauth") {
 		t.Errorf("expected credential 'type: oauth' in output, got:\n%s", output)
 	}
-	if !strings.Contains(output, "axon-credentials") {
-		t.Errorf("expected 'axon-credentials' secret reference in output, got:\n%s", output)
+	if !strings.Contains(output, "kelos-credentials") {
+		t.Errorf("expected 'kelos-credentials' secret reference in output, got:\n%s", output)
 	}
 }
 

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newGetCommand(cfg *ClientConfig) *cobra.Command {
@@ -59,12 +59,12 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				ts := &axonv1alpha1.TaskSpawner{}
+				ts := &kelosv1alpha1.TaskSpawner{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, ts); err != nil {
 					return fmt.Errorf("getting task spawner: %w", err)
 				}
 
-				ts.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("TaskSpawner"))
+				ts.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("TaskSpawner"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, ts)
@@ -74,13 +74,13 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 					if detail {
 						printTaskSpawnerDetail(os.Stdout, ts)
 					} else {
-						printTaskSpawnerTable(os.Stdout, []axonv1alpha1.TaskSpawner{*ts}, false)
+						printTaskSpawnerTable(os.Stdout, []kelosv1alpha1.TaskSpawner{*ts}, false)
 					}
 					return nil
 				}
 			}
 
-			tsList := &axonv1alpha1.TaskSpawnerList{}
+			tsList := &kelosv1alpha1.TaskSpawnerList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -89,7 +89,7 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 				return fmt.Errorf("listing task spawners: %w", err)
 			}
 
-			tsList.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("TaskSpawnerList"))
+			tsList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("TaskSpawnerList"))
 			switch output {
 			case "yaml":
 				return printYAML(os.Stdout, tsList)
@@ -142,12 +142,12 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				task := &axonv1alpha1.Task{}
+				task := &kelosv1alpha1.Task{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, task); err != nil {
 					return fmt.Errorf("getting task: %w", err)
 				}
 
-				task.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("Task"))
+				task.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Task"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, task)
@@ -157,13 +157,13 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 					if detail {
 						printTaskDetail(os.Stdout, task)
 					} else {
-						printTaskTable(os.Stdout, []axonv1alpha1.Task{*task}, false)
+						printTaskTable(os.Stdout, []kelosv1alpha1.Task{*task}, false)
 					}
 					return nil
 				}
 			}
 
-			taskList := &axonv1alpha1.TaskList{}
+			taskList := &kelosv1alpha1.TaskList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -172,7 +172,7 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 				return fmt.Errorf("listing tasks: %w", err)
 			}
 
-			taskList.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("TaskList"))
+			taskList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("TaskList"))
 
 			if len(phases) > 0 {
 				taskList.Items = filterTasksByPhase(taskList.Items, phases)
@@ -230,12 +230,12 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				ws := &axonv1alpha1.Workspace{}
+				ws := &kelosv1alpha1.Workspace{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, ws); err != nil {
 					return fmt.Errorf("getting workspace: %w", err)
 				}
 
-				ws.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("Workspace"))
+				ws.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Workspace"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, ws)
@@ -245,13 +245,13 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 					if detail {
 						printWorkspaceDetail(os.Stdout, ws)
 					} else {
-						printWorkspaceTable(os.Stdout, []axonv1alpha1.Workspace{*ws}, false)
+						printWorkspaceTable(os.Stdout, []kelosv1alpha1.Workspace{*ws}, false)
 					}
 					return nil
 				}
 			}
 
-			wsList := &axonv1alpha1.WorkspaceList{}
+			wsList := &kelosv1alpha1.WorkspaceList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -260,7 +260,7 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 				return fmt.Errorf("listing workspaces: %w", err)
 			}
 
-			wsList.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("WorkspaceList"))
+			wsList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("WorkspaceList"))
 			switch output {
 			case "yaml":
 				return printYAML(os.Stdout, wsList)
@@ -282,29 +282,29 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 	return cmd
 }
 
-var validTaskPhases = map[axonv1alpha1.TaskPhase]bool{
-	axonv1alpha1.TaskPhasePending:   true,
-	axonv1alpha1.TaskPhaseRunning:   true,
-	axonv1alpha1.TaskPhaseWaiting:   true,
-	axonv1alpha1.TaskPhaseSucceeded: true,
-	axonv1alpha1.TaskPhaseFailed:    true,
+var validTaskPhases = map[kelosv1alpha1.TaskPhase]bool{
+	kelosv1alpha1.TaskPhasePending:   true,
+	kelosv1alpha1.TaskPhaseRunning:   true,
+	kelosv1alpha1.TaskPhaseWaiting:   true,
+	kelosv1alpha1.TaskPhaseSucceeded: true,
+	kelosv1alpha1.TaskPhaseFailed:    true,
 }
 
 func validatePhases(phases []string) error {
 	for _, p := range phases {
-		if !validTaskPhases[axonv1alpha1.TaskPhase(p)] {
+		if !validTaskPhases[kelosv1alpha1.TaskPhase(p)] {
 			return fmt.Errorf("unknown phase %q: must be one of Pending, Running, Waiting, Succeeded, Failed", p)
 		}
 	}
 	return nil
 }
 
-func filterTasksByPhase(tasks []axonv1alpha1.Task, phases []string) []axonv1alpha1.Task {
-	phaseSet := make(map[axonv1alpha1.TaskPhase]bool, len(phases))
+func filterTasksByPhase(tasks []kelosv1alpha1.Task, phases []string) []kelosv1alpha1.Task {
+	phaseSet := make(map[kelosv1alpha1.TaskPhase]bool, len(phases))
 	for _, p := range phases {
-		phaseSet[axonv1alpha1.TaskPhase(p)] = true
+		phaseSet[kelosv1alpha1.TaskPhase(p)] = true
 	}
-	filtered := make([]axonv1alpha1.Task, 0, len(tasks))
+	filtered := make([]kelosv1alpha1.Task, 0, len(tasks))
 	for _, t := range tasks {
 		if phaseSet[t.Status.Phase] {
 			filtered = append(filtered, t)

--- a/internal/cli/get_agentconfig.go
+++ b/internal/cli/get_agentconfig.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newGetAgentConfigCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
@@ -37,12 +37,12 @@ func newGetAgentConfigCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				ac := &axonv1alpha1.AgentConfig{}
+				ac := &kelosv1alpha1.AgentConfig{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, ac); err != nil {
 					return fmt.Errorf("getting agent config: %w", err)
 				}
 
-				ac.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("AgentConfig"))
+				ac.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("AgentConfig"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, ac)
@@ -52,13 +52,13 @@ func newGetAgentConfigCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 					if detail {
 						printAgentConfigDetail(os.Stdout, ac)
 					} else {
-						printAgentConfigTable(os.Stdout, []axonv1alpha1.AgentConfig{*ac}, false)
+						printAgentConfigTable(os.Stdout, []kelosv1alpha1.AgentConfig{*ac}, false)
 					}
 					return nil
 				}
 			}
 
-			acList := &axonv1alpha1.AgentConfigList{}
+			acList := &kelosv1alpha1.AgentConfigList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -67,7 +67,7 @@ func newGetAgentConfigCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 				return fmt.Errorf("listing agent configs: %w", err)
 			}
 
-			acList.SetGroupVersionKind(axonv1alpha1.GroupVersion.WithKind("AgentConfigList"))
+			acList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("AgentConfigList"))
 			switch output {
 			case "yaml":
 				return printYAML(os.Stdout, acList)

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"testing"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func TestDetailFlagRegistered(t *testing.T) {
@@ -74,43 +74,43 @@ func TestValidatePhases(t *testing.T) {
 }
 
 func TestFilterTasksByPhase(t *testing.T) {
-	tasks := []axonv1alpha1.Task{
-		{Status: axonv1alpha1.TaskStatus{Phase: axonv1alpha1.TaskPhasePending}},
-		{Status: axonv1alpha1.TaskStatus{Phase: axonv1alpha1.TaskPhaseRunning}},
-		{Status: axonv1alpha1.TaskStatus{Phase: axonv1alpha1.TaskPhaseSucceeded}},
-		{Status: axonv1alpha1.TaskStatus{Phase: axonv1alpha1.TaskPhaseFailed}},
-		{Status: axonv1alpha1.TaskStatus{Phase: axonv1alpha1.TaskPhaseWaiting}},
+	tasks := []kelosv1alpha1.Task{
+		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhasePending}},
+		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseRunning}},
+		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseSucceeded}},
+		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseFailed}},
+		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseWaiting}},
 	}
 
 	tests := []struct {
 		name       string
 		phases     []string
 		wantCount  int
-		wantPhases []axonv1alpha1.TaskPhase
+		wantPhases []kelosv1alpha1.TaskPhase
 	}{
 		{
 			name:       "filter Running only",
 			phases:     []string{"Running"},
 			wantCount:  1,
-			wantPhases: []axonv1alpha1.TaskPhase{axonv1alpha1.TaskPhaseRunning},
+			wantPhases: []kelosv1alpha1.TaskPhase{kelosv1alpha1.TaskPhaseRunning},
 		},
 		{
 			name:      "filter non-completed",
 			phases:    []string{"Pending", "Running", "Waiting"},
 			wantCount: 3,
-			wantPhases: []axonv1alpha1.TaskPhase{
-				axonv1alpha1.TaskPhasePending,
-				axonv1alpha1.TaskPhaseRunning,
-				axonv1alpha1.TaskPhaseWaiting,
+			wantPhases: []kelosv1alpha1.TaskPhase{
+				kelosv1alpha1.TaskPhasePending,
+				kelosv1alpha1.TaskPhaseRunning,
+				kelosv1alpha1.TaskPhaseWaiting,
 			},
 		},
 		{
 			name:      "filter completed",
 			phases:    []string{"Succeeded", "Failed"},
 			wantCount: 2,
-			wantPhases: []axonv1alpha1.TaskPhase{
-				axonv1alpha1.TaskPhaseSucceeded,
-				axonv1alpha1.TaskPhaseFailed,
+			wantPhases: []kelosv1alpha1.TaskPhase{
+				kelosv1alpha1.TaskPhaseSucceeded,
+				kelosv1alpha1.TaskPhaseFailed,
 			},
 		},
 		{

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 // resolveContent returns the content string directly, or if it starts with "@",
@@ -42,15 +42,15 @@ func parseNameContent(s, flagName string) (string, string, error) {
 // parseMCPFlag parses a --mcp flag value in the format "name=JSON" or
 // "name=@file" into an MCPServerSpec. The JSON (or file content) must
 // contain at least a "type" field.
-func parseMCPFlag(s string) (axonv1alpha1.MCPServerSpec, error) {
+func parseMCPFlag(s string) (kelosv1alpha1.MCPServerSpec, error) {
 	parts := strings.SplitN(s, "=", 2)
 	if len(parts) != 2 || parts[0] == "" {
-		return axonv1alpha1.MCPServerSpec{}, fmt.Errorf("invalid --mcp value %q: must be name=JSON or name=@file", s)
+		return kelosv1alpha1.MCPServerSpec{}, fmt.Errorf("invalid --mcp value %q: must be name=JSON or name=@file", s)
 	}
 	name := parts[0]
 	content, err := resolveContent(parts[1])
 	if err != nil {
-		return axonv1alpha1.MCPServerSpec{}, fmt.Errorf("resolving --mcp %q: %w", name, err)
+		return kelosv1alpha1.MCPServerSpec{}, fmt.Errorf("resolving --mcp %q: %w", name, err)
 	}
 
 	var raw struct {
@@ -62,18 +62,18 @@ func parseMCPFlag(s string) (axonv1alpha1.MCPServerSpec, error) {
 		Env     map[string]string `json:"env,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(content), &raw); err != nil {
-		return axonv1alpha1.MCPServerSpec{}, fmt.Errorf("invalid --mcp %q JSON: %w", name, err)
+		return kelosv1alpha1.MCPServerSpec{}, fmt.Errorf("invalid --mcp %q JSON: %w", name, err)
 	}
 	if raw.Type == "" {
-		return axonv1alpha1.MCPServerSpec{}, fmt.Errorf("--mcp %q: \"type\" field is required", name)
+		return kelosv1alpha1.MCPServerSpec{}, fmt.Errorf("--mcp %q: \"type\" field is required", name)
 	}
 	switch raw.Type {
 	case "stdio", "http", "sse":
 	default:
-		return axonv1alpha1.MCPServerSpec{}, fmt.Errorf("--mcp %q: unsupported type %q (must be stdio, http, or sse)", name, raw.Type)
+		return kelosv1alpha1.MCPServerSpec{}, fmt.Errorf("--mcp %q: unsupported type %q (must be stdio, http, or sse)", name, raw.Type)
 	}
 
-	return axonv1alpha1.MCPServerSpec{
+	return kelosv1alpha1.MCPServerSpec{
 		Name:    name,
 		Type:    raw.Type,
 		Command: raw.Command,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -8,10 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const configTemplate = `# Axon configuration file
-# See: https://github.com/axon-core/axon
+const configTemplate = `# Kelos configuration file
+# See: https://github.com/kelos-dev/kelos
 
-# OAuth token (axon auto-creates the Kubernetes secret for you)
+# OAuth token (kelos auto-creates the Kubernetes secret for you)
 oauthToken: ""
 
 # Or use an API key instead:
@@ -57,12 +57,12 @@ func printNextSteps(configPath string) {
 	fmt.Fprintln(os.Stdout, "2. Edit the config file and add your token:")
 	fmt.Fprintf(os.Stdout, "   %s\n", configPath)
 	fmt.Fprintln(os.Stdout, "")
-	fmt.Fprintln(os.Stdout, "3. Install Axon (if not already installed):")
-	fmt.Fprintln(os.Stdout, "   axon install")
+	fmt.Fprintln(os.Stdout, "3. Install Kelos (if not already installed):")
+	fmt.Fprintln(os.Stdout, "   kelos install")
 	fmt.Fprintln(os.Stdout, "")
 	fmt.Fprintln(os.Stdout, "4. Run your first task:")
-	fmt.Fprintln(os.Stdout, "   axon run -p \"Create a hello world program in Python\"")
-	fmt.Fprintln(os.Stdout, "   axon logs <task-name> -f")
+	fmt.Fprintln(os.Stdout, "   kelos run -p \"Create a hello world program in Python\"")
+	fmt.Fprintln(os.Stdout, "   kelos logs <task-name> -f")
 	fmt.Fprintln(os.Stdout, "")
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -21,11 +21,11 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
-	"github.com/axon-core/axon/internal/manifests"
-	"github.com/axon-core/axon/internal/version"
+	"github.com/kelos-dev/kelos/internal/manifests"
+	"github.com/kelos-dev/kelos/internal/version"
 )
 
-const fieldManager = "axon"
+const fieldManager = "kelos"
 
 func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 	var dryRun bool
@@ -34,7 +34,7 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install axon CRDs and controller into the cluster",
+		Short: "Install kelos CRDs and controller into the cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flagVersion != "" {
@@ -70,17 +70,17 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			fmt.Fprintf(os.Stdout, "Installing axon CRDs\n")
+			fmt.Fprintf(os.Stdout, "Installing kelos CRDs\n")
 			if err := applyManifests(ctx, dc, dyn, manifests.InstallCRD); err != nil {
 				return fmt.Errorf("installing CRDs: %w", err)
 			}
 
-			fmt.Fprintf(os.Stdout, "Installing axon controller (version: %s)\n", version.Version)
+			fmt.Fprintf(os.Stdout, "Installing kelos controller (version: %s)\n", version.Version)
 			if err := applyManifests(ctx, dc, dyn, controllerManifest); err != nil {
 				return fmt.Errorf("installing controller: %w", err)
 			}
 
-			fmt.Fprintf(os.Stdout, "Axon installed successfully\n")
+			fmt.Fprintf(os.Stdout, "Kelos installed successfully\n")
 			return nil
 		},
 	}
@@ -136,7 +136,7 @@ func withImagePullPolicy(data []byte, policy string) []byte {
 func newUninstallCommand(cfg *ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Uninstall axon controller and CRDs from the cluster",
+		Short: "Uninstall kelos controller and CRDs from the cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			restConfig, _, err := cfg.resolveConfig()
@@ -155,17 +155,17 @@ func newUninstallCommand(cfg *ClientConfig) *cobra.Command {
 
 			ctx := cmd.Context()
 
-			fmt.Fprintf(os.Stdout, "Removing axon controller\n")
+			fmt.Fprintf(os.Stdout, "Removing kelos controller\n")
 			if err := deleteManifests(ctx, dc, dyn, manifests.InstallController); err != nil {
 				return fmt.Errorf("removing controller: %w", err)
 			}
 
-			fmt.Fprintf(os.Stdout, "Removing axon CRDs\n")
+			fmt.Fprintf(os.Stdout, "Removing kelos CRDs\n")
 			if err := deleteManifests(ctx, dc, dyn, manifests.InstallCRD); err != nil {
 				return fmt.Errorf("removing CRDs: %w", err)
 			}
 
-			fmt.Fprintf(os.Stdout, "Axon uninstalled successfully\n")
+			fmt.Fprintf(os.Stdout, "Kelos uninstalled successfully\n")
 			return nil
 		},
 	}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/axon-core/axon/internal/manifests"
+	"github.com/kelos-dev/kelos/internal/manifests"
 )
 
 func TestParseManifests_SingleDocument(t *testing.T) {
@@ -213,7 +213,7 @@ func TestUninstallCommand_RejectsExtraArgs(t *testing.T) {
 }
 
 func TestVersionedManifest_Latest(t *testing.T) {
-	data := []byte("image: gjkim42/axon-controller:latest")
+	data := []byte("image: gjkim42/kelos-controller:latest")
 	result := versionedManifest(data, "latest")
 	if !bytes.Equal(result, data) {
 		t.Errorf("expected manifest unchanged for latest version, got %s", string(result))
@@ -221,18 +221,18 @@ func TestVersionedManifest_Latest(t *testing.T) {
 }
 
 func TestVersionedManifest_Tagged(t *testing.T) {
-	data := []byte("image: gjkim42/axon-controller:latest")
+	data := []byte("image: gjkim42/kelos-controller:latest")
 	result := versionedManifest(data, "v0.1.0")
-	expected := []byte("image: gjkim42/axon-controller:v0.1.0")
+	expected := []byte("image: gjkim42/kelos-controller:v0.1.0")
 	if !bytes.Equal(result, expected) {
 		t.Errorf("expected %s, got %s", string(expected), string(result))
 	}
 }
 
 func TestVersionedManifest_MultipleImages(t *testing.T) {
-	data := []byte(`image: gjkim42/axon-controller:latest
+	data := []byte(`image: gjkim42/kelos-controller:latest
 args:
-  - --spawner-image=gjkim42/axon-spawner:latest
+  - --spawner-image=gjkim42/kelos-spawner:latest
   - --claude-code-image=gjkim42/claude-code:latest`)
 	result := versionedManifest(data, "v0.2.0")
 	if bytes.Contains(result, []byte(":latest")) {
@@ -260,8 +260,8 @@ func TestVersionedManifest_EmbeddedControllerImageArgs(t *testing.T) {
 		"--codex-image=gjkim42/codex:",
 		"--gemini-image=gjkim42/gemini:",
 		"--opencode-image=gjkim42/opencode:",
-		"--spawner-image=gjkim42/axon-spawner:",
-		"--token-refresher-image=gjkim42/axon-token-refresher:",
+		"--spawner-image=gjkim42/kelos-spawner:",
+		"--token-refresher-image=gjkim42/kelos-token-refresher:",
 	}
 	for _, arg := range expectedArgs {
 		if !bytes.Contains(manifests.InstallController, []byte(arg)) {
@@ -276,8 +276,8 @@ func TestVersionedManifest_EmbeddedControllerImageArgs(t *testing.T) {
 		"--codex-image=gjkim42/codex:v0.3.0",
 		"--gemini-image=gjkim42/gemini:v0.3.0",
 		"--opencode-image=gjkim42/opencode:v0.3.0",
-		"--spawner-image=gjkim42/axon-spawner:v0.3.0",
-		"--token-refresher-image=gjkim42/axon-token-refresher:v0.3.0",
+		"--spawner-image=gjkim42/kelos-spawner:v0.3.0",
+		"--token-refresher-image=gjkim42/kelos-token-refresher:v0.3.0",
 	}
 	for _, arg := range versionedArgs {
 		if !bytes.Contains(result, []byte(arg)) {
@@ -289,14 +289,14 @@ func TestVersionedManifest_EmbeddedControllerImageArgs(t *testing.T) {
 func TestWithImagePullPolicy(t *testing.T) {
 	data := []byte(`      containers:
         - name: manager
-          image: gjkim42/axon-controller:v0.1.0
+          image: gjkim42/kelos-controller:v0.1.0
           args:
             - --leader-elect
             - --claude-code-image=gjkim42/claude-code:v0.1.0
-            - --spawner-image=gjkim42/axon-spawner:v0.1.0`)
+            - --spawner-image=gjkim42/kelos-spawner:v0.1.0`)
 	result := withImagePullPolicy(data, "Always")
 	// Verify container imagePullPolicy appears right after the image line.
-	expected := []byte("          image: gjkim42/axon-controller:v0.1.0\n          imagePullPolicy: Always\n")
+	expected := []byte("          image: gjkim42/kelos-controller:v0.1.0\n          imagePullPolicy: Always\n")
 	if !bytes.Contains(result, expected) {
 		t.Errorf("expected imagePullPolicy right after image line, got:\n%s", string(result))
 	}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newLogsCommand(cfg *ClientConfig) *cobra.Command {
@@ -43,7 +43,7 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 			}
 
 			ctx := context.Background()
-			task := &axonv1alpha1.Task{}
+			task := &kelosv1alpha1.Task{}
 			if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, task); err != nil {
 				return fmt.Errorf("getting task: %w", err)
 			}
@@ -83,10 +83,10 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 	return cmd
 }
 
-func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (*axonv1alpha1.Task, error) {
-	var lastPhase axonv1alpha1.TaskPhase
+func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (*kelosv1alpha1.Task, error) {
+	var lastPhase kelosv1alpha1.TaskPhase
 	for {
-		task := &axonv1alpha1.Task{}
+		task := &kelosv1alpha1.Task{}
 		if err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, task); err != nil {
 			return nil, fmt.Errorf("getting task: %w", err)
 		}
@@ -96,7 +96,7 @@ func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (
 			lastPhase = task.Status.Phase
 		}
 
-		if task.Status.Phase == axonv1alpha1.TaskPhaseFailed {
+		if task.Status.Phase == kelosv1alpha1.TaskPhaseFailed {
 			msg := "unknown error"
 			if task.Status.Message != "" {
 				msg = task.Status.Message

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"sigs.k8s.io/yaml"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
-func taskDuration(status *axonv1alpha1.TaskStatus) string {
+func taskDuration(status *kelosv1alpha1.TaskStatus) string {
 	if status.StartTime == nil {
 		return "-"
 	}
@@ -25,7 +25,7 @@ func taskDuration(status *axonv1alpha1.TaskStatus) string {
 	return duration.HumanDuration(time.Since(status.StartTime.Time))
 }
 
-func printTaskTable(w io.Writer, tasks []axonv1alpha1.Task, allNamespaces bool) {
+func printTaskTable(w io.Writer, tasks []kelosv1alpha1.Task, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tTYPE\tPHASE\tBRANCH\tWORKSPACE\tAGENT CONFIG\tDURATION\tAGE")
@@ -58,7 +58,7 @@ func printTaskTable(w io.Writer, tasks []axonv1alpha1.Task, allNamespaces bool) 
 	tw.Flush()
 }
 
-func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
+func printTaskDetail(w io.Writer, t *kelosv1alpha1.Task) {
 	printField(w, "Name", t.Name)
 	printField(w, "Namespace", t.Namespace)
 	printField(w, "Type", t.Spec.Type)
@@ -132,7 +132,7 @@ func printTaskDetail(w io.Writer, t *axonv1alpha1.Task) {
 	}
 }
 
-func printTaskSpawnerTable(w io.Writer, spawners []axonv1alpha1.TaskSpawner, allNamespaces bool) {
+func printTaskSpawnerTable(w io.Writer, spawners []kelosv1alpha1.TaskSpawner, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tSOURCE\tPHASE\tDISCOVERED\tTASKS\tAGE")
@@ -164,7 +164,7 @@ func printTaskSpawnerTable(w io.Writer, spawners []axonv1alpha1.TaskSpawner, all
 	tw.Flush()
 }
 
-func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
+func printTaskSpawnerDetail(w io.Writer, ts *kelosv1alpha1.TaskSpawner) {
 	printField(w, "Name", ts.Name)
 	printField(w, "Namespace", ts.Namespace)
 	printField(w, "Phase", string(ts.Status.Phase))
@@ -205,7 +205,7 @@ func printTaskSpawnerDetail(w io.Writer, ts *axonv1alpha1.TaskSpawner) {
 	}
 }
 
-func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace, allNamespaces bool) {
+func printWorkspaceTable(w io.Writer, workspaces []kelosv1alpha1.Workspace, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tREPO\tREF\tAGE")
@@ -223,7 +223,7 @@ func printWorkspaceTable(w io.Writer, workspaces []axonv1alpha1.Workspace, allNa
 	tw.Flush()
 }
 
-func printWorkspaceDetail(w io.Writer, ws *axonv1alpha1.Workspace) {
+func printWorkspaceDetail(w io.Writer, ws *kelosv1alpha1.Workspace) {
 	printField(w, "Name", ws.Name)
 	printField(w, "Namespace", ws.Namespace)
 	printField(w, "Repo", ws.Spec.Repo)
@@ -235,7 +235,7 @@ func printWorkspaceDetail(w io.Writer, ws *axonv1alpha1.Workspace) {
 	}
 }
 
-func printAgentConfigTable(w io.Writer, configs []axonv1alpha1.AgentConfig, allNamespaces bool) {
+func printAgentConfigTable(w io.Writer, configs []kelosv1alpha1.AgentConfig, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tPLUGINS\tMCP SERVERS\tAGE")
@@ -255,7 +255,7 @@ func printAgentConfigTable(w io.Writer, configs []axonv1alpha1.AgentConfig, allN
 	tw.Flush()
 }
 
-func printAgentConfigDetail(w io.Writer, ac *axonv1alpha1.AgentConfig) {
+func printAgentConfigDetail(w io.Writer, ac *kelosv1alpha1.AgentConfig) {
 	printField(w, "Name", ac.Name)
 	printField(w, "Namespace", ac.Namespace)
 	if ac.Spec.AgentsMD != "" {

--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -8,17 +8,17 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func TestPrintWorkspaceTable(t *testing.T) {
-	workspaces := []axonv1alpha1.Workspace{
+	workspaces := []kelosv1alpha1.Workspace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "ws-one",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
+			Spec: kelosv1alpha1.WorkspaceSpec{
 				Repo: "https://github.com/org/repo.git",
 				Ref:  "main",
 			},
@@ -28,7 +28,7 @@ func TestPrintWorkspaceTable(t *testing.T) {
 				Name:              "ws-two",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
+			Spec: kelosv1alpha1.WorkspaceSpec{
 				Repo: "https://github.com/org/other.git",
 			},
 		},
@@ -59,14 +59,14 @@ func TestPrintWorkspaceTable(t *testing.T) {
 }
 
 func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
-	workspaces := []axonv1alpha1.Workspace{
+	workspaces := []kelosv1alpha1.Workspace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "ws-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
+			Spec: kelosv1alpha1.WorkspaceSpec{
 				Repo: "https://github.com/org/repo.git",
 				Ref:  "main",
 			},
@@ -77,7 +77,7 @@ func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
+			Spec: kelosv1alpha1.WorkspaceSpec{
 				Repo: "https://github.com/org/other.git",
 			},
 		},
@@ -101,25 +101,25 @@ func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
 func TestPrintTaskTable(t *testing.T) {
 	now := time.Now()
 	startTime := metav1.NewTime(now.Add(-30 * time.Minute))
-	tasks := []axonv1alpha1.Task{
+	tasks := []kelosv1alpha1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-one",
 				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.TaskSpec{
+			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
 				Model:  "claude-sonnet-4-20250514",
 				Branch: "feature/test",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
 					Name: "my-ws",
 				},
-				AgentConfigRef: &axonv1alpha1.AgentConfigReference{
+				AgentConfigRef: &kelosv1alpha1.AgentConfigReference{
 					Name: "my-config",
 				},
 			},
-			Status: axonv1alpha1.TaskStatus{
-				Phase:     axonv1alpha1.TaskPhaseRunning,
+			Status: kelosv1alpha1.TaskStatus{
+				Phase:     kelosv1alpha1.TaskPhaseRunning,
 				StartTime: &startTime,
 			},
 		},
@@ -148,19 +148,19 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 	now := time.Now()
 	startTime := metav1.NewTime(now.Add(-90 * time.Minute))
 	completionTime := metav1.NewTime(now.Add(-60 * time.Minute))
-	tasks := []axonv1alpha1.Task{
+	tasks := []kelosv1alpha1.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.TaskSpec{
+			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
 				Branch: "feat/one",
 			},
-			Status: axonv1alpha1.TaskStatus{
-				Phase: axonv1alpha1.TaskPhaseRunning,
+			Status: kelosv1alpha1.TaskStatus{
+				Phase: kelosv1alpha1.TaskPhaseRunning,
 			},
 		},
 		{
@@ -169,11 +169,11 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
 			},
-			Spec: axonv1alpha1.TaskSpec{
+			Spec: kelosv1alpha1.TaskSpec{
 				Type: "codex",
 			},
-			Status: axonv1alpha1.TaskStatus{
-				Phase:          axonv1alpha1.TaskPhaseSucceeded,
+			Status: kelosv1alpha1.TaskStatus{
+				Phase:          kelosv1alpha1.TaskPhaseSucceeded,
 				StartTime:      &startTime,
 				CompletionTime: &completionTime,
 			},
@@ -197,21 +197,21 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTable(t *testing.T) {
-	spawners := []axonv1alpha1.TaskSpawner{
+	spawners := []kelosv1alpha1.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "spawner-one",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					Cron: &axonv1alpha1.Cron{
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					Cron: &kelosv1alpha1.Cron{
 						Schedule: "*/5 * * * *",
 					},
 				},
 			},
-			Status: axonv1alpha1.TaskSpawnerStatus{
-				Phase: axonv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelosv1alpha1.TaskSpawnerStatus{
+				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -232,22 +232,22 @@ func TestPrintTaskSpawnerTable(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
-	spawners := []axonv1alpha1.TaskSpawner{
+	spawners := []kelosv1alpha1.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "spawner-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					Cron: &axonv1alpha1.Cron{
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					Cron: &kelosv1alpha1.Cron{
 						Schedule: "*/5 * * * *",
 					},
 				},
 			},
-			Status: axonv1alpha1.TaskSpawnerStatus{
-				Phase: axonv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelosv1alpha1.TaskSpawnerStatus{
+				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
 			},
 		},
 		{
@@ -256,18 +256,18 @@ func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					GitHubIssues: &axonv1alpha1.GitHubIssues{},
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 				},
-				TaskTemplate: axonv1alpha1.TaskTemplate{
-					WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+				TaskTemplate: kelosv1alpha1.TaskTemplate{
+					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
 						Name: "my-ws",
 					},
 				},
 			},
-			Status: axonv1alpha1.TaskSpawnerStatus{
-				Phase: axonv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelosv1alpha1.TaskSpawnerStatus{
+				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -288,15 +288,15 @@ func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
 }
 
 func TestPrintWorkspaceDetail(t *testing.T) {
-	ws := &axonv1alpha1.Workspace{
+	ws := &kelosv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-workspace",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.WorkspaceSpec{
+		Spec: kelosv1alpha1.WorkspaceSpec{
 			Repo: "https://github.com/org/repo.git",
 			Ref:  "main",
-			SecretRef: &axonv1alpha1.SecretReference{
+			SecretRef: &kelosv1alpha1.SecretReference{
 				Name: "gh-token",
 			},
 		},
@@ -321,21 +321,21 @@ func TestPrintWorkspaceDetail(t *testing.T) {
 }
 
 func TestPrintTaskTableSingleItem(t *testing.T) {
-	task := axonv1alpha1.Task{
+	task := kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-task",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-30 * time.Minute)),
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type: "claude-code",
 		},
-		Status: axonv1alpha1.TaskStatus{
-			Phase: axonv1alpha1.TaskPhaseSucceeded,
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhaseSucceeded,
 		},
 	}
 
 	var buf bytes.Buffer
-	printTaskTable(&buf, []axonv1alpha1.Task{task}, false)
+	printTaskTable(&buf, []kelosv1alpha1.Task{task}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -347,7 +347,7 @@ func TestPrintTaskTableSingleItem(t *testing.T) {
 	if !strings.Contains(output, "claude-code") {
 		t.Errorf("expected type claude-code in output, got %q", output)
 	}
-	if !strings.Contains(output, string(axonv1alpha1.TaskPhaseSucceeded)) {
+	if !strings.Contains(output, string(kelosv1alpha1.TaskPhaseSucceeded)) {
 		t.Errorf("expected phase Succeeded in output, got %q", output)
 	}
 	if strings.Contains(output, "Prompt:") {
@@ -356,27 +356,27 @@ func TestPrintTaskTableSingleItem(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableSingleItem(t *testing.T) {
-	spawner := axonv1alpha1.TaskSpawner{
+	spawner := kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-spawner",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				Cron: &axonv1alpha1.Cron{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Cron: &kelosv1alpha1.Cron{
 					Schedule: "0 * * * *",
 				},
 			},
 		},
-		Status: axonv1alpha1.TaskSpawnerStatus{
-			Phase:             axonv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelosv1alpha1.TaskSpawnerStatus{
+			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   5,
 			TotalTasksCreated: 3,
 		},
 	}
 
 	var buf bytes.Buffer
-	printTaskSpawnerTable(&buf, []axonv1alpha1.TaskSpawner{spawner}, false)
+	printTaskSpawnerTable(&buf, []kelosv1alpha1.TaskSpawner{spawner}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -394,19 +394,19 @@ func TestPrintTaskSpawnerTableSingleItem(t *testing.T) {
 }
 
 func TestPrintWorkspaceTableSingleItem(t *testing.T) {
-	ws := axonv1alpha1.Workspace{
+	ws := kelosv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-workspace",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 		},
-		Spec: axonv1alpha1.WorkspaceSpec{
+		Spec: kelosv1alpha1.WorkspaceSpec{
 			Repo: "https://github.com/org/repo.git",
 			Ref:  "main",
 		},
 	}
 
 	var buf bytes.Buffer
-	printWorkspaceTable(&buf, []axonv1alpha1.Workspace{ws}, false)
+	printWorkspaceTable(&buf, []kelosv1alpha1.Workspace{ws}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -425,25 +425,25 @@ func TestPrintWorkspaceTableSingleItem(t *testing.T) {
 
 func TestPrintTaskSpawnerDetail(t *testing.T) {
 	lastDiscovery := metav1.NewTime(time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC))
-	spawner := &axonv1alpha1.TaskSpawner{
+	spawner := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				Cron: &axonv1alpha1.Cron{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Cron: &kelosv1alpha1.Cron{
 					Schedule: "0 * * * *",
 				},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:  "claude-code",
 				Model: "claude-sonnet-4-20250514",
 			},
 			PollInterval: "5m",
 		},
-		Status: axonv1alpha1.TaskSpawnerStatus{
-			Phase:             axonv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelosv1alpha1.TaskSpawnerStatus{
+			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
 			DeploymentName:    "my-spawner-deploy",
 			TotalDiscovered:   10,
 			TotalTasksCreated: 7,
@@ -474,12 +474,12 @@ func TestPrintTaskSpawnerDetail(t *testing.T) {
 }
 
 func TestPrintWorkspaceDetailWithoutOptionalFields(t *testing.T) {
-	ws := &axonv1alpha1.Workspace{
+	ws := &kelosv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "minimal-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.WorkspaceSpec{
+		Spec: kelosv1alpha1.WorkspaceSpec{
 			Repo: "https://github.com/org/repo.git",
 		},
 	}
@@ -506,17 +506,17 @@ func TestTaskDuration(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		status axonv1alpha1.TaskStatus
+		status kelosv1alpha1.TaskStatus
 		want   string
 	}{
 		{
 			name:   "no start time",
-			status: axonv1alpha1.TaskStatus{},
+			status: kelosv1alpha1.TaskStatus{},
 			want:   "-",
 		},
 		{
 			name: "completed task",
-			status: axonv1alpha1.TaskStatus{
+			status: kelosv1alpha1.TaskStatus{
 				StartTime:      &startTime,
 				CompletionTime: &completionTime,
 			},
@@ -524,7 +524,7 @@ func TestTaskDuration(t *testing.T) {
 		},
 		{
 			name: "running task",
-			status: axonv1alpha1.TaskStatus{
+			status: kelosv1alpha1.TaskStatus{
 				StartTime: &startTime,
 			},
 			want: "30m",
@@ -548,35 +548,35 @@ func TestPrintTaskDetail(t *testing.T) {
 	ttl := int32(3600)
 	timeout := int64(7200)
 
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "full-task",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   "claude-code",
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 			Model:     "claude-sonnet-4-20250514",
 			Image:     "custom-image:latest",
 			Branch:    "feature/fix",
 			DependsOn: []string{"task-a", "task-b"},
-			WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+			WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
 				Name: "my-ws",
 			},
-			AgentConfigRef: &axonv1alpha1.AgentConfigReference{
+			AgentConfigRef: &kelosv1alpha1.AgentConfigReference{
 				Name: "my-config",
 			},
 			TTLSecondsAfterFinished: &ttl,
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				ActiveDeadlineSeconds: &timeout,
 			},
 		},
-		Status: axonv1alpha1.TaskStatus{
-			Phase:          axonv1alpha1.TaskPhaseSucceeded,
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:          kelosv1alpha1.TaskPhaseSucceeded,
 			JobName:        "full-task-job",
 			PodName:        "full-task-pod",
 			StartTime:      &startTime,
@@ -619,18 +619,18 @@ func TestPrintTaskDetail(t *testing.T) {
 }
 
 func TestPrintAgentConfigTable(t *testing.T) {
-	configs := []axonv1alpha1.AgentConfig{
+	configs := []kelosv1alpha1.AgentConfig{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "config-one",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.AgentConfigSpec{
+			Spec: kelosv1alpha1.AgentConfigSpec{
 				AgentsMD: "some instructions",
-				Plugins: []axonv1alpha1.PluginSpec{
-					{Name: "axon"},
+				Plugins: []kelosv1alpha1.PluginSpec{
+					{Name: "kelos"},
 				},
-				MCPServers: []axonv1alpha1.MCPServerSpec{
+				MCPServers: []kelosv1alpha1.MCPServerSpec{
 					{Name: "github", Type: "http"},
 					{Name: "local", Type: "stdio"},
 				},
@@ -641,7 +641,7 @@ func TestPrintAgentConfigTable(t *testing.T) {
 				Name:              "config-two",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 			},
-			Spec: axonv1alpha1.AgentConfigSpec{},
+			Spec: kelosv1alpha1.AgentConfigSpec{},
 		},
 	}
 
@@ -666,14 +666,14 @@ func TestPrintAgentConfigTable(t *testing.T) {
 }
 
 func TestPrintAgentConfigTableAllNamespaces(t *testing.T) {
-	configs := []axonv1alpha1.AgentConfig{
+	configs := []kelosv1alpha1.AgentConfig{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "config-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: axonv1alpha1.AgentConfigSpec{},
+			Spec: kelosv1alpha1.AgentConfigSpec{},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -681,7 +681,7 @@ func TestPrintAgentConfigTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 			},
-			Spec: axonv1alpha1.AgentConfigSpec{},
+			Spec: kelosv1alpha1.AgentConfigSpec{},
 		},
 	}
 
@@ -701,20 +701,20 @@ func TestPrintAgentConfigTableAllNamespaces(t *testing.T) {
 }
 
 func TestPrintAgentConfigTableSingleItem(t *testing.T) {
-	ac := axonv1alpha1.AgentConfig{
+	ac := kelosv1alpha1.AgentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-config",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 		},
-		Spec: axonv1alpha1.AgentConfigSpec{
-			Plugins: []axonv1alpha1.PluginSpec{
-				{Name: "axon"},
+		Spec: kelosv1alpha1.AgentConfigSpec{
+			Plugins: []kelosv1alpha1.PluginSpec{
+				{Name: "kelos"},
 			},
 		},
 	}
 
 	var buf bytes.Buffer
-	printAgentConfigTable(&buf, []axonv1alpha1.AgentConfig{ac}, false)
+	printAgentConfigTable(&buf, []kelosv1alpha1.AgentConfig{ac}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -729,25 +729,25 @@ func TestPrintAgentConfigTableSingleItem(t *testing.T) {
 }
 
 func TestPrintAgentConfigDetail(t *testing.T) {
-	ac := &axonv1alpha1.AgentConfig{
+	ac := &kelosv1alpha1.AgentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-config",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.AgentConfigSpec{
+		Spec: kelosv1alpha1.AgentConfigSpec{
 			AgentsMD: "Build and test instructions",
-			Plugins: []axonv1alpha1.PluginSpec{
+			Plugins: []kelosv1alpha1.PluginSpec{
 				{
-					Name: "axon",
-					Skills: []axonv1alpha1.SkillDefinition{
+					Name: "kelos",
+					Skills: []kelosv1alpha1.SkillDefinition{
 						{Name: "review", Content: "review content"},
 					},
-					Agents: []axonv1alpha1.AgentDefinition{
+					Agents: []kelosv1alpha1.AgentDefinition{
 						{Name: "triage", Content: "triage content"},
 					},
 				},
 			},
-			MCPServers: []axonv1alpha1.MCPServerSpec{
+			MCPServers: []kelosv1alpha1.MCPServerSpec{
 				{Name: "github", Type: "http"},
 				{Name: "local-tool", Type: "stdio"},
 			},
@@ -762,7 +762,7 @@ func TestPrintAgentConfigDetail(t *testing.T) {
 		"Name:", "my-config",
 		"Namespace:", "default",
 		"Agents MD:", "Build and test instructions",
-		"Plugins:", "axon",
+		"Plugins:", "kelos",
 		"skills=[review]",
 		"agents=[triage]",
 		"MCP Servers:", "github (http)",
@@ -775,12 +775,12 @@ func TestPrintAgentConfigDetail(t *testing.T) {
 }
 
 func TestPrintAgentConfigDetailMinimal(t *testing.T) {
-	ac := &axonv1alpha1.AgentConfig{
+	ac := &kelosv1alpha1.AgentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "minimal-config",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.AgentConfigSpec{},
+		Spec: kelosv1alpha1.AgentConfigSpec{},
 	}
 
 	var buf bytes.Buffer
@@ -802,21 +802,21 @@ func TestPrintAgentConfigDetailMinimal(t *testing.T) {
 }
 
 func TestPrintTaskDetailMinimal(t *testing.T) {
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "minimal-task",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   "claude-code",
 			Prompt: "Do something",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "secret"},
 			},
 		},
-		Status: axonv1alpha1.TaskStatus{
-			Phase: axonv1alpha1.TaskPhasePending,
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhasePending,
 		},
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,7 +11,7 @@ func NewRootCommand() *cobra.Command {
 	var configPath string
 
 	cmd := &cobra.Command{
-		Use:           "axon",
+		Use:           "kelos",
 		Short:         "CLI for managing AI agent Tasks on Kubernetes",
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -34,7 +34,7 @@ func NewRootCommand() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to config file (default ~/.axon/config.yaml)")
+	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to config file (default ~/.kelos/config.yaml)")
 	cmd.PersistentFlags().StringVar(&cfg.Kubeconfig, "kubeconfig", "", "path to kubeconfig file")
 	cmd.PersistentFlags().StringVarP(&cfg.Namespace, "namespace", "n", "", "Kubernetes namespace")
 

--- a/internal/cli/suspend.go
+++ b/internal/cli/suspend.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func newSuspendCommand(cfg *ClientConfig) *cobra.Command {
@@ -52,7 +52,7 @@ func newSuspendTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 
 			alreadySuspended := false
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				ts := &axonv1alpha1.TaskSpawner{}
+				ts := &kelosv1alpha1.TaskSpawner{}
 				if err := cl.Get(ctx, key, ts); err != nil {
 					return fmt.Errorf("getting task spawner: %w", err)
 				}
@@ -123,7 +123,7 @@ func newResumeTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 
 			notSuspended := false
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				ts := &axonv1alpha1.TaskSpawner{}
+				ts := &kelosv1alpha1.TaskSpawner{}
 				if err := cl.Get(ctx, key, ts); err != nil {
 					return fmt.Errorf("getting task spawner: %w", err)
 				}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/axon-core/axon/internal/version"
+	"github.com/kelos-dev/kelos/internal/version"
 )
 
 func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print the axon version",
+		Short: "Print the kelos version",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(version.Version)

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,17 +14,17 @@ import (
 
 func TestBuildClaudeCodeJob_DefaultImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-task",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Hello world",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 			Model: "claude-sonnet-4-20250514",
 		},
@@ -42,9 +42,9 @@ func TestBuildClaudeCodeJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected image %q, got %q", ClaudeCodeImage, container.Image)
 	}
 
-	// Command should be /axon_entrypoint.sh (uniform interface).
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh (uniform interface).
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 
 	// Args should be just the prompt.
@@ -52,34 +52,34 @@ func TestBuildClaudeCodeJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected args [Hello world], got %v", container.Args)
 	}
 
-	// AXON_MODEL should be set with the correct value.
-	foundAxonModel := false
+	// KELOS_MODEL should be set with the correct value.
+	foundKelosModel := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MODEL" {
-			foundAxonModel = true
+		if env.Name == "KELOS_MODEL" {
+			foundKelosModel = true
 			if env.Value != "claude-sonnet-4-20250514" {
-				t.Errorf("AXON_MODEL value: expected %q, got %q", "claude-sonnet-4-20250514", env.Value)
+				t.Errorf("KELOS_MODEL value: expected %q, got %q", "claude-sonnet-4-20250514", env.Value)
 			}
 		}
 	}
-	if !foundAxonModel {
-		t.Error("Expected AXON_MODEL env var to be set")
+	if !foundKelosModel {
+		t.Error("Expected KELOS_MODEL env var to be set")
 	}
 }
 
 func TestBuildClaudeCodeJob_CustomImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-custom",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 			Model: "my-model",
 			Image: "my-custom-agent:latest",
@@ -98,9 +98,9 @@ func TestBuildClaudeCodeJob_CustomImage(t *testing.T) {
 		t.Errorf("Expected image %q, got %q", "my-custom-agent:latest", container.Image)
 	}
 
-	// Command should be /axon_entrypoint.sh (same interface as default).
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh (same interface as default).
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 
 	// Args should be just the prompt.
@@ -108,34 +108,34 @@ func TestBuildClaudeCodeJob_CustomImage(t *testing.T) {
 		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
 	}
 
-	// AXON_MODEL should be set with the correct value.
-	foundAxonModel := false
+	// KELOS_MODEL should be set with the correct value.
+	foundKelosModel := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MODEL" {
-			foundAxonModel = true
+		if env.Name == "KELOS_MODEL" {
+			foundKelosModel = true
 			if env.Value != "my-model" {
-				t.Errorf("AXON_MODEL value: expected %q, got %q", "my-model", env.Value)
+				t.Errorf("KELOS_MODEL value: expected %q, got %q", "my-model", env.Value)
 			}
 		}
 	}
-	if !foundAxonModel {
-		t.Error("Expected AXON_MODEL env var to be set")
+	if !foundKelosModel {
+		t.Error("Expected KELOS_MODEL env var to be set")
 	}
 }
 
 func TestBuildClaudeCodeJob_NoModel(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-no-model",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Hello",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -147,32 +147,32 @@ func TestBuildClaudeCodeJob_NoModel(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 
-	// AXON_MODEL should NOT be set when model is empty.
+	// KELOS_MODEL should NOT be set when model is empty.
 	for _, env := range container.Env {
-		if env.Name == "AXON_MODEL" {
-			t.Error("AXON_MODEL should not be set when model is empty")
+		if env.Name == "KELOS_MODEL" {
+			t.Error("KELOS_MODEL should not be set when model is empty")
 		}
 	}
 }
 
 func TestBuildClaudeCodeJob_WorkspaceWithRef(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-workspace",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
 	}
@@ -224,27 +224,27 @@ func TestBuildClaudeCodeJob_WorkspaceWithRef(t *testing.T) {
 
 func TestBuildClaudeCodeJob_WorkspaceWithInjectedFiles(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-workspace-files",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Inject plugin files",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
 	skillContent := "---\nname: reviewer\n---\nUse this skill for reviews\n"
 	agentsContent := "Follow these team guidelines\n"
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		Files: []axonv1alpha1.WorkspaceFile{
+		Files: []kelosv1alpha1.WorkspaceFile{
 			{
 				Path:    ".claude/skills/reviewer/SKILL.md",
 				Content: skillContent,
@@ -296,24 +296,24 @@ func TestBuildClaudeCodeJob_WorkspaceWithInjectedFiles(t *testing.T) {
 
 func TestBuildClaudeCodeJob_WorkspaceWithInjectedFilesInvalidPath(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-workspace-files-invalid",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Inject plugin files",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
-		Files: []axonv1alpha1.WorkspaceFile{
+		Files: []kelosv1alpha1.WorkspaceFile{
 			{
 				Path:    "../AGENTS.md",
 				Content: "invalid",
@@ -332,26 +332,26 @@ func TestBuildClaudeCodeJob_WorkspaceWithInjectedFilesInvalidPath(t *testing.T) 
 
 func TestBuildClaudeCodeJob_CustomImageWithWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-custom-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 			Image: "my-agent:v1",
 			Model: "gpt-4",
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -363,12 +363,12 @@ func TestBuildClaudeCodeJob_CustomImageWithWorkspace(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 
-	// Custom image with workspace should still use /axon_entrypoint.sh.
+	// Custom image with workspace should still use /kelos_entrypoint.sh.
 	if container.Image != "my-agent:v1" {
 		t.Errorf("Expected image %q, got %q", "my-agent:v1", container.Image)
 	}
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 	if len(container.Args) != 1 || container.Args[0] != "Fix the bug" {
 		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
@@ -390,7 +390,7 @@ func TestBuildClaudeCodeJob_CustomImageWithWorkspace(t *testing.T) {
 		t.Errorf("Expected FSGroup %d, got %d", ClaudeCodeUID, *job.Spec.Template.Spec.SecurityContext.FSGroup)
 	}
 
-	// Should have AXON_MODEL with correct value, ANTHROPIC_API_KEY, GITHUB_TOKEN, GH_TOKEN.
+	// Should have KELOS_MODEL with correct value, ANTHROPIC_API_KEY, GITHUB_TOKEN, GH_TOKEN.
 	envMap := map[string]string{}
 	for _, env := range container.Env {
 		if env.Value != "" {
@@ -399,37 +399,37 @@ func TestBuildClaudeCodeJob_CustomImageWithWorkspace(t *testing.T) {
 			envMap[env.Name] = "(from-secret)"
 		}
 	}
-	for _, name := range []string{"AXON_MODEL", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
+	for _, name := range []string{"KELOS_MODEL", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
 		if _, ok := envMap[name]; !ok {
 			t.Errorf("Expected env var %q to be set", name)
 		}
 	}
-	if envMap["AXON_MODEL"] != "gpt-4" {
-		t.Errorf("AXON_MODEL value: expected %q, got %q", "gpt-4", envMap["AXON_MODEL"])
+	if envMap["KELOS_MODEL"] != "gpt-4" {
+		t.Errorf("KELOS_MODEL value: expected %q, got %q", "gpt-4", envMap["KELOS_MODEL"])
 	}
 }
 
 func TestBuildClaudeCodeJob_WorkspaceWithSecretRefPersistsCredentialHelper(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-persist-cred",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -460,24 +460,24 @@ func TestBuildClaudeCodeJob_WorkspaceWithSecretRefPersistsCredentialHelper(t *te
 
 func TestBuildClaudeCodeJob_EnterpriseWorkspaceSetsGHHostAndEnterpriseToken(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-ghe",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.example.com/my-org/my-repo.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -535,24 +535,24 @@ func TestBuildClaudeCodeJob_EnterpriseWorkspaceSetsGHHostAndEnterpriseToken(t *t
 
 func TestBuildClaudeCodeJob_GithubComWorkspaceUsesGHToken(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-no-ghe",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/my-org/my-repo.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -588,17 +588,17 @@ func TestBuildClaudeCodeJob_GithubComWorkspaceUsesGHToken(t *testing.T) {
 
 func TestBuildCodexJob_DefaultImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-codex",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "openai-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "openai-secret"},
 			},
 			Model: "gpt-4.1",
 		},
@@ -621,9 +621,9 @@ func TestBuildCodexJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected container name %q, got %q", AgentTypeCodex, container.Name)
 	}
 
-	// Command should be /axon_entrypoint.sh (uniform interface).
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh (uniform interface).
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 
 	// Args should be just the prompt.
@@ -631,18 +631,18 @@ func TestBuildCodexJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
 	}
 
-	// AXON_MODEL should be set.
-	foundAxonModel := false
+	// KELOS_MODEL should be set.
+	foundKelosModel := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MODEL" {
-			foundAxonModel = true
+		if env.Name == "KELOS_MODEL" {
+			foundKelosModel = true
 			if env.Value != "gpt-4.1" {
-				t.Errorf("AXON_MODEL value: expected %q, got %q", "gpt-4.1", env.Value)
+				t.Errorf("KELOS_MODEL value: expected %q, got %q", "gpt-4.1", env.Value)
 			}
 		}
 	}
-	if !foundAxonModel {
-		t.Error("Expected AXON_MODEL env var to be set")
+	if !foundKelosModel {
+		t.Error("Expected KELOS_MODEL env var to be set")
 	}
 
 	// CODEX_API_KEY should be set (not ANTHROPIC_API_KEY).
@@ -672,17 +672,17 @@ func TestBuildCodexJob_DefaultImage(t *testing.T) {
 
 func TestBuildCodexJob_CustomImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-codex-custom",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Refactor the module",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "openai-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "openai-secret"},
 			},
 			Image: "my-codex:v2",
 		},
@@ -700,34 +700,34 @@ func TestBuildCodexJob_CustomImage(t *testing.T) {
 		t.Errorf("Expected image %q, got %q", "my-codex:v2", container.Image)
 	}
 
-	// Command should be /axon_entrypoint.sh.
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh.
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 }
 
 func TestBuildCodexJob_WithWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-codex-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "openai-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "openai-secret"},
 			},
 			Model: "gpt-4.1",
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -747,7 +747,7 @@ func TestBuildCodexJob_WithWorkspace(t *testing.T) {
 		t.Fatalf("Expected 1 volume mount, got %d", len(container.VolumeMounts))
 	}
 
-	// Should have CODEX_API_KEY (not ANTHROPIC_API_KEY), AXON_MODEL, GITHUB_TOKEN, GH_TOKEN.
+	// Should have CODEX_API_KEY (not ANTHROPIC_API_KEY), KELOS_MODEL, GITHUB_TOKEN, GH_TOKEN.
 	envMap := map[string]string{}
 	for _, env := range container.Env {
 		if env.Value != "" {
@@ -756,7 +756,7 @@ func TestBuildCodexJob_WithWorkspace(t *testing.T) {
 			envMap[env.Name] = "(from-secret)"
 		}
 	}
-	for _, name := range []string{"AXON_MODEL", "CODEX_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
+	for _, name := range []string{"KELOS_MODEL", "CODEX_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
 		if _, ok := envMap[name]; !ok {
 			t.Errorf("Expected env var %q to be set", name)
 		}
@@ -780,17 +780,17 @@ func TestBuildCodexJob_WithWorkspace(t *testing.T) {
 
 func TestBuildCodexJob_OAuthCredentials(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-codex-oauth",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Review the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeOAuth,
-				SecretRef: axonv1alpha1.SecretReference{Name: "codex-oauth"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "codex-oauth"},
 			},
 		},
 	}
@@ -832,17 +832,17 @@ func TestBuildCodexJob_OAuthCredentials(t *testing.T) {
 
 func TestBuildGeminiJob_DefaultImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gemini",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeGemini,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "gemini-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "gemini-secret"},
 			},
 			Model: "gemini-2.5-pro",
 		},
@@ -865,9 +865,9 @@ func TestBuildGeminiJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected container name %q, got %q", AgentTypeGemini, container.Name)
 	}
 
-	// Command should be /axon_entrypoint.sh (uniform interface).
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh (uniform interface).
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 
 	// Args should be just the prompt.
@@ -875,18 +875,18 @@ func TestBuildGeminiJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
 	}
 
-	// AXON_MODEL should be set.
-	foundAxonModel := false
+	// KELOS_MODEL should be set.
+	foundKelosModel := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MODEL" {
-			foundAxonModel = true
+		if env.Name == "KELOS_MODEL" {
+			foundKelosModel = true
 			if env.Value != "gemini-2.5-pro" {
-				t.Errorf("AXON_MODEL value: expected %q, got %q", "gemini-2.5-pro", env.Value)
+				t.Errorf("KELOS_MODEL value: expected %q, got %q", "gemini-2.5-pro", env.Value)
 			}
 		}
 	}
-	if !foundAxonModel {
-		t.Error("Expected AXON_MODEL env var to be set")
+	if !foundKelosModel {
+		t.Error("Expected KELOS_MODEL env var to be set")
 	}
 
 	// GEMINI_API_KEY should be set (not ANTHROPIC_API_KEY or CODEX_API_KEY).
@@ -919,17 +919,17 @@ func TestBuildGeminiJob_DefaultImage(t *testing.T) {
 
 func TestBuildGeminiJob_CustomImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gemini-custom",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeGemini,
 			Prompt: "Refactor the module",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "gemini-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "gemini-secret"},
 			},
 			Image: "my-gemini:v2",
 		},
@@ -947,34 +947,34 @@ func TestBuildGeminiJob_CustomImage(t *testing.T) {
 		t.Errorf("Expected image %q, got %q", "my-gemini:v2", container.Image)
 	}
 
-	// Command should be /axon_entrypoint.sh.
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh.
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 }
 
 func TestBuildGeminiJob_WithWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gemini-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeGemini,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "gemini-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "gemini-secret"},
 			},
 			Model: "gemini-2.5-pro",
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -994,7 +994,7 @@ func TestBuildGeminiJob_WithWorkspace(t *testing.T) {
 		t.Fatalf("Expected 1 volume mount, got %d", len(container.VolumeMounts))
 	}
 
-	// Should have GEMINI_API_KEY (not ANTHROPIC_API_KEY), AXON_MODEL, GITHUB_TOKEN, GH_TOKEN.
+	// Should have GEMINI_API_KEY (not ANTHROPIC_API_KEY), KELOS_MODEL, GITHUB_TOKEN, GH_TOKEN.
 	envMap := map[string]string{}
 	for _, env := range container.Env {
 		if env.Value != "" {
@@ -1003,7 +1003,7 @@ func TestBuildGeminiJob_WithWorkspace(t *testing.T) {
 			envMap[env.Name] = "(from-secret)"
 		}
 	}
-	for _, name := range []string{"AXON_MODEL", "GEMINI_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
+	for _, name := range []string{"KELOS_MODEL", "GEMINI_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
 		if _, ok := envMap[name]; !ok {
 			t.Errorf("Expected env var %q to be set", name)
 		}
@@ -1030,17 +1030,17 @@ func TestBuildGeminiJob_WithWorkspace(t *testing.T) {
 
 func TestBuildGeminiJob_OAuthCredentials(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gemini-oauth",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeGemini,
 			Prompt: "Review the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeOAuth,
-				SecretRef: axonv1alpha1.SecretReference{Name: "gemini-oauth"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "gemini-oauth"},
 			},
 		},
 	}
@@ -1082,17 +1082,17 @@ func TestBuildGeminiJob_OAuthCredentials(t *testing.T) {
 
 func TestBuildOpenCodeJob_DefaultImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-opencode",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeOpenCode,
 			Prompt: "Fix the bug",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "opencode-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "opencode-secret"},
 			},
 			Model: "anthropic/claude-sonnet-4-20250514",
 		},
@@ -1115,9 +1115,9 @@ func TestBuildOpenCodeJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected container name %q, got %q", AgentTypeOpenCode, container.Name)
 	}
 
-	// Command should be /axon_entrypoint.sh (uniform interface).
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh (uniform interface).
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 
 	// Args should be just the prompt.
@@ -1125,18 +1125,18 @@ func TestBuildOpenCodeJob_DefaultImage(t *testing.T) {
 		t.Errorf("Expected args [Fix the bug], got %v", container.Args)
 	}
 
-	// AXON_MODEL should be set.
-	foundAxonModel := false
+	// KELOS_MODEL should be set.
+	foundKelosModel := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MODEL" {
-			foundAxonModel = true
+		if env.Name == "KELOS_MODEL" {
+			foundKelosModel = true
 			if env.Value != "anthropic/claude-sonnet-4-20250514" {
-				t.Errorf("AXON_MODEL value: expected %q, got %q", "anthropic/claude-sonnet-4-20250514", env.Value)
+				t.Errorf("KELOS_MODEL value: expected %q, got %q", "anthropic/claude-sonnet-4-20250514", env.Value)
 			}
 		}
 	}
-	if !foundAxonModel {
-		t.Error("Expected AXON_MODEL env var to be set")
+	if !foundKelosModel {
+		t.Error("Expected KELOS_MODEL env var to be set")
 	}
 
 	// OPENCODE_API_KEY should be set (not ANTHROPIC_API_KEY, CODEX_API_KEY, or GEMINI_API_KEY).
@@ -1172,17 +1172,17 @@ func TestBuildOpenCodeJob_DefaultImage(t *testing.T) {
 
 func TestBuildOpenCodeJob_CustomImage(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-opencode-custom",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeOpenCode,
 			Prompt: "Refactor the module",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "opencode-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "opencode-secret"},
 			},
 			Image: "my-opencode:v2",
 		},
@@ -1200,34 +1200,34 @@ func TestBuildOpenCodeJob_CustomImage(t *testing.T) {
 		t.Errorf("Expected image %q, got %q", "my-opencode:v2", container.Image)
 	}
 
-	// Command should be /axon_entrypoint.sh.
-	if len(container.Command) != 1 || container.Command[0] != "/axon_entrypoint.sh" {
-		t.Errorf("Expected command [/axon_entrypoint.sh], got %v", container.Command)
+	// Command should be /kelos_entrypoint.sh.
+	if len(container.Command) != 1 || container.Command[0] != "/kelos_entrypoint.sh" {
+		t.Errorf("Expected command [/kelos_entrypoint.sh], got %v", container.Command)
 	}
 }
 
 func TestBuildOpenCodeJob_WithWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-opencode-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeOpenCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "opencode-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "opencode-secret"},
 			},
 			Model: "anthropic/claude-sonnet-4-20250514",
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -1247,7 +1247,7 @@ func TestBuildOpenCodeJob_WithWorkspace(t *testing.T) {
 		t.Fatalf("Expected 1 volume mount, got %d", len(container.VolumeMounts))
 	}
 
-	// Should have OPENCODE_API_KEY (not ANTHROPIC_API_KEY), AXON_MODEL, GITHUB_TOKEN, GH_TOKEN.
+	// Should have OPENCODE_API_KEY (not ANTHROPIC_API_KEY), KELOS_MODEL, GITHUB_TOKEN, GH_TOKEN.
 	envMap := map[string]string{}
 	for _, env := range container.Env {
 		if env.Value != "" {
@@ -1256,7 +1256,7 @@ func TestBuildOpenCodeJob_WithWorkspace(t *testing.T) {
 			envMap[env.Name] = "(from-secret)"
 		}
 	}
-	for _, name := range []string{"AXON_MODEL", "OPENCODE_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
+	for _, name := range []string{"KELOS_MODEL", "OPENCODE_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"} {
 		if _, ok := envMap[name]; !ok {
 			t.Errorf("Expected env var %q to be set", name)
 		}
@@ -1286,17 +1286,17 @@ func TestBuildOpenCodeJob_WithWorkspace(t *testing.T) {
 
 func TestBuildOpenCodeJob_OAuthCredentials(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-opencode-oauth",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeOpenCode,
 			Prompt: "Review the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeOAuth,
-				SecretRef: axonv1alpha1.SecretReference{Name: "opencode-oauth"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "opencode-oauth"},
 			},
 		},
 	}
@@ -1341,17 +1341,17 @@ func TestBuildOpenCodeJob_OAuthCredentials(t *testing.T) {
 
 func TestBuildClaudeCodeJob_UnsupportedType(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-unsupported",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   "unsupported-agent",
 			Prompt: "Hello",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -1366,19 +1366,19 @@ func int64Ptr(v int64) *int64 { return &v }
 
 func TestBuildJob_PodOverridesResources(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-resources",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				Resources: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -1420,19 +1420,19 @@ func TestBuildJob_PodOverridesResources(t *testing.T) {
 
 func TestBuildJob_PodOverridesActiveDeadlineSeconds(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deadline",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				ActiveDeadlineSeconds: int64Ptr(1800),
 			},
 		},
@@ -1453,20 +1453,20 @@ func TestBuildJob_PodOverridesActiveDeadlineSeconds(t *testing.T) {
 
 func TestBuildJob_PodOverridesEnv(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-env",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 			Model: "claude-sonnet-4-20250514",
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				Env: []corev1.EnvVar{
 					{Name: "HTTP_PROXY", Value: "http://proxy:8080"},
 					{Name: "NO_PROXY", Value: "localhost"},
@@ -1497,30 +1497,30 @@ func TestBuildJob_PodOverridesEnv(t *testing.T) {
 	}
 
 	// Built-in env vars should still be present.
-	if envMap["AXON_MODEL"] != "claude-sonnet-4-20250514" {
-		t.Errorf("Expected AXON_MODEL to still be set, got %q", envMap["AXON_MODEL"])
+	if envMap["KELOS_MODEL"] != "claude-sonnet-4-20250514" {
+		t.Errorf("Expected KELOS_MODEL to still be set, got %q", envMap["KELOS_MODEL"])
 	}
 }
 
 func TestBuildJob_PodOverridesEnvBuiltinPrecedence(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-env-precedence",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 			Model: "claude-sonnet-4-20250514",
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				Env: []corev1.EnvVar{
 					// Attempt to override a built-in env var.
-					{Name: "AXON_MODEL", Value: "should-not-take-effect"},
+					{Name: "KELOS_MODEL", Value: "should-not-take-effect"},
 				},
 			},
 		},
@@ -1535,35 +1535,35 @@ func TestBuildJob_PodOverridesEnvBuiltinPrecedence(t *testing.T) {
 
 	// User env vars that collide with built-in names should be filtered out
 	// so that built-in vars always take precedence.
-	var axonModelCount int
+	var kelosModelCount int
 	for _, e := range container.Env {
-		if e.Name == "AXON_MODEL" {
-			axonModelCount++
+		if e.Name == "KELOS_MODEL" {
+			kelosModelCount++
 			if e.Value != "claude-sonnet-4-20250514" {
-				t.Errorf("Expected AXON_MODEL value %q, got %q", "claude-sonnet-4-20250514", e.Value)
+				t.Errorf("Expected KELOS_MODEL value %q, got %q", "claude-sonnet-4-20250514", e.Value)
 			}
 		}
 	}
-	if axonModelCount != 1 {
-		t.Errorf("Expected exactly 1 AXON_MODEL env var, got %d", axonModelCount)
+	if kelosModelCount != 1 {
+		t.Errorf("Expected exactly 1 KELOS_MODEL env var, got %d", kelosModelCount)
 	}
 }
 
 func TestBuildJob_PodOverridesNodeSelector(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-node-selector",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				NodeSelector: map[string]string{
 					"workload-type": "ai-agent",
 					"gpu":           "true",
@@ -1591,19 +1591,19 @@ func TestBuildJob_PodOverridesNodeSelector(t *testing.T) {
 
 func TestBuildJob_PodOverridesAllFields(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-all-overrides",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "openai-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "openai-secret"},
 			},
-			PodOverrides: &axonv1alpha1.PodOverrides{
+			PodOverrides: &kelosv1alpha1.PodOverrides{
 				Resources: &corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -1657,17 +1657,17 @@ func TestBuildJob_PodOverridesAllFields(t *testing.T) {
 
 func TestBuildJob_NoPodOverrides(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-no-overrides",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -1697,22 +1697,22 @@ func TestBuildJob_NoPodOverrides(t *testing.T) {
 
 func TestBuildJob_AgentConfigAgentsMD(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-agentsmd",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Follow TDD. Always write tests first.",
 	}
 
@@ -1723,18 +1723,18 @@ func TestBuildJob_AgentConfigAgentsMD(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 
-	// AXON_AGENTS_MD should be set.
+	// KELOS_AGENTS_MD should be set.
 	foundAgentsMD := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_AGENTS_MD" {
+		if env.Name == "KELOS_AGENTS_MD" {
 			foundAgentsMD = true
 			if env.Value != "Follow TDD. Always write tests first." {
-				t.Errorf("AXON_AGENTS_MD value: expected %q, got %q", "Follow TDD. Always write tests first.", env.Value)
+				t.Errorf("KELOS_AGENTS_MD value: expected %q, got %q", "Follow TDD. Always write tests first.", env.Value)
 			}
 		}
 	}
 	if !foundAgentsMD {
-		t.Error("Expected AXON_AGENTS_MD env var to be set")
+		t.Error("Expected KELOS_AGENTS_MD env var to be set")
 	}
 
 	// No plugin volume or init containers should be created.
@@ -1748,29 +1748,29 @@ func TestBuildJob_AgentConfigAgentsMD(t *testing.T) {
 
 func TestBuildJob_AgentConfigPlugins(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-plugins",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		Plugins: []axonv1alpha1.PluginSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "team-tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "deploy", Content: "Deploy instructions here"},
 				},
-				Agents: []axonv1alpha1.AgentDefinition{
+				Agents: []kelosv1alpha1.AgentDefinition{
 					{Name: "reviewer", Content: "You are a code reviewer"},
 				},
 			},
@@ -1839,41 +1839,41 @@ func TestBuildJob_AgentConfigPlugins(t *testing.T) {
 		t.Error("Expected plugin volume mount on main container")
 	}
 
-	// AXON_PLUGIN_DIR should be set.
+	// KELOS_PLUGIN_DIR should be set.
 	envMap := map[string]string{}
 	for _, env := range container.Env {
 		if env.Value != "" {
 			envMap[env.Name] = env.Value
 		}
 	}
-	if envMap["AXON_PLUGIN_DIR"] != PluginMountPath {
-		t.Errorf("Expected AXON_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["AXON_PLUGIN_DIR"])
+	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
+		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 }
 
 func TestBuildJob_AgentConfigFull(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-full-config",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Follow TDD",
-		Plugins: []axonv1alpha1.PluginSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "deploy", Content: "Deploy content"},
 				},
 			},
@@ -1894,11 +1894,11 @@ func TestBuildJob_AgentConfigFull(t *testing.T) {
 	}
 
 	// Both env vars should be set.
-	if envMap["AXON_AGENTS_MD"] != "Follow TDD" {
-		t.Errorf("Expected AXON_AGENTS_MD=%q, got %q", "Follow TDD", envMap["AXON_AGENTS_MD"])
+	if envMap["KELOS_AGENTS_MD"] != "Follow TDD" {
+		t.Errorf("Expected KELOS_AGENTS_MD=%q, got %q", "Follow TDD", envMap["KELOS_AGENTS_MD"])
 	}
-	if envMap["AXON_PLUGIN_DIR"] != PluginMountPath {
-		t.Errorf("Expected AXON_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["AXON_PLUGIN_DIR"])
+	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
+		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
 	// Should have plugin volume and init container.
@@ -1912,32 +1912,32 @@ func TestBuildJob_AgentConfigFull(t *testing.T) {
 
 func TestBuildJob_AgentConfigWithWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-config-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Follow TDD",
-		Plugins: []axonv1alpha1.PluginSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "deploy", Content: "Deploy content"},
 				},
 			},
@@ -1973,22 +1973,22 @@ func TestBuildJob_AgentConfigWithWorkspace(t *testing.T) {
 
 func TestBuildJob_AgentConfigWithoutWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-config-no-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Follow TDD",
 	}
 
@@ -2006,8 +2006,8 @@ func TestBuildJob_AgentConfigWithoutWorkspace(t *testing.T) {
 			envMap[env.Name] = env.Value
 		}
 	}
-	if envMap["AXON_AGENTS_MD"] != "Follow TDD" {
-		t.Errorf("Expected AXON_AGENTS_MD=%q, got %q", "Follow TDD", envMap["AXON_AGENTS_MD"])
+	if envMap["KELOS_AGENTS_MD"] != "Follow TDD" {
+		t.Errorf("Expected KELOS_AGENTS_MD=%q, got %q", "Follow TDD", envMap["KELOS_AGENTS_MD"])
 	}
 
 	// No workspace volume.
@@ -2023,30 +2023,30 @@ func TestBuildJob_AgentConfigWithoutWorkspace(t *testing.T) {
 
 func TestBuildJob_AgentConfigCodex(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-codex-agentconfig",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Follow TDD. Always write tests first.",
-		Plugins: []axonv1alpha1.PluginSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "team-tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "deploy", Content: "Deploy instructions here"},
 				},
-				Agents: []axonv1alpha1.AgentDefinition{
+				Agents: []kelosv1alpha1.AgentDefinition{
 					{Name: "reviewer", Content: "You are a code reviewer"},
 				},
 			},
@@ -2066,14 +2066,14 @@ func TestBuildJob_AgentConfigCodex(t *testing.T) {
 		}
 	}
 
-	// AXON_AGENTS_MD should be set for codex tasks.
-	if envMap["AXON_AGENTS_MD"] != "Follow TDD. Always write tests first." {
-		t.Errorf("Expected AXON_AGENTS_MD=%q, got %q", "Follow TDD. Always write tests first.", envMap["AXON_AGENTS_MD"])
+	// KELOS_AGENTS_MD should be set for codex tasks.
+	if envMap["KELOS_AGENTS_MD"] != "Follow TDD. Always write tests first." {
+		t.Errorf("Expected KELOS_AGENTS_MD=%q, got %q", "Follow TDD. Always write tests first.", envMap["KELOS_AGENTS_MD"])
 	}
 
-	// AXON_PLUGIN_DIR should be set for codex tasks.
-	if envMap["AXON_PLUGIN_DIR"] != PluginMountPath {
-		t.Errorf("Expected AXON_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["AXON_PLUGIN_DIR"])
+	// KELOS_PLUGIN_DIR should be set for codex tasks.
+	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
+		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
 	// Should have plugin volume and init container.
@@ -2092,27 +2092,27 @@ func TestBuildJob_AgentConfigCodex(t *testing.T) {
 
 func TestBuildJob_AgentConfigGemini(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-gemini-agentconfig",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeGemini,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Use conventional commits.",
-		Plugins: []axonv1alpha1.PluginSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "ci-tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "lint", Content: "Run linter before committing"},
 				},
 			},
@@ -2132,14 +2132,14 @@ func TestBuildJob_AgentConfigGemini(t *testing.T) {
 		}
 	}
 
-	// AXON_AGENTS_MD should be set for gemini tasks.
-	if envMap["AXON_AGENTS_MD"] != "Use conventional commits." {
-		t.Errorf("Expected AXON_AGENTS_MD=%q, got %q", "Use conventional commits.", envMap["AXON_AGENTS_MD"])
+	// KELOS_AGENTS_MD should be set for gemini tasks.
+	if envMap["KELOS_AGENTS_MD"] != "Use conventional commits." {
+		t.Errorf("Expected KELOS_AGENTS_MD=%q, got %q", "Use conventional commits.", envMap["KELOS_AGENTS_MD"])
 	}
 
-	// AXON_PLUGIN_DIR should be set for gemini tasks.
-	if envMap["AXON_PLUGIN_DIR"] != PluginMountPath {
-		t.Errorf("Expected AXON_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["AXON_PLUGIN_DIR"])
+	// KELOS_PLUGIN_DIR should be set for gemini tasks.
+	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
+		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
 	// Should have plugin volume and init container.
@@ -2158,30 +2158,30 @@ func TestBuildJob_AgentConfigGemini(t *testing.T) {
 
 func TestBuildJob_AgentConfigOpenCode(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-opencode-agentconfig",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeOpenCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Always run tests before committing.",
-		Plugins: []axonv1alpha1.PluginSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "dev-tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "test", Content: "Run unit tests first"},
 				},
-				Agents: []axonv1alpha1.AgentDefinition{
+				Agents: []kelosv1alpha1.AgentDefinition{
 					{Name: "linter", Content: "You are a code linter"},
 				},
 			},
@@ -2201,14 +2201,14 @@ func TestBuildJob_AgentConfigOpenCode(t *testing.T) {
 		}
 	}
 
-	// AXON_AGENTS_MD should be set for opencode tasks.
-	if envMap["AXON_AGENTS_MD"] != "Always run tests before committing." {
-		t.Errorf("Expected AXON_AGENTS_MD=%q, got %q", "Always run tests before committing.", envMap["AXON_AGENTS_MD"])
+	// KELOS_AGENTS_MD should be set for opencode tasks.
+	if envMap["KELOS_AGENTS_MD"] != "Always run tests before committing." {
+		t.Errorf("Expected KELOS_AGENTS_MD=%q, got %q", "Always run tests before committing.", envMap["KELOS_AGENTS_MD"])
 	}
 
-	// AXON_PLUGIN_DIR should be set for opencode tasks.
-	if envMap["AXON_PLUGIN_DIR"] != PluginMountPath {
-		t.Errorf("Expected AXON_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["AXON_PLUGIN_DIR"])
+	// KELOS_PLUGIN_DIR should be set for opencode tasks.
+	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
+		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
 	// Should have plugin volume and init container.
@@ -2227,58 +2227,58 @@ func TestBuildJob_AgentConfigOpenCode(t *testing.T) {
 
 func TestBuildJob_AgentConfigPluginNamePathTraversal(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-traversal",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
 	tests := []struct {
 		name       string
-		config     *axonv1alpha1.AgentConfigSpec
+		config     *kelosv1alpha1.AgentConfigSpec
 		wantErrStr string
 	}{
 		{
 			name: "plugin name with slash",
-			config: &axonv1alpha1.AgentConfigSpec{
-				Plugins: []axonv1alpha1.PluginSpec{
-					{Name: "../../etc", Skills: []axonv1alpha1.SkillDefinition{{Name: "s", Content: "c"}}},
+			config: &kelosv1alpha1.AgentConfigSpec{
+				Plugins: []kelosv1alpha1.PluginSpec{
+					{Name: "../../etc", Skills: []kelosv1alpha1.SkillDefinition{{Name: "s", Content: "c"}}},
 				},
 			},
 			wantErrStr: "path separators",
 		},
 		{
 			name: "skill name with slash",
-			config: &axonv1alpha1.AgentConfigSpec{
-				Plugins: []axonv1alpha1.PluginSpec{
-					{Name: "ok", Skills: []axonv1alpha1.SkillDefinition{{Name: "../evil", Content: "c"}}},
+			config: &kelosv1alpha1.AgentConfigSpec{
+				Plugins: []kelosv1alpha1.PluginSpec{
+					{Name: "ok", Skills: []kelosv1alpha1.SkillDefinition{{Name: "../evil", Content: "c"}}},
 				},
 			},
 			wantErrStr: "path separators",
 		},
 		{
 			name: "agent name dot-dot",
-			config: &axonv1alpha1.AgentConfigSpec{
-				Plugins: []axonv1alpha1.PluginSpec{
-					{Name: "ok", Agents: []axonv1alpha1.AgentDefinition{{Name: "..", Content: "c"}}},
+			config: &kelosv1alpha1.AgentConfigSpec{
+				Plugins: []kelosv1alpha1.PluginSpec{
+					{Name: "ok", Agents: []kelosv1alpha1.AgentDefinition{{Name: "..", Content: "c"}}},
 				},
 			},
 			wantErrStr: "path traversal",
 		},
 		{
 			name: "plugin name is dot",
-			config: &axonv1alpha1.AgentConfigSpec{
-				Plugins: []axonv1alpha1.PluginSpec{
-					{Name: ".", Skills: []axonv1alpha1.SkillDefinition{{Name: "s", Content: "c"}}},
+			config: &kelosv1alpha1.AgentConfigSpec{
+				Plugins: []kelosv1alpha1.PluginSpec{
+					{Name: ".", Skills: []kelosv1alpha1.SkillDefinition{{Name: "s", Content: "c"}}},
 				},
 			},
 			wantErrStr: "path traversal",
@@ -2300,23 +2300,23 @@ func TestBuildJob_AgentConfigPluginNamePathTraversal(t *testing.T) {
 
 func TestBuildJob_BranchSetupInitContainer(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-branch",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
 			Branch: "feature-x",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
 	}
@@ -2343,8 +2343,8 @@ func TestBuildJob_BranchSetupInitContainer(t *testing.T) {
 		t.Fatalf("Expected command [sh -c ...], got %v", branchSetup.Command)
 	}
 	script := branchSetup.Command[2]
-	if !strings.Contains(script, "$AXON_BRANCH") {
-		t.Error("Expected branch-setup script to reference $AXON_BRANCH")
+	if !strings.Contains(script, "$KELOS_BRANCH") {
+		t.Error("Expected branch-setup script to reference $KELOS_BRANCH")
 	}
 	if !strings.Contains(script, "git checkout") {
 		t.Error("Expected branch-setup script to include git checkout")
@@ -2357,52 +2357,52 @@ func TestBuildJob_BranchSetupInitContainer(t *testing.T) {
 		t.Error("Expected no credential helper without secretRef")
 	}
 
-	// Verify AXON_BRANCH env var on init container.
+	// Verify KELOS_BRANCH env var on init container.
 	var foundBranch bool
 	for _, env := range branchSetup.Env {
-		if env.Name == "AXON_BRANCH" && env.Value == "feature-x" {
+		if env.Name == "KELOS_BRANCH" && env.Value == "feature-x" {
 			foundBranch = true
 		}
 	}
 	if !foundBranch {
-		t.Error("Expected AXON_BRANCH=feature-x env var on branch-setup")
+		t.Error("Expected KELOS_BRANCH=feature-x env var on branch-setup")
 	}
 
-	// Verify AXON_BRANCH env var on main container.
+	// Verify KELOS_BRANCH env var on main container.
 	mainContainer := job.Spec.Template.Spec.Containers[0]
 	var foundMainBranch bool
 	for _, env := range mainContainer.Env {
-		if env.Name == "AXON_BRANCH" && env.Value == "feature-x" {
+		if env.Name == "KELOS_BRANCH" && env.Value == "feature-x" {
 			foundMainBranch = true
 		}
 	}
 	if !foundMainBranch {
-		t.Error("Expected AXON_BRANCH=feature-x env var on main container")
+		t.Error("Expected KELOS_BRANCH=feature-x env var on main container")
 	}
 }
 
 func TestBuildJob_BranchSetupWithSecretRefUsesCredentialHelper(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-branch-cred",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
 			Branch: "feature-y",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -2442,18 +2442,18 @@ func TestBuildJob_BranchSetupWithSecretRefUsesCredentialHelper(t *testing.T) {
 
 func TestBuildJob_BranchWithoutWorkspaceNoInitContainer(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-branch-no-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
 			Branch: "feature-z",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -2468,41 +2468,41 @@ func TestBuildJob_BranchWithoutWorkspaceNoInitContainer(t *testing.T) {
 		t.Errorf("Expected 0 init containers without workspace, got %d", len(job.Spec.Template.Spec.InitContainers))
 	}
 
-	// AXON_BRANCH should still be set on the main container.
+	// KELOS_BRANCH should still be set on the main container.
 	mainContainer := job.Spec.Template.Spec.Containers[0]
 	var foundBranch bool
 	for _, env := range mainContainer.Env {
-		if env.Name == "AXON_BRANCH" && env.Value == "feature-z" {
+		if env.Name == "KELOS_BRANCH" && env.Value == "feature-z" {
 			foundBranch = true
 		}
 	}
 	if !foundBranch {
-		t.Error("Expected AXON_BRANCH=feature-z env var even without workspace")
+		t.Error("Expected KELOS_BRANCH=feature-z env var even without workspace")
 	}
 }
 
 func TestBuildJob_BranchEnvDoesNotMutateWorkspaceEnvVars(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-branch-env-safety",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
 			Branch: "feature-w",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "main",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -2512,19 +2512,19 @@ func TestBuildJob_BranchEnvDoesNotMutateWorkspaceEnvVars(t *testing.T) {
 		t.Fatalf("Build() returned error: %v", err)
 	}
 
-	// The git-clone init container should NOT have AXON_BRANCH in its env.
+	// The git-clone init container should NOT have KELOS_BRANCH in its env.
 	gitClone := job.Spec.Template.Spec.InitContainers[0]
 	if gitClone.Name != "git-clone" {
 		t.Fatalf("Expected first init container to be git-clone, got %s", gitClone.Name)
 	}
 	for _, env := range gitClone.Env {
-		if env.Name == "AXON_BRANCH" {
-			t.Error("git-clone init container should not have AXON_BRANCH env var (slice mutation bug)")
+		if env.Name == "KELOS_BRANCH" {
+			t.Error("git-clone init container should not have KELOS_BRANCH env var (slice mutation bug)")
 		}
 	}
 }
 
-func TestBuildJob_AxonAgentTypeAlwaysSet(t *testing.T) {
+func TestBuildJob_KelosAgentTypeAlwaysSet(t *testing.T) {
 	tests := []struct {
 		name      string
 		agentType string
@@ -2538,17 +2538,17 @@ func TestBuildJob_AxonAgentTypeAlwaysSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			builder := NewJobBuilder()
-			task := &axonv1alpha1.Task{
+			task := &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-agent-type",
 					Namespace: "default",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   tt.agentType,
 					Prompt: "Hello",
-					Credentials: axonv1alpha1.Credentials{
-						Type:      axonv1alpha1.CredentialTypeAPIKey,
-						SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeAPIKey,
+						SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 					},
 				},
 			}
@@ -2561,15 +2561,15 @@ func TestBuildJob_AxonAgentTypeAlwaysSet(t *testing.T) {
 			container := job.Spec.Template.Spec.Containers[0]
 			found := false
 			for _, env := range container.Env {
-				if env.Name == "AXON_AGENT_TYPE" {
+				if env.Name == "KELOS_AGENT_TYPE" {
 					found = true
 					if env.Value != tt.agentType {
-						t.Errorf("AXON_AGENT_TYPE: expected %q, got %q", tt.agentType, env.Value)
+						t.Errorf("KELOS_AGENT_TYPE: expected %q, got %q", tt.agentType, env.Value)
 					}
 				}
 			}
 			if !found {
-				t.Error("Expected AXON_AGENT_TYPE env var to be set")
+				t.Error("Expected KELOS_AGENT_TYPE env var to be set")
 			}
 		})
 	}
@@ -2577,23 +2577,23 @@ func TestBuildJob_AxonAgentTypeAlwaysSet(t *testing.T) {
 
 func TestBuildJob_AgentConfigMCPServers(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{
 				Name: "github",
 				Type: "http",
@@ -2616,15 +2616,15 @@ func TestBuildJob_AgentConfigMCPServers(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 
-	// AXON_MCP_SERVERS should be set.
+	// KELOS_MCP_SERVERS should be set.
 	var mcpJSON string
 	for _, env := range container.Env {
-		if env.Name == "AXON_MCP_SERVERS" {
+		if env.Name == "KELOS_MCP_SERVERS" {
 			mcpJSON = env.Value
 		}
 	}
 	if mcpJSON == "" {
-		t.Fatal("Expected AXON_MCP_SERVERS env var to be set")
+		t.Fatal("Expected KELOS_MCP_SERVERS env var to be set")
 	}
 
 	// Verify the JSON structure matches .mcp.json format.
@@ -2638,7 +2638,7 @@ func TestBuildJob_AgentConfigMCPServers(t *testing.T) {
 		} `json:"mcpServers"`
 	}
 	if err := json.Unmarshal([]byte(mcpJSON), &parsed); err != nil {
-		t.Fatalf("Failed to parse AXON_MCP_SERVERS JSON: %v", err)
+		t.Fatalf("Failed to parse KELOS_MCP_SERVERS JSON: %v", err)
 	}
 
 	if len(parsed.MCPServers) != 2 {
@@ -2684,23 +2684,23 @@ func TestBuildJob_AgentConfigMCPServers(t *testing.T) {
 
 func TestBuildJob_AgentConfigMCPServersWithHTTPHeaders(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp-headers",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{
 				Name:    "secure-api",
 				Type:    "http",
@@ -2719,12 +2719,12 @@ func TestBuildJob_AgentConfigMCPServersWithHTTPHeaders(t *testing.T) {
 
 	var mcpJSON string
 	for _, env := range container.Env {
-		if env.Name == "AXON_MCP_SERVERS" {
+		if env.Name == "KELOS_MCP_SERVERS" {
 			mcpJSON = env.Value
 		}
 	}
 	if mcpJSON == "" {
-		t.Fatal("Expected AXON_MCP_SERVERS env var to be set")
+		t.Fatal("Expected KELOS_MCP_SERVERS env var to be set")
 	}
 
 	var parsed struct {
@@ -2733,7 +2733,7 @@ func TestBuildJob_AgentConfigMCPServersWithHTTPHeaders(t *testing.T) {
 		} `json:"mcpServers"`
 	}
 	if err := json.Unmarshal([]byte(mcpJSON), &parsed); err != nil {
-		t.Fatalf("Failed to parse AXON_MCP_SERVERS JSON: %v", err)
+		t.Fatalf("Failed to parse KELOS_MCP_SERVERS JSON: %v", err)
 	}
 
 	secureAPI, ok := parsed.MCPServers["secure-api"]
@@ -2747,32 +2747,32 @@ func TestBuildJob_AgentConfigMCPServersWithHTTPHeaders(t *testing.T) {
 
 func TestBuildJob_AgentConfigMCPServersWithPluginsAndAgentsMD(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp-full",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
 		AgentsMD: "Follow TDD",
-		Plugins: []axonv1alpha1.PluginSpec{
+		Plugins: []kelosv1alpha1.PluginSpec{
 			{
 				Name: "tools",
-				Skills: []axonv1alpha1.SkillDefinition{
+				Skills: []kelosv1alpha1.SkillDefinition{
 					{Name: "deploy", Content: "Deploy content"},
 				},
 			},
 		},
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{
 				Name: "github",
 				Type: "http",
@@ -2794,15 +2794,15 @@ func TestBuildJob_AgentConfigMCPServersWithPluginsAndAgentsMD(t *testing.T) {
 		}
 	}
 
-	// All three should be set: AXON_AGENTS_MD, AXON_PLUGIN_DIR, AXON_MCP_SERVERS.
-	if envMap["AXON_AGENTS_MD"] != "Follow TDD" {
-		t.Errorf("Expected AXON_AGENTS_MD=%q, got %q", "Follow TDD", envMap["AXON_AGENTS_MD"])
+	// All three should be set: KELOS_AGENTS_MD, KELOS_PLUGIN_DIR, KELOS_MCP_SERVERS.
+	if envMap["KELOS_AGENTS_MD"] != "Follow TDD" {
+		t.Errorf("Expected KELOS_AGENTS_MD=%q, got %q", "Follow TDD", envMap["KELOS_AGENTS_MD"])
 	}
-	if envMap["AXON_PLUGIN_DIR"] != PluginMountPath {
-		t.Errorf("Expected AXON_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["AXON_PLUGIN_DIR"])
+	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
+		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
-	if envMap["AXON_MCP_SERVERS"] == "" {
-		t.Error("Expected AXON_MCP_SERVERS to be set")
+	if envMap["KELOS_MCP_SERVERS"] == "" {
+		t.Error("Expected KELOS_MCP_SERVERS to be set")
 	}
 
 	// Should have plugin volume and init container.
@@ -2816,23 +2816,23 @@ func TestBuildJob_AgentConfigMCPServersWithPluginsAndAgentsMD(t *testing.T) {
 
 func TestBuildJob_AgentConfigMCPServersCodex(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp-codex",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeCodex,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "openai-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "openai-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{
 				Name: "github",
 				Type: "http",
@@ -2849,34 +2849,34 @@ func TestBuildJob_AgentConfigMCPServersCodex(t *testing.T) {
 	container := job.Spec.Template.Spec.Containers[0]
 	foundMCP := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MCP_SERVERS" {
+		if env.Name == "KELOS_MCP_SERVERS" {
 			foundMCP = true
 		}
 	}
 	if !foundMCP {
-		t.Error("Expected AXON_MCP_SERVERS env var to be set for codex")
+		t.Error("Expected KELOS_MCP_SERVERS env var to be set for codex")
 	}
 }
 
 func TestBuildJob_AgentConfigMCPServersGemini(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp-gemini",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeGemini,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "gemini-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "gemini-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{
 				Name: "github",
 				Type: "http",
@@ -2893,34 +2893,34 @@ func TestBuildJob_AgentConfigMCPServersGemini(t *testing.T) {
 	container := job.Spec.Template.Spec.Containers[0]
 	foundMCP := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_MCP_SERVERS" {
+		if env.Name == "KELOS_MCP_SERVERS" {
 			foundMCP = true
 		}
 	}
 	if !foundMCP {
-		t.Error("Expected AXON_MCP_SERVERS env var to be set for gemini")
+		t.Error("Expected KELOS_MCP_SERVERS env var to be set for gemini")
 	}
 }
 
 func TestBuildJob_AgentConfigMCPServersEmptyName(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp-empty-name",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{
 				Name: "",
 				Type: "http",
@@ -2940,23 +2940,23 @@ func TestBuildJob_AgentConfigMCPServersEmptyName(t *testing.T) {
 
 func TestBuildJob_AgentConfigMCPServersDuplicateName(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-mcp-dup",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix issue",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	agentConfig := &axonv1alpha1.AgentConfigSpec{
-		MCPServers: []axonv1alpha1.MCPServerSpec{
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
 			{Name: "github", Type: "http", URL: "https://api.githubcopilot.com/mcp/"},
 			{Name: "github", Type: "sse", URL: "https://other.example.com/sse"},
 		},
@@ -2985,22 +2985,22 @@ func TestBuildJob_AgentConfigMCPServerNamePathTraversal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			builder := NewJobBuilder()
-			task := &axonv1alpha1.Task{
+			task := &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-mcp-traversal",
 					Namespace: "default",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   AgentTypeClaudeCode,
 					Prompt: "Fix issue",
-					Credentials: axonv1alpha1.Credentials{
-						Type:      axonv1alpha1.CredentialTypeAPIKey,
-						SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeAPIKey,
+						SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 					},
 				},
 			}
-			agentConfig := &axonv1alpha1.AgentConfigSpec{
-				MCPServers: []axonv1alpha1.MCPServerSpec{
+			agentConfig := &kelosv1alpha1.AgentConfigSpec{
+				MCPServers: []kelosv1alpha1.MCPServerSpec{
 					{Name: tt.mcpName, Type: "http", URL: "https://example.com/mcp"},
 				},
 			}
@@ -3015,24 +3015,24 @@ func TestBuildJob_AgentConfigMCPServerNamePathTraversal(t *testing.T) {
 	}
 }
 
-func TestBuildJob_AxonBaseBranchSetWhenWorkspaceRefPresent(t *testing.T) {
+func TestBuildJob_KelosBaseBranchSetWhenWorkspaceRefPresent(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-base-branch",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 		Ref:  "develop",
 	}
@@ -3045,36 +3045,36 @@ func TestBuildJob_AxonBaseBranchSetWhenWorkspaceRefPresent(t *testing.T) {
 	container := job.Spec.Template.Spec.Containers[0]
 	found := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_BASE_BRANCH" {
+		if env.Name == "KELOS_BASE_BRANCH" {
 			found = true
 			if env.Value != "develop" {
-				t.Errorf("AXON_BASE_BRANCH: expected %q, got %q", "develop", env.Value)
+				t.Errorf("KELOS_BASE_BRANCH: expected %q, got %q", "develop", env.Value)
 			}
 		}
 	}
 	if !found {
-		t.Error("Expected AXON_BASE_BRANCH env var to be set when workspace.Ref is non-empty")
+		t.Error("Expected KELOS_BASE_BRANCH env var to be set when workspace.Ref is non-empty")
 	}
 }
 
-func TestBuildJob_AxonBaseBranchAbsentWhenRefEmpty(t *testing.T) {
+func TestBuildJob_KelosBaseBranchAbsentWhenRefEmpty(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-base-branch-empty",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/example/repo.git",
 	}
 
@@ -3085,25 +3085,25 @@ func TestBuildJob_AxonBaseBranchAbsentWhenRefEmpty(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 	for _, env := range container.Env {
-		if env.Name == "AXON_BASE_BRANCH" {
-			t.Error("AXON_BASE_BRANCH should not be set when workspace.Ref is empty")
+		if env.Name == "KELOS_BASE_BRANCH" {
+			t.Error("KELOS_BASE_BRANCH should not be set when workspace.Ref is empty")
 		}
 	}
 }
 
-func TestBuildJob_AxonBaseBranchAbsentWithoutWorkspace(t *testing.T) {
+func TestBuildJob_KelosBaseBranchAbsentWithoutWorkspace(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-base-branch-no-ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -3115,33 +3115,33 @@ func TestBuildJob_AxonBaseBranchAbsentWithoutWorkspace(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 	for _, env := range container.Env {
-		if env.Name == "AXON_BASE_BRANCH" {
-			t.Error("AXON_BASE_BRANCH should not be set when workspace is nil")
+		if env.Name == "KELOS_BASE_BRANCH" {
+			t.Error("KELOS_BASE_BRANCH should not be set when workspace is nil")
 		}
 	}
 }
 
 func TestBuildJob_WorkspaceWithOneRemote(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-one-remote",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/org/repo.git",
 		Ref:  "main",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "private", URL: "https://github.com/user/repo.git"},
 		},
 	}
@@ -3174,25 +3174,25 @@ func TestBuildJob_WorkspaceWithOneRemote(t *testing.T) {
 
 func TestBuildJob_WorkspaceWithMultipleRemotes(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-multi-remote",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/org/repo.git",
 		Ref:  "main",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "private", URL: "https://github.com/user/repo.git"},
 			{Name: "downstream", URL: "https://github.com/vendor/repo.git"},
 		},
@@ -3225,22 +3225,22 @@ func TestBuildJob_WorkspaceWithMultipleRemotes(t *testing.T) {
 
 func TestBuildJob_WorkspaceWithNoRemotesNoRemoteSetupContainer(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-no-remotes",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/org/repo.git",
 		Ref:  "main",
 	}
@@ -3259,26 +3259,26 @@ func TestBuildJob_WorkspaceWithNoRemotesNoRemoteSetupContainer(t *testing.T) {
 
 func TestBuildJob_RemoteSetupOrderingWithBranchSetup(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-remote-order",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Work on feature",
 			Branch: "feature-x",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/org/repo.git",
 		Ref:  "main",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "private", URL: "https://github.com/user/repo.git"},
 		},
 	}
@@ -3316,24 +3316,24 @@ func TestBuildJob_RemoteSetupOrderingWithBranchSetup(t *testing.T) {
 
 func TestBuildJob_RemoteSetupQuotesShellMetacharacters(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-remote-injection",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Do work",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/org/repo.git",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "bad;rm -rf /", URL: "https://evil.com$(whoami)"},
 		},
 	}
@@ -3363,25 +3363,25 @@ func TestBuildJob_RemoteSetupQuotesShellMetacharacters(t *testing.T) {
 
 func TestBuildJob_WorkspaceWithUpstreamRemoteInjectsEnv(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-upstream-env",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/my-fork/repo.git",
 		Ref:  "main",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "upstream", URL: "https://github.com/upstream-org/repo.git"},
 		},
 	}
@@ -3394,40 +3394,40 @@ func TestBuildJob_WorkspaceWithUpstreamRemoteInjectsEnv(t *testing.T) {
 	mainContainer := job.Spec.Template.Spec.Containers[0]
 	found := false
 	for _, env := range mainContainer.Env {
-		if env.Name == "AXON_UPSTREAM_REPO" {
+		if env.Name == "KELOS_UPSTREAM_REPO" {
 			found = true
 			if env.Value != "upstream-org/repo" {
-				t.Errorf("AXON_UPSTREAM_REPO = %q, want %q", env.Value, "upstream-org/repo")
+				t.Errorf("KELOS_UPSTREAM_REPO = %q, want %q", env.Value, "upstream-org/repo")
 			}
 			break
 		}
 	}
 	if !found {
-		t.Error("Expected AXON_UPSTREAM_REPO env var on main container")
+		t.Error("Expected KELOS_UPSTREAM_REPO env var on main container")
 	}
 }
 
 func TestBuildJob_WorkspaceWithNonUpstreamRemoteNoEnv(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-no-upstream-env",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/my-fork/repo.git",
 		Ref:  "main",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "other", URL: "https://github.com/other-org/repo.git"},
 		},
 	}
@@ -3439,33 +3439,33 @@ func TestBuildJob_WorkspaceWithNonUpstreamRemoteNoEnv(t *testing.T) {
 
 	mainContainer := job.Spec.Template.Spec.Containers[0]
 	for _, env := range mainContainer.Env {
-		if env.Name == "AXON_UPSTREAM_REPO" {
-			t.Errorf("Expected no AXON_UPSTREAM_REPO env var, but found value %q", env.Value)
+		if env.Name == "KELOS_UPSTREAM_REPO" {
+			t.Errorf("Expected no KELOS_UPSTREAM_REPO env var, but found value %q", env.Value)
 		}
 	}
 }
 
 func TestBuildJob_WorkspaceWithInvalidUpstreamRemoteNoEnv(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-invalid-upstream",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Fix the code",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
 
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/my-fork/repo.git",
 		Ref:  "main",
-		Remotes: []axonv1alpha1.GitRemote{
+		Remotes: []kelosv1alpha1.GitRemote{
 			{Name: "upstream", URL: "not-a-valid-url"},
 		},
 	}
@@ -3477,28 +3477,28 @@ func TestBuildJob_WorkspaceWithInvalidUpstreamRemoteNoEnv(t *testing.T) {
 
 	mainContainer := job.Spec.Template.Spec.Containers[0]
 	for _, env := range mainContainer.Env {
-		if env.Name == "AXON_UPSTREAM_REPO" {
-			t.Errorf("Expected no AXON_UPSTREAM_REPO for invalid URL, but found value %q", env.Value)
+		if env.Name == "KELOS_UPSTREAM_REPO" {
+			t.Errorf("Expected no KELOS_UPSTREAM_REPO for invalid URL, but found value %q", env.Value)
 		}
 	}
 }
 
 func TestBuildJob_TaskSpawnerLabelInjectsEnv(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner-env",
 			Namespace: "default",
 			Labels: map[string]string{
-				"axon.io/taskspawner": "axon-workers",
+				"kelos.dev/taskspawner": "kelos-workers",
 			},
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Hello",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -3511,31 +3511,31 @@ func TestBuildJob_TaskSpawnerLabelInjectsEnv(t *testing.T) {
 	container := job.Spec.Template.Spec.Containers[0]
 	found := false
 	for _, env := range container.Env {
-		if env.Name == "AXON_TASKSPAWNER" {
+		if env.Name == "KELOS_TASKSPAWNER" {
 			found = true
-			if env.Value != "axon-workers" {
-				t.Errorf("AXON_TASKSPAWNER: expected %q, got %q", "axon-workers", env.Value)
+			if env.Value != "kelos-workers" {
+				t.Errorf("KELOS_TASKSPAWNER: expected %q, got %q", "kelos-workers", env.Value)
 			}
 		}
 	}
 	if !found {
-		t.Error("Expected AXON_TASKSPAWNER env var to be set when label is present")
+		t.Error("Expected KELOS_TASKSPAWNER env var to be set when label is present")
 	}
 }
 
 func TestBuildJob_NoTaskSpawnerLabelNoEnv(t *testing.T) {
 	builder := NewJobBuilder()
-	task := &axonv1alpha1.Task{
+	task := &kelosv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-no-spawner-env",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpec{
+		Spec: kelosv1alpha1.TaskSpec{
 			Type:   AgentTypeClaudeCode,
 			Prompt: "Hello",
-			Credentials: axonv1alpha1.Credentials{
-				Type:      axonv1alpha1.CredentialTypeAPIKey,
-				SecretRef: axonv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: kelosv1alpha1.SecretReference{Name: "my-secret"},
 			},
 		},
 	}
@@ -3547,8 +3547,8 @@ func TestBuildJob_NoTaskSpawnerLabelNoEnv(t *testing.T) {
 
 	container := job.Spec.Template.Spec.Containers[0]
 	for _, env := range container.Env {
-		if env.Name == "AXON_TASKSPAWNER" {
-			t.Errorf("Expected no AXON_TASKSPAWNER env var when label is absent, but found value %q", env.Value)
+		if env.Name == "KELOS_TASKSPAWNER" {
+			t.Errorf("Expected no KELOS_TASKSPAWNER env var when label is absent, but found value %q", env.Value)
 		}
 	}
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -9,7 +9,7 @@ var (
 	// taskCreatedTotal counts the total number of Tasks for which a Job was created.
 	taskCreatedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "axon_task_created_total",
+			Name: "kelos_task_created_total",
 			Help: "Total number of Tasks for which a Job was created",
 		},
 		[]string{"namespace", "type"},
@@ -18,7 +18,7 @@ var (
 	// taskCompletedTotal counts the total number of Tasks that reached a terminal phase.
 	taskCompletedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "axon_task_completed_total",
+			Name: "kelos_task_completed_total",
 			Help: "Total number of Tasks that reached a terminal phase",
 		},
 		[]string{"namespace", "type", "phase"},
@@ -27,7 +27,7 @@ var (
 	// taskDurationSeconds records the duration of Task execution.
 	taskDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "axon_task_duration_seconds",
+			Name:    "kelos_task_duration_seconds",
 			Help:    "Duration of Task execution from start to completion",
 			Buckets: []float64{30, 60, 120, 300, 600, 1200, 1800, 3600},
 		},
@@ -37,7 +37,7 @@ var (
 	// reconcileErrorsTotal counts the total number of reconciliation errors.
 	reconcileErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "axon_reconcile_errors_total",
+			Name: "kelos_reconcile_errors_total",
 			Help: "Total number of reconciliation errors",
 		},
 		[]string{"controller"},
@@ -46,7 +46,7 @@ var (
 	// taskCostUSD records the cost in USD of completed Tasks.
 	taskCostUSD = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "axon_task_cost_usd_total",
+			Name: "kelos_task_cost_usd_total",
 			Help: "Total cost in USD of completed Tasks",
 		},
 		[]string{"namespace", "type", "spawner", "model"},
@@ -55,7 +55,7 @@ var (
 	// taskInputTokens records the total input tokens consumed by completed Tasks.
 	taskInputTokens = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "axon_task_input_tokens_total",
+			Name: "kelos_task_input_tokens_total",
 			Help: "Total input tokens consumed by completed Tasks",
 		},
 		[]string{"namespace", "type", "spawner", "model"},
@@ -64,7 +64,7 @@ var (
 	// taskOutputTokens records the total output tokens consumed by completed Tasks.
 	taskOutputTokens = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "axon_task_output_tokens_total",
+			Name: "kelos_task_output_tokens_total",
 			Help: "Total output tokens consumed by completed Tasks",
 		},
 		[]string{"namespace", "type", "spawner", "model"},

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 func TestMetricsRegistered(t *testing.T) {
@@ -125,7 +125,7 @@ func TestTaskOutputTokensCounter(t *testing.T) {
 func TestRecordCostTokenMetrics(t *testing.T) {
 	tests := []struct {
 		name       string
-		task       *axonv1alpha1.Task
+		task       *kelosv1alpha1.Task
 		results    map[string]string
 		wantCost   float64
 		wantInput  float64
@@ -133,12 +133,12 @@ func TestRecordCostTokenMetrics(t *testing.T) {
 	}{
 		{
 			name: "All metrics present",
-			task: &axonv1alpha1.Task{
+			task: &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "record-ns-1",
-					Labels:    map[string]string{"axon.io/taskspawner": "spawner-1"},
+					Labels:    map[string]string{"kelos.dev/taskspawner": "spawner-1"},
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:  "claude-code",
 					Model: "opus",
 				},
@@ -154,12 +154,12 @@ func TestRecordCostTokenMetrics(t *testing.T) {
 		},
 		{
 			name: "Only cost present",
-			task: &axonv1alpha1.Task{
+			task: &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "record-ns-2",
-					Labels:    map[string]string{"axon.io/taskspawner": "spawner-2"},
+					Labels:    map[string]string{"kelos.dev/taskspawner": "spawner-2"},
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:  "claude-code",
 					Model: "sonnet",
 				},
@@ -171,11 +171,11 @@ func TestRecordCostTokenMetrics(t *testing.T) {
 		},
 		{
 			name: "No spawner label or model",
-			task: &axonv1alpha1.Task{
+			task: &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "record-ns-3",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type: "codex",
 				},
 			},
@@ -190,12 +190,12 @@ func TestRecordCostTokenMetrics(t *testing.T) {
 		},
 		{
 			name: "Invalid cost value is ignored",
-			task: &axonv1alpha1.Task{
+			task: &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "record-ns-4",
-					Labels:    map[string]string{"axon.io/taskspawner": "spawner-4"},
+					Labels:    map[string]string{"kelos.dev/taskspawner": "spawner-4"},
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:  "claude-code",
 					Model: "opus",
 				},
@@ -208,12 +208,12 @@ func TestRecordCostTokenMetrics(t *testing.T) {
 		},
 		{
 			name: "Negative values are ignored",
-			task: &axonv1alpha1.Task{
+			task: &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "record-ns-5",
-					Labels:    map[string]string{"axon.io/taskspawner": "spawner-5"},
+					Labels:    map[string]string{"kelos.dev/taskspawner": "spawner-5"},
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:  "claude-code",
 					Model: "opus",
 				},
@@ -228,7 +228,7 @@ func TestRecordCostTokenMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spawner := tt.task.Labels["axon.io/taskspawner"]
+			spawner := tt.task.Labels["kelos.dev/taskspawner"]
 			model := tt.task.Spec.Model
 			labels := []string{tt.task.Namespace, tt.task.Spec.Type, spawner, model}
 

--- a/internal/controller/output_parser.go
+++ b/internal/controller/output_parser.go
@@ -3,12 +3,12 @@ package controller
 import "strings"
 
 const (
-	outputStartMarker = "---AXON_OUTPUTS_START---"
-	outputEndMarker   = "---AXON_OUTPUTS_END---"
+	outputStartMarker = "---KELOS_OUTPUTS_START---"
+	outputEndMarker   = "---KELOS_OUTPUTS_END---"
 )
 
 // ParseOutputs extracts output lines from log data between the
-// ---AXON_OUTPUTS_START--- and ---AXON_OUTPUTS_END--- markers.
+// ---KELOS_OUTPUTS_START--- and ---KELOS_OUTPUTS_END--- markers.
 func ParseOutputs(logData string) []string {
 	startIdx := strings.Index(logData, outputStartMarker)
 	if startIdx == -1 {

--- a/internal/controller/output_parser_test.go
+++ b/internal/controller/output_parser_test.go
@@ -18,33 +18,33 @@ func TestParseOutputs(t *testing.T) {
 		},
 		{
 			name:     "empty between markers",
-			logData:  "---AXON_OUTPUTS_START---\n---AXON_OUTPUTS_END---\n",
+			logData:  "---KELOS_OUTPUTS_START---\n---KELOS_OUTPUTS_END---\n",
 			expected: nil,
 		},
 		{
 			name:     "whitespace only between markers",
-			logData:  "---AXON_OUTPUTS_START---\n  \n  \n---AXON_OUTPUTS_END---\n",
+			logData:  "---KELOS_OUTPUTS_START---\n  \n  \n---KELOS_OUTPUTS_END---\n",
 			expected: nil,
 		},
 		{
 			name:     "branch only",
-			logData:  "---AXON_OUTPUTS_START---\nbranch: axon-task-123\n---AXON_OUTPUTS_END---\n",
-			expected: []string{"branch: axon-task-123"},
+			logData:  "---KELOS_OUTPUTS_START---\nbranch: kelos-task-123\n---KELOS_OUTPUTS_END---\n",
+			expected: []string{"branch: kelos-task-123"},
 		},
 		{
 			name: "branch and PR URL",
-			logData: "---AXON_OUTPUTS_START---\nbranch: axon-task-123\n" +
-				"pr: https://github.com/org/repo/pull/456\n---AXON_OUTPUTS_END---\n",
+			logData: "---KELOS_OUTPUTS_START---\nbranch: kelos-task-123\n" +
+				"pr: https://github.com/org/repo/pull/456\n---KELOS_OUTPUTS_END---\n",
 			expected: []string{
-				"branch: axon-task-123",
+				"branch: kelos-task-123",
 				"pr: https://github.com/org/repo/pull/456",
 			},
 		},
 		{
 			name: "branch and multiple PR URLs",
-			logData: "---AXON_OUTPUTS_START---\nbranch: feature-branch\n" +
+			logData: "---KELOS_OUTPUTS_START---\nbranch: feature-branch\n" +
 				"pr: https://github.com/org/repo/pull/1\n" +
-				"pr: https://github.com/org/repo/pull/2\n---AXON_OUTPUTS_END---\n",
+				"pr: https://github.com/org/repo/pull/2\n---KELOS_OUTPUTS_END---\n",
 			expected: []string{
 				"branch: feature-branch",
 				"pr: https://github.com/org/repo/pull/1",
@@ -54,8 +54,8 @@ func TestParseOutputs(t *testing.T) {
 		{
 			name: "markers in noisy log data",
 			logData: "Starting agent...\nProcessing task...\nDone.\n" +
-				"---AXON_OUTPUTS_START---\nbranch: my-branch\n" +
-				"pr: https://github.com/org/repo/pull/99\n---AXON_OUTPUTS_END---\n" +
+				"---KELOS_OUTPUTS_START---\nbranch: my-branch\n" +
+				"pr: https://github.com/org/repo/pull/99\n---KELOS_OUTPUTS_END---\n" +
 				"Exiting with code 0\n",
 			expected: []string{
 				"branch: my-branch",
@@ -64,15 +64,15 @@ func TestParseOutputs(t *testing.T) {
 		},
 		{
 			name: "all output keys including commit, base-branch, and usage",
-			logData: "---AXON_OUTPUTS_START---\nbranch: axon-task-42\n" +
+			logData: "---KELOS_OUTPUTS_START---\nbranch: kelos-task-42\n" +
 				"pr: https://github.com/org/repo/pull/42\n" +
 				"commit: abc123def456\n" +
 				"base-branch: main\n" +
 				"input-tokens: 1500\n" +
 				"output-tokens: 800\n" +
-				"cost-usd: 0.025\n---AXON_OUTPUTS_END---\n",
+				"cost-usd: 0.025\n---KELOS_OUTPUTS_END---\n",
 			expected: []string{
-				"branch: axon-task-42",
+				"branch: kelos-task-42",
 				"pr: https://github.com/org/repo/pull/42",
 				"commit: abc123def456",
 				"base-branch: main",
@@ -83,12 +83,12 @@ func TestParseOutputs(t *testing.T) {
 		},
 		{
 			name:     "start marker without end marker",
-			logData:  "---AXON_OUTPUTS_START---\nbranch: broken\n",
+			logData:  "---KELOS_OUTPUTS_START---\nbranch: broken\n",
 			expected: nil,
 		},
 		{
 			name:     "end marker before start marker",
-			logData:  "---AXON_OUTPUTS_END---\n---AXON_OUTPUTS_START---\nbranch: wrong-order\n",
+			logData:  "---KELOS_OUTPUTS_END---\n---KELOS_OUTPUTS_START---\nbranch: wrong-order\n",
 			expected: nil,
 		},
 	}
@@ -176,7 +176,7 @@ func TestResultsFromOutputs(t *testing.T) {
 		{
 			name: "new output keys in results map",
 			outputs: []string{
-				"branch: axon-task-42",
+				"branch: kelos-task-42",
 				"commit: abc123def456",
 				"base-branch: main",
 				"input-tokens: 1500",
@@ -184,7 +184,7 @@ func TestResultsFromOutputs(t *testing.T) {
 				"cost-usd: 0.025",
 			},
 			expected: map[string]string{
-				"branch":        "axon-task-42",
+				"branch":        "kelos-task-42",
 				"commit":        "abc123def456",
 				"base-branch":   "main",
 				"input-tokens":  "1500",

--- a/internal/controller/taskspawner_deployment_builder.go
+++ b/internal/controller/taskspawner_deployment_builder.go
@@ -10,21 +10,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 const (
 	// DefaultSpawnerImage is the default image for the spawner binary.
-	DefaultSpawnerImage = "gjkim42/axon-spawner:latest"
+	DefaultSpawnerImage = "gjkim42/kelos-spawner:latest"
 
 	// DefaultTokenRefresherImage is the default image for the token refresher sidecar.
-	DefaultTokenRefresherImage = "gjkim42/axon-token-refresher:latest"
+	DefaultTokenRefresherImage = "gjkim42/kelos-token-refresher:latest"
 
 	// SpawnerServiceAccount is the service account used by spawner Deployments.
-	SpawnerServiceAccount = "axon-spawner"
+	SpawnerServiceAccount = "kelos-spawner"
 
 	// SpawnerClusterRole is the ClusterRole referenced by spawner RoleBindings.
-	SpawnerClusterRole = "axon-spawner-role"
+	SpawnerClusterRole = "kelos-spawner-role"
 )
 
 // DeploymentBuilder constructs Kubernetes Deployments for TaskSpawners.
@@ -48,7 +48,7 @@ func NewDeploymentBuilder() *DeploymentBuilder {
 // for GitHub API authentication. The isGitHubApp parameter indicates whether
 // the workspace secret contains GitHub App credentials, which requires a
 // token refresher sidecar.
-func (b *DeploymentBuilder) Build(ts *axonv1alpha1.TaskSpawner, workspace *axonv1alpha1.WorkspaceSpec, isGitHubApp bool) *appsv1.Deployment {
+func (b *DeploymentBuilder) Build(ts *kelosv1alpha1.TaskSpawner, workspace *kelosv1alpha1.WorkspaceSpec, isGitHubApp bool) *appsv1.Deployment {
 	replicas := int32(1)
 
 	args := []string{
@@ -214,10 +214,10 @@ func (b *DeploymentBuilder) Build(ts *axonv1alpha1.TaskSpawner, workspace *axonv
 	}
 
 	labels := map[string]string{
-		"app.kubernetes.io/name":       "axon",
+		"app.kubernetes.io/name":       "kelos",
 		"app.kubernetes.io/component":  "spawner",
-		"app.kubernetes.io/managed-by": "axon-controller",
-		"axon.io/taskspawner":          ts.Name,
+		"app.kubernetes.io/managed-by": "kelos-controller",
+		"kelos.dev/taskspawner":        ts.Name,
 	}
 
 	spawnerContainer := corev1.Container{

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,33 +25,33 @@ func TestParseGitHubOwnerRepo(t *testing.T) {
 	}{
 		{
 			name:      "HTTPS URL",
-			repoURL:   "https://github.com/axon-core/axon.git",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			repoURL:   "https://github.com/kelos-dev/kelos.git",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "HTTPS URL without .git",
-			repoURL:   "https://github.com/axon-core/axon",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			repoURL:   "https://github.com/kelos-dev/kelos",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "HTTPS URL with trailing slash",
-			repoURL:   "https://github.com/axon-core/axon/",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			repoURL:   "https://github.com/kelos-dev/kelos/",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "SSH URL",
-			repoURL:   "git@github.com:axon-core/axon.git",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			repoURL:   "git@github.com:kelos-dev/kelos.git",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "SSH URL without .git",
-			repoURL:   "git@github.com:axon-core/axon",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			repoURL:   "git@github.com:kelos-dev/kelos",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "HTTPS URL with org",
@@ -96,17 +96,17 @@ func TestParseGitHubRepo(t *testing.T) {
 	}{
 		{
 			name:      "github.com HTTPS",
-			repoURL:   "https://github.com/axon-core/axon.git",
+			repoURL:   "https://github.com/kelos-dev/kelos.git",
 			wantHost:  "github.com",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "github.com SSH",
-			repoURL:   "git@github.com:axon-core/axon.git",
+			repoURL:   "git@github.com:kelos-dev/kelos.git",
 			wantHost:  "github.com",
-			wantOwner: "axon-core",
-			wantRepo:  "axon",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
 		},
 		{
 			name:      "GitHub Enterprise HTTPS",
@@ -195,14 +195,14 @@ func TestGitHubAPIBaseURL(t *testing.T) {
 func TestBuildDeploymentWithEnterpriseURL(t *testing.T) {
 	builder := NewDeploymentBuilder()
 
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
 		},
 	}
@@ -214,7 +214,7 @@ func TestBuildDeploymentWithEnterpriseURL(t *testing.T) {
 	}{
 		{
 			name:              "github.com repo does not include api-base-url arg",
-			repoURL:           "https://github.com/axon-core/axon.git",
+			repoURL:           "https://github.com/kelos-dev/kelos.git",
 			wantAPIBaseURLArg: "",
 		},
 		{
@@ -226,7 +226,7 @@ func TestBuildDeploymentWithEnterpriseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			workspace := &axonv1alpha1.WorkspaceSpec{
+			workspace := &kelosv1alpha1.WorkspaceSpec{
 				Repo: tt.repoURL,
 			}
 			dep := builder.Build(ts, workspace, false)
@@ -254,24 +254,24 @@ func TestBuildDeploymentWithEnterpriseURL(t *testing.T) {
 
 func TestDeploymentBuilder_GitHubApp(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
-		Repo: "https://github.com/axon-core/axon.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-app-creds",
 		},
 	}
@@ -334,24 +334,24 @@ func TestDeploymentBuilder_GitHubApp(t *testing.T) {
 
 func TestDeploymentBuilder_GitHubAppEnterprise(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.example.com/my-org/my-repo.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-app-creds",
 		},
 	}
@@ -376,24 +376,24 @@ func TestDeploymentBuilder_GitHubAppEnterprise(t *testing.T) {
 
 func TestDeploymentBuilder_GitHubAppGitHubCom(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
-		Repo: "https://github.com/axon-core/axon.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-app-creds",
 		},
 	}
@@ -415,24 +415,24 @@ func TestDeploymentBuilder_GitHubAppGitHubCom(t *testing.T) {
 
 func TestDeploymentBuilder_PAT(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
-		Repo: "https://github.com/axon-core/axon.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "github-token",
 		},
 	}
@@ -463,21 +463,21 @@ func TestDeploymentBuilder_PAT(t *testing.T) {
 
 func TestDeploymentBuilder_Jira(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				Jira: &axonv1alpha1.Jira{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Jira: &kelosv1alpha1.Jira{
 					BaseURL:   "https://mycompany.atlassian.net",
 					Project:   "PROJ",
 					JQL:       "status = Open",
-					SecretRef: axonv1alpha1.SecretReference{Name: "jira-creds"},
+					SecretRef: kelosv1alpha1.SecretReference{Name: "jira-creds"},
 				},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type: "claude-code",
 			},
 		},
@@ -553,20 +553,20 @@ func TestDeploymentBuilder_Jira(t *testing.T) {
 
 func TestBuildDeploymentWithGitHubIssuesRepoOverride(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{
 					Repo: "https://github.com/upstream-org/upstream-repo.git",
 				},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/my-fork/upstream-repo.git",
 	}
 
@@ -600,20 +600,20 @@ func TestBuildDeploymentWithGitHubIssuesRepoOverride(t *testing.T) {
 
 func TestBuildDeploymentWithGitHubIssuesRepoOverrideEnterprise(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{
 					Repo: "https://github.example.com/upstream-org/upstream-repo.git",
 				},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
 		Repo: "https://github.com/my-fork/upstream-repo.git",
 	}
 
@@ -634,20 +634,20 @@ func TestBuildDeploymentWithGitHubIssuesRepoOverrideEnterprise(t *testing.T) {
 
 func TestDeploymentBuilder_JiraNoJQL(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				Jira: &axonv1alpha1.Jira{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Jira: &kelosv1alpha1.Jira{
 					BaseURL:   "https://jira.example.com",
 					Project:   "TEST",
-					SecretRef: axonv1alpha1.SecretReference{Name: "jira-creds"},
+					SecretRef: kelosv1alpha1.SecretReference{Name: "jira-creds"},
 				},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type: "claude-code",
 			},
 		},
@@ -667,18 +667,18 @@ func boolPtr(v bool) *bool { return &v }
 
 func TestUpdateDeployment_SuspendScalesDown(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 			Suspend: boolPtr(true),
 		},
@@ -694,7 +694,7 @@ func TestUpdateDeployment_SuspendScalesDown(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -726,18 +726,18 @@ func TestUpdateDeployment_SuspendScalesDown(t *testing.T) {
 
 func TestUpdateDeployment_ResumeScalesUp(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 			Suspend: boolPtr(false),
 		},
@@ -752,7 +752,7 @@ func TestUpdateDeployment_ResumeScalesUp(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -784,18 +784,18 @@ func TestUpdateDeployment_ResumeScalesUp(t *testing.T) {
 
 func TestUpdateDeployment_NoUpdateWhenReplicasMatch(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
@@ -806,7 +806,7 @@ func TestUpdateDeployment_NoUpdateWhenReplicasMatch(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -838,24 +838,24 @@ func TestUpdateDeployment_NoUpdateWhenReplicasMatch(t *testing.T) {
 
 func TestUpdateDeployment_PATToGitHubApp(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
-		Repo: "https://github.com/axon-core/axon.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "my-secret",
 		},
 	}
@@ -866,7 +866,7 @@ func TestUpdateDeployment_PATToGitHubApp(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -935,24 +935,24 @@ func TestUpdateDeployment_PATToGitHubApp(t *testing.T) {
 
 func TestUpdateDeployment_GitHubAppToPAT(t *testing.T) {
 	builder := NewDeploymentBuilder()
-	ts := &axonv1alpha1.TaskSpawner{
+	ts := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-spawner",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
-	workspace := &axonv1alpha1.WorkspaceSpec{
-		Repo: "https://github.com/axon-core/axon.git",
-		SecretRef: &axonv1alpha1.SecretReference{
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
 			Name: "my-secret",
 		},
 	}
@@ -963,7 +963,7 @@ func TestUpdateDeployment_GitHubAppToPAT(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1031,7 +1031,7 @@ func TestFindTaskSpawnersForSecret(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1040,78 +1040,78 @@ func TestFindTaskSpawnersForSecret(t *testing.T) {
 		},
 	}
 	// Workspace referencing the secret
-	ws := &axonv1alpha1.Workspace{
+	ws := &kelosv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.WorkspaceSpec{
-			Repo: "https://github.com/axon-core/axon.git",
-			SecretRef: &axonv1alpha1.SecretReference{
+		Spec: kelosv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/kelos-dev/kelos.git",
+			SecretRef: &kelosv1alpha1.SecretReference{
 				Name: "my-secret",
 			},
 		},
 	}
 	// Workspace not referencing the secret
-	wsOther := &axonv1alpha1.Workspace{
+	wsOther := &kelosv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ws-other",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.WorkspaceSpec{
-			Repo: "https://github.com/axon-core/other.git",
-			SecretRef: &axonv1alpha1.SecretReference{
+		Spec: kelosv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/kelos-dev/other.git",
+			SecretRef: &kelosv1alpha1.SecretReference{
 				Name: "other-secret",
 			},
 		},
 	}
 	// TaskSpawner referencing ws (should be returned)
-	ts1 := &axonv1alpha1.TaskSpawner{
+	ts1 := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "spawner-1",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
 	// TaskSpawner referencing ws-other (should not be returned)
-	ts2 := &axonv1alpha1.TaskSpawner{
+	ts2 := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "spawner-2",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws-other"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws-other"},
 			},
 		},
 	}
 	// TaskSpawner with no workspaceRef (should not be returned)
-	ts3 := &axonv1alpha1.TaskSpawner{
+	ts3 := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "spawner-3",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				Jira: &axonv1alpha1.Jira{
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Jira: &kelosv1alpha1.Jira{
 					BaseURL:   "https://jira.example.com",
 					Project:   "TEST",
-					SecretRef: axonv1alpha1.SecretReference{Name: "jira-creds"},
+					SecretRef: kelosv1alpha1.SecretReference{Name: "jira-creds"},
 				},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type: "claude-code",
 			},
 		},
@@ -1142,63 +1142,63 @@ func TestFindTaskSpawnersForWorkspace(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(axonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
 
-	ws := &axonv1alpha1.Workspace{
+	ws := &kelosv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ws",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.WorkspaceSpec{
-			Repo: "https://github.com/axon-core/axon.git",
+		Spec: kelosv1alpha1.WorkspaceSpec{
+			Repo: "https://github.com/kelos-dev/kelos.git",
 		},
 	}
 
 	// TaskSpawner referencing ws (should be returned)
-	ts1 := &axonv1alpha1.TaskSpawner{
+	ts1 := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "spawner-1",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
 	// Another TaskSpawner referencing ws (should also be returned)
-	ts2 := &axonv1alpha1.TaskSpawner{
+	ts2 := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "spawner-2",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
 			},
 		},
 	}
 	// TaskSpawner referencing different workspace (should not be returned)
-	ts3 := &axonv1alpha1.TaskSpawner{
+	ts3 := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "spawner-3",
 			Namespace: "default",
 		},
-		Spec: axonv1alpha1.TaskSpawnerSpec{
-			When: axonv1alpha1.When{
-				GitHubIssues: &axonv1alpha1.GitHubIssues{},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 			},
-			TaskTemplate: axonv1alpha1.TaskTemplate{
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
 				Type:         "claude-code",
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "other-ws"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "other-ws"},
 			},
 		},
 	}

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: agentconfigs.axon.io
+  name: agentconfigs.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: AgentConfig
     listKind: AgentConfigList
@@ -166,9 +166,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: tasks.axon.io
+  name: tasks.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: Task
     listKind: TaskList
@@ -600,9 +600,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: taskspawners.axon.io
+  name: taskspawners.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: TaskSpawner
     listKind: TaskSpawnerList
@@ -705,7 +705,7 @@ spec:
                   branch:
                     description: |-
                       Branch is the git branch spawned Tasks should work on.
-                      Supports Go text/template variables from the work item, e.g. "axon-task-{{.Number}}".
+                      Supports Go text/template variables from the work item, e.g. "kelos-task-{{.Number}}".
                       Available variables: {{.ID}}, {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}}, {{.Comments}}, {{.Labels}}, {{.Kind}}, {{.Time}}, {{.Schedule}}.
                     type: string
                   credentials:
@@ -1059,7 +1059,7 @@ spec:
                       excludeComments:
                         description: |-
                           ExcludeComments enables comment-based exclusion. When set, issues that
-                          have a comment matching any of these strings (e.g., "/axon needs-input")
+                          have a comment matching any of these strings (e.g., "/kelos needs-input")
                           are excluded unless a subsequent TriggerComment overrides it. Comments
                           are scanned in reverse chronological order — the most recent matching
                           command wins.
@@ -1107,7 +1107,7 @@ spec:
                       triggerComment:
                         description: |-
                           TriggerComment enables comment-based discovery. When set, only issues
-                          that have a comment matching this string (e.g., "/axon pick-up") are
+                          that have a comment matching this string (e.g., "/kelos pick-up") are
                           included. This is useful for repos where you lack label permissions.
                           If ExcludeComments is also set, TriggerComment doubles as a resume
                           command — the most recent match between TriggerComment and
@@ -1266,9 +1266,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-  name: workspaces.axon.io
+  name: workspaces.kelos.dev
 spec:
-  group: axon.io
+  group: kelos.dev
   names:
     kind: Workspace
     listKind: WorkspaceList

--- a/internal/manifests/install.yaml
+++ b/internal/manifests/install.yaml
@@ -2,22 +2,22 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: axon-system
+  name: kelos-system
   labels:
-    app.kubernetes.io/name: axon
+    app.kubernetes.io/name: kelos
     app.kubernetes.io/component: manager
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: axon-controller
-  namespace: axon-system
+  name: kelos-controller
+  namespace: kelos-system
 # BEGIN GENERATED: controller-rbac
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: axon-controller-role
+  name: kelos-controller-role
 rules:
 - apiGroups:
   - ""
@@ -72,7 +72,19 @@ rules:
   - update
   - watch
 - apiGroups:
-  - axon.io
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kelos.dev
   resources:
   - agentconfigs
   - workspaces
@@ -81,7 +93,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - axon.io
+  - kelos.dev
   resources:
   - tasks
   - taskspawners
@@ -94,14 +106,14 @@ rules:
   - update
   - watch
 - apiGroups:
-  - axon.io
+  - kelos.dev
   resources:
   - tasks/finalizers
   - taskspawners/finalizers
   verbs:
   - update
 - apiGroups:
-  - axon.io
+  - kelos.dev
   resources:
   - tasks/status
   - taskspawners/status
@@ -109,18 +121,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -135,10 +135,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: axon-spawner-role
+  name: kelos-spawner-role
 rules:
   - apiGroups:
-      - axon.io
+      - kelos.dev
     resources:
       - taskspawners
     verbs:
@@ -146,7 +146,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - axon.io
+      - kelos.dev
     resources:
       - taskspawners/status
     verbs:
@@ -154,7 +154,7 @@ rules:
       - update
       - patch
   - apiGroups:
-      - axon.io
+      - kelos.dev
     resources:
       - tasks
     verbs:
@@ -165,21 +165,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: axon-controller-rolebinding
+  name: kelos-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: axon-controller-role
+  name: kelos-controller-role
 subjects:
   - kind: ServiceAccount
-    name: axon-controller
-    namespace: axon-system
+    name: kelos-controller
+    namespace: kelos-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: axon-leader-election-role
-  namespace: axon-system
+  name: kelos-leader-election-role
+  namespace: kelos-system
 rules:
   - apiGroups:
       - ""
@@ -216,51 +216,51 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: axon-leader-election-rolebinding
-  namespace: axon-system
+  name: kelos-leader-election-rolebinding
+  namespace: kelos-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: axon-leader-election-role
+  name: kelos-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: axon-controller
-    namespace: axon-system
+    name: kelos-controller
+    namespace: kelos-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: axon-controller-manager
-  namespace: axon-system
+  name: kelos-controller-manager
+  namespace: kelos-system
   labels:
-    app.kubernetes.io/name: axon
+    app.kubernetes.io/name: kelos
     app.kubernetes.io/component: manager
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: axon
+      app.kubernetes.io/name: kelos
       app.kubernetes.io/component: manager
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: axon
+        app.kubernetes.io/name: kelos
         app.kubernetes.io/component: manager
     spec:
-      serviceAccountName: axon-controller
+      serviceAccountName: kelos-controller
       securityContext:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: gjkim42/axon-controller:latest
+          image: gjkim42/kelos-controller:latest
           args:
             - --leader-elect
             - --claude-code-image=gjkim42/claude-code:latest
             - --codex-image=gjkim42/codex:latest
             - --gemini-image=gjkim42/gemini:latest
             - --opencode-image=gjkim42/opencode:latest
-            - --spawner-image=gjkim42/axon-spawner:latest
-            - --token-refresher-image=gjkim42/axon-token-refresher:latest
+            - --spawner-image=gjkim42/kelos-spawner:latest
+            - --token-refresher-image=gjkim42/kelos-token-refresher:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/source/github_test.go
+++ b/internal/source/github_test.go
@@ -396,7 +396,7 @@ func TestDiscoverComments(t *testing.T) {
 func TestDiscoverExcludeLabels(t *testing.T) {
 	issues := []githubIssue{
 		{Number: 1, Title: "Bug 1", Body: "Body 1", HTMLURL: "https://github.com/o/r/issues/1", Labels: []githubLabel{{Name: "bug"}}},
-		{Number: 2, Title: "Needs input", Body: "Body 2", HTMLURL: "https://github.com/o/r/issues/2", Labels: []githubLabel{{Name: "bug"}, {Name: "axon/needs-input"}}},
+		{Number: 2, Title: "Needs input", Body: "Body 2", HTMLURL: "https://github.com/o/r/issues/2", Labels: []githubLabel{{Name: "bug"}, {Name: "kelos/needs-input"}}},
 		{Number: 3, Title: "Feature", Body: "Body 3", HTMLURL: "https://github.com/o/r/issues/3", Labels: []githubLabel{{Name: "enhancement"}}},
 	}
 
@@ -413,7 +413,7 @@ func TestDiscoverExcludeLabels(t *testing.T) {
 	s := &GitHubSource{
 		Owner:         "owner",
 		Repo:          "repo",
-		ExcludeLabels: []string{"axon/needs-input"},
+		ExcludeLabels: []string{"kelos/needs-input"},
 		BaseURL:       server.URL,
 	}
 
@@ -452,7 +452,7 @@ func TestDiscoverExcludeLabelsNoMatch(t *testing.T) {
 	s := &GitHubSource{
 		Owner:         "owner",
 		Repo:          "repo",
-		ExcludeLabels: []string{"axon/needs-input"},
+		ExcludeLabels: []string{"kelos/needs-input"},
 		BaseURL:       server.URL,
 	}
 
@@ -640,7 +640,7 @@ func TestDiscoverTriggerComment(t *testing.T) {
 		case r.URL.Path == "/repos/owner/repo/issues":
 			json.NewEncoder(w).Encode(issues)
 		case r.URL.Path == "/repos/owner/repo/issues/1/comments":
-			json.NewEncoder(w).Encode([]githubComment{{Body: "/axon pick-up"}})
+			json.NewEncoder(w).Encode([]githubComment{{Body: "/kelos pick-up"}})
 		case r.URL.Path == "/repos/owner/repo/issues/2/comments":
 			json.NewEncoder(w).Encode([]githubComment{{Body: "Just a regular comment"}})
 		}
@@ -651,7 +651,7 @@ func TestDiscoverTriggerComment(t *testing.T) {
 		Owner:          "owner",
 		Repo:           "repo",
 		BaseURL:        server.URL,
-		TriggerComment: "/axon pick-up",
+		TriggerComment: "/kelos pick-up",
 	}
 
 	items, err := s.Discover(context.Background())
@@ -680,7 +680,7 @@ func TestDiscoverExcludeComment(t *testing.T) {
 		case r.URL.Path == "/repos/owner/repo/issues/1/comments":
 			json.NewEncoder(w).Encode([]githubComment{{Body: "Normal comment"}})
 		case r.URL.Path == "/repos/owner/repo/issues/2/comments":
-			json.NewEncoder(w).Encode([]githubComment{{Body: "/axon needs-input"}})
+			json.NewEncoder(w).Encode([]githubComment{{Body: "/kelos needs-input"}})
 		}
 	}))
 	defer server.Close()
@@ -689,7 +689,7 @@ func TestDiscoverExcludeComment(t *testing.T) {
 		Owner:           "owner",
 		Repo:            "repo",
 		BaseURL:         server.URL,
-		ExcludeComments: []string{"/axon needs-input"},
+		ExcludeComments: []string{"/kelos needs-input"},
 	}
 
 	items, err := s.Discover(context.Background())
@@ -719,9 +719,9 @@ func TestDiscoverMultipleExcludeComments(t *testing.T) {
 		case r.URL.Path == "/repos/owner/repo/issues/1/comments":
 			json.NewEncoder(w).Encode([]githubComment{{Body: "Normal comment"}})
 		case r.URL.Path == "/repos/owner/repo/issues/2/comments":
-			json.NewEncoder(w).Encode([]githubComment{{Body: "/axon needs-input"}})
+			json.NewEncoder(w).Encode([]githubComment{{Body: "/kelos needs-input"}})
 		case r.URL.Path == "/repos/owner/repo/issues/3/comments":
-			json.NewEncoder(w).Encode([]githubComment{{Body: "/axon pause"}})
+			json.NewEncoder(w).Encode([]githubComment{{Body: "/kelos pause"}})
 		}
 	}))
 	defer server.Close()
@@ -730,7 +730,7 @@ func TestDiscoverMultipleExcludeComments(t *testing.T) {
 		Owner:           "owner",
 		Repo:            "repo",
 		BaseURL:         server.URL,
-		ExcludeComments: []string{"/axon needs-input", "/axon pause"},
+		ExcludeComments: []string{"/kelos needs-input", "/kelos pause"},
 	}
 
 	items, err := s.Discover(context.Background())
@@ -759,15 +759,15 @@ func TestDiscoverTriggerAsResume(t *testing.T) {
 		case r.URL.Path == "/repos/owner/repo/issues/1/comments":
 			// Trigger, then exclude, then trigger again — trigger is most recent, so issue should be included
 			json.NewEncoder(w).Encode([]githubComment{
-				{Body: "/axon pick-up"},
-				{Body: "/axon needs-input"},
-				{Body: "/axon pick-up"},
+				{Body: "/kelos pick-up"},
+				{Body: "/kelos needs-input"},
+				{Body: "/kelos pick-up"},
 			})
 		case r.URL.Path == "/repos/owner/repo/issues/2/comments":
 			// Trigger then exclude — exclude is most recent, so issue should be excluded
 			json.NewEncoder(w).Encode([]githubComment{
-				{Body: "/axon pick-up"},
-				{Body: "/axon needs-input"},
+				{Body: "/kelos pick-up"},
+				{Body: "/kelos needs-input"},
 			})
 		}
 	}))
@@ -777,8 +777,8 @@ func TestDiscoverTriggerAsResume(t *testing.T) {
 		Owner:           "owner",
 		Repo:            "repo",
 		BaseURL:         server.URL,
-		TriggerComment:  "/axon pick-up",
-		ExcludeComments: []string{"/axon needs-input"},
+		TriggerComment:  "/kelos pick-up",
+		ExcludeComments: []string{"/kelos needs-input"},
 	}
 
 	items, err := s.Discover(context.Background())
@@ -806,11 +806,11 @@ func TestDiscoverTriggerAndExcludeComment(t *testing.T) {
 		case r.URL.Path == "/repos/owner/repo/issues":
 			json.NewEncoder(w).Encode(issues)
 		case r.URL.Path == "/repos/owner/repo/issues/1/comments":
-			json.NewEncoder(w).Encode([]githubComment{{Body: "/axon pick-up"}})
+			json.NewEncoder(w).Encode([]githubComment{{Body: "/kelos pick-up"}})
 		case r.URL.Path == "/repos/owner/repo/issues/2/comments":
 			json.NewEncoder(w).Encode([]githubComment{
-				{Body: "/axon pick-up"},
-				{Body: "/axon needs-input"},
+				{Body: "/kelos pick-up"},
+				{Body: "/kelos needs-input"},
 			})
 		case r.URL.Path == "/repos/owner/repo/issues/3/comments":
 			json.NewEncoder(w).Encode([]githubComment{{Body: "Just a comment"}})
@@ -822,8 +822,8 @@ func TestDiscoverTriggerAndExcludeComment(t *testing.T) {
 		Owner:           "owner",
 		Repo:            "repo",
 		BaseURL:         server.URL,
-		TriggerComment:  "/axon pick-up",
-		ExcludeComments: []string{"/axon needs-input"},
+		TriggerComment:  "/kelos pick-up",
+		ExcludeComments: []string{"/kelos needs-input"},
 	}
 
 	items, err := s.Discover(context.Background())
@@ -854,85 +854,85 @@ func TestPassesCommentFilter(t *testing.T) {
 		},
 		{
 			name:           "trigger present",
-			triggerComment: "/axon pick-up",
-			comments:       "/axon pick-up",
+			triggerComment: "/kelos pick-up",
+			comments:       "/kelos pick-up",
 			want:           true,
 		},
 		{
 			name:           "trigger absent",
-			triggerComment: "/axon pick-up",
+			triggerComment: "/kelos pick-up",
 			comments:       "no trigger here",
 			want:           false,
 		},
 		{
 			name:           "trigger empty comments",
-			triggerComment: "/axon pick-up",
+			triggerComment: "/kelos pick-up",
 			comments:       "",
 			want:           false,
 		},
 		{
 			name:            "exclude present",
-			excludeComments: []string{"/axon needs-input"},
-			comments:        "/axon needs-input",
+			excludeComments: []string{"/kelos needs-input"},
+			comments:        "/kelos needs-input",
 			want:            false,
 		},
 		{
 			name:            "exclude absent",
-			excludeComments: []string{"/axon needs-input"},
+			excludeComments: []string{"/kelos needs-input"},
 			comments:        "normal comment",
 			want:            true,
 		},
 		{
 			name:            "trigger as resume after exclude",
-			triggerComment:  "/axon pick-up",
-			excludeComments: []string{"/axon needs-input"},
-			comments:        "/axon pick-up\n---\n/axon needs-input\n---\n/axon pick-up",
+			triggerComment:  "/kelos pick-up",
+			excludeComments: []string{"/kelos needs-input"},
+			comments:        "/kelos pick-up\n---\n/kelos needs-input\n---\n/kelos pick-up",
 			want:            true,
 		},
 		{
 			name:            "exclude after trigger",
-			triggerComment:  "/axon pick-up",
-			excludeComments: []string{"/axon needs-input"},
-			comments:        "/axon pick-up\n---\n/axon needs-input",
+			triggerComment:  "/kelos pick-up",
+			excludeComments: []string{"/kelos needs-input"},
+			comments:        "/kelos pick-up\n---\n/kelos needs-input",
 			want:            false,
 		},
 		{
 			name:            "both set but neither found",
-			triggerComment:  "/axon pick-up",
-			excludeComments: []string{"/axon needs-input"},
+			triggerComment:  "/kelos pick-up",
+			excludeComments: []string{"/kelos needs-input"},
 			comments:        "normal comment",
 			want:            false,
 		},
 		{
 			name:            "command must be on its own line",
-			excludeComments: []string{"/axon needs-input"},
-			comments:        "please do /axon needs-input for me",
+			excludeComments: []string{"/kelos needs-input"},
+			comments:        "please do /kelos needs-input for me",
 			want:            true,
 		},
 		{
 			name:            "multiple exclude comments",
-			excludeComments: []string{"/axon needs-input", "/axon pause"},
-			comments:        "/axon pause",
+			excludeComments: []string{"/kelos needs-input", "/kelos pause"},
+			comments:        "/kelos pause",
 			want:            false,
 		},
 		{
 			name:            "multiple exclude comments none match",
-			excludeComments: []string{"/axon needs-input", "/axon pause"},
+			excludeComments: []string{"/kelos needs-input", "/kelos pause"},
 			comments:        "normal comment",
 			want:            true,
 		},
 		{
 			name:            "multiple exclude with trigger resume",
-			triggerComment:  "/axon pick-up",
-			excludeComments: []string{"/axon needs-input", "/axon pause"},
-			comments:        "/axon pick-up\n---\n/axon pause\n---\n/axon pick-up",
+			triggerComment:  "/kelos pick-up",
+			excludeComments: []string{"/kelos needs-input", "/kelos pause"},
+			comments:        "/kelos pick-up\n---\n/kelos pause\n---\n/kelos pick-up",
 			want:            true,
 		},
 		{
 			name:            "multiple exclude second matches most recent",
-			triggerComment:  "/axon pick-up",
-			excludeComments: []string{"/axon needs-input", "/axon pause"},
-			comments:        "/axon pick-up\n---\n/axon pause",
+			triggerComment:  "/kelos pick-up",
+			excludeComments: []string{"/kelos needs-input", "/kelos pause"},
+			comments:        "/kelos pick-up\n---\n/kelos pause",
 			want:            false,
 		},
 	}
@@ -958,12 +958,12 @@ func TestContainsCommand(t *testing.T) {
 		cmd  string
 		want bool
 	}{
-		{"exact match", "/axon pick-up", "/axon pick-up", true},
-		{"with whitespace", "  /axon pick-up  ", "/axon pick-up", true},
-		{"multiline match", "some text\n/axon pick-up\nmore text", "/axon pick-up", true},
-		{"no match", "some text without command", "/axon pick-up", false},
-		{"partial match in word", "do /axon pick-up now", "/axon pick-up", false},
-		{"empty body", "", "/axon pick-up", false},
+		{"exact match", "/kelos pick-up", "/kelos pick-up", true},
+		{"with whitespace", "  /kelos pick-up  ", "/kelos pick-up", true},
+		{"multiline match", "some text\n/kelos pick-up\nmore text", "/kelos pick-up", true},
+		{"no match", "some text without command", "/kelos pick-up", false},
+		{"partial match in word", "do /kelos pick-up now", "/kelos pick-up", false},
+		{"empty body", "", "/kelos pick-up", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/source/prompt_test.go
+++ b/internal/source/prompt_test.go
@@ -159,12 +159,12 @@ func TestRenderTemplate(t *testing.T) {
 		Kind:   "Issue",
 	}
 
-	result, err := RenderTemplate("axon-task-{{.Number}}", item)
+	result, err := RenderTemplate("kelos-task-{{.Number}}", item)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != "axon-task-42" {
-		t.Errorf("expected %q, got %q", "axon-task-42", result)
+	if result != "kelos-task-42" {
+		t.Errorf("expected %q, got %q", "kelos-task-42", result)
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// Version is the current version of the axon binary. It is set at build time
+// Version is the current version of the kelos binary. It is set at build time
 // via ldflags. When unset (e.g. during development or go install) it falls
 // back to the module version from Go build info, and finally to "latest".
 var Version = "latest"

--- a/local-run.sh
+++ b/local-run.sh
@@ -20,9 +20,9 @@ fi
 make image REGISTRY="${REGISTRY}" VERSION="${LOCAL_IMAGE_TAG}"
 
 images=(
-  "${REGISTRY}/axon-controller:${LOCAL_IMAGE_TAG}"
-  "${REGISTRY}/axon-spawner:${LOCAL_IMAGE_TAG}"
-  "${REGISTRY}/axon-token-refresher:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-controller:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-spawner:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-token-refresher:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/claude-code:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/codex:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/gemini:${LOCAL_IMAGE_TAG}"
@@ -33,8 +33,8 @@ for image in "${images[@]}"; do
   kind load docker-image --name "${KIND_CLUSTER_NAME}" "${image}"
 done
 
-go install github.com/axon-core/axon/cmd/axon
+go install github.com/kelos-dev/kelos/cmd/kelos
 
-axon install --version "${LOCAL_IMAGE_TAG}" --image-pull-policy IfNotPresent
-kubectl rollout restart deployment/axon-controller-manager -n axon-system
-kubectl rollout status deployment/axon-controller-manager -n axon-system
+kelos install --version "${LOCAL_IMAGE_TAG}" --image-pull-policy IfNotPresent
+kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
+kubectl rollout status deployment/kelos-controller-manager -n kelos-system

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -30,10 +30,10 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 ARG OPENCODE_VERSION=1.2.6
 RUN npm install -g opencode-ai@${OPENCODE_VERSION}
 
-COPY opencode/axon_entrypoint.sh /axon_entrypoint.sh
-RUN chmod +x /axon_entrypoint.sh
+COPY opencode/kelos_entrypoint.sh /kelos_entrypoint.sh
+RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/axon-capture /axon/axon-capture
+COPY bin/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.opencode && chown -R agent:agent /home/agent

--- a/pkg/generated/clientset/versioned/clientset.go
+++ b/pkg/generated/clientset/versioned/clientset.go
@@ -22,7 +22,7 @@ import (
 	fmt "fmt"
 	http "net/http"
 
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -19,9 +19,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/axon-core/axon/pkg/generated/clientset/versioned"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
-	fakeapiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake"
+	clientset "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	fakeapiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/pkg/generated/clientset/versioned/fake/register.go
+++ b/pkg/generated/clientset/versioned/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/generated/clientset/versioned/scheme/register.go
+++ b/pkg/generated/clientset/versioned/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/agentconfig.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/agentconfig.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	context "context"
 
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	scheme "github.com/axon-core/axon/pkg/generated/clientset/versioned/scheme"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	scheme "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/api_client.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/api_client.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	http "net/http"
 
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	scheme "github.com/axon-core/axon/pkg/generated/clientset/versioned/scheme"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	scheme "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_agentconfig.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_agentconfig.go
@@ -19,8 +19,8 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	v1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
 )
 

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	v1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_task.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_task.go
@@ -19,8 +19,8 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	v1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
 )
 

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_taskspawner.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_taskspawner.go
@@ -19,8 +19,8 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	v1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
 )
 

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_workspace.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/fake/fake_workspace.go
@@ -19,8 +19,8 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	v1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
 )
 

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/task.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/task.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	context "context"
 
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	scheme "github.com/axon-core/axon/pkg/generated/clientset/versioned/scheme"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	scheme "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/taskspawner.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/taskspawner.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	context "context"
 
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	scheme "github.com/axon-core/axon/pkg/generated/clientset/versioned/scheme"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	scheme "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/generated/clientset/versioned/typed/api/v1alpha1/workspace.go
+++ b/pkg/generated/clientset/versioned/typed/api/v1alpha1/workspace.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	context "context"
 
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	scheme "github.com/axon-core/axon/pkg/generated/clientset/versioned/scheme"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	scheme "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/generated/informers/externalversions/api/interface.go
+++ b/pkg/generated/informers/externalversions/api/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package api
 
 import (
-	v1alpha1 "github.com/axon-core/axon/pkg/generated/informers/externalversions/api/v1alpha1"
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/api/v1alpha1"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/generated/informers/externalversions/api/v1alpha1/agentconfig.go
+++ b/pkg/generated/informers/externalversions/api/v1alpha1/agentconfig.go
@@ -22,10 +22,10 @@ import (
 	context "context"
 	time "time"
 
-	axonapiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	versioned "github.com/axon-core/axon/pkg/generated/clientset/versioned"
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/listers/api/v1alpha1"
+	kelosapiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	versioned "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/listers/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -83,7 +83,7 @@ func NewFilteredAgentConfigInformer(client versioned.Interface, namespace string
 				return client.ApiV1alpha1().AgentConfigs(namespace).Watch(ctx, options)
 			},
 		}, client),
-		&axonapiv1alpha1.AgentConfig{},
+		&kelosapiv1alpha1.AgentConfig{},
 		resyncPeriod,
 		indexers,
 	)
@@ -94,7 +94,7 @@ func (f *agentConfigInformer) defaultInformer(client versioned.Interface, resync
 }
 
 func (f *agentConfigInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&axonapiv1alpha1.AgentConfig{}, f.defaultInformer)
+	return f.factory.InformerFor(&kelosapiv1alpha1.AgentConfig{}, f.defaultInformer)
 }
 
 func (f *agentConfigInformer) Lister() apiv1alpha1.AgentConfigLister {

--- a/pkg/generated/informers/externalversions/api/v1alpha1/interface.go
+++ b/pkg/generated/informers/externalversions/api/v1alpha1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/generated/informers/externalversions/api/v1alpha1/task.go
+++ b/pkg/generated/informers/externalversions/api/v1alpha1/task.go
@@ -22,10 +22,10 @@ import (
 	context "context"
 	time "time"
 
-	axonapiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	versioned "github.com/axon-core/axon/pkg/generated/clientset/versioned"
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/listers/api/v1alpha1"
+	kelosapiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	versioned "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/listers/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -83,7 +83,7 @@ func NewFilteredTaskInformer(client versioned.Interface, namespace string, resyn
 				return client.ApiV1alpha1().Tasks(namespace).Watch(ctx, options)
 			},
 		}, client),
-		&axonapiv1alpha1.Task{},
+		&kelosapiv1alpha1.Task{},
 		resyncPeriod,
 		indexers,
 	)
@@ -94,7 +94,7 @@ func (f *taskInformer) defaultInformer(client versioned.Interface, resyncPeriod 
 }
 
 func (f *taskInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&axonapiv1alpha1.Task{}, f.defaultInformer)
+	return f.factory.InformerFor(&kelosapiv1alpha1.Task{}, f.defaultInformer)
 }
 
 func (f *taskInformer) Lister() apiv1alpha1.TaskLister {

--- a/pkg/generated/informers/externalversions/api/v1alpha1/taskspawner.go
+++ b/pkg/generated/informers/externalversions/api/v1alpha1/taskspawner.go
@@ -22,10 +22,10 @@ import (
 	context "context"
 	time "time"
 
-	axonapiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	versioned "github.com/axon-core/axon/pkg/generated/clientset/versioned"
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/listers/api/v1alpha1"
+	kelosapiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	versioned "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/listers/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -83,7 +83,7 @@ func NewFilteredTaskSpawnerInformer(client versioned.Interface, namespace string
 				return client.ApiV1alpha1().TaskSpawners(namespace).Watch(ctx, options)
 			},
 		}, client),
-		&axonapiv1alpha1.TaskSpawner{},
+		&kelosapiv1alpha1.TaskSpawner{},
 		resyncPeriod,
 		indexers,
 	)
@@ -94,7 +94,7 @@ func (f *taskSpawnerInformer) defaultInformer(client versioned.Interface, resync
 }
 
 func (f *taskSpawnerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&axonapiv1alpha1.TaskSpawner{}, f.defaultInformer)
+	return f.factory.InformerFor(&kelosapiv1alpha1.TaskSpawner{}, f.defaultInformer)
 }
 
 func (f *taskSpawnerInformer) Lister() apiv1alpha1.TaskSpawnerLister {

--- a/pkg/generated/informers/externalversions/api/v1alpha1/workspace.go
+++ b/pkg/generated/informers/externalversions/api/v1alpha1/workspace.go
@@ -22,10 +22,10 @@ import (
 	context "context"
 	time "time"
 
-	axonapiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	versioned "github.com/axon-core/axon/pkg/generated/clientset/versioned"
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
-	apiv1alpha1 "github.com/axon-core/axon/pkg/generated/listers/api/v1alpha1"
+	kelosapiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	versioned "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
+	apiv1alpha1 "github.com/kelos-dev/kelos/pkg/generated/listers/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -83,7 +83,7 @@ func NewFilteredWorkspaceInformer(client versioned.Interface, namespace string, 
 				return client.ApiV1alpha1().Workspaces(namespace).Watch(ctx, options)
 			},
 		}, client),
-		&axonapiv1alpha1.Workspace{},
+		&kelosapiv1alpha1.Workspace{},
 		resyncPeriod,
 		indexers,
 	)
@@ -94,7 +94,7 @@ func (f *workspaceInformer) defaultInformer(client versioned.Interface, resyncPe
 }
 
 func (f *workspaceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&axonapiv1alpha1.Workspace{}, f.defaultInformer)
+	return f.factory.InformerFor(&kelosapiv1alpha1.Workspace{}, f.defaultInformer)
 }
 
 func (f *workspaceInformer) Lister() apiv1alpha1.WorkspaceLister {

--- a/pkg/generated/informers/externalversions/factory.go
+++ b/pkg/generated/informers/externalversions/factory.go
@@ -23,9 +23,9 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "github.com/axon-core/axon/pkg/generated/clientset/versioned"
-	api "github.com/axon-core/axon/pkg/generated/informers/externalversions/api"
-	internalinterfaces "github.com/axon-core/axon/pkg/generated/informers/externalversions/internalinterfaces"
+	versioned "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
+	api "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/api"
+	internalinterfaces "github.com/kelos-dev/kelos/pkg/generated/informers/externalversions/internalinterfaces"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/generated/informers/externalversions/generic.go
+++ b/pkg/generated/informers/externalversions/generic.go
@@ -21,7 +21,7 @@ package externalversions
 import (
 	fmt "fmt"
 
-	v1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	v1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -21,7 +21,7 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "github.com/axon-core/axon/pkg/generated/clientset/versioned"
+	versioned "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/generated/listers/api/v1alpha1/agentconfig.go
+++ b/pkg/generated/listers/api/v1alpha1/agentconfig.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/generated/listers/api/v1alpha1/task.go
+++ b/pkg/generated/listers/api/v1alpha1/task.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/generated/listers/api/v1alpha1/taskspawner.go
+++ b/pkg/generated/listers/api/v1alpha1/taskspawner.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/generated/listers/api/v1alpha1/workspace.go
+++ b/pkg/generated/listers/api/v1alpha1/workspace.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	apiv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -1,6 +1,6 @@
 # Self-Development Orchestration Patterns
 
-This directory contains real-world orchestration patterns used by the Axon project itself for autonomous development.
+This directory contains real-world orchestration patterns used by the Kelos project itself for autonomous development.
 
 ## Overview
 
@@ -20,10 +20,10 @@ Before deploying these examples, you need to create the following resources:
 Create a Workspace that points to your repository:
 
 ```yaml
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
-  name: axon-agent
+  name: kelos-agent
 spec:
   repo: https://github.com/your-org/your-repo.git
   ref: main
@@ -51,13 +51,13 @@ Create a secret with your AI agent credentials:
 
 **For OAuth (Claude Code):**
 ```bash
-kubectl create secret generic axon-credentials \
+kubectl create secret generic kelos-credentials \
   --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-claude-oauth-token>
 ```
 
 **For API Key:**
 ```bash
-kubectl create secret generic axon-credentials \
+kubectl create secret generic kelos-credentials \
   --from-literal=ANTHROPIC_API_KEY=<your-api-key>
 ```
 
@@ -80,32 +80,32 @@ GitHub Actions:
 
 The target cluster must already have:
 
-- Axon installed
-- `Workspace` named `axon-agent`
-- Secret `axon-credentials`
+- Kelos installed
+- `Workspace` named `kelos-agent`
+- Secret `kelos-credentials`
 
-### axon-workers.yaml
+### kelos-workers.yaml
 
-This TaskSpawner picks up open GitHub issues labeled with `actor/axon` and creates autonomous agent tasks to fix them.
+This TaskSpawner picks up open GitHub issues labeled with `actor/kelos` and creates autonomous agent tasks to fix them.
 
 **Key features:**
 - Automatically checks for existing PRs and updates them incrementally
 - Self-reviews PRs before requesting human review
 - Ensures CI passes before completion
-- Labels issues with `axon/needs-input` when human input is needed
+- Labels issues with `kelos/needs-input` when human input is needed
 - Creates a feedback loop: remove the label to re-queue the issue
 - Supports manual reset via `/reset-worker` comment from a repository admin:
-  - Deletes `Task/axon-workers-<ISSUE-NUMBER>` so it can be recreated with the same name
-  - Removes `axon/needs-input` from the relevant issue and PR
+  - Deletes `Task/kelos-workers-<ISSUE-NUMBER>` so it can be recreated with the same name
+  - Removes `kelos/needs-input` from the relevant issue and PR
 
 **Deploy:**
 ```bash
 # First, ensure all prerequisites are created
 kubectl apply -f - <<EOF
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Workspace
 metadata:
-  name: axon-agent
+  name: kelos-agent
 spec:
   repo: https://github.com/your-org/your-repo.git
   ref: main
@@ -115,7 +115,7 @@ spec:
 EOF
 
 # Then deploy the TaskSpawner
-kubectl apply -f self-development/axon-workers.yaml
+kubectl apply -f self-development/kelos-workers.yaml
 ```
 
 **Monitor:**
@@ -124,19 +124,19 @@ kubectl apply -f self-development/axon-workers.yaml
 kubectl get tasks -w
 
 # Check TaskSpawner status
-kubectl get taskspawner axon-workers -o yaml
+kubectl get taskspawner kelos-workers -o yaml
 
 # View logs from a specific task
 kubectl logs -l job-name=<job-name> -f
 ```
 
-### axon-fake-user.yaml
+### kelos-fake-user.yaml
 
 This TaskSpawner runs daily to test the developer experience as if you were a new user.
 
 **Deploy:**
 ```bash
-kubectl apply -f self-development/axon-fake-user.yaml
+kubectl apply -f self-development/kelos-fake-user.yaml
 ```
 
 This spawner uses a daily cron schedule (`0 9 * * *`) and will create a task each day to:
@@ -145,28 +145,28 @@ This spawner uses a daily cron schedule (`0 9 * * *`) and will create a task eac
 - Review examples and identify gaps
 - Create GitHub issues for any problems found
 
-### axon-fake-strategist.yaml
+### kelos-fake-strategist.yaml
 
-This TaskSpawner runs every 12 hours to strategically explore new ways to use and improve Axon.
+This TaskSpawner runs every 12 hours to strategically explore new ways to use and improve Kelos.
 
 **Deploy:**
 ```bash
-kubectl apply -f self-development/axon-fake-strategist.yaml
+kubectl apply -f self-development/kelos-fake-strategist.yaml
 ```
 
 This spawner uses a cron schedule (`0 */12 * * *`) and will create a task every 12 hours to focus on one of:
-- **New Use Cases** — explore what types of projects/teams could benefit from Axon, propose example TaskSpawner configs
+- **New Use Cases** — explore what types of projects/teams could benefit from Kelos, propose example TaskSpawner configs
 - **Workflow Improvements** — analyze existing self-development configs and suggest better patterns, prompts, or automation flows
-- **Integration Opportunities** — identify tools/platforms Axon could integrate with (CI systems, monitoring, chat ops, etc.)
-- **New CRDs & API Extensions** — propose new Custom Resource Definitions or extensions to existing CRDs that would expand Axon's capabilities
+- **Integration Opportunities** — identify tools/platforms Kelos could integrate with (CI systems, monitoring, chat ops, etc.)
+- **New CRDs & API Extensions** — propose new Custom Resource Definitions or extensions to existing CRDs that would expand Kelos's capabilities
 
-### axon-self-update.yaml
+### kelos-self-update.yaml
 
 This TaskSpawner runs daily to review and update the self-development workflow files themselves.
 
 **Deploy:**
 ```bash
-kubectl apply -f self-development/axon-self-update.yaml
+kubectl apply -f self-development/kelos-self-update.yaml
 ```
 
 This spawner uses a daily cron schedule (`0 6 * * *`, every day at 06:00 UTC) and will create a task to focus on one of:
@@ -225,11 +225,11 @@ To adapt these examples for your own repository:
 
 ## Feedback Loop Pattern
 
-The key pattern in these examples is the `excludeLabels: [axon/needs-input]` configuration. This creates an autonomous feedback loop:
+The key pattern in these examples is the `excludeLabels: [kelos/needs-input]` configuration. This creates an autonomous feedback loop:
 
-1. Agent picks up an open issue without the `axon/needs-input` label
+1. Agent picks up an open issue without the `kelos/needs-input` label
 2. Agent investigates, creates/updates a PR, and self-reviews
-3. If the agent needs human input, it adds the `axon/needs-input` label
+3. If the agent needs human input, it adds the `kelos/needs-input` label
 4. The issue is excluded from future polls until a human removes the label
 5. Removing the label re-queues the issue on the next poll
 
@@ -240,8 +240,8 @@ This allows agents to work fully autonomously while gracefully handing off to hu
 **TaskSpawner not creating tasks:**
 - Check the TaskSpawner status: `kubectl get taskspawner <name> -o yaml`
 - Verify the Workspace exists: `kubectl get workspace`
-- Ensure credentials are correctly configured: `kubectl get secret axon-credentials`
-- Check TaskSpawner logs: `kubectl logs deployment/axon-controller-manager -n axon-system`
+- Ensure credentials are correctly configured: `kubectl get secret kelos-credentials`
+- Check TaskSpawner logs: `kubectl logs deployment/kelos-controller-manager -n kelos-system`
 
 **Tasks failing immediately:**
 - Verify the agent credentials are valid
@@ -251,11 +251,11 @@ This allows agents to work fully autonomously while gracefully handing off to hu
 **Agent not creating PRs:**
 - Ensure the `github-token` secret exists and is referenced in the Workspace
 - Verify the token has `repo` permissions
-- Check if git user is configured in the agent prompt (see `axon-workers.yaml` for example)
+- Check if git user is configured in the agent prompt (see `kelos-workers.yaml` for example)
 
 ## Next Steps
 
 - Read the [main README](../README.md) for more details on Tasks and Workspaces
 - Review the [agent image interface](../docs/agent-image-interface.md) to create custom agents
 - Check existing TaskSpawners: `kubectl get taskspawners`
-- Monitor task execution: `axon get tasks` or `kubectl get tasks`
+- Monitor task execution: `kelos get tasks` or `kubectl get tasks`

--- a/self-development/agentconfig.yaml
+++ b/self-development/agentconfig.yaml
@@ -1,10 +1,10 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: AgentConfig
 metadata:
-  name: axon-dev-agent
+  name: kelos-dev-agent
 spec:
   agentsMD: |
-    # Axon Development Agent
+    # Kelos Development Agent
 
     ## Environment
     You are running in an ephemeral container environment. Your file system
@@ -13,7 +13,7 @@ spec:
 
     ## Identity
     - Always run at the start: `git config user.name "Gunju Kim" && git config user.email "gjkim042@gmail.com"`
-    - When commenting on issues or PRs, always start with "🤖 **Axon Agent** @gjkim42\n\n"
+    - When commenting on issues or PRs, always start with "🤖 **Kelos Agent** @gjkim42\n\n"
       so it is clearly distinguishable from human comments and triggers a notification
 
     ## Standards

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -1,7 +1,7 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
-  name: axon-fake-strategist
+  name: kelos-fake-strategist
 spec:
   when:
     cron:
@@ -9,14 +9,14 @@ spec:
   maxConcurrency: 1
   taskTemplate:
     workspaceRef:
-      name: axon-agent
+      name: kelos-agent
     model: opus
     type: claude-code
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:
-        name: axon-credentials
+        name: kelos-credentials
     podOverrides:
       resources:
         requests:
@@ -28,16 +28,16 @@ spec:
           memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
-      name: axon-dev-agent
+      name: kelos-dev-agent
     promptTemplate: |
-      You are a strategic product thinker for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
-      Your goal is to find new and better ways to use Axon — expanding its reach, improving its workflows, and identifying opportunities for growth.
+      You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
+      Your goal is to find new and better ways to use Kelos — expanding its reach, improving its workflows, and identifying opportunities for growth.
 
       Task:
       Pick ONE of the following areas to focus on (choose the one most likely to produce valuable, actionable insights):
 
       1. **New Use Cases**
-         - Explore what types of projects, teams, or industries could benefit from Axon
+         - Explore what types of projects, teams, or industries could benefit from Kelos
          - Look at trending developer workflows and identify where autonomous agents could help
          - Propose example TaskSpawner configs for new use cases
          - Consider both technical and non-technical audiences
@@ -49,21 +49,21 @@ spec:
          - Propose improvements backed by concrete examples
 
       3. **Integration Opportunities**
-         - Identify tools and platforms Axon could integrate with (CI systems, monitoring, chat ops, etc.)
-         - Evaluate how Axon could fit into existing developer toolchains
+         - Identify tools and platforms Kelos could integrate with (CI systems, monitoring, chat ops, etc.)
+         - Evaluate how Kelos could fit into existing developer toolchains
          - Propose specific integration designs with example configs
          - Consider ecosystem partners and complementary projects
 
       4. **New CRDs & API Extensions**
          - Review existing CRDs and identify limitations or missing features
-         - Propose new Custom Resource Definitions that would expand Axon's capabilities
+         - Propose new Custom Resource Definitions that would expand Kelos's capabilities
          - Suggest extensions to existing CRDs with concrete use cases
          - Consider backward compatibility and incremental adoption
 
       Actions:
       - Create a GitHub issue with your findings and proposals:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-axon --label axon/needs-input
+        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos --label kelos/needs-input
         ```
       - Do NOT create PRs. Only create issues
       - Prefer well-researched issues with clear proposals over broad, vague suggestions
@@ -73,6 +73,6 @@ spec:
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-axon" (`gh issue list --label generated-by-axon --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
   pollInterval: 1m

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -1,7 +1,7 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
-  name: axon-fake-user
+  name: kelos-fake-user
 spec:
   when:
     cron:
@@ -9,14 +9,14 @@ spec:
   maxConcurrency: 1
   taskTemplate:
     workspaceRef:
-      name: axon-agent
+      name: kelos-agent
     model: sonnet
     type: claude-code
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:
-        name: axon-credentials
+        name: kelos-credentials
     podOverrides:
       resources:
         requests:
@@ -28,17 +28,17 @@ spec:
           memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
-      name: axon-dev-agent
+      name: kelos-dev-agent
     promptTemplate: |
-      You are a developer experience tester for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
-      Your goal is to improve Axon so that more developers adopt it. Act as a new user trying out the project for the first time.
+      You are a developer experience tester for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
+      Your goal is to improve Kelos so that more developers adopt it. Act as a new user trying out the project for the first time.
 
       Task:
       Pick ONE of the following areas to focus on (choose the one most likely to have actionable improvements):
 
       1. **Documentation & Onboarding**
          - Read the README and try to follow the getting-started instructions
-         - Check if CLI help text (`axon --help`, `axon run --help`, etc.) is clear
+         - Check if CLI help text (`kelos --help`, `kelos run --help`, etc.) is clear
          - Look for missing or outdated documentation
 
       2. **Developer Experience**
@@ -54,7 +54,7 @@ spec:
       Actions:
       - If you find an issue, create a GitHub issue:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-axon --label axon/needs-input
+        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos --label kelos/needs-input
         ```
       - Do NOT create PRs. Only create issues
 
@@ -62,6 +62,6 @@ spec:
       - Focus on ONE area per run, do it thoroughly
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-axon" (`gh issue list --label generated-by-axon --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
   pollInterval: 1m

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -1,7 +1,7 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
-  name: axon-self-update
+  name: kelos-self-update
 spec:
   when:
     cron:
@@ -9,14 +9,14 @@ spec:
   maxConcurrency: 1
   taskTemplate:
     workspaceRef:
-      name: axon-agent
+      name: kelos-agent
     model: opus
     type: claude-code
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:
-        name: axon-credentials
+        name: kelos-credentials
     podOverrides:
       resources:
         requests:
@@ -28,13 +28,13 @@ spec:
           memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
-      name: axon-dev-agent
+      name: kelos-dev-agent
     promptTemplate: |
-      You are a self-improvement agent for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
-      Your goal is to review and update the self-development workflow files that define how Axon develops itself.
+      You are a self-improvement agent for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
+      Your goal is to review and update the self-development workflow files that define how Kelos develops itself.
 
       The self-development directory (`self-development/`) contains TaskSpawner definitions, AgentConfig, and task templates
-      that orchestrate Axon's autonomous development loop. These files evolve as the project grows — prompts need tuning,
+      that orchestrate Kelos's autonomous development loop. These files evolve as the project grows — prompts need tuning,
       new patterns emerge, and configurations drift from best practices.
 
       Task:
@@ -43,7 +43,7 @@ spec:
       1. **Prompt Tuning**
          - Review prompts in all TaskSpawner definitions (`self-development/*.yaml`)
          - Compare prompts against actual agent behavior by checking recent PRs and issues created by agents
-           (`gh pr list --label generated-by-axon --limit 20`, `gh issue list --label generated-by-axon --limit 20`)
+           (`gh pr list --label generated-by-kelos --limit 20`, `gh issue list --label generated-by-kelos --limit 20`)
          - Identify prompts that produce low-quality output, miss edge cases, or lack clarity
          - Propose improved prompt wording backed by evidence from past agent runs
 
@@ -67,14 +67,14 @@ spec:
       Actions:
       - If you find improvements, create a PR:
         ```
-        git checkout -b axon-self-update-{{.ID}}
+        git checkout -b kelos-self-update-{{.ID}}
         # ... make changes ...
-        git push -u origin axon-self-update-{{.ID}}
-        gh pr create --title "<title>" --body "<description>" --label generated-by-axon --label ok-to-test
+        git push -u origin kelos-self-update-{{.ID}}
+        gh pr create --title "<title>" --body "<description>" --label generated-by-kelos --label ok-to-test
         ```
       - If the changes are too large or need discussion, create an issue instead:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-axon --label axon/needs-input
+        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos --label kelos/needs-input
         ```
 
       Constraints:
@@ -83,6 +83,6 @@ spec:
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence from the codebase and recent agent activity
       - Keep changes minimal and focused
-      - Before creating output, review recent issues and PRs labeled "generated-by-axon" to avoid overlap
+      - Before creating output, review recent issues and PRs labeled "generated-by-kelos" to avoid overlap
       - If after review you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output
   pollInterval: 1m

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -1,7 +1,7 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
-  name: axon-triage
+  name: kelos-triage
 spec:
   when:
     githubIssues:
@@ -11,21 +11,21 @@ spec:
       labels:
         - needs-actor
       excludeLabels:
-        - axon/needs-input
+        - kelos/needs-input
   maxConcurrency: 8
   taskTemplate:
     workspaceRef:
-      name: axon-agent
+      name: kelos-agent
     model: opus
     type: claude-code
     credentials:
       type: oauth
       secretRef:
-        name: axon-credentials
+        name: kelos-credentials
     agentConfigRef:
-      name: axon-dev-agent
+      name: kelos-dev-agent
     promptTemplate: |
-      You are a triage agent for the Axon project (github.com/axon-core/axon).
+      You are a triage agent for the Kelos project (github.com/kelos-dev/kelos).
       Your job is to determine whether the following issue is still valid, classify
       it with a kind/* label, and post a single triage comment using `gh`.
 
@@ -81,7 +81,7 @@ spec:
       Format the comment as:
 
       ```
-      ## Axon Triage Report
+      ## Kelos Triage Report
 
       **Kind**: <kind label applied>
 
@@ -95,9 +95,9 @@ spec:
       **Recommendation**: KEEP OPEN / CLOSE (with reason)
       ```
 
-      After posting the comment, add the `axon/needs-input` label so a maintainer
+      After posting the comment, add the `kelos/needs-input` label so a maintainer
       can review the triage and the issue is not re-processed:
-        `gh issue edit {{.Number}} --add-label axon/needs-input`
+        `gh issue edit {{.Number}} --add-label kelos/needs-input`
 
       Do NOT open PRs, push code, or modify any files. Read-only analysis only
       (except for the comment and labels above).

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -1,14 +1,14 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
-  name: axon-workers
+  name: kelos-workers
 spec:
   when:
     githubIssues:
       labels:
-        - actor/axon
+        - actor/kelos
       excludeLabels:
-        - axon/needs-input
+        - kelos/needs-input
       priorityLabels:
         - priority/critical-urgent
         - priority/imporant-soon
@@ -17,14 +17,14 @@ spec:
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:
-      name: axon-agent
+      name: kelos-agent
     model: opus
     type: claude-code
     ttlSecondsAfterFinished: 3600
     credentials:
       type: oauth
       secretRef:
-        name: axon-credentials
+        name: kelos-credentials
     podOverrides:
       resources:
         requests:
@@ -35,9 +35,9 @@ spec:
           cpu: "1"
           memory: "2Gi"
           ephemeral-storage: "4Gi"
-    branch: "axon-task-{{.Number}}"
+    branch: "kelos-task-{{.Number}}"
     agentConfigRef:
-      name: axon-dev-agent
+      name: kelos-dev-agent
     promptTemplate: |
       You are a coding agent. You either
       - create a PR to fix the issue
@@ -45,21 +45,21 @@ spec:
       - comment on the issue or the PR if you cannot fix it
 
       Pre-checklist:
-      - Label the PR with "generated-by-axon" and "ok-to-test":
-        - gh pr edit <number> --add-label generated-by-axon --add-label ok-to-test
+      - Label the PR with "generated-by-kelos" and "ok-to-test":
+        - gh pr edit <number> --add-label generated-by-kelos --add-label ok-to-test
 
       Task:
       - 0. Set up your working branch. Run this exactly:
         ```
         git fetch --unshallow || true; git fetch origin main; git rebase origin/main
         ```
-      - 1. Check if a PR already exists for branch axon-task-{{.Number}}.
+      - 1. Check if a PR already exists for branch kelos-task-{{.Number}}.
 
       If a PR already exists:
       - 2a. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments).
       - 3a. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
       - 4a. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work.
-      - 5a. Commit and push your changes to origin axon-task-{{.Number}}.
+      - 5a. Commit and push your changes to origin kelos-task-{{.Number}}.
       - 6a. /review the PR to verify your changes address the feedback. If changes are needed, make them, commit and push, then /review again. Repeat until the review passes.
       - 7a. Update the PR title and description to reflect the final diff.
       - 8a. Make sure the PR passes all CI tests.
@@ -67,16 +67,16 @@ spec:
       If no PR exists:
       - 2b. Investigate the issue #{{.Number}}.
       - 3b. Create a commit that fixes the issue.
-      - 4b. Push your branch to origin axon-task-{{.Number}}.
+      - 4b. Push your branch to origin kelos-task-{{.Number}}.
       - 5b. Create a PR, then /review it. If changes are needed, make them, commit and push, then /review again. Repeat until the review passes.
       - 6b. Update the PR title and description to reflect the final diff.
       - 7b. Make sure the PR passes all CI tests.
 
       Post-checklist:
-      - Add axon/needs-input label to the issue (gh issue edit {{.Number}} --add-label axon/needs-input) and leave a comment for the reason if any of the following applies:
+      - Add kelos/needs-input label to the issue (gh issue edit {{.Number}} --add-label kelos/needs-input) and leave a comment for the reason if any of the following applies:
         - The PR is ready for review, please take a look.
         - Commented on the issue or the PR for more information.
         - You cannot make any progress on the issue, explain why.
       - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
-        - gh issue create --title "<title>" --body "<description>" --label generated-by-axon --label axon/needs-input
+        - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos --label kelos/needs-input
   pollInterval: 1m

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -1,21 +1,21 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
-  generateName: axon-fake-strategist-manual-
+  generateName: kelos-fake-strategist-manual-
   labels:
-    axon.run/type: fake-strategist-manual
+    kelos.dev/type: fake-strategist-manual
 spec:
   workspaceRef:
-    name: axon-agent
+    name: kelos-agent
   model: opus
   type: claude-code
   ttlSecondsAfterFinished: 864000
   credentials:
     type: oauth
     secretRef:
-      name: axon-credentials
+      name: kelos-credentials
   agentConfigRef:
-    name: axon-dev-agent
+    name: kelos-dev-agent
   podOverrides:
     resources:
       requests:
@@ -27,14 +27,14 @@ spec:
         memory: "2Gi"
         ephemeral-storage: "2Gi"
   prompt: |
-    You are a strategic product thinker for the Axon framework — a Kubernetes-native controller that runs autonomous AI coding agents.
-    Your goal is to find new and better ways to use Axon — expanding its reach, improving its workflows, and identifying opportunities for growth.
+    You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
+    Your goal is to find new and better ways to use Kelos — expanding its reach, improving its workflows, and identifying opportunities for growth.
 
     Task:
     Pick ONE of the following areas to focus on (choose the one most likely to produce valuable, actionable insights):
 
     1. **New Use Cases**
-       - Explore what types of projects, teams, or industries could benefit from Axon
+       - Explore what types of projects, teams, or industries could benefit from Kelos
        - Look at trending developer workflows and identify where autonomous agents could help
        - Propose example TaskSpawner configs for new use cases
        - Consider both technical and non-technical audiences
@@ -46,20 +46,20 @@ spec:
        - Propose improvements backed by concrete examples
 
     3. **Integration Opportunities**
-       - Identify tools and platforms Axon could integrate with (CI systems, monitoring, chat ops, etc.)
-       - Evaluate how Axon could fit into existing developer toolchains
+       - Identify tools and platforms Kelos could integrate with (CI systems, monitoring, chat ops, etc.)
+       - Evaluate how Kelos could fit into existing developer toolchains
        - Propose specific integration designs with example configs
        - Consider ecosystem partners and complementary projects
 
     4. **New CRDs & API Extensions**
        - Review existing CRDs and identify limitations or missing features
-       - Propose new Custom Resource Definitions that would expand Axon's capabilities
+       - Propose new Custom Resource Definitions that would expand Kelos's capabilities
        - Suggest extensions to existing CRDs with concrete use cases
        - Consider backward compatibility and incremental adoption
 
     Actions:
     - Create a GitHub issue with your findings and proposals:
-      gh issue create --title "<title>" --body "<description>" --label generated-by-axon --label axon/needs-input
+      gh issue create --title "<title>" --body "<description>" --label generated-by-kelos --label kelos/needs-input
     - Do NOT create PRs. Only create issues
     - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
@@ -68,5 +68,5 @@ spec:
     - Do not create duplicate issues — check existing issues first with `gh issue list`
     - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
     - Keep changes minimal and focused
-    - Before creating output, review recent issues labeled "generated-by-axon" (`gh issue list --label generated-by-axon --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+    - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
     - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/tasks/squash-commits-task.yaml
+++ b/self-development/tasks/squash-commits-task.yaml
@@ -1,21 +1,21 @@
-apiVersion: axon.io/v1alpha1
+apiVersion: kelos.dev/v1alpha1
 kind: Task
 metadata:
-  name: axon-workers-${ISSUE_NUMBER}
+  name: kelos-workers-${ISSUE_NUMBER}
   labels:
-    axon.run/type: squash-commits
+    kelos.dev/type: squash-commits
 spec:
   workspaceRef:
-    name: axon-agent
+    name: kelos-agent
   model: sonnet
   type: claude-code
   ttlSecondsAfterFinished: 3600
   credentials:
     type: oauth
     secretRef:
-      name: axon-credentials
+      name: kelos-credentials
   agentConfigRef:
-    name: axon-dev-agent
+    name: kelos-dev-agent
   podOverrides:
     resources:
       requests:

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/test/e2e/framework"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
 var _ = Describe("CLI", func() {
@@ -21,9 +21,9 @@ var _ = Describe("CLI", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Task via CLI")
-		framework.Axon("run",
+		framework.Kelos("run",
 			"-n", f.Namespace,
-			"-p", "Print 'Hello from Axon CLI e2e test' to stdout",
+			"-p", "Print 'Hello from Kelos CLI e2e test' to stdout",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
 			"--model", testModel,
@@ -34,30 +34,30 @@ var _ = Describe("CLI", func() {
 		f.WaitForJobCompletion("cli-task")
 
 		By("verifying task status via CLI get (detail)")
-		output := framework.AxonOutput("get", "task", "cli-task", "-n", f.Namespace)
+		output := framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace)
 		Expect(output).To(ContainSubstring("Succeeded"))
 
 		By("verifying YAML output for a single task")
-		output = framework.AxonOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		output = framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: Task"))
 		Expect(output).To(ContainSubstring("name: cli-task"))
 
 		By("verifying JSON output for a single task")
-		output = framework.AxonOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		output = framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "Task"`))
 		Expect(output).To(ContainSubstring(`"name": "cli-task"`))
 
 		By("verifying task logs via CLI")
-		logs := framework.AxonOutput("logs", "cli-task", "-n", f.Namespace)
+		logs := framework.KelosOutput("logs", "cli-task", "-n", f.Namespace)
 		Expect(logs).NotTo(BeEmpty())
 
 		By("deleting task via CLI")
-		framework.Axon("delete", "task", "cli-task", "-n", f.Namespace)
+		framework.Kelos("delete", "task", "cli-task", "-n", f.Namespace)
 
 		By("verifying task is no longer listed")
-		output = framework.AxonOutput("get", "tasks", "-n", f.Namespace)
+		output = framework.KelosOutput("get", "tasks", "-n", f.Namespace)
 		Expect(output).NotTo(ContainSubstring("cli-task"))
 	})
 
@@ -67,7 +67,7 @@ var _ = Describe("CLI", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Task and immediately following logs")
-		framework.Axon("run",
+		framework.Kelos("run",
 			"-n", f.Namespace,
 			"-p", "Print 'Hello from follow test' to stdout",
 			"--secret", "claude-credentials",
@@ -75,7 +75,7 @@ var _ = Describe("CLI", func() {
 			"--name", "cli-follow-task",
 		)
 
-		stdout, stderr := framework.AxonOutputWithStderr("logs", "cli-follow-task", "-n", f.Namespace, "-f")
+		stdout, stderr := framework.KelosOutputWithStderr("logs", "cli-follow-task", "-n", f.Namespace, "-f")
 		By("verifying stderr contains streaming status")
 		Expect(stderr).To(ContainSubstring("Streaming container (claude-code) logs..."))
 		By("verifying stderr contains result summary")
@@ -90,18 +90,18 @@ var _ = Describe("CLI", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace resource")
-		f.CreateWorkspace(&axonv1alpha1.Workspace{
+		f.CreateWorkspace(&kelosv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-cli-workspace",
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
-				Repo: "https://github.com/axon-core/axon.git",
+			Spec: kelosv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/kelos-dev/kelos.git",
 				Ref:  "main",
 			},
 		})
 
 		By("creating a Task with workspace via CLI")
-		framework.Axon("run",
+		framework.Kelos("run",
 			"-n", f.Namespace,
 			"-p", "Run 'git log --oneline -1' and print the output",
 			"--secret", "claude-credentials",
@@ -115,102 +115,102 @@ var _ = Describe("CLI", func() {
 		f.WaitForJobCompletion("cli-ws-task")
 
 		By("verifying task status via CLI get (detail)")
-		output := framework.AxonOutput("get", "task", "cli-ws-task", "-n", f.Namespace, "--detail")
+		output := framework.KelosOutput("get", "task", "cli-ws-task", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("Succeeded"))
 		Expect(output).To(ContainSubstring("Workspace"))
 
 		By("verifying task logs via CLI")
-		logs := framework.AxonOutput("logs", "cli-ws-task", "-n", f.Namespace)
+		logs := framework.KelosOutput("logs", "cli-ws-task", "-n", f.Namespace)
 		Expect(logs).NotTo(BeEmpty())
 
 		By("deleting task via CLI")
-		framework.Axon("delete", "task", "cli-ws-task", "-n", f.Namespace)
+		framework.Kelos("delete", "task", "cli-ws-task", "-n", f.Namespace)
 
 		By("verifying task is no longer listed")
-		output = framework.AxonOutput("get", "tasks", "-n", f.Namespace)
+		output = framework.KelosOutput("get", "tasks", "-n", f.Namespace)
 		Expect(output).NotTo(ContainSubstring("cli-ws-task"))
 	})
 })
 
 var _ = Describe("create", func() {
 	It("should fail without a resource type", func() {
-		framework.AxonFail("create")
+		framework.KelosFail("create")
 	})
 })
 
 var _ = Describe("delete", func() {
 	It("should fail without a resource type", func() {
-		framework.AxonFail("delete")
+		framework.KelosFail("delete")
 	})
 
 	It("should fail for a nonexistent task", func() {
-		framework.AxonFail("delete", "task", "nonexistent-task-name")
+		framework.KelosFail("delete", "task", "nonexistent-task-name")
 	})
 
 	It("should fail for a nonexistent workspace", func() {
-		framework.AxonFail("delete", "workspace", "nonexistent-workspace-name")
+		framework.KelosFail("delete", "workspace", "nonexistent-workspace-name")
 	})
 
 	It("should fail for a nonexistent taskspawner", func() {
-		framework.AxonFail("delete", "taskspawner", "nonexistent-spawner-name")
+		framework.KelosFail("delete", "taskspawner", "nonexistent-spawner-name")
 	})
 })
 
 var _ = Describe("get", func() {
 	It("should fail without a resource type", func() {
-		framework.AxonFail("get")
+		framework.KelosFail("get")
 	})
 
 	It("should succeed with 'tasks' alias", func() {
-		framework.AxonOutput("get", "tasks")
+		framework.KelosOutput("get", "tasks")
 	})
 
 	It("should succeed with 'task' subcommand", func() {
-		framework.AxonOutput("get", "task")
+		framework.KelosOutput("get", "task")
 	})
 
 	It("should succeed with 'workspaces' alias", func() {
-		framework.AxonOutput("get", "workspaces")
+		framework.KelosOutput("get", "workspaces")
 	})
 
 	It("should succeed with 'workspace' subcommand", func() {
-		framework.AxonOutput("get", "workspace")
+		framework.KelosOutput("get", "workspace")
 	})
 
 	It("should fail for a nonexistent task", func() {
-		framework.AxonFail("get", "task", "nonexistent-task-name")
+		framework.KelosFail("get", "task", "nonexistent-task-name")
 	})
 
 	It("should fail for a nonexistent workspace", func() {
-		framework.AxonFail("get", "workspace", "nonexistent-workspace-name")
+		framework.KelosFail("get", "workspace", "nonexistent-workspace-name")
 	})
 
 	It("should output task list in YAML format", func() {
-		output := framework.AxonOutput("get", "tasks", "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		output := framework.KelosOutput("get", "tasks", "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: TaskList"))
 	})
 
 	It("should output task list in JSON format", func() {
-		output := framework.AxonOutput("get", "tasks", "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		output := framework.KelosOutput("get", "tasks", "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "TaskList"`))
 	})
 
 	It("should output workspace list in YAML format", func() {
-		output := framework.AxonOutput("get", "workspaces", "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		output := framework.KelosOutput("get", "workspaces", "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: WorkspaceList"))
 	})
 
 	It("should output workspace list in JSON format", func() {
-		output := framework.AxonOutput("get", "workspaces", "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		output := framework.KelosOutput("get", "workspaces", "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "WorkspaceList"`))
 	})
 
 	It("should fail with unknown output format", func() {
-		framework.AxonFail("get", "tasks", "-o", "invalid")
+		framework.KelosFail("get", "tasks", "-o", "invalid")
 	})
 })
 
@@ -219,37 +219,37 @@ var _ = Describe("workspace CRUD", func() {
 
 	It("should create, get, and delete a workspace", func() {
 		By("creating a workspace via CLI")
-		framework.Axon("create", "workspace", "test-ws",
+		framework.Kelos("create", "workspace", "test-ws",
 			"-n", f.Namespace,
-			"--repo", "https://github.com/axon-core/axon.git",
+			"--repo", "https://github.com/kelos-dev/kelos.git",
 			"--ref", "main",
 		)
 
 		By("verifying workspace exists via get")
-		output := framework.AxonOutput("get", "workspace", "test-ws", "-n", f.Namespace)
+		output := framework.KelosOutput("get", "workspace", "test-ws", "-n", f.Namespace)
 		Expect(output).To(ContainSubstring("test-ws"))
-		Expect(output).To(ContainSubstring("https://github.com/axon-core/axon.git"))
+		Expect(output).To(ContainSubstring("https://github.com/kelos-dev/kelos.git"))
 
 		By("verifying workspace in list")
-		output = framework.AxonOutput("get", "workspaces", "-n", f.Namespace)
+		output = framework.KelosOutput("get", "workspaces", "-n", f.Namespace)
 		Expect(output).To(ContainSubstring("test-ws"))
 
 		By("verifying YAML output")
-		output = framework.AxonOutput("get", "workspace", "test-ws", "-n", f.Namespace, "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		output = framework.KelosOutput("get", "workspace", "test-ws", "-n", f.Namespace, "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: Workspace"))
 		Expect(output).To(ContainSubstring("name: test-ws"))
 
 		By("verifying JSON output")
-		output = framework.AxonOutput("get", "workspace", "test-ws", "-n", f.Namespace, "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		output = framework.KelosOutput("get", "workspace", "test-ws", "-n", f.Namespace, "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "Workspace"`))
 
 		By("deleting workspace via CLI")
-		framework.Axon("delete", "workspace", "test-ws", "-n", f.Namespace)
+		framework.Kelos("delete", "workspace", "test-ws", "-n", f.Namespace)
 
 		By("verifying workspace is deleted")
-		framework.AxonFail("get", "workspace", "test-ws", "-n", f.Namespace)
+		framework.KelosFail("get", "workspace", "test-ws", "-n", f.Namespace)
 	})
 })
 
@@ -258,13 +258,13 @@ var _ = Describe("agentconfig CRUD", func() {
 
 	It("should create and verify an agentconfig", func() {
 		By("creating an agentconfig via CLI")
-		framework.Axon("create", "agentconfig", "test-ac",
+		framework.Kelos("create", "agentconfig", "test-ac",
 			"-n", f.Namespace,
 			"--agents-md", "Follow TDD",
 		)
 
 		By("verifying agentconfig exists via typed client")
-		ac, err := f.AxonClientset.ApiV1alpha1().AgentConfigs(f.Namespace).Get(
+		ac, err := f.KelosClientset.ApiV1alpha1().AgentConfigs(f.Namespace).Get(
 			context.TODO(), "test-ac", metav1.GetOptions{},
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -281,7 +281,7 @@ var _ = Describe("CLI with namespace flag", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Task via CLI with namespace flag")
-		framework.Axon("run",
+		framework.Kelos("run",
 			"-n", f.Namespace,
 			"-p", "Print 'hello' to stdout",
 			"--secret", "claude-credentials",
@@ -292,7 +292,7 @@ var _ = Describe("CLI with namespace flag", func() {
 
 		By("verifying task exists only in the test namespace")
 		Eventually(func() string {
-			return framework.AxonOutput("get", "tasks", "-n", f.Namespace)
+			return framework.KelosOutput("get", "tasks", "-n", f.Namespace)
 		}, 30*time.Second, time.Second).Should(ContainSubstring("ns-task"))
 	})
 })

--- a/test/e2e/opencode_test.go
+++ b/test/e2e/opencode_test.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/test/e2e/framework"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
 // openCodeTestModel uses a free OpenCode model so e2e tests require no authentication.
@@ -21,17 +21,17 @@ var _ = Describe("OpenCode Task", func() {
 			"OPENCODE_API_KEY=")
 
 		By("creating an OpenCode Task")
-		f.CreateTask(&axonv1alpha1.Task{
+		f.CreateTask(&kelosv1alpha1.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "opencode-task",
 			},
-			Spec: axonv1alpha1.TaskSpec{
+			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "opencode",
 				Model:  openCodeTestModel,
 				Prompt: "Print 'Hello from OpenCode e2e test' to stdout",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeAPIKey,
-					SecretRef: axonv1alpha1.SecretReference{Name: "opencode-credentials"},
+				Credentials: kelosv1alpha1.Credentials{
+					Type:      kelosv1alpha1.CredentialTypeAPIKey,
+					SecretRef: kelosv1alpha1.SecretReference{Name: "opencode-credentials"},
 				},
 			},
 		})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
 const testModel = "haiku"
@@ -20,7 +20,7 @@ var (
 
 type agentTestConfig struct {
 	AgentType      string
-	CredentialType axonv1alpha1.CredentialType
+	CredentialType kelosv1alpha1.CredentialType
 	SecretName     string
 	SecretKey      string
 	SecretValue    *string
@@ -31,7 +31,7 @@ type agentTestConfig struct {
 var agentConfigs = []agentTestConfig{
 	{
 		AgentType:      "claude-code",
-		CredentialType: axonv1alpha1.CredentialTypeOAuth,
+		CredentialType: kelosv1alpha1.CredentialTypeOAuth,
 		SecretName:     "claude-credentials",
 		SecretKey:      "CLAUDE_CODE_OAUTH_TOKEN",
 		SecretValue:    &oauthToken,
@@ -40,7 +40,7 @@ var agentConfigs = []agentTestConfig{
 	},
 	{
 		AgentType:      "codex",
-		CredentialType: axonv1alpha1.CredentialTypeOAuth,
+		CredentialType: kelosv1alpha1.CredentialTypeOAuth,
 		SecretName:     "codex-credentials",
 		SecretKey:      "CODEX_AUTH_JSON",
 		SecretValue:    &codexAuthJSON,

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/test/e2e/framework"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
 func describeAgentTests(cfg agentTestConfig) {
@@ -27,17 +27,17 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Task")
-			f.CreateTask(&axonv1alpha1.Task{
+			f.CreateTask(&kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "basic-task",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
-					Prompt: "Print 'Hello from Axon e2e test' to stdout",
-					Credentials: axonv1alpha1.Credentials{
+					Prompt: "Print 'Hello from Kelos e2e test' to stdout",
+					Credentials: kelosv1alpha1.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: kelosv1alpha1.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
@@ -71,30 +71,30 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Workspace resource")
-			f.CreateWorkspace(&axonv1alpha1.Workspace{
+			f.CreateWorkspace(&kelosv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "e2e-workspace",
 				},
-				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/axon-core/axon.git",
+				Spec: kelosv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
 			})
 
 			By("creating a Task with workspace ref")
-			f.CreateTask(&axonv1alpha1.Task{
+			f.CreateTask(&kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ws-task",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Create a file called 'test.txt' with the content 'hello' in the current directory and print 'done'",
-					Credentials: axonv1alpha1.Credentials{
+					Credentials: kelosv1alpha1.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: kelosv1alpha1.SecretReference{Name: cfg.SecretName},
 					},
-					WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-workspace"},
+					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-workspace"},
 				},
 			})
 
@@ -132,30 +132,30 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Workspace resource")
-			f.CreateWorkspace(&axonv1alpha1.Workspace{
+			f.CreateWorkspace(&kelosv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "e2e-outputs-workspace",
 				},
-				Spec: axonv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/axon-core/axon.git",
+				Spec: kelosv1alpha1.WorkspaceSpec{
+					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
 			})
 
 			By("creating a Task with workspace ref")
-			f.CreateTask(&axonv1alpha1.Task{
+			f.CreateTask(&kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "outputs-task",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'hello' to stdout",
-					Credentials: axonv1alpha1.Credentials{
+					Credentials: kelosv1alpha1.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: kelosv1alpha1.SecretReference{Name: cfg.SecretName},
 					},
-					WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-outputs-workspace"},
+					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-outputs-workspace"},
 				},
 			})
 
@@ -171,8 +171,8 @@ func describeAgentTests(cfg agentTestConfig) {
 			By("verifying output markers appear in Pod logs")
 			logs := f.GetJobLogs("outputs-task")
 			GinkgoWriter.Printf("Job logs:\n%s\n", logs)
-			Expect(logs).To(ContainSubstring("---AXON_OUTPUTS_START---"))
-			Expect(logs).To(ContainSubstring("---AXON_OUTPUTS_END---"))
+			Expect(logs).To(ContainSubstring("---KELOS_OUTPUTS_START---"))
+			Expect(logs).To(ContainSubstring("---KELOS_OUTPUTS_END---"))
 
 			By("verifying Outputs field contains branch, commit, base-branch, and usage")
 			outputs := f.GetTaskOutputs("outputs-task")
@@ -215,34 +215,34 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating Task A")
-			f.CreateTask(&axonv1alpha1.Task{
+			f.CreateTask(&kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dep-chain-a",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'Task A done' to stdout",
-					Credentials: axonv1alpha1.Credentials{
+					Credentials: kelosv1alpha1.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: kelosv1alpha1.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
 
 			By("creating Task B that depends on Task A")
-			f.CreateTask(&axonv1alpha1.Task{
+			f.CreateTask(&kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dep-chain-b",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:      cfg.AgentType,
 					Model:     cfg.Model,
 					Prompt:    "Print 'Task B done' to stdout",
 					DependsOn: []string{"dep-chain-a"},
-					Credentials: axonv1alpha1.Credentials{
+					Credentials: kelosv1alpha1.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: kelosv1alpha1.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
@@ -278,17 +278,17 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Task")
-			f.CreateTask(&axonv1alpha1.Task{
+			f.CreateTask(&kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cleanup-task",
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'Hello' to stdout",
-					Credentials: axonv1alpha1.Credentials{
+					Credentials: kelosv1alpha1.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: axonv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: kelosv1alpha1.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
@@ -326,17 +326,17 @@ var _ = Describe("Task with make available", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Task that uses make")
-		f.CreateTask(&axonv1alpha1.Task{
+		f.CreateTask(&kelosv1alpha1.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "make-task",
 			},
-			Spec: axonv1alpha1.TaskSpec{
+			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
 				Model:  testModel,
 				Prompt: "Run 'make --version' and print the output",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelosv1alpha1.Credentials{
+					Type:      kelosv1alpha1.CredentialTypeOAuth,
+					SecretRef: kelosv1alpha1.SecretReference{Name: "claude-credentials"},
 				},
 			},
 		})
@@ -378,31 +378,31 @@ var _ = Describe("Task with workspace and secretRef", func() {
 			"GITHUB_TOKEN="+githubToken)
 
 		By("creating a Workspace resource with secretRef")
-		f.CreateWorkspace(&axonv1alpha1.Workspace{
+		f.CreateWorkspace(&kelosv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-github-workspace",
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
-				Repo:      "https://github.com/axon-core/axon.git",
+			Spec: kelosv1alpha1.WorkspaceSpec{
+				Repo:      "https://github.com/kelos-dev/kelos.git",
 				Ref:       "main",
-				SecretRef: &axonv1alpha1.SecretReference{Name: "workspace-credentials"},
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "workspace-credentials"},
 			},
 		})
 
 		By("creating a Task with workspace ref")
-		f.CreateTask(&axonv1alpha1.Task{
+		f.CreateTask(&kelosv1alpha1.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "github-task",
 			},
-			Spec: axonv1alpha1.TaskSpec{
+			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
 				Model:  testModel,
 				Prompt: "Run 'gh auth status' and print the output",
-				Credentials: axonv1alpha1.Credentials{
-					Type:      axonv1alpha1.CredentialTypeOAuth,
-					SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelosv1alpha1.Credentials{
+					Type:      kelosv1alpha1.CredentialTypeOAuth,
+					SecretRef: kelosv1alpha1.SecretReference{Name: "claude-credentials"},
 				},
-				WorkspaceRef: &axonv1alpha1.WorkspaceReference{Name: "e2e-github-workspace"},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-github-workspace"},
 			},
 		})
 

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/test/e2e/framework"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
 var _ = Describe("TaskSpawner", func() {
@@ -20,7 +20,7 @@ var _ = Describe("TaskSpawner", func() {
 		}
 	})
 
-	// This test requires at least one open GitHub issue in axon-core/axon
+	// This test requires at least one open GitHub issue in kelos-dev/kelos
 	// with the "do-not-remove/e2e-anchor" label. See issue #117.
 	It("should create a spawner Deployment and discover issues", func() {
 		By("creating GitHub token secret")
@@ -32,38 +32,38 @@ var _ = Describe("TaskSpawner", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace resource with secretRef")
-		f.CreateWorkspace(&axonv1alpha1.Workspace{
+		f.CreateWorkspace(&kelosv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-spawner-workspace",
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
-				Repo:      "https://github.com/axon-core/axon.git",
+			Spec: kelosv1alpha1.WorkspaceSpec{
+				Repo:      "https://github.com/kelos-dev/kelos.git",
 				Ref:       "main",
-				SecretRef: &axonv1alpha1.SecretReference{Name: "github-token"},
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "github-token"},
 			},
 		})
 
 		By("creating a TaskSpawner")
-		f.CreateTaskSpawner(&axonv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "spawner",
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					GitHubIssues: &axonv1alpha1.GitHubIssues{
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					GitHubIssues: &kelosv1alpha1.GitHubIssues{
 						Labels:        []string{"do-not-remove/e2e-anchor"},
 						ExcludeLabels: []string{"e2e-exclude-placeholder"},
 						State:         "open",
 					},
 				},
-				TaskTemplate: axonv1alpha1.TaskTemplate{
+				TaskTemplate: kelosv1alpha1.TaskTemplate{
 					Type: "claude-code",
-					WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
 						Name: "e2e-spawner-workspace",
 					},
-					Credentials: axonv1alpha1.Credentials{
-						Type:      axonv1alpha1.CredentialTypeOAuth,
-						SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeOAuth,
+						SecretRef: kelosv1alpha1.SecretReference{Name: "claude-credentials"},
 					},
 					PromptTemplate: "Fix: {{.Title}}\n{{.Body}}",
 				},
@@ -81,62 +81,62 @@ var _ = Describe("TaskSpawner", func() {
 
 		By("verifying at least one Task was created")
 		Eventually(func() []string {
-			return f.ListTaskNames("axon.io/taskspawner=spawner")
+			return f.ListTaskNames("kelos.dev/taskspawner=spawner")
 		}, 3*time.Minute, 10*time.Second).ShouldNot(BeEmpty())
 	})
 
 	It("should be accessible via CLI", func() {
 		By("creating a Workspace resource")
-		f.CreateWorkspace(&axonv1alpha1.Workspace{
+		f.CreateWorkspace(&kelosv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-spawner-workspace",
 			},
-			Spec: axonv1alpha1.WorkspaceSpec{
-				Repo: "https://github.com/axon-core/axon.git",
+			Spec: kelosv1alpha1.WorkspaceSpec{
+				Repo: "https://github.com/kelos-dev/kelos.git",
 			},
 		})
 
 		By("creating a TaskSpawner")
-		f.CreateTaskSpawner(&axonv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "spawner",
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					GitHubIssues: &axonv1alpha1.GitHubIssues{},
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					GitHubIssues: &kelosv1alpha1.GitHubIssues{},
 				},
-				TaskTemplate: axonv1alpha1.TaskTemplate{
+				TaskTemplate: kelosv1alpha1.TaskTemplate{
 					Type: "claude-code",
-					WorkspaceRef: &axonv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
 						Name: "e2e-spawner-workspace",
 					},
-					Credentials: axonv1alpha1.Credentials{
-						Type:      axonv1alpha1.CredentialTypeOAuth,
-						SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeOAuth,
+						SecretRef: kelosv1alpha1.SecretReference{Name: "claude-credentials"},
 					},
 				},
 				PollInterval: "5m",
 			},
 		})
 
-		By("verifying axon get taskspawners lists it")
-		output := framework.AxonOutput("get", "taskspawners", "-n", f.Namespace)
+		By("verifying kelos get taskspawners lists it")
+		output := framework.KelosOutput("get", "taskspawners", "-n", f.Namespace)
 		Expect(output).To(ContainSubstring("spawner"))
 
-		By("verifying axon get taskspawner shows detail")
-		output = framework.AxonOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "--detail")
+		By("verifying kelos get taskspawner shows detail")
+		output = framework.KelosOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("spawner"))
 		Expect(output).To(ContainSubstring("GitHub Issues"))
 
 		By("verifying YAML output for a single taskspawner")
-		output = framework.AxonOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		output = framework.KelosOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: TaskSpawner"))
 		Expect(output).To(ContainSubstring("name: spawner"))
 
 		By("verifying JSON output for a single taskspawner")
-		output = framework.AxonOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		output = framework.KelosOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "TaskSpawner"`))
 		Expect(output).To(ContainSubstring(`"name": "spawner"`))
 
@@ -145,7 +145,7 @@ var _ = Describe("TaskSpawner", func() {
 
 		By("verifying it disappears from list")
 		Eventually(func() string {
-			return framework.AxonOutput("get", "taskspawners", "-n", f.Namespace)
+			return framework.KelosOutput("get", "taskspawners", "-n", f.Namespace)
 		}, 30*time.Second, time.Second).ShouldNot(ContainSubstring("spawner"))
 	})
 })
@@ -159,22 +159,22 @@ var _ = Describe("Cron TaskSpawner", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a cron TaskSpawner with every-minute schedule")
-		f.CreateTaskSpawner(&axonv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cron-spawner",
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					Cron: &axonv1alpha1.Cron{
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					Cron: &kelosv1alpha1.Cron{
 						Schedule: "* * * * *",
 					},
 				},
-				TaskTemplate: axonv1alpha1.TaskTemplate{
+				TaskTemplate: kelosv1alpha1.TaskTemplate{
 					Type:  "claude-code",
 					Model: testModel,
-					Credentials: axonv1alpha1.Credentials{
-						Type:      axonv1alpha1.CredentialTypeOAuth,
-						SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeOAuth,
+						SecretRef: kelosv1alpha1.SecretReference{Name: "claude-credentials"},
 					},
 					PromptTemplate: "Cron triggered at {{.Time}} (schedule: {{.Schedule}}). Print 'Hello from cron'",
 				},
@@ -192,39 +192,39 @@ var _ = Describe("Cron TaskSpawner", func() {
 
 		By("verifying at least one Task was created")
 		Eventually(func() []string {
-			return f.ListTaskNames("axon.io/taskspawner=cron-spawner")
+			return f.ListTaskNames("kelos.dev/taskspawner=cron-spawner")
 		}, 3*time.Minute, 10*time.Second).ShouldNot(BeEmpty())
 	})
 
 	It("should be accessible via CLI with cron source info", func() {
 		By("creating a cron TaskSpawner")
-		f.CreateTaskSpawner(&axonv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cron-spawner",
 			},
-			Spec: axonv1alpha1.TaskSpawnerSpec{
-				When: axonv1alpha1.When{
-					Cron: &axonv1alpha1.Cron{
+			Spec: kelosv1alpha1.TaskSpawnerSpec{
+				When: kelosv1alpha1.When{
+					Cron: &kelosv1alpha1.Cron{
 						Schedule: "0 9 * * 1",
 					},
 				},
-				TaskTemplate: axonv1alpha1.TaskTemplate{
+				TaskTemplate: kelosv1alpha1.TaskTemplate{
 					Type: "claude-code",
-					Credentials: axonv1alpha1.Credentials{
-						Type:      axonv1alpha1.CredentialTypeOAuth,
-						SecretRef: axonv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeOAuth,
+						SecretRef: kelosv1alpha1.SecretReference{Name: "claude-credentials"},
 					},
 				},
 				PollInterval: "5m",
 			},
 		})
 
-		By("verifying axon get taskspawners lists it")
-		output := framework.AxonOutput("get", "taskspawners", "-n", f.Namespace)
+		By("verifying kelos get taskspawners lists it")
+		output := framework.KelosOutput("get", "taskspawners", "-n", f.Namespace)
 		Expect(output).To(ContainSubstring("cron-spawner"))
 
-		By("verifying axon get taskspawner shows cron detail")
-		output = framework.AxonOutput("get", "taskspawner", "cron-spawner", "-n", f.Namespace, "--detail")
+		By("verifying kelos get taskspawner shows cron detail")
+		output = framework.KelosOutput("get", "taskspawner", "cron-spawner", "-n", f.Namespace, "--detail")
 		Expect(output).To(ContainSubstring("cron-spawner"))
 		Expect(output).To(ContainSubstring("Cron"))
 		Expect(output).To(ContainSubstring("0 9 * * 1"))
@@ -234,41 +234,41 @@ var _ = Describe("Cron TaskSpawner", func() {
 
 		By("verifying it disappears from list")
 		Eventually(func() string {
-			return framework.AxonOutput("get", "taskspawners", "-n", f.Namespace)
+			return framework.KelosOutput("get", "taskspawners", "-n", f.Namespace)
 		}, 30*time.Second, time.Second).ShouldNot(ContainSubstring("cron-spawner"))
 	})
 })
 
 var _ = Describe("get taskspawner", func() {
 	It("should succeed with 'taskspawners' alias", func() {
-		framework.AxonOutput("get", "taskspawners")
+		framework.KelosOutput("get", "taskspawners")
 	})
 
 	It("should succeed with 'ts' alias", func() {
-		framework.AxonOutput("get", "ts")
+		framework.KelosOutput("get", "ts")
 	})
 
 	It("should succeed with 'taskspawner' subcommand", func() {
-		framework.AxonOutput("get", "taskspawner")
+		framework.KelosOutput("get", "taskspawner")
 	})
 
 	It("should fail for a nonexistent taskspawner", func() {
-		framework.AxonFail("get", "taskspawner", "nonexistent-spawner")
+		framework.KelosFail("get", "taskspawner", "nonexistent-spawner")
 	})
 
 	It("should output taskspawner list in YAML format", func() {
-		output := framework.AxonOutput("get", "taskspawners", "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: axon.io/v1alpha1"))
+		output := framework.KelosOutput("get", "taskspawners", "-o", "yaml")
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: TaskSpawnerList"))
 	})
 
 	It("should output taskspawner list in JSON format", func() {
-		output := framework.AxonOutput("get", "taskspawners", "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "axon.io/v1alpha1"`))
+		output := framework.KelosOutput("get", "taskspawners", "-o", "json")
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "TaskSpawnerList"`))
 	})
 
 	It("should fail with unknown output format", func() {
-		framework.AxonFail("get", "taskspawners", "-o", "invalid")
+		framework.KelosFail("get", "taskspawners", "-o", "invalid")
 	})
 })

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/internal/cli"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/internal/cli"
 )
 
 func runCLI(kubeconfigPath, namespace string, args ...string) error {
@@ -44,7 +44,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the workspace exists in the cluster")
-			ws := &axonv1alpha1.Workspace{}
+			ws := &kelosv1alpha1.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "my-ws", Namespace: ns.Name}, ws)).To(Succeed())
 			Expect(ws.Spec.Repo).To(Equal("https://github.com/org/repo.git"))
 			Expect(ws.Spec.Ref).To(Equal("main"))
@@ -96,7 +96,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the workspace has secretRef")
-			ws := &axonv1alpha1.Workspace{}
+			ws := &kelosv1alpha1.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "secret-ws", Namespace: ns.Name}, ws)).To(Succeed())
 			Expect(ws.Spec.SecretRef).NotTo(BeNil())
 			Expect(ws.Spec.SecretRef.Name).To(Equal("my-gh-secret"))
@@ -123,7 +123,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying workspace exists")
-			ws := &axonv1alpha1.Workspace{}
+			ws := &kelosv1alpha1.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alias-ws", Namespace: ns.Name}, ws)).To(Succeed())
 
 			By("Getting workspace using 'ws' alias succeeds")
@@ -152,12 +152,12 @@ var _ = Describe("CLI Workspace Commands", func() {
 
 			By("Creating workspaces")
 			for _, name := range []string{"ws-alpha", "ws-beta"} {
-				ws := &axonv1alpha1.Workspace{
+				ws := &kelosv1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: axonv1alpha1.WorkspaceSpec{
+					Spec: kelosv1alpha1.WorkspaceSpec{
 						Repo: "https://github.com/org/repo.git",
 					},
 				}
@@ -188,17 +188,17 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Creating multiple tasks directly")
 			for _, name := range []string{"task-a", "task-b", "task-c"} {
-				task := &axonv1alpha1.Task{
+				task := &kelosv1alpha1.Task{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: axonv1alpha1.TaskSpec{
+					Spec: kelosv1alpha1.TaskSpec{
 						Type:   "claude-code",
 						Prompt: "test",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -213,7 +213,7 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Verifying all tasks are deleted")
 			Eventually(func() int {
-				taskList := &axonv1alpha1.TaskList{}
+				taskList := &kelosv1alpha1.TaskList{}
 				Expect(k8sClient.List(ctx, taskList, client.InNamespace(ns.Name))).To(Succeed())
 				count := 0
 				for _, t := range taskList.Items {
@@ -240,12 +240,12 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Creating multiple workspaces directly")
 			for _, name := range []string{"ws-a", "ws-b"} {
-				ws := &axonv1alpha1.Workspace{
+				ws := &kelosv1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: axonv1alpha1.WorkspaceSpec{
+					Spec: kelosv1alpha1.WorkspaceSpec{
 						Repo: "https://github.com/org/repo.git",
 					},
 				}
@@ -258,7 +258,7 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Verifying all workspaces are deleted")
 			Eventually(func() int {
-				wsList := &axonv1alpha1.WorkspaceList{}
+				wsList := &kelosv1alpha1.WorkspaceList{}
 				Expect(k8sClient.List(ctx, wsList, client.InNamespace(ns.Name))).To(Succeed())
 				return len(wsList.Items)
 			}, 10*time.Second, 250*time.Millisecond).Should(Equal(0))
@@ -279,17 +279,17 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Creating multiple task spawners directly")
 			for _, name := range []string{"ts-a", "ts-b"} {
-				ts := &axonv1alpha1.TaskSpawner{
+				ts := &kelosv1alpha1.TaskSpawner{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: axonv1alpha1.TaskSpawnerSpec{
-						TaskTemplate: axonv1alpha1.TaskTemplate{
+					Spec: kelosv1alpha1.TaskSpawnerSpec{
+						TaskTemplate: kelosv1alpha1.TaskTemplate{
 							Type: "claude-code",
-							Credentials: axonv1alpha1.Credentials{
-								Type: axonv1alpha1.CredentialTypeAPIKey,
-								SecretRef: axonv1alpha1.SecretReference{
+							Credentials: kelosv1alpha1.Credentials{
+								Type: kelosv1alpha1.CredentialTypeAPIKey,
+								SecretRef: kelosv1alpha1.SecretReference{
 									Name: "test-secret",
 								},
 							},
@@ -305,7 +305,7 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Verifying all task spawners are deleted")
 			Eventually(func() bool {
-				tsList := &axonv1alpha1.TaskSpawnerList{}
+				tsList := &kelosv1alpha1.TaskSpawnerList{}
 				Expect(k8sClient.List(ctx, tsList, client.InNamespace(ns.Name))).To(Succeed())
 				for _, ts := range tsList.Items {
 					if ts.DeletionTimestamp == nil {
@@ -369,17 +369,17 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner directly")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -396,7 +396,7 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 
 			By("Verifying the task spawner is deleted")
 			Eventually(func() bool {
-				ts2 := &axonv1alpha1.TaskSpawner{}
+				ts2 := &kelosv1alpha1.TaskSpawner{}
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: "my-spawner", Namespace: ns.Name}, ts2)
 				if err == nil {
 					return ts2.DeletionTimestamp != nil
@@ -417,17 +417,17 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner directly")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "alias-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -444,7 +444,7 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 
 			By("Verifying the task spawner is deleted")
 			Eventually(func() bool {
-				ts2 := &axonv1alpha1.TaskSpawner{}
+				ts2 := &kelosv1alpha1.TaskSpawner{}
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: "alias-spawner", Namespace: ns.Name}, ts2)
 				if err == nil {
 					return ts2.DeletionTimestamp != nil
@@ -465,17 +465,17 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-del",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -502,12 +502,12 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &axonv1alpha1.Workspace{
+			ws := &kelosv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ws-del",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.WorkspaceSpec{
+				Spec: kelosv1alpha1.WorkspaceSpec{
 					Repo: "https://github.com/org/repo.git",
 				},
 			}
@@ -533,17 +533,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-suspend-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -559,7 +559,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner has suspend=true")
-			updatedTS := &axonv1alpha1.TaskSpawner{}
+			updatedTS := &kelosv1alpha1.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cli-suspend-spawner", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeTrue())
@@ -578,18 +578,18 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 
 			By("Creating a TaskSpawner already suspended")
 			suspend := true
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-suspend-idem",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
 					Suspend: &suspend,
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -605,7 +605,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner is still suspended")
-			updatedTS := &axonv1alpha1.TaskSpawner{}
+			updatedTS := &kelosv1alpha1.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cli-suspend-idem", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeTrue())
@@ -624,18 +624,18 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 
 			By("Creating a suspended TaskSpawner")
 			suspend := true
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-resume-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
 					Suspend: &suspend,
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -651,7 +651,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner has suspend=false")
-			updatedTS := &axonv1alpha1.TaskSpawner{}
+			updatedTS := &kelosv1alpha1.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cli-resume-spawner", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeFalse())
@@ -669,17 +669,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner (not suspended)")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-resume-idem",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -707,17 +707,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "alias-suspend",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -733,7 +733,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner is suspended")
-			updatedTS := &axonv1alpha1.TaskSpawner{}
+			updatedTS := &kelosv1alpha1.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alias-suspend", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeTrue())
@@ -760,17 +760,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-suspend-comp",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},

--- a/test/integration/completion_test.go
+++ b/test/integration/completion_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/internal/cli"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/internal/cli"
 )
 
 func writeEnvtestKubeconfig() string {
@@ -58,17 +58,17 @@ var _ = Describe("Completion", func() {
 
 			By("Creating Tasks")
 			for _, name := range []string{"task-alpha", "task-beta"} {
-				task := &axonv1alpha1.Task{
+				task := &kelosv1alpha1.Task{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: axonv1alpha1.TaskSpec{
+					Spec: kelosv1alpha1.TaskSpec{
 						Type:   "claude-code",
 						Prompt: "test",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -96,17 +96,17 @@ var _ = Describe("Completion", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &axonv1alpha1.TaskSpawner{
+			ts := &kelosv1alpha1.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-one",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: axonv1alpha1.TaskTemplate{
+				Spec: kelosv1alpha1.TaskSpawnerSpec{
+					TaskTemplate: kelosv1alpha1.TaskTemplate{
 						Type: "claude-code",
-						Credentials: axonv1alpha1.Credentials{
-							Type: axonv1alpha1.CredentialTypeAPIKey,
-							SecretRef: axonv1alpha1.SecretReference{
+						Credentials: kelosv1alpha1.Credentials{
+							Type: kelosv1alpha1.CredentialTypeAPIKey,
+							SecretRef: kelosv1alpha1.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -133,17 +133,17 @@ var _ = Describe("Completion", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Task")
-			task := &axonv1alpha1.Task{
+			task := &kelosv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-gamma",
 					Namespace: ns.Name,
 				},
-				Spec: axonv1alpha1.TaskSpec{
+				Spec: kelosv1alpha1.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "test",
-					Credentials: axonv1alpha1.Credentials{
-						Type: axonv1alpha1.CredentialTypeAPIKey,
-						SecretRef: axonv1alpha1.SecretReference{
+					Credentials: kelosv1alpha1.Credentials{
+						Type: kelosv1alpha1.CredentialTypeAPIKey,
+						SecretRef: kelosv1alpha1.SecretReference{
 							Name: "test-secret",
 						},
 					},

--- a/test/integration/install_script_test.go
+++ b/test/integration/install_script_test.go
@@ -26,19 +26,19 @@ var _ = Describe("Install Script", Ordered, func() {
 		repoRoot, err = filepath.Abs(filepath.Join("..", ".."))
 		Expect(err).NotTo(HaveOccurred())
 
-		buildCmd := exec.Command("make", "build", "WHAT=cmd/axon")
+		buildCmd := exec.Command("make", "build", "WHAT=cmd/kelos")
 		buildCmd.Dir = repoRoot
 		buildCmd.Stdout = GinkgoWriter
 		buildCmd.Stderr = GinkgoWriter
 		Expect(buildCmd.Run()).To(Succeed())
 
-		builtBinary := filepath.Join(repoRoot, "bin", "axon")
+		builtBinary := filepath.Join(repoRoot, "bin", "kelos")
 		Expect(builtBinary).To(BeAnExistingFile())
 
 		binaryData, err = os.ReadFile(builtBinary)
 		Expect(err).NotTo(HaveOccurred())
 
-		binaryName = fmt.Sprintf("axon-%s-%s", runtime.GOOS, runtime.GOARCH)
+		binaryName = fmt.Sprintf("kelos-%s-%s", runtime.GOOS, runtime.GOARCH)
 	})
 
 	BeforeEach(func() {
@@ -56,14 +56,14 @@ var _ = Describe("Install Script", Ordered, func() {
 		server.Close()
 	})
 
-	It("Should install the axon CLI binary", func() {
+	It("Should install the kelos CLI binary", func() {
 		By("Running hack/install.sh with a temporary install directory")
 		installDir := GinkgoT().TempDir()
 		installScript := filepath.Join(repoRoot, "hack", "install.sh")
 
 		cmd := exec.Command("bash", installScript)
 		cmd.Env = append(os.Environ(),
-			"AXON_RELEASE_URL="+server.URL,
+			"KELOS_RELEASE_URL="+server.URL,
 			"INSTALL_DIR="+installDir,
 		)
 		cmd.Stdout = GinkgoWriter
@@ -71,7 +71,7 @@ var _ = Describe("Install Script", Ordered, func() {
 		Expect(cmd.Run()).To(Succeed())
 
 		By("Verifying the binary was installed")
-		installedBinary := filepath.Join(installDir, "axon")
+		installedBinary := filepath.Join(installDir, "kelos")
 		Expect(installedBinary).To(BeAnExistingFile())
 
 		By("Verifying the installed binary is executable")
@@ -94,7 +94,7 @@ var _ = Describe("Install Script", Ordered, func() {
 
 		cmd := exec.Command("bash", installScript)
 		cmd.Env = append(os.Environ(),
-			"AXON_RELEASE_URL="+server.URL,
+			"KELOS_RELEASE_URL="+server.URL,
 			"INSTALL_DIR="+installDir,
 		)
 		cmd.Stdout = GinkgoWriter
@@ -102,7 +102,7 @@ var _ = Describe("Install Script", Ordered, func() {
 		Expect(cmd.Run()).To(Succeed())
 
 		By("Verifying the directory was created and binary was installed")
-		installedBinary := filepath.Join(installDir, "axon")
+		installedBinary := filepath.Join(installDir, "kelos")
 		Expect(installedBinary).To(BeAnExistingFile())
 	})
 
@@ -115,7 +115,7 @@ var _ = Describe("Install Script", Ordered, func() {
 
 		cmd := exec.Command("bash", installScript)
 		cmd.Env = append(os.Environ(),
-			"AXON_RELEASE_URL="+server.URL,
+			"KELOS_RELEASE_URL="+server.URL,
 			"INSTALL_DIR="+installDir,
 		)
 		output, err := cmd.CombinedOutput()

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -19,9 +19,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	axonv1alpha1 "github.com/axon-core/axon/api/v1alpha1"
-	"github.com/axon-core/axon/internal/controller"
-	"github.com/axon-core/axon/internal/githubapp"
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/internal/controller"
+	"github.com/kelos-dev/kelos/internal/githubapp"
 )
 
 var (
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = axonv1alpha1.AddToScheme(scheme.Scheme)
+	err = kelosv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 		Scheme:       mgr.GetScheme(),
 		JobBuilder:   controller.NewJobBuilder(),
 		TokenClient:  tokenClient,
-		Recorder:     mgr.GetEventRecorderFor("axon-controller"),
+		Recorder:     mgr.GetEventRecorderFor("kelos-controller"),
 		BranchLocker: controller.NewBranchLocker(),
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		DeploymentBuilder: controller.NewDeploymentBuilder(),
-		Recorder:          mgr.GetEventRecorderFor("axon-controller"),
+		Recorder:          mgr.GetEventRecorderFor("kelos-controller"),
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -109,13 +109,13 @@ var _ = BeforeSuite(func() {
 
 	// Verify all CRDs are fully established by attempting to list each custom resource type
 	Eventually(func() error {
-		return k8sClient.List(ctx, &axonv1alpha1.TaskList{})
+		return k8sClient.List(ctx, &kelosv1alpha1.TaskList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 	Eventually(func() error {
-		return k8sClient.List(ctx, &axonv1alpha1.TaskSpawnerList{})
+		return k8sClient.List(ctx, &kelosv1alpha1.TaskSpawnerList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 	Eventually(func() error {
-		return k8sClient.List(ctx, &axonv1alpha1.WorkspaceList{})
+		return k8sClient.List(ctx, &kelosv1alpha1.WorkspaceList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 })
 


### PR DESCRIPTION
xref #456 

## Summary

- Full project rename: org `axon-core` → `kelos-dev`, repo `axon` → `kelos`
- Go module path: `github.com/axon-core/axon` → `github.com/kelos-dev/kelos`
- API group: `axon.io` → `kelos.dev`
- All binary/image names: `axon-*` → `kelos-*`
- All env vars: `AXON_*` → `KELOS_*`
- K8s resource names, labels, annotations, and finalizers
- CLI commands, help text, config paths (`.axon` → `.kelos`)
- Docs, README, examples, self-development resources
- Regenerated deepcopy, CRDs, install manifests, and clientset
- GCP service account references (`axon-core-axon-gh-action`, `providers/axon`) preserved as external infrastructure

## Test plan

- [x] `make verify` passes
- [x] `make test` — all unit tests pass
- [x] `make test-integration` — all 87 integration tests pass
- [x] `make build` — all binaries build successfully
- [x] Zero leftover `axon` references (excluding preserved GCP SAs)
- [ ] CI e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)