### PR TITLE
Disable cursor e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,6 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
           KELOS_BIN: ${{ github.workspace }}/bin/kelos
         run: make test-e2e

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -15,7 +15,6 @@ const testModel = "haiku"
 var (
 	oauthToken    string
 	codexAuthJSON string
-	cursorAPIKey  string
 	githubToken   string
 )
 
@@ -48,15 +47,6 @@ var agentConfigs = []agentTestConfig{
 		Model:          "gpt-5.1-codex-mini",
 		EnvVar:         "CODEX_AUTH_JSON",
 	},
-	{
-		AgentType:      "cursor",
-		CredentialType: kelosv1alpha1.CredentialTypeAPIKey,
-		SecretName:     "cursor-credentials",
-		SecretKey:      "CURSOR_API_KEY",
-		SecretValue:    &cursorAPIKey,
-		Model:          "auto",
-		EnvVar:         "CURSOR_API_KEY",
-	},
 }
 
 func TestE2E(t *testing.T) {
@@ -67,7 +57,6 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	oauthToken = os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")
 	codexAuthJSON = os.Getenv("CODEX_AUTH_JSON")
-	cursorAPIKey = os.Getenv("CURSOR_API_KEY")
 	githubToken = os.Getenv("GITHUB_TOKEN")
 
 	// Each credential env var is checked individually so that a
@@ -78,7 +67,7 @@ var _ = BeforeSuite(func() {
 			Fail(cfg.EnvVar + " is set but empty")
 		}
 	}
-	if oauthToken == "" && codexAuthJSON == "" && cursorAPIKey == "" {
-		Fail("No agent credentials set (CLAUDE_CODE_OAUTH_TOKEN, CODEX_AUTH_JSON, CURSOR_API_KEY)")
+	if oauthToken == "" && codexAuthJSON == "" {
+		Fail("No agent credentials set (CLAUDE_CODE_OAUTH_TOKEN, CODEX_AUTH_JSON)")
 	}
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Disables cursor e2e tests because the Cursor free budget is fully used. The cursor container image is still built and loaded into kind — only the test execution and `CURSOR_API_KEY` env var are removed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The cursor Docker image continues to be loaded into the kind cluster so it remains available if tests are re-enabled later.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Cursor e2e tests to avoid using the exhausted free budget. Removed the Cursor agent from the e2e suite and stopped exporting `CURSOR_API_KEY` in CI; the Cursor image is still built and loaded into kind for future re-enabling.

<sup>Written for commit 017ecae3688ad3131d84deb4aca33c80699332e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

