### PR TITLE
Update GCP WIF provider and service account for kelos-dev/kelos

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -24,8 +24,8 @@ jobs:
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
-      GCP_SERVICE_ACCOUNT_EMAIL: axon-core-axon-gh-action@gjkim-400213.iam.gserviceaccount.com
-      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/axon
+      GCP_SERVICE_ACCOUNT_EMAIL: kelos-gh-action@gjkim-400213.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/kelos
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/reset-kelos-worker.yaml
+++ b/.github/workflows/reset-kelos-worker.yaml
@@ -30,8 +30,8 @@ jobs:
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
-      GCP_SERVICE_ACCOUNT_EMAIL: axon-core-axon-gh-action@gjkim-400213.iam.gserviceaccount.com
-      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/axon
+      GCP_SERVICE_ACCOUNT_EMAIL: kelos-gh-action@gjkim-400213.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/kelos
     steps:
       - name: Determine if reset is requested
         id: gate

--- a/.github/workflows/run-fake-strategist.yaml
+++ b/.github/workflows/run-fake-strategist.yaml
@@ -24,8 +24,8 @@ jobs:
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
-      GCP_SERVICE_ACCOUNT_EMAIL: axon-core-axon-gh-action@gjkim-400213.iam.gserviceaccount.com
-      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/axon
+      GCP_SERVICE_ACCOUNT_EMAIL: kelos-gh-action@gjkim-400213.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/kelos
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/squash-kelos-worker-commits.yaml
+++ b/.github/workflows/squash-kelos-worker-commits.yaml
@@ -30,8 +30,8 @@ jobs:
       GCP_PROJECT_ID: gjkim-400213
       GKE_CLUSTER_NAME: gjkim
       GKE_CLUSTER_LOCATION: asia-northeast3
-      GCP_SERVICE_ACCOUNT_EMAIL: axon-core-axon-gh-action@gjkim-400213.iam.gserviceaccount.com
-      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/axon
+      GCP_SERVICE_ACCOUNT_EMAIL: kelos-gh-action@gjkim-400213.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/317215297044/locations/global/workloadIdentityPools/github/providers/kelos
     steps:
       - name: Determine if reset is requested
         id: gate


### PR DESCRIPTION
## Summary
- Create new GCP service account (`kelos-gh-action`) and WIF OIDC provider (`providers/kelos`) for the renamed `kelos-dev/kelos` repository
- Grant `roles/container.admin` and `roles/container.developer` to the new SA
- Update all 4 GCP-authenticated workflow files to use the new SA and WIF provider

## Test plan
- [ ] Trigger `deploy-dev` workflow via `workflow_dispatch` to confirm GCP WIF auth works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)