### PR TITLE
Documentation site planning analysis

### DIFF
--- a/docs-planning/RECOMMENDATION.md
+++ b/docs-planning/RECOMMENDATION.md
@@ -1,0 +1,115 @@
+# Recommendation: Should Kelos Build a Documentation Site?
+
+## Verdict: Yes, but scoped tightly — and fix the foundations first
+
+The three analyses converge on a nuanced answer: Kelos has real documentation problems that need solving, but a full doc site isn't the first step. The right sequence is **fix the existing docs first, then build the site on a solid foundation.**
+
+---
+
+## Where the Analyses Agreed
+
+All three teammates independently confirmed the same things:
+
+1. **The existing docs are surprisingly good for a project this age.** The README, Quick Start, and 7 examples form a usable learning path. This is a strength to build on, not throw away.
+
+2. **There are real, specific gaps.** Jira integration is completely undocumented. 8+ API fields are missing from reference.md. Credential docs are scattered across 5 locations with inconsistent naming. No troubleshooting guide exists. These aren't hypothetical — the auditor cited exact files and line numbers.
+
+3. **Quick wins exist regardless of the doc site decision.** All three identified improvements (troubleshooting guide, reference completeness, better CLI help) that would help users today.
+
+4. **The project's complexity already strains a README-only approach.** 4 CRDs, 4 agent types, 3 event sources, 2 auth methods, 2 credential types, dependency chaining, MCP servers, plugins — the auditor counted 83+ CRD fields and the advocate counted 15+ conceptual topics. This is too much for a single README.
+
+## Where They Disagreed
+
+| Question | Auditor | Researcher | Advocate |
+|----------|---------|------------|----------|
+| Is the README adequate? | Getting long, gaps are serious | Multi-audience problem, can't scale | "Near-complete user guide" |
+| Is a doc site premature? | Implied yes (via gap severity) | No — comparable projects all launched early | Yes — 48 stars, 2 contributors |
+| What's the biggest risk? | Stale/incomplete reference | Users getting stuck (14 open doc issues) | Maintenance burden on 2 people |
+| What comparable projects show | — | Every surveyed project launched docs early | — |
+| ROI of a doc site now | — | High (credibility signal, reduces issue volume) | Low (personal responses scale fine at 48 stars) |
+
+**The core tension:** The researcher found that every comparable K8s project (Argo, Tekton, Dagger, Kueue, Flux) launched doc sites early — some at day one. The advocate counters that those projects had institutional backing (CNCF, VC funding, foundation donation) that Kelos doesn't. Both are right.
+
+---
+
+## The Recommendation
+
+### Phase 1: Fix the foundations (do this now, ~3-5 days of work)
+
+Before building a site, fix the content that will go in it:
+
+1. **Complete the reference docs.** Add the 8+ missing fields (workspace `remotes`, TaskSpawner `triggerComment`/`excludeComments`/`assignee`/`author`/`priorityLabels`/`repo`, Jira source). The auditor identified every gap with line numbers — this is straightforward work.
+
+2. **Write a troubleshooting guide** (`docs/troubleshooting.md`). All three analyses flagged this as missing. Cover: credential errors, workspace failures, rate limits, task immutability errors, pod failures, how to read controller logs.
+
+3. **Consolidate credential documentation.** Currently scattered across 5 locations. Write one authoritative section that distinguishes agent credentials (Anthropic/OpenAI) from workspace credentials (GitHub PAT/App), and reference it from everywhere else.
+
+4. **Add a concepts page** (`docs/concepts.md`). Answer the questions the auditor identified: When do I need a Workspace? What's the difference between AgentConfig and prompt instructions? When TaskSpawner vs manual Tasks? Include a simple decision tree.
+
+5. **Fix the Quick Start ordering** (issue #305) and credential confusion (issue #201). The researcher identified these as blockers for every new user.
+
+### Phase 2: Build the doc site (after Phase 1, ~1-2 weeks)
+
+Once the content is solid, build the site with a **minimal initial scope**:
+
+**Framework:** Docusaurus (already set up in this repo). Aligns with Dagger's approach. Good DX, React-based, versioning support when needed later.
+
+**Initial pages — and nothing more:**
+
+| Page | Source | Priority |
+|------|--------|----------|
+| Home / Overview | New (project pitch + architecture diagram) | P0 |
+| Quick Start | Migrated from README, with fixes from Phase 1 | P0 |
+| Concepts (4 CRDs explained) | New from Phase 1 concepts.md | P0 |
+| Examples | Migrated from examples/ READMEs | P0 |
+| API Reference | Migrated from docs/reference.md (completed) | P1 |
+| Troubleshooting | From Phase 1 troubleshooting.md | P1 |
+| Agent Image Interface | Migrated from docs/agent-image-interface.md | P2 |
+| CLI Reference | Extracted from reference.md | P2 |
+
+**Explicitly NOT in scope for v1:**
+- Versioned docs (premature for v1alpha1)
+- Blog
+- Multi-language support
+- Operator/admin guide (fold into concepts for now)
+- Auto-generated API reference from Go types (nice-to-have, not now)
+
+### Phase 3: Sustain (ongoing)
+
+The advocate's maintenance concern is real. Mitigate it:
+
+- **Keep docs in the same repo as code** (or require doc updates in the same PR as API changes). The advocate's key evidence — commit `628dfd5` fixing drifted example field names — shows that even co-located docs drift. A separate repo would be worse.
+- **Use CI to check for drift.** A simple script that compares documented fields against Go struct tags would catch the reference gap problem automatically.
+- **Leverage the self-development pipeline.** The researcher noted that `kelos-fake-user.yaml` already simulates new user experiences. A doc-review agent could flag stale content.
+- **Resist scope creep.** The advocate's "empty restaurant" warning is valid — 8 solid pages beat 20 stub pages.
+
+---
+
+## Signals That Would Change This Recommendation
+
+If Phase 1 fixes resolve most user friction (tracked via GitHub issue closure rate), you could delay Phase 2 longer. Conversely, accelerate Phase 2 if:
+
+- Stars cross 200+ (the advocate's threshold)
+- More than 2-3 external contributors appear
+- GitHub issues tagged `kind/docs` keep growing despite Phase 1 fixes
+- Users explicitly ask for a doc site
+
+---
+
+## Quick Wins — Do These Regardless
+
+These cost hours, not days, and help immediately:
+
+1. **Document Jira integration.** It's fully coded and completely invisible. Even a section in the README unblocks Jira users.
+2. **Add missing fields to reference.md.** The auditor listed them all with line numbers.
+3. **Deduplicate the template variables table.** Currently in 3 places (reference.md, self-development/README.md, partially in README). Single source of truth, link from elsewhere.
+4. **Add `CONTRIBUTING.md`.** Community health is at 37%. This is table stakes.
+5. **Fix the credential naming inconsistency.** `token` vs `secretRef` vs `oauthToken` — add a mapping table or unify the terminology.
+
+---
+
+## Summary
+
+The auditor showed the gaps are real and specific. The researcher showed that comparable projects don't wait. The advocate showed that maintenance burden on 2 contributors is a genuine constraint. The synthesis: **do both, in sequence.** Fix the content first (Phase 1), then build the site on solid foundations (Phase 2). Don't let perfect be the enemy of good — but also don't build a house on a cracked foundation.
+
+The fact that `kelos-docsite` already exists as a repo suggests you've already been thinking about this. The recommendation is: finish the content work before investing heavily in the presentation layer.

--- a/docs-planning/counterarguments.md
+++ b/docs-planning/counterarguments.md
@@ -1,0 +1,183 @@
+# Counterarguments: Why NOT to Build a Documentation Site Right Now
+
+## Executive Summary
+
+Kelos is at v0.14.0 with 2 active contributors, ~48 GitHub stars, and a rapidly evolving API surface. Building a dedicated documentation site right now is **premature optimization** that will create a maintenance burden disproportionate to the project's current scale and contributor capacity. The existing documentation is already surprisingly comprehensive. There are higher-ROI investments that would serve users better.
+
+---
+
+## 1. Premature Optimization — The Numbers Don't Justify It
+
+### Project Scale (as of Feb 2026)
+
+| Metric | Value |
+|--------|-------|
+| Version | v0.14.0 (v1alpha1 API) |
+| GitHub stars | ~48 |
+| Git contributors | 2 (Gunju Kim, Aslak Knutsen) |
+| Total commits | 450 |
+| Go source files | 130 |
+| CRD type definition lines | 745 (across 4 `*_types.go` files) |
+
+### The existing docs are already substantial
+
+| File | Lines | Content |
+|------|-------|---------|
+| `README.md` | 583 | Quick start, how it works, examples, security, cost, FAQ |
+| `docs/reference.md` | 310 | Full CRD field reference, CLI reference, config reference |
+| `docs/agent-image-interface.md` | 132 | Custom image interface spec |
+| Example READMEs (7 dirs) | ~400+ | Step-by-step walkthroughs for each pattern |
+| YAML examples | 25 files | Ready-to-apply manifests |
+| **Total** | **~1,400+ lines** | Covers nearly every feature |
+
+**The README alone is a near-complete user guide.** It includes: Quick Start (with `kind` setup), How It Works (with architecture diagram), 5 runnable example patterns with YAML, orchestration patterns, security considerations, cost management, FAQ, CLI reference, and development guide. A doc site would mostly be re-organizing this same content with navigation chrome.
+
+### Cost/benefit at this scale
+
+At ~48 stars, the user base is likely under 20 active users. The question isn't "would a doc site be nice?" — it's "would a doc site be a better use of 2 contributors' time than anything else?" Every hour spent on a doc site is an hour NOT spent on:
+- Shipping features that attract users
+- Fixing bugs that retain users
+- Writing examples that teach users
+- Improving error messages that unblock users
+
+**Doc sites become ROI-positive when the project has enough users that the docs scale better than individual support.** At ~48 stars, personal responses in GitHub issues likely still outperform any documentation.
+
+---
+
+## 2. Maintenance Cost — The Surface Area Is Already Large
+
+### CRD Field Count (from `api/v1alpha1/*_types.go`)
+
+I counted every struct field that would need documenting:
+
+| Struct | Fields |
+|--------|--------|
+| `TaskSpec` | 11 (type, prompt, credentials, model, image, workspaceRef, agentConfigRef, dependsOn, branch, ttlSecondsAfterFinished, podOverrides) |
+| `TaskStatus` | 8 (phase, jobName, podName, startTime, completionTime, message, outputs, results) |
+| `PodOverrides` | 4 (resources, activeDeadlineSeconds, env, nodeSelector) |
+| `Credentials` | 2 (type, secretRef) |
+| `WorkspaceSpec` | 5 (repo, ref, secretRef, remotes, files) |
+| `AgentConfigSpec` | 3 (agentsMD, plugins, mcpServers) |
+| `PluginSpec` | 3 (name, skills, agents) |
+| `MCPServerSpec` | 7 (name, type, command, args, url, headers, env) |
+| `TaskSpawnerSpec` | 6 (when, taskTemplate, pollInterval, maxConcurrency, suspend, maxTotalTasks) |
+| `GitHubIssues` | 10 (repo, types, labels, excludeLabels, state, triggerComment, excludeComments, assignee, author, priorityLabels) |
+| `Jira` | 4 (baseUrl, project, jql, secretRef) |
+| `TaskTemplate` | 11 (type, credentials, model, image, workspaceRef, agentConfigRef, dependsOn, branch, promptTemplate, ttlSecondsAfterFinished, podOverrides) |
+| `TaskSpawnerStatus` | 9 (phase, deploymentName, cronJobName, totalDiscovered, totalTasksCreated, activeTasks, lastDiscoveryTime, message, conditions) |
+| **Total** | **~83 fields** |
+
+### Concepts requiring documentation
+
+Beyond field references, a doc site would need conceptual pages for:
+
+1. **4 CRD resources** — Task, Workspace, AgentConfig, TaskSpawner
+2. **4 agent types** — claude-code, codex, gemini, opencode (each with distinct credential flows)
+3. **3 event source types** — GitHub Issues, Cron, Jira
+4. **2 authentication methods** — PAT vs GitHub App (with secret structure differences)
+5. **2 credential types** — API key vs OAuth
+6. **Dependency chaining** — `dependsOn`, result passing via Go templates, `.Deps` map structure
+7. **Branch serialization** — mutex behavior, interaction with `dependsOn`
+8. **MCP servers** — 3 transport types (stdio, http, sse), each with different config fields
+9. **Plugins** — skills, agents, plugin directories
+10. **Agent Image Interface** — entrypoint, env vars, UID, output capture protocol
+11. **CLI** — ~10 commands with multiple flags each
+12. **Config file** — `~/.kelos/config.yaml` with its own schema
+13. **Orchestration patterns** — self-development, fork workflows, fleet refactoring
+14. **Security model** — pod isolation, token scoping, RBAC
+15. **Cost management** — model selection, maxConcurrency, timeouts
+
+**That's 15+ conceptual topics and 83+ reference fields.** With the API still at `v1alpha1`, these fields WILL change. Every change requires updating both the code AND the docs. Two contributors cannot sustain this.
+
+### The v1alpha1 problem
+
+The API is explicitly `v1alpha1` — it signals instability. Recent commits show the API is still actively evolving:
+- `628dfd5` — Fixed incorrect field names in example workspace.yaml (docs were already wrong)
+- `0572e18` — Added GitHub App authentication (new Workspace fields)
+- `83d2dae` — Changed cron-based TaskSpawners to use CronJob (new status fields)
+- `6052977` — Added TriggerComment support (new GitHubIssues fields)
+
+A doc site amplifies the cost of every API change. Without one, you update `README.md` and `docs/reference.md`. With a doc site, you update the source files, the site content, verify cross-links, check rendering, and deploy.
+
+---
+
+## 3. Better Alternatives — Higher ROI Investments
+
+The same engineering effort could go into things that help users more:
+
+### A. Better README organization (2-4 hours)
+
+The README is 583 lines and covers everything, but it's getting long. A lightweight restructuring — splitting the Quick Start into its own file, moving the CLI reference to `docs/` — would improve discoverability without the overhead of a site.
+
+### B. More examples (4-8 hours per example)
+
+The 7 examples are the project's best documentation. They're concrete, runnable, and self-contained. Adding examples for common pain points (Jira integration, multi-repo fan-out, GitHub Enterprise setup, using custom images) would directly help users more than a doc site.
+
+### C. Better error messages (ongoing)
+
+When `628dfd5` fixed incorrect field names in an example, the real question is: **why didn't the controller's error message tell the user what was wrong?** Investing in validation webhooks and clear error messages eliminates an entire class of documentation needs. The best documentation is an error message that tells you exactly what to fix.
+
+### D. Inline godoc (2-4 hours)
+
+The Go types already have decent comments (e.g., `// Branch is the git branch this Task works on. The controller ensures only one Task with the same Branch value runs at a time.`). Improving these and publishing via pkg.go.dev costs nearly zero maintenance — godoc stays in sync with the code by definition.
+
+### E. Troubleshooting guide (2-4 hours)
+
+A single `docs/troubleshooting.md` addressing common issues (credential errors, workspace not found, rate limits, pod failures) would provide more value per line than any doc site page.
+
+---
+
+## 4. Risks of Building Too Early
+
+### Stale documentation
+
+Stale docs are worse than no docs. Users who follow outdated instructions waste time and lose trust. With `v1alpha1` APIs changing every few releases, the probability of staleness is high.
+
+Evidence this is already happening:
+- Commit `628dfd5` (the most recent non-merge commit): "Fix incorrect field names in example 05 workspace.yaml" — the examples themselves, which live right next to the code, already drifted. A doc site living in a separate repo or build pipeline would drift faster.
+
+### Version drift
+
+When docs and code diverge, users can't tell which to trust. A doc site creates a second "source of truth" that can silently fall behind. The README/reference approach keeps docs close to the code where they're more likely to be updated during the same PR.
+
+### Split attention
+
+Two contributors means every task has high opportunity cost. Time spent on docs infrastructure (choosing a framework, designing the site, setting up CI/CD for docs, configuring a domain) is time not spent on the product itself. For a pre-1.0, low-adoption project, product improvement is almost always more impactful than documentation polish.
+
+### Premature terminology commitment
+
+A doc site forces you to commit to terminology and conceptual models. If you write a "Concepts" page explaining that Tasks are "ephemeral units of work," but later realize Tasks should be persistent, you've created an artifact that resists change. Right now, the terminology is in the code and can evolve freely.
+
+### The "empty restaurant" effect
+
+A doc site with sparse content looks worse than no doc site at all. If you launch with 5 pages where 3 are stubs or "TODO" sections, users perceive the project as unfinished or abandoned. The current README gives an impression of completeness because it IS complete for the current scope.
+
+---
+
+## 5. Minimum Viable Improvement — What to Do Instead
+
+If the goal is "make Kelos easier to learn," here's the smallest investment that meaningfully helps users WITHOUT a full doc site:
+
+### Tier 1: Zero-maintenance improvements (1-2 days)
+
+1. **Split the README.** Move "Cost and Limits" and "Security Considerations" to `docs/`. Keep the README focused on Quick Start, Why Kelos, and Examples. Add a clean "Documentation" section with links.
+2. **Add a `docs/troubleshooting.md`.** Cover the top 5 failure modes users hit (bad credentials, missing workspace, rate limits, pod OOM, branch conflicts).
+3. **Improve CLI `--help` text.** Make `kelos run --help` comprehensive enough that users rarely need the docs. This is zero-maintenance because it ships with the binary.
+
+### Tier 2: Low-maintenance improvements (3-5 days)
+
+4. **Add 2-3 more examples.** Jira integration, GitHub Enterprise, and custom agent images are the obvious gaps.
+5. **Expand `docs/reference.md`** with a "Common Patterns" section showing real-world YAML snippets (not just field tables).
+6. **Add validation webhooks** that produce clear error messages for the most common misconfigurations.
+
+### Tier 3: Only if user demand proves it (1-2 weeks)
+
+7. **A simple doc site** — but ONLY after reaching ~200+ stars, 5+ contributors, or receiving repeated requests for better docs in GitHub issues. Use the simplest possible setup (GitHub Pages + a single-page generator) and migrate the existing markdown files with minimal changes.
+
+---
+
+## Conclusion
+
+Building a documentation site for Kelos right now is solving a problem the project doesn't yet have. The existing README + reference docs + 7 examples already cover nearly the entire feature surface. The two active contributors' time is better spent on product improvements, better error messages, and more examples. A doc site should be triggered by user demand (GitHub issues asking "where are the docs?"), not by aspirational project maturity.
+
+**The first documentation site is free. Keeping it accurate costs forever.**

--- a/docs-planning/docs-audit.md
+++ b/docs-planning/docs-audit.md
@@ -1,0 +1,227 @@
+# Documentation Audit: Kelos Project
+
+## Files Reviewed
+
+- `README.md` (584 lines)
+- `docs/reference.md` (310 lines)
+- `docs/agent-image-interface.md` (133 lines)
+- `examples/README.md` and all 7 example READMEs + YAML files
+- `self-development/README.md` (272 lines) + key YAML files
+- `CLAUDE.md` / `AGENTS.md` (identical, 24 lines each)
+- `api/v1alpha1/task_types.go`, `taskspawner_types.go`, `workspace_types.go`, `agentconfig_types.go`
+
+---
+
+## 1. What's Working Well
+
+### Strong README Structure
+The `README.md` is well-organized with a clear hierarchy: Demo → Why Kelos → Quick Start → How It Works → Examples → Reference → Security → Cost/Limits → FAQ. This follows the "inverted pyramid" pattern well — users get the value proposition immediately.
+
+### Excellent Quick Start
+The Quick Start section (README.md:54-213) gets users from zero to a running task in 4 steps. The `kind` cluster hint in a collapsible section is a nice touch. The CLI-first approach (`kelos run -p "..."`) is much more accessible than starting with raw YAML.
+
+### Examples Are Genuinely Useful
+The 7 examples form a logical progression:
+1. Simple task (no workspace)
+2. Task with workspace (git repo)
+3. TaskSpawner for issues
+4. TaskSpawner with cron
+5. AgentConfig injection
+6. Fork workflow
+7. Task pipeline
+
+Each example README follows a consistent template: Use Case → Resources table → Steps → Notes. The YAML files include `# TODO:` comments for placeholders — this is a good pattern for copy-paste-edit workflows.
+
+### Good "Why" Section
+README.md:44-52 clearly articulates five differentiators. Each bullet leads with a bolded phrase and expands with specifics. The comparison framing ("Orchestration, not just execution") is effective.
+
+### Self-Development as Showcase
+The `self-development/` directory (README.md:415-425, self-development/README.md) is a compelling real-world example. It demonstrates the product's own capabilities by showing how Kelos uses itself for autonomous development. The feedback loop pattern (`excludeLabels: [kelos/needs-input]`) is well-explained.
+
+### Security Section is Responsible
+README.md:463-481 takes a responsible approach — it's clear about what agents CAN and CANNOT do, and the `--dangerously-skip-permissions` explanation (line 479) proactively addresses a common concern.
+
+---
+
+## 2. What's Confusing, Buried, or Duplicated
+
+### Reference Doc is Incomplete — Significant Gaps vs. Code
+
+The `docs/reference.md` is the authoritative API reference, but it's missing several fields that exist in the Go types:
+
+**Workspace — missing fields:**
+- `spec.remotes[]` (GitRemote) — defined in `workspace_types.go:8-17`, used in example 06-fork-workflow, but completely absent from `docs/reference.md`. The Workspace table only lists `repo`, `ref`, `secretRef.name`, and `files[]`.
+
+**TaskSpawner GitHubIssues — missing fields:**
+- `triggerComment` (taskspawner_types.go:80-87) — comment-based discovery trigger
+- `excludeComments` (taskspawner_types.go:89-95) — comment-based exclusion
+- `assignee` (taskspawner_types.go:97-101) — filter by assignee
+- `author` (taskspawner_types.go:103-107) — filter by issue creator
+- `priorityLabels` (taskspawner_types.go:109-115) — priority ordering for task creation
+- `repo` override (taskspawner_types.go:51-57) — override which repo to poll
+
+None of these six fields appear anywhere in `docs/reference.md`. The `priorityLabels` field is actively used in `self-development/kelos-workers.yaml:13-17` but never documented.
+
+**TaskSpawner Jira source — entirely undocumented:**
+- The `Jira` struct (taskspawner_types.go:118-146) defines a complete Jira integration with `baseUrl`, `project`, `jql`, and `secretRef`. This is not mentioned anywhere in any documentation file — not in the README, not in the reference, not in any example.
+
+### Credential Configuration is Scattered and Confusing
+
+Credential setup is spread across at least 5 locations:
+1. README.md Quick Start (lines 111-153) — config.yaml format
+2. README.md YAML section (lines 174-226) — Kubernetes Secret + Task YAML
+3. docs/reference.md Configuration section (lines 178-198) — config.yaml fields
+4. docs/reference.md Workspace Authentication (lines 53-87) — workspace secrets
+5. docs/agent-image-interface.md (lines 27-46) — environment variable mapping
+
+A newcomer trying to understand "how do I set up credentials?" would need to read all five locations and mentally merge them. The distinction between agent credentials (Anthropic/OpenAI key) and workspace credentials (GitHub token) is never explicitly called out as two separate concepts.
+
+### `token` vs `secretRef` vs `oauthToken` Naming Confusion
+
+The config.yaml uses `oauthToken` and `token` (README.md:114-118):
+```yaml
+oauthToken: <your-oauth-token>
+workspace:
+  token: <github-token>
+```
+
+The YAML resources use `secretRef` and `credentials.secretRef`:
+```yaml
+credentials:
+  secretRef:
+    name: claude-oauth-token
+workspace:
+  secretRef:
+    name: github-token
+```
+
+These are the same concepts but with different names depending on whether you use CLI/config or YAML. This mapping is never explicitly documented.
+
+### AgentConfig `plugins` vs Workspace `files` Overlap
+
+Both AgentConfig (agentconfig_types.go:15-19) and Workspace (workspace_types.go:55-60) can inject files into the agent's environment:
+- AgentConfig `plugins` → mounted as plugin directories
+- Workspace `files[]` → written into the cloned repo
+
+The docs mention both but never explain when to use which. The Workspace `files` description says it can inject "plugin-like assets such as skills" — this directly overlaps with AgentConfig's purpose. A newcomer would not know which mechanism to choose.
+
+### "How It Works" Diagram is an Image, Not Text
+
+README.md:232 references an image hosted on GitHub user-attachments. This means:
+- It's not searchable
+- It can't be updated without re-uploading
+- It's not accessible (no alt text beyond "kelos-resources")
+
+### Duplicate Template Variable Tables
+
+The promptTemplate variables table appears in THREE places:
+1. `docs/reference.md:136-149`
+2. `self-development/README.md:210-221`
+3. README.md doesn't have the table but describes `.Deps` at line 361-382
+
+The tables in reference.md and self-development/README.md are copies. If one is updated, the other risks going stale.
+
+---
+
+## 3. Gaps Between Code and Docs
+
+### Jira Integration — Zero Documentation
+The biggest gap. `taskspawner_types.go:118-146` defines a full Jira source with:
+- `baseUrl`, `project`, `jql` fields
+- Secret-based auth (JIRA_TOKEN, optional JIRA_USER)
+- Support for both Jira Cloud (Basic auth) and Data Center (Bearer token)
+
+There is no mention of Jira anywhere in the README, reference, examples, or FAQ. A user reading the docs would have no idea Jira is supported.
+
+### Fork Workflow — Advanced but Under-documented
+Example 06 demonstrates the fork workflow, but the key enabler — `spec.when.githubIssues.repo` override — is not documented in `docs/reference.md`. Similarly, `workspace.spec.remotes` is used in the example but absent from the reference.
+
+### Comment-Based Triggers — Powerful but Hidden
+`triggerComment` and `excludeComments` (taskspawner_types.go:79-95) enable a comment-based workflow for repos where you lack label permissions. This is a significant feature for open-source contribution scenarios but is completely undocumented.
+
+### GitHub Enterprise Support — Mentioned Only in Env Vars
+`docs/agent-image-interface.md:41` mentions `GH_ENTERPRISE_TOKEN` and `GH_HOST` environment variables for GitHub Enterprise, but this capability is never mentioned in the main README or reference doc. An enterprise user would not discover this.
+
+### Task Immutability
+`task_types.go:183` has a validation rule: `"Task spec is immutable after creation"`. This is never documented. A user trying to update a running task's prompt would get an opaque error.
+
+### `kelos create workspace` and `kelos create agentconfig` CLI Commands
+These appear in the CLI reference table (reference.md:273-274) but have no examples, no flags documented, and no explanation. A user seeing them would have to guess at usage.
+
+---
+
+## 4. Discoverability for Newcomers
+
+### Good: Top-Down Entry Point
+A newcomer landing on the README gets a clear path: Demo → Why → Quick Start → Examples. The Quick Start's 4-step flow is accessible.
+
+### Problem: No Conceptual Overview
+There is no document that explains the mental model. The "Core Primitives" section (README.md:238-258) lists the four resources but doesn't explain how they relate or when you'd use each one. Questions like:
+- "When do I need a Workspace vs. just running without one?"
+- "What's the difference between AgentConfig and putting instructions in the prompt?"
+- "When should I use TaskSpawner vs. just creating Tasks?"
+
+These require reading multiple sections and inferring the answers.
+
+### Problem: No Troubleshooting Guide
+The self-development README has a "Troubleshooting" section (self-development/README.md:249-264), but it's buried inside self-development, which most newcomers won't explore. The main README has no troubleshooting section — only a single tip about controller logs (README.md:171-172).
+
+### Problem: No "What Happens When Things Go Wrong"
+If a task fails, the docs never explain:
+- How to view the failure reason (`status.message`, `status.phase`)
+- How to retry a failed task (delete and recreate? Is there a retry mechanism?)
+- What the Pod logs contain and how to interpret them
+- Common failure modes (rate limiting, invalid credentials, Git auth failures)
+
+### Problem: Agent Type Differences Aren't Compared
+The docs mention four agent types (claude-code, codex, gemini, opencode) but never compare them. A newcomer choosing between agents has no guidance on:
+- Which features work with which agents (plugins only work with claude-code)
+- Credential differences between agents
+- Capability differences
+- Cost/performance tradeoffs
+
+---
+
+## 5. Progression from Simple to Complex
+
+### Good: Examples Follow a Learning Curve
+The 7 examples progress logically:
+- 01: Minimal (just a task + secret)
+- 02: Add workspace (git repo)
+- 03: Add automation (TaskSpawner)
+- 04: Add scheduling (Cron)
+- 05: Add configuration (AgentConfig)
+- 06: Advanced pattern (Fork workflow)
+- 07: Advanced pattern (Pipeline with dependencies)
+
+### Problem: No Intermediate "How-To" Layer
+There's a gap between "here's a working example" and "here's the full API reference." Missing middle layer would include:
+- How to set up cost controls (maxConcurrency, timeouts)
+- How to debug a failing agent
+- How to structure prompts for best results
+- How to set up branch protection with Kelos
+- How to migrate from CLI-only to YAML-managed
+
+### Problem: Self-Development is Aspirational, Not Instructional
+The `self-development/` directory is impressive but serves more as a showcase than a learning resource. The prompts in `kelos-workers.yaml` (83 lines of promptTemplate) are highly Kelos-specific. A newcomer wanting to build their own autonomous workflow doesn't get intermediate steps between "simple task" and "full self-development pipeline."
+
+### Problem: Reference Doc Assumes Familiarity
+`docs/reference.md` is a flat list of fields. It works well as a lookup table for someone who already understands the system, but it doesn't help someone learning. There are no:
+- Explanatory notes about common patterns
+- Cross-references between related fields
+- Warnings about common mistakes
+- Examples within the reference itself
+
+---
+
+## Summary: Overall Documentation Health
+
+| Aspect | Rating | Notes |
+|--------|--------|-------|
+| Getting started | Good | Quick Start is accessible; CLI-first approach works well |
+| API completeness | Poor | At least 8 fields undocumented; Jira integration entirely missing |
+| Example quality | Good | Consistent format, logical progression, runnable YAML |
+| Conceptual clarity | Fair | Mental model must be inferred; no explicit concept docs |
+| Troubleshooting | Poor | Essentially absent from main docs |
+| Discoverability | Fair | Good entry point, but advanced features are hidden |
+| Maintenance burden | Concerning | Triple-duplicated tables, image-only diagrams, scattered credential docs |

--- a/docs-planning/user-research.md
+++ b/docs-planning/user-research.md
@@ -1,0 +1,237 @@
+# User Perspective Research: Kelos Documentation
+
+## 1. User Personas
+
+Based on analysis of README.md, examples/, self-development/, and GitHub issues.
+
+### Persona A: Platform Engineer / Internal Developer Platform Builder (Primary)
+
+**Evidence:**
+- README emphasizes scalable parallelism, fan-out across repos, Kubernetes scheduling/resource management (line 51)
+- GitHub App auth recommended "for organizations" and "production/org use" (lines 142-152)
+- `maxConcurrency`, `maxTotalTasks`, namespace RBAC isolation, scoped ServiceAccounts — organizational-scale controls
+- Fleet-wide refactoring and AI Worker Pools explicitly named as use cases (lines 431-433)
+- ArgoCD/GitOps integration highlighted
+
+**K8s experience:** High. Comfortable with CRDs, RBAC, ServiceAccounts, namespace isolation, ArgoCD.
+
+**Workflow:** Deploy Kelos into shared cluster, configure GitHub App auth for the org, define reusable Workspaces and AgentConfigs, let developers trigger tasks via `kelos run` or declarative YAML.
+
+### Persona B: DevOps / Automation Engineer
+
+**Evidence:**
+- "Hands-Free CI/CD" use case (line 432)
+- "Event-Driven Bug Fixing" via GitHub issue labels (line 430)
+- Cron-triggered TaskSpawner (example 04)
+- self-development pipeline with `kelos-triage.yaml` at concurrency 8
+
+**K8s experience:** Intermediate. Uses existing cluster infrastructure but may not build clusters from scratch.
+
+**Workflow:** Wire GitHub issue labels to TaskSpawners, configure cron schedules, integrate outputs into Slack/CI dashboards.
+
+### Persona C: Individual Developer / Indie Hacker (Aspirational)
+
+**Evidence:**
+- Quick Start framing: "Get running in 5 minutes"
+- `kelos run -p "Fix the bug..."` one-liner demo (line 276)
+- `kind create cluster` as local option (line 68)
+- FAQ explicitly addresses "Can I use Kelos without Kubernetes?" (line 530)
+
+**K8s experience:** Low to intermediate.
+
+**Friction:** Highest. They want `pip install && run` but get `kind create cluster && kelos install && kubectl apply -f secret.yaml`. The Kubernetes requirement is a hard gate.
+
+### Persona D: Open-Source Maintainer
+
+**Evidence:**
+- Example 06 "Fork Workflow" — for contributors without upstream push access
+- `kelos-workers.yaml` includes "Check if PR already exists" logic
+- self-development/ shows Kelos managing its own contributions
+
+**K8s experience:** Intermediate.
+
+---
+
+## 2. User Journey: Discovery to First Task
+
+### Step-by-step path and friction points
+
+| Step | Action | Friction Level | Notes |
+|------|--------|---------------|-------|
+| 0. Discovery | Land on README | Low | Clear tagline, demo section, video embed |
+| 1. Prerequisites | Need K8s cluster (1.28+) | **HIGH** | Hard-blocked without K8s. `kind` escape hatch exists but adds significant overhead |
+| 2. Install CLI | `curl ... \| bash` or `go install` | Low | Single binary, straightforward |
+| 3. Install to cluster | `kelos install` | Medium | Requires kubectl + cluster admin permissions |
+| 4. Configure | `kelos init` + edit config | **HIGH** | 4 credential types to understand (Claude OAuth, API key, Codex OAuth, GitHub PAT/App). No "start here" recommendation |
+| 5. Run first task | `kelos run -p "..."` | Medium | Works, but ephemeral warning appears *after* setup. Results disappear without workspace config |
+| 6. See results | `kelos logs` | Medium | No next-step guidance after task creation (issue #183) |
+
+### Critical friction points
+
+1. **Cluster requirement gate** — FAQ acknowledges users will ask "Can I use this without K8s?" Answer is no. `kind` works locally but adds significant setup.
+
+2. **Credential complexity** — Before the first task, users must understand: AI agent credentials (OAuth vs API key), GitHub credentials (PAT vs GitHub App), and workspace config. The README presents these in parallel without "start here" guidance.
+
+3. **Step ordering contradiction** — Issue #305: The CLI's `kelos init` suggests order `init -> install -> run`, but README shows `install -> init -> run`. Directly contradicts what users see.
+
+4. **OAuth vs API key confusion** — Issue #201: `--credential-type` defaults to `api-key` in CLI code, but Quick Start presents OAuth first. Users picking one type may get silent failures.
+
+5. **Ephemeral result surprise** — Warning "Without a workspace, the agent runs in an ephemeral pod — any files it creates are lost" appears after config setup, not before. Users running example 01 (no workspace) will wonder why there's no git output.
+
+6. **No debugging path** — Main troubleshooting guidance is one tip: "check the controller logs." Issue #365 requests a troubleshooting guide.
+
+7. **No decision tree** — Should I use `kelos run` or YAML? Example 01 or 02? Which agent type? Which credential type? README presents options without guidance.
+
+---
+
+## 3. GitHub Signals
+
+### Repo Stats
+- **Age:** ~4 weeks (created 2026-02-01)
+- **Stars:** 50 | Forks: 8 | Contributors: 2
+- **Community health:** 37% — no CONTRIBUTING.md, no code of conduct, no issue/PR templates
+- **Open issues:** 64 (most generated by Kelos self-development pipeline)
+- **Discussions:** Not enabled
+
+### Documentation Issues (14 open, tagged `kind/docs`)
+
+**Onboarding blockers (affects every new user):**
+| Issue | Title | Priority |
+|-------|-------|----------|
+| #305 | Quick Start ordering creates confusion | `priority/important-longterm`, `good first issue` |
+| #201 | OAuth vs API key credential confusion | — |
+| #195 | Config file should link to token sources | — |
+
+**Reference gaps (affects users past hello-world):**
+| Issue | Title |
+|-------|-------|
+| #205 | `promptTemplate` variables incomplete (7 documented, 10 exist) |
+| #221 | Valid `--model` values inconsistent |
+| #202 | No examples for Codex or Gemini (`good first issue`) |
+| #204 | TaskSpawner GitHub Issues repo determination unclear |
+
+**Operational gaps:**
+| Issue | Title |
+|-------|-------|
+| #365 | Missing troubleshooting guide |
+| #242 | Missing task cleanup/lifecycle guidance |
+
+**Use case documentation:**
+| Issue | Title |
+|-------|-------|
+| #384 | AI-powered dependency maintenance |
+| #291 | PR review, fleet migration, security audit patterns |
+| #328 | Orchestrator pattern |
+
+### CLI UX Issues (9 open)
+- `kelos run` provides no next-step guidance (#183)
+- `kelos run --help` doesn't mention credentials required (#162)
+- `kelos run --watch` doesn't show results on completion (#402)
+- Error message when controller not installed is unhelpful (#196)
+
+### Key Insight
+The `kelos-fake-user.yaml` self-development agent literally simulates a new user experience, rotating through "Documentation & Onboarding," "Developer Experience," and "Examples & Use Cases." This reveals maintainers are already aware of onboarding friction.
+
+---
+
+## 4. Comparable Projects
+
+### Documentation Framework Survey
+
+| Project | Stars | Contributors | Doc Framework | Doc Site |
+|---------|-------|-------------|---------------|----------|
+| Argo Workflows | 16,500 | 926 | MkDocs + ReadTheDocs | argo-workflows.readthedocs.io |
+| Tekton | 8,900 | 367 | Hugo | tekton.dev/docs |
+| Dagger | 15,500 | 296 | Docusaurus | docs.dagger.io |
+| Concourse CI | 7,800 | ~372 | Booklit (custom) | concourse-ci.org |
+| Flux CD | 7,900 | 179 | Hugo + Docsy | fluxcd.io |
+| Kueue | 2,300 | — | Hugo | kueue.sigs.k8s.io |
+| Crossplane | 11,500 | — | Hugo | docs.crossplane.io |
+
+**Framework popularity in K8s ecosystem:** Hugo is the plurality choice (Tekton, Flux, Kueue, Crossplane). MkDocs used by Argo. Docusaurus used by Dagger.
+
+### When Did They Create Doc Sites?
+
+| Project | Stars at doc site launch | Context |
+|---------|------------------------|---------|
+| Tekton | ~0 (same month as launch, March 2019) | Foundation-donated project |
+| Dagger | ~0 (at public launch, March 2022) | VC-funded, docs as product |
+| Kueue | ~500-1,000 (early life) | kubernetes-sigs umbrella |
+| Argo Workflows | ~1,000-3,000 (estimated) | Grew organically |
+| Concourse | Very early | Commercial backing (Pivotal/VMware) |
+
+**Key finding:** No project in this cohort waited until "big enough" for a doc site. Projects with institutional backing launched with doc sites from day one. Even Kueue (2,300 stars, smallest surveyed) has a full Hugo site.
+
+### Documentation Structure Patterns
+
+Common sections across all surveyed projects:
+1. **Getting Started / Quick Start** — Every project has this
+2. **Concepts** — Explaining the mental model (especially CRD-based projects)
+3. **Installation / Operator Guide** — Separate from user-facing docs
+4. **CLI Reference** — Auto-generated or hand-written
+5. **Examples / How-to Guides** — Practical, task-oriented
+6. **API Reference** — CRD field-level docs
+7. **Contributing** — Developer guide
+
+### What Dagger Does Well (most relevant model)
+- Docusaurus-based (same as kelos-docsite already)
+- Covers 8 SDK languages with unified structure
+- Quickstarts are language-specific
+- Cookbook section for practical recipes
+- FAQ is prominent and addresses real user questions
+
+---
+
+## 5. Project Maturity Assessment
+
+### Current State
+- **Version:** v0.14.0
+- **Stars:** ~50
+- **Contributors:** 2 (gjkim42, aslakknutsen)
+- **Age:** ~4 weeks
+- **Community health:** 37%
+- **Unique aspect:** Project uses itself (self-development pipeline) — a strong credibility signal
+
+### What This Means for Documentation
+
+**Arguments FOR a doc site now:**
+1. Every comparable project created docs early (or at launch)
+2. 14 open `kind/docs` issues already — documentation needs are real and growing
+3. README is already long and multi-audience (users, operators, contributors)
+4. The project's complexity (4 CRDs, multiple agent types, multiple credential types) exceeds what a README can handle well
+5. A doc site is a credibility signal for early adopters evaluating the project
+
+**Factors to consider:**
+1. Only 2 contributors — maintenance burden matters
+2. ~50 stars — external user base is tiny; most "users" are the maintainers themselves
+3. APIs are still evolving (v0.14.0) — docs will need frequent updates
+4. The self-development pipeline could potentially help maintain docs
+
+### Maturity-Appropriate Documentation Strategy
+
+At this stage, the comparable projects suggest:
+- A doc site with **focused, minimal scope** — not trying to match Argo's 7-section structure
+- Prioritize: Quick Start (fixing the ordering/credential issues), Concepts (the 4 CRDs), CLI Reference, Examples
+- Avoid: versioned docs, multi-language support, extensive operator guides
+- The existing Docusaurus setup in kelos-docsite aligns with Dagger's approach and is a reasonable framework choice
+
+---
+
+## 6. Existing Documentation Inventory
+
+| Path | Contents | Audience |
+|------|----------|----------|
+| `README.md` | Main entry: what/why/quickstart/examples/reference/security/cost/FAQ | All |
+| `docs/reference.md` | Complete field-level API reference for 4 CRDs + CLI flags | Users/operators |
+| `docs/agent-image-interface.md` | Technical spec for custom agent images | Advanced users |
+| `examples/README.md` | Index + how-to for all 7 examples | Users |
+| `examples/NN-*/README.md` | Per-example walkthroughs | Users |
+| `self-development/README.md` | Architecture + deployment guide for self-dev pipeline | Operators/contributors |
+
+### What's Missing
+- No troubleshooting guide
+- No conceptual guide (when to use TaskSpawner vs `kelos run`, when to use which credential type)
+- No comparison/migration guide (local Claude Code vs Kelos)
+- No cost estimation guidance beyond general notes
+- No CONTRIBUTING.md
+- No Codex or Gemini examples despite advertised support


### PR DESCRIPTION
## Summary
- Three-angle analysis of whether Kelos should build a documentation site
- **Auditor**: cataloged every doc gap with file:line citations (Jira undocumented, 8+ missing API fields, scattered credential docs)
- **Researcher**: mapped user personas, journey friction points, and comparable project approaches (Argo, Tekton, Dagger, Kueue)
- **Advocate**: built the case against (maintenance burden on 2 contributors, v1alpha1 instability, better alternatives)
- **Recommendation**: Yes, but fix foundations first — phased approach with quick wins

## Files
- `docs-planning/RECOMMENDATION.md` — synthesized verdict with phased plan
- `docs-planning/docs-audit.md` — current state audit
- `docs-planning/user-research.md` — user perspective and comparable projects
- `docs-planning/counterarguments.md` — case against building too early

## Test plan
- [ ] Review each analysis file for accuracy against the actual codebase
- [ ] Decide on Phase 1 quick wins to pursue first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a planning analysis for a Kelos documentation site and a phased recommendation: fix doc foundations now, then build a minimal Docusaurus site. Highlights concrete gaps and quick wins to improve onboarding and reduce doc-related issues.

- **New Features**
  - docs-planning/RECOMMENDATION.md: phased plan (foundations → minimal site → sustain).
  - docs-planning/docs-audit.md: catalog of current gaps with file:line citations.
  - docs-planning/user-research.md: personas, journey friction, and peer project survey.
  - docs-planning/counterarguments.md: risks and ROI case against building too early.

- **Migration**
  - Complete missing API/reference fields and add a troubleshooting guide.
  - Consolidate credential docs and add a concise concepts page.
  - Fix Quick Start ordering and credential defaults.
  - Agree on v1 site scope (small set of pages) after Phase 1 is done.

<sup>Written for commit e30ab4e9c237a01d4458ab2b753e9da50c3c0165. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

