### PR TITLE
Update images in README for Kelos documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supports **Claude Code**, **OpenAI Codex**, **Google Gemini**, **OpenCode**, and
 
 Kelos orchestrates the flow from external events to autonomous execution:
 
-<img width="2521" height="1582" alt="kelos-resources" src="https://github.com/user-attachments/assets/456c0534-22c0-4d90-b461-e34e33b07dd1" />
+<img width="2310" height="1582" alt="kelos-resources" src="https://github.com/user-attachments/assets/e36bdfef-5dfe-4e8f-ac74-9e66ab17f621" />
 
 You define what needs to be done, and Kelos handles the "how" — from cloning the right repo and injecting credentials to running the agent and capturing its outputs (branch names, commit SHAs, PR URLs, and token usage).
 
@@ -63,7 +63,7 @@ TaskSpawner watches external sources (e.g., GitHub Issues) and automatically cre
 
 Kelos develops itself. Five TaskSpawners run 24/7, each handling a different part of the development lifecycle — fully autonomous.
 
-<img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/87c9bf09-b316-473e-9784-1ad8c4601fae" />
+<img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/7e8978ab-8b2f-496d-b3e3-d25ea9f01fbf" />
 
 | TaskSpawner | Trigger | Model | Description |
 |---|---|---|---|

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -4,7 +4,7 @@ This directory contains real-world orchestration patterns used by the Kelos proj
 
 ## How It Works
 
-<img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/08153d3f-71d0-42b5-9fb0-2e2bdccb2a5d" />
+<img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/7e8978ab-8b2f-496d-b3e3-d25ea9f01fbf" />
 
 All agents share an `AgentConfig` (`agentconfig.yaml`) that defines git identity, comment signatures, and standard constraints.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the architecture and self-development diagrams in README and self-development/README to new image assets. Adjusted the architecture diagram width from 2521 to 2310 for better layout and unified the self-development image across both docs.

<sup>Written for commit 831238007760873911a4dbf2f1bd60d6c2604852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

