### PR TITLE
self-development: Add env to kelos-pr-responder

### DIFF
--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -8,7 +8,6 @@ spec:
       labels:
         - generated-by-kelos
       state: open
-      reviewState: changes_requested
       triggerComment: /kelos pick-up
       draft: false
       excludeComments:
@@ -34,6 +33,15 @@ spec:
           cpu: "1"
           memory: "2Gi"
           ephemeral-storage: "4Gi"
+      env:
+        - name: GIT_AUTHOR_NAME
+          value: "Gunju Kim"
+        - name: GIT_AUTHOR_EMAIL
+          value: "gjkim042@gmail.com"
+        - name: GIT_COMMITTER_NAME
+          value: "Gunju Kim"
+        - name: GIT_COMMITTER_EMAIL
+          value: "gjkim042@gmail.com"
     branch: "{{.Branch}}"
     agentConfigRef:
       name: kelos-dev-agent


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This
- adds env to kelos-pr-responder so that it can use proper git authentication
- handle pull requests regardless of their reviewState

#### Which issue(s) this PR is related to:

<!--
Fixes #<issue number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
none
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Git author/committer env vars to `kelos-pr-responder` so commits have the right identity and pushes authenticate in CI. Remove the `reviewState: changes_requested` filter so the responder handles PRs regardless of review state.

<sup>Written for commit e81ae8f5a93bcb12d24c099f0ec8cd34c0ba21da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

