### PR TITLE
Fix release notes to use git history instead of date ranges

### DIFF
--- a/hack/release-notes/main.go
+++ b/hack/release-notes/main.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
@@ -162,46 +163,27 @@ func findPreviousTag(version string) (string, error) {
 	return "", fmt.Errorf("could not determine previous release tag")
 }
 
-// collectPRs returns PR numbers merged between previousTag and version.
+// collectPRs returns PR numbers merged between previousTag and version by
+// parsing merge commit messages from git history.
 func collectPRs(previousTag, version string) ([]string, error) {
-	mergeBase, err := gitOutput("merge-base", previousTag, version)
+	out, err := gitOutput("log", previousTag+".."+version, "--merges", "--oneline")
 	if err != nil {
-		return nil, fmt.Errorf("finding merge base: %w", err)
+		return nil, fmt.Errorf("listing merge commits: %w", err)
 	}
-	mergeBase = strings.TrimSpace(mergeBase)
+	return parsePRNumbers(out), nil
+}
 
-	mergeFrom, err := gitOutput("log", "-1", "--format=%cI", mergeBase)
-	if err != nil {
-		return nil, fmt.Errorf("getting merge-base date: %w", err)
-	}
-	mergeFrom = strings.TrimSpace(mergeFrom)
+var mergePRRe = regexp.MustCompile(`Merge pull request #(\d+)`)
 
-	mergeUntil, err := gitOutput("log", "-1", "--format=%cI", version)
-	if err != nil {
-		return nil, fmt.Errorf("getting version date: %w", err)
-	}
-	mergeUntil = strings.TrimSpace(mergeUntil)
-
-	out, err := runCommand("gh", "pr", "list",
-		"--state", "merged",
-		"--base", "main",
-		"--search", fmt.Sprintf("merged:%s..%s", mergeFrom, mergeUntil),
-		"--json", "number",
-		"--jq", ".[].number",
-		"--limit", "500",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("listing merged PRs: %w", err)
-	}
-
+// parsePRNumbers extracts PR numbers from git log --merges --oneline output.
+func parsePRNumbers(gitLogOutput string) []string {
 	var numbers []string
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			numbers = append(numbers, line)
+	for _, line := range strings.Split(gitLogOutput, "\n") {
+		if m := mergePRRe.FindStringSubmatch(line); m != nil {
+			numbers = append(numbers, m[1])
 		}
 	}
-	return numbers, nil
+	return numbers
 }
 
 // fetchPR retrieves the body and labels of a PR via the GitHub CLI.

--- a/hack/release-notes/main_test.go
+++ b/hack/release-notes/main_test.go
@@ -20,6 +20,49 @@ import (
 	"testing"
 )
 
+func TestParsePRNumbers(t *testing.T) {
+	tests := []struct {
+		name string
+		log  string
+		want []string
+	}{
+		{
+			name: "standard merge commits",
+			log:  "abc1234 Merge pull request #523 from org/feature-branch\ndef5678 Merge pull request #525 from org/bugfix-branch",
+			want: []string{"523", "525"},
+		},
+		{
+			name: "mixed merge and non-merge commits",
+			log:  "abc1234 Merge pull request #100 from org/branch\ndef5678 Some regular commit\nghi9012 Merge pull request #200 from org/other",
+			want: []string{"100", "200"},
+		},
+		{
+			name: "no merge commits",
+			log:  "abc1234 Some commit\ndef5678 Another commit",
+			want: nil,
+		},
+		{
+			name: "empty output",
+			log:  "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePRNumbers(tt.log)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parsePRNumbers() returned %d items, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parsePRNumbers()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestExtractNote(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The release notes tool (`hack/release-notes/main.go`) previously found PRs by querying GitHub's API with a date range derived from git committer dates. This caused PRs to be missed when GitHub's `mergedAt` timestamp differed from the git committer date — for example, PR #523 was missing from the v0.16.0 release notes.

This PR replaces the date-based `collectPRs` with a git-history-based approach that parses PR numbers directly from merge commit messages (`Merge pull request #NNN`) between the two tags. This is both simpler and more reliable.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verified that `go run ./hack/release-notes v0.16.0` now correctly includes PR #523.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release notes generation to read merged PRs from git history instead of date ranges from GitHub. This prevents missed PRs when timestamps differ (e.g., #523 in v0.16.0) and simplifies the tool.

- **Bug Fixes**
  - Parse PR numbers from merge commit messages between tags (git log --merges).
  - Remove date-based GitHub API query for merged PRs.
  - Add unit tests for PR number parsing.

<sup>Written for commit 29f32c8f9c77a99a68a809086425437a5eb43791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

