### PR TITLE
Fix retest workflow by setting GH_REPO for gh CLI

### DIFF
--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Trigger CI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
           HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid)


### PR DESCRIPTION
## Summary
- Set `GH_REPO` environment variable in the retest workflow so `gh` CLI commands work without `actions/checkout`
- Without this, `gh pr view` and other commands fail with `fatal: not a git repository`

## Test plan
- [ ] Comment `/retest` on a PR and verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set GH_REPO in the retest workflow so gh CLI commands run without actions/checkout. This fixes "fatal: not a git repository" errors and lets /retest complete successfully.

<sup>Written for commit edacffdae97dfc50425d2c0379a4706cfb24c613. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

