### PR TITLE
Fix label events overwriting CI check statuses

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,16 +5,20 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
   merge_group:
+  workflow_dispatch:
+    inputs:
+      ok-to-test:
+        description: Run e2e tests
+        type: boolean
+        default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.event.action == 'labeled' }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +31,6 @@ jobs:
         run: make build
 
   verify:
-    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +43,6 @@ jobs:
         run: make verify
 
   test:
-    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +55,6 @@ jobs:
         run: make test
 
   test-integration:
-    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +67,8 @@ jobs:
         run: make test-integration
 
   test-e2e:
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: >-
+      github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.ok-to-test) || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -1,0 +1,47 @@
+name: Retest
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  retest:
+    if: >-
+      github.event.issue.pull_request && contains(github.event.comment.body, '/retest')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Check permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" -q .permission)
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "User ${{ github.event.comment.user.login }} does not have write permission (permission=$PERMISSION)"
+            exit 1
+          fi
+
+      - name: Trigger CI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)
+          RUN_ID=$(gh run list --workflow=ci.yaml --commit="$HEAD_SHA" --limit=1 --json databaseId -q '.[0].databaseId')
+
+          if [ -n "$RUN_ID" ]; then
+            CONCLUSION=$(gh run view "$RUN_ID" --json conclusion -q .conclusion)
+            if [ "$CONCLUSION" = "failure" ]; then
+              gh run rerun "$RUN_ID" --failed
+              exit 0
+            elif [ -z "$CONCLUSION" ]; then
+              echo "CI is already in progress (run $RUN_ID)"
+              exit 0
+            fi
+          fi
+
+          HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
+          OK_TO_TEST=$(gh pr view "$PR_NUMBER" --json labels -q '[.labels[].name] | any(. == "ok-to-test")')
+          gh workflow run ci.yaml --ref "$HEAD_REF" -f "ok-to-test=$OK_TO_TEST"


### PR DESCRIPTION
## Summary
- Remove `labeled` from CI `pull_request` triggers to prevent label events from reporting jobs as SKIPPED, which overwrites previous SUCCESS checks
- Add `workflow_dispatch` trigger with `ok-to-test` input for manual CI runs
- Add `/retest` comment workflow that re-runs only failed jobs or dispatches a fresh CI run with current label state

## Test plan
- [ ] Open a PR → CI runs (build/verify/test/test-integration, test-e2e based on ok-to-test label)
- [ ] Add a label → CI does NOT re-trigger
- [ ] Comment `/retest` on a failed run → only failed jobs re-run
- [ ] Comment `/retest` on a passing run → fresh CI dispatched with current label state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops label changes from re-triggering CI and overwriting successful checks with SKIPPED. Adds a safe, permission-gated way to rerun CI on demand.

- **Bug Fixes**
  - Remove label-triggered runs and all label-specific job guards; stabilize concurrency using workflow + ref name so SKIPPED no longer overwrites SUCCESS.

- **New Features**
  - Add workflow_dispatch with an ok-to-test input to control e2e on manual runs.
  - Add a /retest comment workflow that requires write/admin permission, reruns only failed jobs, skips if CI is in progress, or dispatches a fresh CI using current labels.

<sup>Written for commit 34d2ff30d181ac3a15a4f996492fa6fdfc384a7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

