### PR TITLE
Fix ok-to-test label cancelling in-progress CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
   workflow_dispatch:
     inputs:
@@ -14,11 +15,15 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: >-
+    ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}${{
+      github.event.action == 'labeled' && '-labeled' || ''
+    }}
   cancel-in-progress: true
 
 jobs:
   build:
+    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +36,7 @@ jobs:
         run: make build
 
   verify:
+    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +49,7 @@ jobs:
         run: make verify
 
   test:
+    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +62,7 @@ jobs:
         run: make test
 
   test-integration:
+    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -3,8 +3,6 @@ name: Retest
 on:
   issue_comment:
     types: [created]
-  pull_request_target:
-    types: [labeled]
 
 jobs:
   retest:
@@ -36,11 +34,14 @@ jobs:
 
           if [ -n "$RUN_ID" ]; then
             CONCLUSION=$(gh run view "$RUN_ID" --json conclusion -q .conclusion)
-            if [ "$CONCLUSION" = "failure" ]; then
+            if [ -z "$CONCLUSION" ]; then
+              echo "CI is already in progress (run $RUN_ID)"
+              exit 0
+            elif [ "$CONCLUSION" = "failure" ]; then
               gh run rerun "$RUN_ID" --failed
               exit 0
-            elif [ -z "$CONCLUSION" ]; then
-              echo "CI is already in progress (run $RUN_ID)"
+            else
+              gh run rerun "$RUN_ID"
               exit 0
             fi
           fi
@@ -48,18 +49,3 @@ jobs:
           HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
           OK_TO_TEST=$(gh pr view "$PR_NUMBER" --json labels -q '[.labels[].name] | any(. == "ok-to-test")')
           gh workflow run ci.yaml --ref "$HEAD_REF" -f "ok-to-test=$OK_TO_TEST"
-
-  trigger-on-ok-to-test:
-    if: >-
-      github.event_name == 'pull_request_target' && github.event.label.name == 'ok-to-test'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Trigger CI
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          gh workflow run ci.yaml --ref "$HEAD_REF" -f "ok-to-test=true"


### PR DESCRIPTION
## Summary

- Handle `ok-to-test` label natively via `pull_request` `labeled` event type instead of `workflow_dispatch`, so GitHub properly associates the run with the PR
- Use a separate concurrency group (`CI-branch-labeled`) for labeled events to prevent label additions from cancelling in-progress `CI-branch` runs
- Remove `trigger-on-ok-to-test` job from `retest.yaml` (now handled by `ci.yaml`)
- Fix `/retest` fallback to rerun cancelled/success runs via `gh run rerun` instead of only handling failures

## Test plan

- [ ] Push to PR → CI runs normally in `CI-branch` concurrency group
- [ ] Add `ok-to-test` label → CI runs in `CI-branch-labeled` group with `test-e2e`, does not cancel the push-triggered run
- [ ] Add another label → runs in `CI-branch-labeled` group, doesn't cancel `CI-branch` run
- [ ] `/retest` on a failed PR → uses `gh run rerun --failed`
- [ ] `/retest` on a cancelled PR → uses `gh run rerun` (full rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the ok-to-test label from cancelling in-progress CI and ensures runs link to the PR. Also reduces wasted minutes on non-ok-to-test label events and tightens /retest behavior.

- **Bug Fixes**
  - Handle ok-to-test via the pull_request labeled event in ci.yaml so runs attach to the PR.
  - Use a separate concurrency group with a -labeled suffix for label events to avoid cancelling push/synchronize runs.
  - Run CI jobs only when the label is ok-to-test; skip jobs on other label events.
  - Update /retest to rerun failed or full runs when cancelled/successful, no-op when a run is in progress; remove the ok-to-test trigger job from retest.yaml.

<sup>Written for commit e863ef05f660b0a032c2c362bf01ed84102a3b1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

