### PR TITLE
Prevent concurrent release workflow runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     tags: ["v*"]
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds a `concurrency` group to the release workflow so that only one release runs at a time. New triggers queue until the in-progress run finishes (`cancel-in-progress: false`), preventing partial releases from a cancelled mid-run workflow.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`cancel-in-progress: false` was chosen over `true` because cancelling a release mid-way could leave partial images pushed or a half-created GitHub release.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub Actions concurrency to the release workflow so only one release runs at a time. New triggers queue while a run is in progress (`cancel-in-progress: false`) to avoid partial artifacts or half-created releases.

<sup>Written for commit 012a4a044e8f2228f7b1e367d4aeb7be0131f9b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

