### PR TITLE
Analyze whether to build a documentation site

### DIFF
--- a/RECOMMENDATION.md
+++ b/RECOMMENDATION.md
@@ -1,0 +1,119 @@
+# Documentation Site Recommendation
+
+## Verdict: Not Yet — But Sooner Than You'd Think
+
+The answer is **not yet**, but with a concrete trigger: **build the doc site when the API reaches v1beta1 or when you're ready to actively recruit contributors/users** — whichever comes first. In the meantime, there are high-impact improvements that take hours, not days, and address the real pain users are hitting right now.
+
+This isn't a "no" — it's a "sequence it right."
+
+---
+
+## How We Got Here
+
+Three independent analyses examined this from different angles:
+
+| Analyst | Perspective | Conclusion |
+|---------|------------|------------|
+| **Auditor** ([docs-audit.md](docs-audit.md)) | What do we actually have? | Docs are strong for the stage but hitting limits — 3 major features undocumented, no conceptual guides, poor discoverability |
+| **Researcher** ([user-research.md](user-research.md)) | What do users experience? | 38 docs issues in <1 month, 2 "very high friction" points in the user journey, all comparable projects have doc sites |
+| **Devil's Advocate** ([counterarguments.md](counterarguments.md)) | Why not build it now? | 27-day-old project, 1 real contributor, 2 API changes/day, v1alpha1 instability, targeted fixes are cheaper |
+
+---
+
+## Where They Agreed
+
+All three analyses converged on these points:
+
+1. **The existing README is genuinely good.** Well-structured, honest, progressive disclosure via `<details>` blocks. This is not a documentation-neglected project.
+
+2. **Troubleshooting documentation is the #1 gap.** The auditor found no troubleshooting guide anywhere. The researcher identified debugging as a "very high friction" journey step. The devil's advocate lists it as the highest-impact fix (~2 hours).
+
+3. **Several shipped features have zero documentation.** Jira integration, comment-based triggers (`TriggerComment`/`ExcludeComments`), priority labels, assignee/author filters — all exist in the API types but appear nowhere in docs. This is a content problem, not a format problem.
+
+4. **Credential setup is confusing.** Five separate GitHub issues about OAuth vs API key, where to get tokens, and which credentials are needed when. The auditor found four different explanations of workspace auth scattered across files.
+
+5. **The content must improve regardless of format.** A doc site with the same gaps is just a fancier version of the same problem. Content first, infrastructure second.
+
+---
+
+## Where They Disagreed
+
+### The timing question
+
+The researcher argues **now**: 38 docs issues in a month, 490 unique visitors in 2 weeks, all comparable K8s tools have doc sites — users expect it and are hitting walls without it.
+
+The devil's advocate argues **not yet**: 27 days old, 1 contributor doing 99.6% of work, 2 API changes per day, v1alpha1 means no stability guarantees. A doc site is premature optimization.
+
+**My read:** Both are right about different things. The user friction is real and documented (38 issues isn't noise). But the API instability is also real — documenting 124 fields that change twice daily is a maintenance trap. The resolution is to **fix the content problems now** (in-repo, where they stay in sync) and **build the site infrastructure when the API stabilizes** (so you're not maintaining two sources of truth during a period of rapid change).
+
+### The form factor question
+
+The researcher says a 584-line README can't scale and needs search/navigation. The devil's advocate says in-repo markdown is the right format because it versions with the code.
+
+**My read:** These aren't mutually exclusive. Modern doc site tools (mkdocs-material, Docusaurus) render in-repo markdown into a searchable site. The content stays in the repo, versioned with the code. The "site" is just a build step. But setting up that build step has a cost (CI pipeline, hosting, theme config, nav structure) that isn't justified until the content is worth navigating.
+
+---
+
+## Recommendation
+
+### Phase 1: Quick wins now (this week, ~8 hours)
+
+These improvements address real user pain, require no infrastructure, and stay in sync with code:
+
+| Action | Impact | Effort | Addresses |
+|--------|--------|--------|-----------|
+| Add troubleshooting FAQ to README | High | ~2 hrs | #365, user journey step 7 |
+| Create CONTRIBUTING.md | High | ~1 hr | #219, contributor onboarding |
+| Document Jira integration in reference.md | High | ~1 hr | Completely missing feature |
+| Document TriggerComment, ExcludeComments, PriorityLabels, Assignee, Author in reference.md | High | ~1 hr | 5 undocumented fields |
+| Add Workspace `remotes` to reference.md | Medium | ~30 min | Missing from reference, only in example 06 |
+| Add `Example` blocks to CLI cobra commands | Medium | ~2 hrs | CLI discoverability |
+| Deduplicate or differentiate AGENTS.md vs CLAUDE.md | Low | ~30 min | Identical files causing confusion |
+
+### Phase 2: Content expansion (this month, ~6 hours)
+
+Write the missing conceptual content — still as in-repo markdown, but structured so it can become doc site pages later:
+
+| Action | Notes |
+|--------|-------|
+| Credential & authentication guide | Unified guide: API key vs OAuth vs GitHub App, which secrets for what, end-to-end flow |
+| Task lifecycle guide | Phases, branch serialization, dependency resolution, with a state diagram |
+| Architecture overview | Controller, Jobs/Deployments/CronJobs under the hood, reconciliation loop |
+| Improve error messages in code | Actionable guidance in the errors themselves — this is documentation that can never go stale |
+
+Put these in `docs/` with a `docs/README.md` index. This creates a natural structure that maps directly to doc site pages later.
+
+### Phase 3: Doc site (when ready)
+
+**Trigger criteria** — build the site when at least 2 of these are true:
+- API reaches v1beta1 (stability guarantee means docs won't churn daily)
+- 5+ regular contributors (onboarding cost justifies the investment)
+- 200+ stars (enough users that discoverability matters at scale)
+- You're actively promoting the project (conference talks, blog posts, outreach)
+
+**When you build it:**
+- **Framework:** mkdocs-material. It's what Argo Workflows uses, it renders in-repo markdown, has search built in, and is the standard for K8s ecosystem projects. Docusaurus is also viable but is heavier (React-based) and more common in the JS ecosystem.
+- **Structure (Diataxis framework):**
+  - Tutorials: Getting Started, First TaskSpawner, First Pipeline
+  - How-to Guides: Authentication, Fork Workflows, Custom Agent Images, Jira Integration
+  - Reference: CRD specs (auto-generated from types if possible), CLI reference, Config file reference
+  - Explanation: Architecture, Task Lifecycle, Security Model
+- **Scope:** Start with the content from Phases 1-2 reorganized into the structure above. Don't write new content just for the site launch.
+- **Keep it in-repo:** `docs/` directory, built by CI, deployed to GitHub Pages. One repo, one PR process, one review cycle.
+
+---
+
+## What NOT to Do
+
+1. **Don't build a doc site and leave the content gaps.** A searchable site with no troubleshooting guide is still useless for a stuck user.
+2. **Don't auto-generate CRD reference docs from Go types right now.** The types change too fast. Wait for v1beta1 when the structure stabilizes.
+3. **Don't split docs into a separate repo.** Version drift is the #1 risk the devil's advocate identified, and a separate repo maximizes that risk.
+4. **Don't add a blog/changelog to the doc site.** GitHub Releases already serves this purpose. Don't create another thing to maintain.
+
+---
+
+## Summary
+
+The project has strong documentation for its age. The pain points are specific and addressable: missing troubleshooting, undocumented features, credential confusion. These are content problems that should be fixed in-repo now. A doc site is the right eventual destination — it's what every comparable project has — but building one before the API stabilizes and the content gaps are filled would create maintenance burden without proportional user value.
+
+Do the content work first. The site infrastructure is a couple days of work when the time is right. The content is the hard part, and you can start that today.

--- a/counterarguments.md
+++ b/counterarguments.md
@@ -1,0 +1,205 @@
+# The Case Against Building a Documentation Site Right Now
+
+## Executive Summary
+
+Kelos is a **27-day-old project** with **one dominant contributor** (99.6% of commits), a **v1alpha1 API with no stability guarantees**, and **50+ open issues** — most of which are feature requests still awaiting triage. Building a documentation site now would be premature, expensive to maintain, and solve the wrong problem. The real documentation gaps are a missing troubleshooting guide, absent CONTRIBUTING.md, and weak CLI help text — none of which require a dedicated site.
+
+---
+
+## 1. Premature Optimization
+
+### The numbers tell a clear story
+
+| Metric | Value | What it means |
+|--------|-------|---------------|
+| Project age | 27 days (created Feb 1, 2026) | Barely past initial development |
+| GitHub stars | 50 | Minimal external awareness |
+| Forks | 8 | Very few external users |
+| Contributors | 3 (548 of 550 commits from one person) | Single-author project in practice |
+| Version | v0.14.0 (pre-1.0) | Not yet considered stable |
+| Open issues | 50+ (40+ marked `kelos/needs-input`) | Core design decisions still pending |
+| Release cadence | ~1 release every 2-3 days | API surface expanding rapidly |
+
+### What this means
+
+The project is in the **"feature explosion" phase** — capabilities are being added faster than they can be documented. In the last 27 days, Kelos has gone from v0.4.0 to v0.14.0 (10 minor versions), adding CronJob support, Jira integration, MCP servers, GitHub App authentication, TaskSpawner filtering, and task pipelines.
+
+A documentation site assumes a **stable surface to document**. Kelos doesn't have that yet. The 40+ issues marked `kelos/needs-input` represent unresolved design decisions that could reshape the API. Building a doc site now means building on sand.
+
+### Comparable project timing
+
+Most Kubernetes-native projects didn't build dedicated doc sites until they had:
+- Hundreds of stars and dozens of contributors
+- A stable (v1+) API or at least a beta API
+- External production users generating real documentation needs
+- A contributor community that needed onboarding documentation
+
+Kelos has none of these yet.
+
+---
+
+## 2. Maintenance Cost Will Be Brutal
+
+### API surface area
+
+Kelos has **4 CRDs** with substantial complexity:
+
+| CRD | JSON fields | Validation rules | Nested struct types |
+|-----|------------|------------------|---------------------|
+| Task | 33 | 8 | 5 |
+| TaskSpawner | 51 | 16 | 8+ |
+| Workspace | 16 | 7 | 3 |
+| AgentConfig | 24 | 5 | 5 |
+| **Total** | **124 fields** | **36 validation rules** | **20+ nested types** |
+
+Every one of those 124 fields needs accurate documentation. Every validation rule needs to be explained. Every nested type needs its own section.
+
+### API change velocity
+
+The `api/v1alpha1/` directory has seen **57 commits** in the project's 27-day lifetime — roughly **2 API changes per day**. Recent changes include:
+
+- Breaking field relocations (workspaceRef moved from GitHubIssues to TaskTemplate level)
+- New nested structures (secretRef field nesting for headers/env)
+- New CRD capabilities (MCP servers, Jira integration, GitHub App auth)
+- Validation rule changes (CEL rules, enum constraints, immutability enforcement)
+- New required fields added to existing types
+
+### The maintenance math
+
+At the current rate of ~2 API changes per day:
+- A doc site would need **daily review** to stay accurate
+- Each breaking change requires updating reference docs, examples, and potentially tutorials
+- With a single contributor doing 99.6% of development, **documentation maintenance directly competes with feature development**
+
+The v1alpha1 designation means there are **no stability guarantees**. Fields can be removed, renamed, or restructured in any release. A doc site documenting today's API could be materially wrong within a week.
+
+### What stale docs cost
+
+Stale documentation is **worse than no documentation**. A user who follows an outdated doc site tutorial and gets cryptic errors will:
+1. Lose trust in the project
+2. File issues that waste developer time
+3. Conclude the project is abandoned or poorly maintained
+
+With the README, staleness is obvious — it's right there in the repo, updated alongside the code. A separate doc site creates a second source of truth that silently drifts.
+
+---
+
+## 3. Better Ways to Spend the Same Effort
+
+The existing documentation is actually quite good for a 27-day-old project:
+
+- **README.md**: 583 lines, well-structured with Quick Start, architecture diagrams, 5 example patterns, security considerations, cost/limits section, and FAQ
+- **docs/reference.md**: 309 lines of field-by-field CRD reference
+- **docs/agent-image-interface.md**: 132 lines of agent interface specification
+- **examples/**: 7 complete working examples with READMEs covering all major use cases
+- **self-development/README.md**: Excellent workflow documentation with diagrams
+
+The effort to build and maintain a doc site (conservatively 20-40 hours to set up, plus ongoing maintenance) could instead address the **actual gaps** in the current documentation:
+
+### Gap 1: No troubleshooting guide (HIGH impact, ~2 hours)
+
+There is no troubleshooting section anywhere in the project. Users who hit errors have no guidance. Common scenarios that need coverage:
+- TaskSpawner creates no tasks (wrong labels, missing secret)
+- Task fails immediately (invalid credentials, kubeconfig issues)
+- Task hangs in Waiting phase (dependency name typo)
+- `kelos run` reports "secret not found"
+
+### Gap 2: No CONTRIBUTING.md (HIGH impact, ~1 hour)
+
+The project has no contributor guide at all. For a project that wants to grow beyond one contributor, this is a critical gap. It should cover:
+- Local dev setup (`make verify`, `make test`)
+- Code organization (cmd/, internal/, api/)
+- PR expectations and review process
+
+### Gap 3: CLI help text lacks examples (MEDIUM impact, ~2 hours)
+
+The CLI commands have `Short` descriptions but no `Long` descriptions or `Example` fields. Users running `kelos run --help` see a description but no practical usage example. Adding examples to the cobra commands is trivial and immediately helpful.
+
+### Gap 4: Error messages lack actionable guidance (MEDIUM impact, ~3 hours)
+
+Error messages use proper wrapping (`fmt.Errorf` with `%w`) but don't tell users what to do next. For example:
+- "creating discovery client: %w" — should suggest checking kubeconfig
+- Credential failures — should suggest which auth method to try
+- Workspace not found — should suggest `kelos get workspaces`
+
+### Gap 5: Missing examples for edge cases (LOW impact, ~3 hours)
+
+The 7 existing examples cover the happy path well. Missing scenarios:
+- Resource constraints (CPU/memory limits)
+- Private repository authentication (SSH keys, GitHub App)
+- Error recovery and debugging workflows
+
+**Total cost of all five gaps: ~11 hours.** That's less than half the effort of setting up a doc site, and addresses the problems users actually have.
+
+---
+
+## 4. Risks of Building Too Early
+
+### Risk 1: Version drift between docs and code
+
+A doc site creates a **second source of truth**. The README lives in the repo and is updated in the same PR that changes the code. A doc site requires a separate update process. With 2 API changes per day and one contributor, this synchronization will break.
+
+### Risk 2: Splitting attention from core development
+
+The project has 50+ open issues, most marked `kelos/needs-input`. The sole active contributor's time is the project's most scarce resource. Every hour spent on doc site infrastructure is an hour not spent on:
+- Resolving the 40+ issues awaiting design decisions
+- Stabilizing the API toward v1beta1
+- Adding tests (the project has integration and e2e tests, but coverage could improve)
+- Improving error messages and CLI UX
+
+### Risk 3: Premature information architecture
+
+A doc site imposes structure — navigation, categories, hierarchy. With the API still in flux, that structure will need repeated reorganization. Today's "Getting Started" tutorial may reference fields that don't exist next month. Today's "Advanced Configuration" page may become basic default behavior.
+
+### Risk 4: False signal of maturity
+
+A polished doc site signals to users that the project is stable and production-ready. Kelos is v0.14.0 with a v1alpha1 API. Users who see a professional doc site may deploy to production and be surprised by breaking changes. The current README correctly sets expectations — it's clearly a project README, not a product manual.
+
+### Risk 5: Documentation debt accumulation
+
+Once a doc site exists, every feature must be documented there. This creates a new category of work (documentation debt) that competes with code debt. For a single-contributor project, this can become a psychological burden that slows development — "I can't ship this feature until I update the docs" or worse, "I shipped but forgot to update the docs."
+
+---
+
+## 5. Minimum Viable Alternative
+
+Instead of a documentation site, here's the smallest set of improvements that would meaningfully help users:
+
+### Tier 1: Do this week (~4 hours total)
+
+1. **Add a Troubleshooting section to README.md** — 10-15 FAQ entries covering the most common failure modes with solutions. This is the single highest-impact documentation improvement possible.
+
+2. **Create CONTRIBUTING.md** — Local dev setup, test commands, code organization, PR guidelines. Unblocks community contributions.
+
+3. **Add `Example` fields to CLI cobra commands** — Users running `--help` see practical usage patterns immediately.
+
+### Tier 2: Do this month (~4 hours total)
+
+4. **Improve error messages** — Add actionable next steps to the 10 most common error paths. This is documentation embedded in the product itself — it can never go stale.
+
+5. **Add a "What to do when things go wrong" section to examples/** — Each example README gets 5-10 lines about common failures and debugging.
+
+### Tier 3: Do when the API stabilizes
+
+6. **Consider a doc site** — Once the API reaches v1beta1 or v1, the project has 10+ contributors, and there's a genuine user community generating documentation needs, a doc site becomes justified.
+
+### Why this works
+
+- All improvements live **in the repo**, so they're versioned with the code
+- No new infrastructure to maintain (no static site generator, hosting, CI pipeline)
+- Each improvement is **independently valuable** — you can ship one without the others
+- Total effort: ~8 hours for Tiers 1-2, delivering more user value than a doc site would
+
+---
+
+## Conclusion
+
+The case against a doc site is not that documentation doesn't matter — it absolutely does. The case is that **a doc site is the wrong form factor for this project at this stage**. The project is 27 days old, has one active contributor, a rapidly changing v1alpha1 API, and 50+ unresolved design decisions. The actual documentation gaps (troubleshooting, contributor guide, CLI help, error messages) are best addressed with targeted, in-repo improvements that stay in sync with the code by default.
+
+Build a doc site when:
+- The API reaches v1beta1 or later
+- There are 5+ regular contributors who need onboarding
+- There are 200+ stars indicating genuine external user base
+- Users are filing issues that can only be solved with structured documentation (tutorials, conceptual guides, migration paths)
+
+Until then, invest in making the existing README, examples, CLI help, and error messages as good as they can be. That's where users actually look for help, and that's where improvements will have the highest return.

--- a/docs-audit.md
+++ b/docs-audit.md
@@ -1,0 +1,241 @@
+# Documentation Audit: Kelos Project
+
+## Executive Summary
+
+Kelos has **strong documentation for an early-stage project** — the README is well-structured, examples are thorough, and the reference doc is comprehensive. However, the documentation has significant **discoverability, fragmentation, and gap problems** that will worsen as the project grows. Key findings:
+
+- **2 doc files** (`docs/reference.md`, `docs/agent-image-interface.md`) carry the entire reference burden
+- **3 major API features** are undocumented or barely mentioned (Jira integration, comment-based triggers, priority labels)
+- **Information is scattered** across README, docs/, examples/, and self-development/ with no navigation or search
+- **No conceptual guides** exist — only reference tables and examples
+
+---
+
+## 1. What's Working Well
+
+### 1.1 README.md is excellent for its purpose
+The README (`README.md`, 584 lines) serves as both landing page and getting-started guide. Strengths:
+
+- **Clear value proposition** (lines 1-20): One-liner + supported agents + demo in the first screenful
+- **Quick Start is genuinely quick** (lines 54-213): 4 numbered steps, collapsible alternatives, copy-pasteable commands
+- **Real-world examples inline** (lines 261-425): TaskSpawner, dependency chains, AgentConfig, self-development pipeline — all with both CLI and YAML equivalents
+- **Security and cost sections** (lines 463-519): Honest, practical advice with concrete YAML snippets for `maxConcurrency`, `activeDeadlineSeconds`, `suspend`
+- **Progressive disclosure via `<details>` blocks**: kubectl alternative (line 174), API key auth (line 215), CLI reference (line 444) — keeps the main flow clean
+
+### 1.2 Examples are well-structured and progressive
+The `examples/` directory (7 examples) follows a clear learning progression:
+
+| Example | Builds On | New Concept |
+|---------|-----------|-------------|
+| 01-simple-task | — | Minimal Task + API key |
+| 02-task-with-workspace | 01 | Git workspace + OAuth |
+| 03-taskspawner-github-issues | 02 | Auto-spawn from GitHub issues |
+| 04-taskspawner-cron | 02 | Cron-triggered tasks |
+| 05-task-with-agentconfig | 02 | Reusable config + plugins |
+| 06-fork-workflow | 03 | Fork/upstream pattern |
+| 07-task-pipeline | 02 | dependsOn + result passing |
+
+Each example has:
+- A README with use case, resource table, step-by-step instructions, and cleanup
+- All necessary YAML files with `# TODO:` placeholders
+- `examples/README.md` ties them together with a summary table
+
+### 1.3 Reference doc covers the API surface well
+`docs/reference.md` (310 lines) provides field-level documentation for all 4 CRDs plus CLI flags. It accurately reflects the Go types with Required/Optional annotations and descriptions.
+
+### 1.4 Agent Image Interface is thorough
+`docs/agent-image-interface.md` (133 lines) is a solid technical spec for custom image authors. The environment variable table (lines 29-46), output capture protocol (lines 68-101), and entrypoint pattern (lines 109-125) give everything needed to build a compatible image.
+
+### 1.5 Self-development README is a strong showcase
+`self-development/README.md` (272 lines) documents 5 TaskSpawner patterns with clear tables, deploy commands, and a well-explained "feedback loop" pattern. It doubles as both documentation and proof that Kelos works in production.
+
+---
+
+## 2. What's Confusing, Buried, Duplicated, or Missing
+
+### 2.1 Duplicated content across files
+
+**promptTemplate variables table** appears in 3 places with identical content:
+- `docs/reference.md` lines 136-149
+- `self-development/README.md` lines 210-221
+- `README.md` lines 361-382 (partial, in prose form)
+
+If any of these get updated, the others will drift.
+
+**Workspace authentication** is explained in:
+- `README.md` lines 121-153 (inline in Quick Start)
+- `docs/reference.md` lines 53-87 (formal reference)
+- `examples/02-task-with-workspace/README.md` lines 54-64 (GitHub App note)
+- `self-development/README.md` lines 16-37 (prerequisite)
+
+Four slightly different explanations of the same concept.
+
+**CLI commands** appear in:
+- `README.md` lines 444-461 (collapsed summary table)
+- `docs/reference.md` lines 254-309 (full reference with flags)
+
+### 2.2 Missing conceptual documentation
+
+There are **no conceptual guides** explaining:
+
+- **Architecture overview**: How does the controller work? What's the reconciliation loop? What Kubernetes resources does it create under the hood (Jobs, Deployments, CronJobs)?
+- **Task lifecycle**: The phases (Pending → Waiting → Running → Succeeded/Failed) are mentioned in the reference table (`docs/reference.md` line 155) but never explained with a diagram or state machine.
+- **Branch serialization**: Mentioned in `README.md` line 321 ("Tasks sharing the same branch are serialized automatically") and `examples/07-task-pipeline/README.md` lines 62-64, but never fully explained. What happens when a second task targets the same branch? Does it queue? Does it fail?
+- **How credentials flow**: The agent image interface doc lists env vars, but there's no end-to-end explanation of how a secret becomes an env var in the agent pod.
+- **Troubleshooting guide**: Only `self-development/README.md` lines 249-264 has troubleshooting content, and it's specific to self-development. No general troubleshooting guide exists.
+
+### 2.3 Buried information
+
+- **GitHub Enterprise support**: Only discoverable by reading `docs/agent-image-interface.md` lines 40-41 (`GH_ENTERPRISE_TOKEN`, `GH_HOST`). Not mentioned in README or reference.
+- **`spec.files[]` on Workspace**: Listed in `docs/reference.md` line 51 and defined in `api/v1alpha1/workspace_types.go` lines 19-29, but never shown in any example. The Go type comment explains it can inject skills and instruction files — a useful feature with zero documentation beyond the field table.
+- **Task immutability**: The Go type has a CEL validation rule (`api/v1alpha1/task_types.go` line 183: `rule="self == oldSelf",message="Task spec is immutable after creation"`) — important operational knowledge that's not mentioned anywhere in docs.
+- **The `kelos create workspace` and `kelos create agentconfig` commands**: Listed in `docs/reference.md` line 273-274 but never demonstrated in any example or tutorial.
+- **`workspace.name` vs `workspace.repo` in config**: `docs/reference.md` lines 203-243 explains the two forms, but the Quick Start only shows the inline `repo` form. Users might not discover they can reference an existing Workspace by name.
+
+### 2.4 Confusing elements
+
+- **CLAUDE.md vs AGENTS.md**: Both exist at the repo root. `CLAUDE.md` and `AGENTS.md` have **identical content** (same 24 lines). It's unclear why both exist or which takes precedence. The AgentConfig docs reference writing to `~/.claude/CLAUDE.md`, adding to the confusion.
+- **`oauthToken: "@~/.codex/auth.json"` syntax** (`README.md` line 133): The `@` prefix for file references is never explained. Is this a Kelos convention? A Codex convention? What other fields support it?
+- **"Type" field naming collision**: `spec.type` on Task means "agent type" (claude-code, codex, etc.), while `spec.credentials.type` means credential type (api-key, oauth), and `spec.mcpServers[].type` means transport type (stdio, http, sse). Same field name, three different meanings.
+- **Config file vs YAML resources**: The Quick Start uses `~/.kelos/config.yaml` with `oauthToken` and `workspace.token`, while the YAML examples use Kubernetes Secrets. The relationship between these two approaches is never clearly explained. When does the CLI auto-create secrets vs when must you create them manually?
+
+---
+
+## 3. Gaps Between Code Capabilities and Documentation
+
+### 3.1 Jira integration — COMPLETELY UNDOCUMENTED
+
+The `api/v1alpha1/taskspawner_types.go` lines 118-146 define a full `Jira` struct:
+
+```go
+type Jira struct {
+    BaseURL   string          `json:"baseUrl"`
+    Project   string          `json:"project"`
+    JQL       string          `json:"jql,omitempty"`
+    SecretRef SecretReference `json:"secretRef"`
+}
+```
+
+With detailed comments about Cloud vs Data Center auth patterns. This feature is:
+- Not mentioned in README.md
+- Not mentioned in docs/reference.md
+- Has no example in examples/
+- Has no mention anywhere in the entire documentation
+
+### 3.2 Comment-based triggers — UNDOCUMENTED
+
+`api/v1alpha1/taskspawner_types.go` lines 79-95 define `TriggerComment` and `ExcludeComments`:
+
+```go
+TriggerComment  string   `json:"triggerComment,omitempty"`
+ExcludeComments []string `json:"excludeComments,omitempty"`
+```
+
+These enable a slash-command pattern (e.g., `/kelos pick-up`) for repos where you lack label permissions. The Go comments explain the interaction between trigger and exclude comments well, but this is **nowhere in the documentation**.
+
+### 3.3 Priority labels — UNDOCUMENTED
+
+`api/v1alpha1/taskspawner_types.go` lines 109-115 define `PriorityLabels`:
+
+```go
+PriorityLabels []string `json:"priorityLabels,omitempty"`
+```
+
+This enables label-based prioritization when `maxConcurrency` limits task creation. Not documented anywhere.
+
+### 3.4 Assignee and Author filters — UNDOCUMENTED
+
+`api/v1alpha1/taskspawner_types.go` lines 97-107 define `Assignee` and `Author` fields with server-side GitHub API filtering. Not in `docs/reference.md` TaskSpawner table.
+
+### 3.5 Workspace `Remotes` field — UNDOCUMENTED in reference
+
+`api/v1alpha1/workspace_types.go` lines 8-17 define `GitRemote` and lines 48-53 define `Remotes` on WorkspaceSpec with CEL validation (no "origin" name, unique names). The field:
+- Is used in `examples/06-fork-workflow/workspace.yaml`
+- Is explained in `examples/06-fork-workflow/README.md`
+- Is **NOT** listed in `docs/reference.md` Workspace table
+
+### 3.6 GitHub Issues `Types` field — partially documented
+
+The `Types` field (`api/v1alpha1/taskspawner_types.go` lines 59-63) allows filtering for `"issues"`, `"pulls"`, or both. It appears in `docs/reference.md` line 115 but has no example showing how to use it for PR-triggered workflows.
+
+### 3.7 Workspace `Files` field — in reference but no example
+
+Listed in `docs/reference.md` line 51 (`spec.files[]`), defined in `api/v1alpha1/workspace_types.go` lines 19-29. The Go comment explains use cases (injecting skills, CLAUDE.md) but no example demonstrates it. This is distinct from AgentConfig's plugins — `files` is a workspace-level injection mechanism.
+
+---
+
+## 4. Discoverability Assessment
+
+### 4.1 No search capability
+
+With only 2 files in `docs/`, finding information requires knowing which file to look in. A user wondering "how do I set up Jira integration" would find nothing. A user searching for "timeout" would need to check README, reference, and examples separately.
+
+### 4.2 No navigation or table of contents
+
+- `docs/` has no index file
+- README.md links to `docs/reference.md` and `docs/agent-image-interface.md` but there's no way to discover all available docs
+- `self-development/README.md` is a rich source of patterns but is not linked from `docs/` at all
+- No sitemap, no sidebar, no breadcrumbs
+
+### 4.3 No clear reading path for different audiences
+
+Three distinct user types exist:
+1. **New user**: Wants Quick Start → first task → first workspace → first TaskSpawner
+2. **Operator**: Wants security, cost controls, RBAC, monitoring, troubleshooting
+3. **Custom agent builder**: Wants the agent image interface spec
+
+Currently all three audiences must navigate the same README and hope they find the relevant `<details>` block.
+
+### 4.4 Cross-reference quality
+
+Good cross-references:
+- README → `docs/reference.md` sections (lines 437-442)
+- README → `docs/agent-image-interface.md` (lines 22, 50)
+- README → `examples/` directory (line 425)
+- Example READMEs → `docs/reference.md` sections
+
+Missing cross-references:
+- No link from anywhere to `self-development/` except README line 421
+- `docs/reference.md` never links to relevant examples
+- `docs/agent-image-interface.md` never links to the entrypoint source files it references (line 129-132)
+
+### 4.5 Information density
+
+The README is 584 lines. While well-organized with collapsible sections, it carries too much weight — Quick Start, concepts, examples, security, cost, FAQ, CLI reference, and development all in one file. Users scrolling past the Quick Start to find "how do I chain tasks" must scan ~200 lines of content.
+
+---
+
+## 5. Summary of Documentation Inventory
+
+| Location | Files | Lines | Purpose |
+|----------|-------|-------|---------|
+| `README.md` | 1 | 584 | Landing page + Quick Start + examples + security + FAQ |
+| `docs/` | 2 | 443 | Reference tables + agent image spec |
+| `examples/` | 7 dirs | ~380 (READMEs) + ~250 (YAML) | Progressive examples with step-by-step guides |
+| `self-development/` | 1 README + 6 YAML | 272 + ~600 | Real-world orchestration patterns |
+| `CLAUDE.md` / `AGENTS.md` | 2 | 24 each | AI assistant conventions (identical content) |
+| **Total** | ~20 files | ~2,600 lines | — |
+
+### Feature documentation coverage
+
+| Feature | Documented? | Where |
+|---------|------------|-------|
+| Task (basic) | Yes | README, reference, examples 01-02 |
+| Workspace (basic) | Yes | README, reference, examples 02 |
+| TaskSpawner (GitHub Issues) | Yes | README, reference, examples 03 |
+| TaskSpawner (Cron) | Yes | README, reference, examples 04 |
+| AgentConfig | Yes | README, reference, examples 05 |
+| dependsOn / pipelines | Yes | README, reference, examples 07 |
+| Fork workflow | Yes | Examples 06 |
+| Custom agent images | Yes | docs/agent-image-interface.md |
+| Self-development patterns | Yes | self-development/README.md |
+| CLI reference | Yes | README, reference |
+| Workspace `remotes` | Partial | Example 06 only, missing from reference |
+| Workspace `files` | Partial | Reference table only, no example |
+| GitHub Enterprise | Barely | Agent image interface env var table only |
+| Jira integration | **No** | Only in Go types |
+| TriggerComment / ExcludeComments | **No** | Only in Go types |
+| PriorityLabels | **No** | Only in Go types |
+| Assignee / Author filters | **No** | Only in Go types |
+| Task immutability | **No** | Only in Go CEL validation rule |
+| Config file ↔ YAML resource relationship | **No** | Fragments across README + reference |

--- a/user-research.md
+++ b/user-research.md
@@ -1,0 +1,230 @@
+# User Perspective Research — Kelos Documentation Site Analysis
+
+## 1. GitHub Issues & Discussions Signal
+
+### Volume: 38 total `kind/docs` issues (14 open, 24 closed)
+
+For a project that is **less than 1 month old** with only **50 stars** and **2 contributors**, having 38 documentation-specific issues is a massive signal. That's roughly 1 docs issue for every 1.3 stars.
+
+### Open Docs Issues (14) — Categorized
+
+**Onboarding/Quick Start friction (5 issues):**
+- #305: Quick Start ordering creates confusion about when to install
+- #201: OAuth vs API key credential type is confusing
+- #195: Config file should link to where users can obtain tokens
+- #365: Missing troubleshooting guide for common failures
+- #221: Missing guidance on valid model values for --model flag
+
+**Missing documentation for existing features (5 issues):**
+- #242: Missing guidance on task cleanup and lifecycle management
+- #205: TaskSpawner promptTemplate variables incomplete
+- #204: TaskSpawner GitHub Issues example doesn't explain how repo is determined
+- #202: Missing usage examples for Codex and Gemini agent types
+- #207: Self-development TaskSpawners use aggressive 1m pollInterval without explanation
+
+**Missing guides/use cases (3 issues):**
+- #384: New use case: AI-powered dependency maintenance
+- #291: New use cases: PR review, fleet migration, security audit, and beyond
+- #328: Orchestrator pattern
+
+**Meta (1 issue):**
+- #219: Update contributing guide
+
+### Closed Docs Issues (24) — Patterns
+
+Many closed issues reveal problems users already hit:
+- #454: Example 05 had incorrect field names (broken YAML)
+- #436: GitHub App auth was fully implemented but completely undocumented
+- #243: Quick Start didn't explain where to obtain credentials
+- #229: Quick Start lacked context about what happens during first run
+- #220: No explanation of where task output goes without a workspace
+- #251: Demo used misleading custom task name without explaining --name
+- #222, #231: Missing standalone YAML examples (filed twice — strong signal)
+- #245: Inconsistent secret naming across examples
+- #159, #163, #161: Multiple Quick Start gaps fixed
+
+### Discussions
+
+Only 1 discussion exists (the default welcome post, #288). No community Q&A activity yet.
+
+### Key Takeaway
+
+The docs issues represent **real user friction**, not feature requests. Multiple issues describe the exact moment where a new user gets stuck: credential setup, understanding task output, debugging failures. These are the kinds of problems a doc site solves better than a README.
+
+---
+
+## 2. Likely Users — Who Would Use Kelos?
+
+### Primary Persona: Platform Engineers / DevOps Engineers
+- **Background:** Kubernetes-fluent, familiar with operators and CRDs, comfortable with `kubectl` and YAML
+- **Motivation:** Wants to automate repetitive coding tasks at scale — fix bugs, update docs, refactor across repos
+- **Discovery path:** Likely finds Kelos through Hacker News, Twitter/X, or searching for "Kubernetes AI agent orchestration"
+- **Pain points:** Already juggling many tools; needs Kelos to be immediately understandable or they'll move on
+
+### Secondary Persona: AI/ML Engineers Exploring Agentic Workflows
+- **Background:** Strong on AI/ML, moderate Kubernetes knowledge
+- **Motivation:** Wants to run Claude/Codex/Gemini agents at scale without building infra
+- **Discovery path:** Finds via "Claude Code Kubernetes" or "autonomous AI agents" searches
+- **Pain points:** May need more hand-holding on Kubernetes concepts; the current docs assume K8s fluency
+
+### Tertiary Persona: Engineering Managers / Tech Leads
+- **Background:** Evaluating tools for team adoption
+- **Motivation:** Looking for ROI story — can this automate issue triage, PR review, CI fix?
+- **Discovery path:** Team member shares it, or sees it mentioned in AI/DevOps newsletter
+- **Pain points:** Needs to quickly understand value prop, security model, and cost implications without reading all the YAML
+
+### What All Personas Need
+1. **Quick understanding** of what Kelos does (README handles this well)
+2. **Step-by-step getting started** that doesn't assume prior context (current Quick Start has gaps)
+3. **Reference docs** they can search/navigate when building real workflows (currently a single reference.md file)
+4. **Patterns and recipes** beyond hello-world (partially covered by examples/)
+5. **Troubleshooting** when things go wrong (currently missing)
+
+---
+
+## 3. User Journey Map
+
+### Step 1: Discovery (README.md)
+**Experience:** Good. The README has a clear value prop, demo CLI output, and a video. The "Why Kelos?" section is compelling.
+**Friction:** Moderate. Users see the demo but can't try it immediately — they need a K8s cluster, credentials, and setup first.
+
+### Step 2: Decide to Try It (Prerequisites)
+**Experience:** OK. Prerequisites are listed (K8s 1.28+), with a `kind` expandable section.
+**Friction:** High for non-K8s users. No guidance on what "Kubernetes cluster" means practically or how much it costs.
+
+### Step 3: Install CLI
+**Experience:** Simple — one curl command or `go install`.
+**Friction:** Low.
+
+### Step 4: Install Kelos to Cluster
+**Experience:** One command (`kelos install`).
+**Friction:** Medium. Issue #305 notes that the ordering (install before init) is confusing. The `kelos init` output says "Install Kelos (if not already installed)" suggesting init should come first.
+
+### Step 5: Configure Credentials (~/.kelos/config.yaml)
+**Experience:** This is the biggest pain point.
+**Friction:** Very High.
+- Issue #201: OAuth vs API key confusion — README shows OAuth first, but CLI defaults to api-key
+- Issue #195: Config file doesn't link to where to get tokens
+- Users need BOTH an AI provider credential AND optionally a GitHub token — this two-credential requirement isn't clearly communicated
+
+### Step 6: Run First Task
+**Experience:** The command itself is simple (`kelos run -p "..."`)
+**Friction:** Medium.
+- Issue #220 (closed): Users didn't understand that without a workspace, output is ephemeral
+- Issue #163 (closed): Users didn't know how to get the task name from output
+
+### Step 7: Debug When Things Go Wrong
+**Experience:** Very poor.
+**Friction:** Very High.
+- Only guidance: "check controller logs" (one line in README)
+- No troubleshooting section, no common failure patterns
+- Users are left guessing whether it's a credential issue, cluster issue, or agent issue
+
+### Step 8: Build Real Workflows (Beyond Hello World)
+**Experience:** Moderate. 7 examples exist covering common patterns.
+**Friction:** Medium-High.
+- Examples are YAML-heavy with `# TODO:` placeholders
+- No narrative explanation of WHY you'd use each pattern
+- Reference doc is a single flat file — no search, no deep linking, no navigation
+
+### Journey Score Card
+
+| Step | Friction | Current Doc Coverage |
+|------|----------|---------------------|
+| Discovery | Low | README (good) |
+| Prerequisites | Medium | README (adequate) |
+| Install CLI | Low | README (good) |
+| Install Kelos | Medium | README (ordering issue) |
+| Configure Credentials | **Very High** | README (improved, still confusing) |
+| Run First Task | Medium | README (adequate) |
+| Debug Failures | **Very High** | Almost none |
+| Build Real Workflows | Medium-High | Examples + reference.md |
+
+---
+
+## 4. Comparable Projects Analysis
+
+### Argo Workflows
+- **Stars:** 16,483
+- **Created:** Aug 2017 (by Applatix, acquired by Intuit 2018)
+- **Doc site:** Yes — [argoproj.github.io/workflows](https://argoproj.github.io/workflows/) and [argo-workflows.readthedocs.io](https://argo-workflows.readthedocs.io/en/latest/)
+- **When:** Docs evolved with the project. Initially in-repo markdown, then moved to mkdocs + ReadTheDocs as the project grew. The GitHub Pages umbrella site serves all Argo projects.
+- **CNCF:** Incubating April 2020, Graduated March 2022
+- **Doc structure:** Getting Started, Walk Through, Examples, Fields Reference, CLI Reference, Architecture
+- **Key insight:** Argo started with in-repo markdown and examples. The formal doc site came as the project reached hundreds of stars and CNCF adoption. They use mkdocs (docs-as-code) which keeps docs in the same repo.
+
+### Tekton
+- **Stars:** 8,901
+- **Created:** Aug 2018 (spun off from Knative Build)
+- **Doc site:** Yes — [tekton.dev](https://tekton.dev/docs/)
+- **When:** tekton.dev launched early in the project's lifecycle, around the time of CDF donation (March 2019). Beta release of the Pipeline API in March 2020.
+- **CDF:** Donated to Continuous Delivery Foundation March 2019, Graduated October 2022
+- **Doc structure:** Getting Started (Tasks, Pipelines), Concepts, How-to Guides, Reference, Blog
+- **Key insight:** Tekton had organizational backing (Google, CDF) from the start, which funded proper docs infrastructure early. Their docs follow the [Diátaxis framework](https://diataxis.fr/) (tutorials, how-to guides, reference, explanation).
+
+### Dagger
+- **Stars:** 15,477
+- **Created:** Nov 2019 (by Solomon Hykes, Docker founder)
+- **Doc site:** Yes — [docs.dagger.io](https://docs.dagger.io/)
+- **When:** Launched simultaneously with the public beta in March 2022. Docs were ready on day one.
+- **Funding:** $20M Series A at launch
+- **Doc structure:** Quickstarts, Key Concepts, Guides, Examples, API Reference, Cookbook, FAQ
+- **Key insight:** Dagger launched with docs-as-a-first-class-product. Being VC-backed, they invested in docs before going public. Their docs site went through a major redesign when they pivoted from CUE to SDK-based approach.
+
+### Summary Comparison
+
+| Project | Stars at doc site launch | Doc site timing | Key driver |
+|---------|------------------------|-----------------|------------|
+| Argo Workflows | ~500-1000 (est.) | Evolved gradually from in-repo markdown | Community growth, CNCF process |
+| Tekton | ~100-500 (est.) | Very early (org-backed) | Google/CDF backing, enterprise adoption |
+| Dagger | ~0 (launched together) | Day 1 of public launch | VC funding, product-company model |
+| **Kelos** | **50** | **None yet** | **Early-stage, 2 contributors** |
+
+### What Kelos Can Learn
+
+1. **All comparable projects have doc sites** — this is table stakes for Kubernetes-native tooling targeting platform engineers.
+2. **docs-as-code (mkdocs/docusaurus) is the standard** — Argo uses mkdocs, Tekton uses a custom site, Dagger uses Docusaurus. All keep docs in the same repo as code.
+3. **Start simple, grow with the project** — Argo's approach of starting with in-repo markdown and evolving to a doc site is the most applicable model for Kelos's stage.
+4. **The Diátaxis framework works** — Tekton's structure (tutorials, how-to, reference, explanation) is the gold standard for K8s tooling docs.
+5. **A doc site solves the "single README" problem** — At 584 lines, the Kelos README is already dense. A doc site enables search, navigation, deep linking, and progressive disclosure.
+
+---
+
+## 5. Repo Traffic & Growth Context
+
+- **490 unique visitors** in the last 2 weeks (Feb 14-27)
+- **3,943 total views** in the same period
+- **Peak day:** Feb 27 with 574 views (41 unique)
+- **Average:** ~35 unique visitors/day
+
+This traffic level means real people are discovering and evaluating Kelos every day. Each visitor hitting the README wall on credentials or debugging is a potential user lost.
+
+---
+
+## 6. Synthesis
+
+### The Case FOR a Doc Site (from user perspective)
+
+1. **38 docs issues in <1 month** = users are struggling with documentation
+2. **The user journey has 2 "very high friction" points** (credentials, debugging) that a README can't solve well
+3. **All comparable K8s-native workflow tools have doc sites** — it's an expectation for this audience
+4. **490 unique visitors in 2 weeks** — real users are evaluating Kelos right now
+5. **The README is at 584 lines** and growing — it's past the point where a single file serves well
+6. **Search and navigation** are impossible in the current flat-file structure
+
+### The Case AGAINST (or "not yet")
+
+1. **50 stars, 2 contributors** — the content isn't stabilized yet; a doc site adds maintenance overhead
+2. **Argo's path** (gradual evolution from in-repo markdown) is also valid and lower-effort
+3. **The docs content needs to be written first** — a doc site is just infrastructure; without content improvements, it's lipstick on a pig
+4. **Opportunity cost** — time spent on doc site infrastructure is time not spent on features
+
+### Recommendation from User Perspective
+
+A documentation site would **meaningfully improve the user experience** at this stage. The current pain points (credential confusion, missing troubleshooting, undiscoverable reference docs) are best solved by structured documentation with navigation, search, and progressive disclosure.
+
+The minimum viable approach: use **mkdocs-material** (like Argo) or **Docusaurus** (like Dagger), keep docs in the same repo, and start with the content that addresses the top user friction points:
+1. Improved Getting Started tutorial
+2. Credential/authentication guide
+3. Troubleshooting guide
+4. Searchable API reference


### PR DESCRIPTION
## Summary

Three independent research streams analyzed whether Kelos should build a documentation site, each from a different angle:

- **docs-audit.md** — Thorough audit of all existing docs (README, docs/, examples/, self-development/, API types). Found 3 major API features completely undocumented (Jira, comment triggers, priority labels), no conceptual guides, and content scattered across 20+ files with no navigation.

- **user-research.md** — User perspective analysis including GitHub issues (38 `kind/docs` issues in <1 month), user personas, journey mapping (2 "very high friction" points at credential setup and debugging), and comparable projects (Argo, Tekton, Dagger all have doc sites).

- **counterarguments.md** — Data-driven case against building now: 27-day-old project, 1 dominant contributor, 2 API changes/day, v1alpha1 instability, and targeted in-repo fixes would cost ~8 hours vs 20-40 for a doc site.

- **RECOMMENDATION.md** — Synthesis with a clear verdict: **not yet**, but do the content work now so the site is straightforward when the time comes.

### Recommended phased approach:
1. **This week (~8 hrs):** Troubleshooting FAQ, CONTRIBUTING.md, document undocumented API features, CLI examples
2. **This month (~6 hrs):** Conceptual guides (auth, task lifecycle, architecture) as standalone docs/ files
3. **When ready:** mkdocs-material doc site, triggered by v1beta1 / 5+ contributors / 200+ stars

## Test plan
- [ ] Review each analysis file for accuracy against the codebase
- [ ] Validate GitHub issues data cited in user-research.md
- [ ] Confirm API field counts and undocumented features in docs-audit.md
- [ ] Assess whether the phased recommendation aligns with project priorities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a four-part analysis on whether to build a documentation site and recommends not building it yet. Provides a phased plan to fix key content gaps now and set clear triggers for a future mkdocs site.

- **New Features**
  - Added docs-audit.md, user-research.md, counterarguments.md, and RECOMMENDATION.md with a phased plan.

- **Migration**
  - This week (~8h): add Troubleshooting FAQ, CONTRIBUTING.md, document Jira/comment triggers/priority labels/assignee/author, add CLI examples, dedupe AGENTS.md/CLAUDE.md.
  - This month (~6h): write conceptual guides (auth, task lifecycle, architecture) in docs/.
  - When ready: build mkdocs-material site when API hits v1beta1 or there are 5+ contributors or 200+ stars.

<sup>Written for commit 17a1e242feede0ab98d3c5f507d34a211bed085e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

