### PR TITLE
self-development: Use GPT-5.4 for triage

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -53,16 +53,28 @@ The token needs these permissions:
 
 Create a secret with your AI agent credentials:
 
-**For OAuth (Claude Code):**
+**For Claude Code (OAuth):**
 ```bash
 kubectl create secret generic kelos-credentials \
   --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-claude-oauth-token>
 ```
 
-**For API Key:**
+**For Claude Code (API Key):**
 ```bash
 kubectl create secret generic kelos-credentials \
   --from-literal=ANTHROPIC_API_KEY=<your-api-key>
+```
+
+**For Codex (OAuth):**
+```bash
+kubectl create secret generic kelos-credentials \
+  --from-literal=CODEX_AUTH_JSON=<your-codex-auth-json>
+```
+
+**For Codex (API Key):**
+```bash
+kubectl create secret generic kelos-credentials \
+  --from-literal=CODEX_API_KEY=<your-openai-api-key>
 ```
 
 ## TaskSpawners
@@ -118,7 +130,7 @@ Picks up open GitHub issues labeled `needs-actor` and performs automated triage.
 | | |
 |---|---|
 | **Trigger** | GitHub Issues with `needs-actor` label |
-| **Model** | Opus |
+| **Model** | GPT-5.4 (Codex) |
 | **Concurrency** | 8 |
 
 **For each issue, the agent:**
@@ -269,7 +281,7 @@ To adapt these examples for your own repository:
    ```yaml
    spec:
      taskTemplate:
-       model: sonnet  # or opus for more complex tasks
+       model: sonnet  # or opus, gpt-5.4, etc. depending on the agent type
    ```
 
 ## Feedback Loop Pattern

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -16,8 +16,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.4
+    type: codex
     ttlSecondsAfterFinished: 3600
     credentials:
       type: oauth


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs
/kind feature
-->

#### What this PR does / why we need it:

This updates self-development's kelos-triage to use GPT-5.4 (Codex) instead of Opus (Claude Code) so that triage would be more objective on the issues created by Claude.

Also updates the self-development README to reflect the new model and adds Codex credential setup instructions.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
NONE
```