### PR TITLE
Rewrite README to lead with workflow-as-YAML narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> &middot;
+  <a href="#kelos-developing-kelos">Kelos Developing Kelos</a> &middot;
   <a href="#examples">Examples</a> &middot;
   <a href="docs/reference.md">Reference</a> &middot;
   <a href="examples/">YAML Manifests</a>
@@ -58,27 +59,9 @@ TaskSpawner watches external sources (e.g., GitHub Issues) and automatically cre
 
 </details>
 
-## Demo
-
-```bash
-# Run multiple tasks in parallel across your repo
-$ kelos run -p "Fix the bug described in issue #42 and open a PR" --name fix-42
-$ kelos run -p "Add unit tests for the auth module" --name add-tests
-$ kelos run -p "Update API docs for v2 endpoints" --name update-docs
-
-# Watch all tasks progress simultaneously
-$ kelos get tasks
-NAME          TYPE          PHASE     BRANCH                WORKSPACE   AGENT CONFIG   DURATION   AGE
-fix-42        claude-code   Running   kelos-task-fix-42      my-repo     my-config      2m         2m
-add-tests     claude-code   Running   kelos-task-add-tests   my-repo     my-config      1m         1m
-update-docs   claude-code   Running   kelos-task-update-docs my-repo     my-config      45s        45s
-```
-
-https://github.com/user-attachments/assets/bb10e8ba-ecdf-4dc5-9a74-070d9335a00b
-
 ## Kelos Developing Kelos
 
-This is the crown jewel: a fully autonomous development pipeline where Kelos develops itself. Five TaskSpawners run 24/7, each handling a different part of the development lifecycle.
+Kelos develops itself. Five TaskSpawners run 24/7, each handling a different part of the development lifecycle — fully autonomous.
 
 <img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/969e6832-c480-4df2-bcc0-bf9314ece2d4" />
 


### PR DESCRIPTION
## Summary
- Reframe the README around the idea that the biggest unlock is defining development workflows as YAML, not just sandboxing agents
- Promote the self-development pipeline ("Kelos Developing Kelos") to a top-level section with a summary table of all 5 TaskSpawners and an inline YAML snippet
- Move "How It Works" (with Core Primitives) right after the intro for immediate architectural context
- Add "Workflow as YAML" as the first bullet in Why Kelos, reframe the opening line
- Reorder examples to lead with workflow patterns (Auto-fix → Chain tasks → Create PRs → Inject instructions)
- Update internal anchor links to match new section names

## Test plan
- [ ] Render the markdown on the PR preview and verify all sections display correctly
- [ ] Verify all internal anchor links resolve (especially `#kelos-developing-kelos`, `#auto-fix-github-issues-with-taskspawner`)
- [ ] Verify external links (badges, docs, examples) are unchanged
- [ ] Confirm no technical content was lost — only moved, reframed, or expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite README to lead with workflow-as-YAML and spotlight the self-development pipeline. Removes the CLI demo, reorders sections, and adds a nav link to Kelos Developing Kelos.

- **Refactors**
  - New intro focused on workflow-as-YAML; added “Workflow as YAML” to Why Kelos.
  - Promoted “Kelos Developing Kelos” to top-level with a table and trimmed YAML; added navbar link and tightened intro.
  - Moved “How It Works” and Core Primitives directly after the intro.
  - Reordered Examples to lead with workflow patterns (auto-fix, chain into pipelines, create PRs, inject instructions).
  - Removed the CLI Demo; updated internal anchors (including links to `#kelos-developing-kelos`); external links unchanged.

<sup>Written for commit 2792057b6f8d9e88fa5db985f9137ec541992665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

