### PR TITLE
Fix release title and create as draft

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          gh release create "$VERSION" --verify-tag --notes-file /tmp/release-notes.md || true
+          gh release create "$VERSION" --verify-tag --draft --title "$VERSION" --notes-file /tmp/release-notes.md || true
           gh release upload "$VERSION" --clobber \
             bin/kelos-* \
             bin/checksums.txt


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the release workflow so that:
1. The GitHub release title is explicitly set to the tag name (e.g. `v0.16.0`) instead of inheriting the annotated tag message (e.g. `v0.16.0: Merge pull request #123 from ...`).
2. Releases are created as drafts, allowing review before publishing.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the GitHub release title to the tag (e.g., v0.16.0) and create releases as drafts. This ensures clear titles and allows review before publishing.

<sup>Written for commit b25f30eec793d6f9eb9f55e3a053d0fbb37984b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

