### PR TITLE
Update README tagline and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Kelos</h1>
 
-<p align="center"><strong>Turn your development workflow into YAML. Orchestrate autonomous AI coding agents on Kubernetes.</strong></p>
+<p align="center"><strong>Declaratively orchestrate autonomous AI coding agents on Kubernetes.</strong></p>
 
 <p align="center">
   <a href="https://github.com/kelos-dev/kelos/actions/workflows/ci.yaml"><img src="https://github.com/kelos-dev/kelos/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
@@ -18,7 +18,7 @@
   <a href="examples/">YAML Manifests</a>
 </p>
 
-Kelos lets you **define your development workflow as YAML** and run it continuously on Kubernetes. Declare what triggers agents, what they do, and how they hand off — Kelos handles the rest.
+Kelos lets you **define your development workflow as Kubernetes resources** and run it continuously. Declare what triggers agents, what they do, and how they hand off — Kelos handles the rest.
 
 Kelos develops Kelos through six TaskSpawners run 24/7: triaging issues, fixing bugs, responding to PR feedback, testing DX, brainstorming improvements, and tuning their own prompts. [See the full pipeline below.](#kelos-developing-kelos)
 


### PR DESCRIPTION
/kind docs

#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Updates the README tagline and opening description to emphasize the Kubernetes-native approach rather than leading with YAML:

- Tagline: "Declaratively orchestrate autonomous AI coding agents on Kubernetes."
- Description: "define your development workflow as Kubernetes resources"

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Pure copy change, no code modifications.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README to emphasize Kubernetes-native workflows over YAML.
Tagline is now "Declaratively orchestrate autonomous AI coding agents on Kubernetes," and the intro says "define your development workflow as Kubernetes resources."

<sup>Written for commit 83704f916fa38715e79d5b16d5faff8c669175c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

