### PR TITLE
Fix GitHub API rate limit via ETag caching transport

### DIFF
--- a/cmd/kelos-spawner/main.go
+++ b/cmd/kelos-spawner/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -87,6 +88,10 @@ func main() {
 
 	log.Info("Starting spawner", "taskspawner", key, "oneShot", oneShot)
 
+	httpClient := &http.Client{
+		Transport: source.NewETagTransport(http.DefaultTransport, log),
+	}
+
 	cfgArgs := spawnerRuntimeConfig{
 		GitHubOwner:      githubOwner,
 		GitHubRepo:       githubRepo,
@@ -95,6 +100,7 @@ func main() {
 		JiraBaseURL:      jiraBaseURL,
 		JiraProject:      jiraProject,
 		JiraJQL:          jiraJQL,
+		HTTPClient:       httpClient,
 	}
 
 	if oneShot {
@@ -157,13 +163,13 @@ func runReportingCycle(ctx context.Context, cl client.Client, key types.Namespac
 	return nil
 }
 
-func runCycle(ctx context.Context, cl client.Client, key types.NamespacedName, githubOwner, githubRepo, githubAPIBaseURL, githubTokenFile, jiraBaseURL, jiraProject, jiraJQL string) error {
+func runCycle(ctx context.Context, cl client.Client, key types.NamespacedName, githubOwner, githubRepo, githubAPIBaseURL, githubTokenFile, jiraBaseURL, jiraProject, jiraJQL string, httpClient *http.Client) error {
 	var ts kelosv1alpha1.TaskSpawner
 	if err := cl.Get(ctx, key, &ts); err != nil {
 		return fmt.Errorf("fetching TaskSpawner: %w", err)
 	}
 
-	src, err := buildSource(&ts, githubOwner, githubRepo, githubAPIBaseURL, githubTokenFile, jiraBaseURL, jiraProject, jiraJQL)
+	src, err := buildSource(&ts, githubOwner, githubRepo, githubAPIBaseURL, githubTokenFile, jiraBaseURL, jiraProject, jiraJQL, httpClient)
 	if err != nil {
 		return fmt.Errorf("building source: %w", err)
 	}
@@ -452,7 +458,7 @@ func reportingEnabled(ts *kelosv1alpha1.TaskSpawner) bool {
 	return false
 }
 
-func buildSource(ts *kelosv1alpha1.TaskSpawner, owner, repo, apiBaseURL, tokenFile, jiraBaseURL, jiraProject, jiraJQL string) (source.Source, error) {
+func buildSource(ts *kelosv1alpha1.TaskSpawner, owner, repo, apiBaseURL, tokenFile, jiraBaseURL, jiraProject, jiraJQL string, httpClient *http.Client) (source.Source, error) {
 	if ts.Spec.When.GitHubIssues != nil {
 		gh := ts.Spec.When.GitHubIssues
 		token, err := readGitHubToken(tokenFile)
@@ -470,6 +476,7 @@ func buildSource(ts *kelosv1alpha1.TaskSpawner, owner, repo, apiBaseURL, tokenFi
 			Author:          gh.Author,
 			Token:           token,
 			BaseURL:         apiBaseURL,
+			Client:          httpClient,
 			TriggerComment:  gh.TriggerComment,
 			ExcludeComments: gh.ExcludeComments,
 			PriorityLabels:  gh.PriorityLabels,
@@ -492,6 +499,7 @@ func buildSource(ts *kelosv1alpha1.TaskSpawner, owner, repo, apiBaseURL, tokenFi
 			Author:          gh.Author,
 			Token:           token,
 			BaseURL:         apiBaseURL,
+			Client:          httpClient,
 			ReviewState:     gh.ReviewState,
 			TriggerComment:  gh.TriggerComment,
 			ExcludeComments: gh.ExcludeComments,

--- a/cmd/kelos-spawner/main_test.go
+++ b/cmd/kelos-spawner/main_test.go
@@ -112,7 +112,7 @@ func newTask(name, namespace, spawnerName string, phase kelosv1alpha1.TaskPhase)
 func TestBuildSource_GitHubIssuesWithBaseURL(t *testing.T) {
 	ts := newTaskSpawner("spawner", "default", nil)
 
-	src, err := buildSource(ts, "my-org", "my-repo", "https://github.example.com/api/v3", "", "", "", "")
+	src, err := buildSource(ts, "my-org", "my-repo", "https://github.example.com/api/v3", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestBuildSource_GitHubIssuesWithBaseURL(t *testing.T) {
 func TestBuildSource_GitHubIssuesDefaultBaseURL(t *testing.T) {
 	ts := newTaskSpawner("spawner", "default", nil)
 
-	src, err := buildSource(ts, "kelos-dev", "kelos", "", "", "", "", "")
+	src, err := buildSource(ts, "kelos-dev", "kelos", "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestBuildSource_GitHubPullRequests(t *testing.T) {
 		},
 	}
 
-	src, err := buildSource(ts, "kelos-dev", "kelos", "https://github.example.com/api/v3", "", "", "", "")
+	src, err := buildSource(ts, "kelos-dev", "kelos", "https://github.example.com/api/v3", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestBuildSource_Jira(t *testing.T) {
 	t.Setenv("JIRA_USER", "user@example.com")
 	t.Setenv("JIRA_TOKEN", "jira-api-token")
 
-	src, err := buildSource(ts, "", "", "", "", "https://mycompany.atlassian.net", "PROJ", "status = Open")
+	src, err := buildSource(ts, "", "", "", "", "https://mycompany.atlassian.net", "PROJ", "status = Open", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1002,7 +1002,7 @@ func TestBuildSource_PriorityLabelsPassedToSource(t *testing.T) {
 		"priority/imporant-soon",
 	}
 
-	src, err := buildSource(ts, "owner", "repo", "", "", "", "", "")
+	src, err := buildSource(ts, "owner", "repo", "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1029,7 +1029,7 @@ func TestRunCycleWithSource_CommentFieldsPassedToSource(t *testing.T) {
 		ExcludeComments: []string{"/kelos needs-input"},
 	}
 
-	src, err := buildSource(ts, "owner", "repo", "", "", "", "", "")
+	src, err := buildSource(ts, "owner", "repo", "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/cmd/kelos-spawner/reconciler.go
+++ b/cmd/kelos-spawner/reconciler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +29,7 @@ type spawnerRuntimeConfig struct {
 	JiraBaseURL      string
 	JiraProject      string
 	JiraJQL          string
+	HTTPClient       *http.Client
 }
 
 type spawnerReconciler struct {
@@ -66,7 +68,7 @@ func (r *spawnerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func runOnce(ctx context.Context, cl client.Client, key types.NamespacedName, cfg spawnerRuntimeConfig) (time.Duration, error) {
-	if err := runCycle(ctx, cl, key, cfg.GitHubOwner, cfg.GitHubRepo, cfg.GitHubAPIBaseURL, cfg.GitHubTokenFile, cfg.JiraBaseURL, cfg.JiraProject, cfg.JiraJQL); err != nil {
+	if err := runCycle(ctx, cl, key, cfg.GitHubOwner, cfg.GitHubRepo, cfg.GitHubAPIBaseURL, cfg.GitHubTokenFile, cfg.JiraBaseURL, cfg.JiraProject, cfg.JiraJQL, cfg.HTTPClient); err != nil {
 		return 0, err
 	}
 

--- a/internal/source/etag_transport.go
+++ b/internal/source/etag_transport.go
@@ -1,0 +1,91 @@
+package source
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+type cachedEntry struct {
+	etag   string
+	body   []byte
+	header http.Header
+}
+
+type etagTransport struct {
+	base  http.RoundTripper
+	log   logr.Logger
+	mu    sync.Mutex
+	cache map[string]*cachedEntry
+}
+
+// NewETagTransport wraps a base RoundTripper with transparent ETag caching.
+// GET requests that return an ETag header are cached; subsequent requests for
+// the same URL send If-None-Match and, on 304, return the cached body as a
+// synthetic 200 response. Conditional requests returning 304 do not count
+// against the GitHub API rate limit.
+func NewETagTransport(base http.RoundTripper, log logr.Logger) http.RoundTripper {
+	return &etagTransport{
+		base:  base,
+		log:   log.WithName("etag-cache"),
+		cache: make(map[string]*cachedEntry),
+	}
+}
+
+func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodGet {
+		return t.base.RoundTrip(req)
+	}
+
+	key := req.URL.String()
+
+	t.mu.Lock()
+	entry := t.cache[key]
+	t.mu.Unlock()
+
+	if entry != nil {
+		req = req.Clone(req.Context())
+		req.Header.Set("If-None-Match", entry.etag)
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotModified && entry != nil {
+		resp.Body.Close()
+		t.log.V(1).Info("Cache hit", "url", key)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     entry.header.Clone(),
+			Body:       io.NopCloser(bytes.NewReader(entry.body)),
+			Request:    req,
+		}, nil
+	}
+
+	etag := resp.Header.Get("ETag")
+	if resp.StatusCode == http.StatusOK && etag != "" {
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		t.mu.Lock()
+		t.cache[key] = &cachedEntry{
+			etag:   etag,
+			body:   body,
+			header: resp.Header.Clone(),
+		}
+		t.mu.Unlock()
+
+		t.log.Info("Cached response", "url", key, "etag", etag)
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	return resp, nil
+}

--- a/internal/source/etag_transport_test.go
+++ b/internal/source/etag_transport_test.go
@@ -1,0 +1,245 @@
+package source
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestETagTransport_CachesOnSecondRequest(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == `"abc123"` {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		hits.Add(1)
+		w.Header().Set("ETag", `"abc123"`)
+		w.Write([]byte(`{"data":"hello"}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewETagTransport(http.DefaultTransport, logr.Discard())}
+
+	// First request — should hit the server and cache.
+	resp1, err := client.Get(srv.URL + "/repos/owner/repo/issues")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if resp1.StatusCode != 200 {
+		t.Fatalf("Expected 200 on first request, got %d", resp1.StatusCode)
+	}
+	if string(body1) != `{"data":"hello"}` {
+		t.Fatalf("Unexpected body: %s", body1)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("Expected 1 server hit, got %d", hits.Load())
+	}
+
+	// Second request — should get 304 from server, cached body from transport.
+	resp2, err := client.Get(srv.URL + "/repos/owner/repo/issues")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != 200 {
+		t.Fatalf("Expected 200 on cached request, got %d", resp2.StatusCode)
+	}
+	if string(body2) != `{"data":"hello"}` {
+		t.Fatalf("Unexpected cached body: %s", body2)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("Expected server to still have 1 hit after cache, got %d", hits.Load())
+	}
+}
+
+func TestETagTransport_SkipsNonGET(t *testing.T) {
+	var hits atomic.Int32
+	var gotIfNoneMatch bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.Header.Get("If-None-Match") != "" {
+			gotIfNoneMatch = true
+		}
+		w.Header().Set("ETag", `"xyz"`)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewETagTransport(http.DefaultTransport, logr.Discard())}
+
+	// POST request — should not be cached.
+	resp, err := client.Post(srv.URL+"/api", "text/plain", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Second POST — should hit the server again, not be served from cache.
+	resp, err = client.Post(srv.URL+"/api", "text/plain", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if gotIfNoneMatch {
+		t.Fatal("POST requests should not use ETag caching")
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("Expected 2 server hits for POST requests, got %d", hits.Load())
+	}
+}
+
+func TestETagTransport_PassesThroughErrors(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("rate limited"))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewETagTransport(http.DefaultTransport, logr.Discard())}
+
+	resp, err := client.Get(srv.URL + "/repos/owner/repo/issues")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Fatalf("Expected 403, got %d", resp.StatusCode)
+	}
+	if string(body) != "rate limited" {
+		t.Fatalf("Unexpected body: %s", body)
+	}
+
+	// Second request should hit the server again (error responses are not cached).
+	resp2, err := client.Get(srv.URL + "/repos/owner/repo/issues")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+
+	if resp2.StatusCode != 403 {
+		t.Fatalf("Expected 403 on second request, got %d", resp2.StatusCode)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("Expected 2 server hits for error responses, got %d", hits.Load())
+	}
+}
+
+func TestETagTransport_UpdatesCacheOnNewETag(t *testing.T) {
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := reqCount.Add(1)
+		switch n {
+		case 1:
+			w.Header().Set("ETag", `"v1"`)
+			w.Write([]byte(`{"version":1}`))
+		case 2:
+			if got := r.Header.Get("If-None-Match"); got != `"v1"` {
+				t.Errorf("Request 2: expected If-None-Match=\"v1\", got %q", got)
+				return
+			}
+			// Data changed — return new body with new ETag.
+			w.Header().Set("ETag", `"v2"`)
+			w.Write([]byte(`{"version":2}`))
+		case 3:
+			if got := r.Header.Get("If-None-Match"); got != `"v2"` {
+				t.Errorf("Request 3: expected If-None-Match=\"v2\", got %q", got)
+				return
+			}
+			// Data unchanged — return 304.
+			w.WriteHeader(http.StatusNotModified)
+		default:
+			t.Errorf("Unexpected request %d with If-None-Match=%q", n, r.Header.Get("If-None-Match"))
+		}
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewETagTransport(http.DefaultTransport, logr.Discard())}
+	url := srv.URL + "/repos/owner/repo/issues"
+
+	// First request — cache v1.
+	resp1, err := client.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if string(body1) != `{"version":1}` {
+		t.Fatalf("Expected v1 body, got %s", body1)
+	}
+
+	// Second request — server returns 200 with new ETag, cache should update to v2.
+	resp2, err := client.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if string(body2) != `{"version":2}` {
+		t.Fatalf("Expected v2 body, got %s", body2)
+	}
+
+	// Third request — server returns 304, should get cached v2 body.
+	resp3, err := client.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body3, _ := io.ReadAll(resp3.Body)
+	resp3.Body.Close()
+
+	if string(body3) != `{"version":2}` {
+		t.Fatalf("Expected cached v2 body, got %s", body3)
+	}
+	if reqCount.Load() != 3 {
+		t.Fatalf("Expected 3 server requests, got %d", reqCount.Load())
+	}
+}
+
+func TestETagTransport_NoETagHeader(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Write([]byte("no etag"))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewETagTransport(http.DefaultTransport, logr.Discard())}
+
+	resp, err := client.Get(srv.URL + "/data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if string(body) != "no etag" {
+		t.Fatalf("Unexpected body: %s", body)
+	}
+
+	// Second request should hit server again since no ETag was returned.
+	resp2, err := client.Get(srv.URL + "/data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+
+	if hits.Load() != 2 {
+		t.Fatalf("Expected 2 server hits without ETag caching, got %d", hits.Load())
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `taskspawner-loop` controller re-fetches all issues/PRs and their comments from scratch every discovery cycle, quickly exhausting the GitHub API rate limit (403).

This adds a caching `http.RoundTripper` that transparently handles `ETag`/`If-None-Match` headers. Responses to conditional requests that return `304 Not Modified` do **not** count against the GitHub rate limit, dramatically reducing API consumption for unchanged data.

The caching is transparent at the HTTP transport level — no changes to the GitHub source fetch methods (`github.go`, `github_pr.go`) were needed.

#### Which issue(s) this PR is related to:

Fixes #681

#### Special notes for your reviewer:

- Only GET requests are cached; POST/PATCH pass through unchanged
- Error responses (403, 500, etc.) are never cached
- The `*http.Client` is created once in `main()` and shared across all discovery cycles so the cache persists between cycles
- Existing source structs already had a `Client *http.Client` field — this PR just wires it up

#### Does this PR introduce a user-facing change?

```release-note
Add ETag-based HTTP caching to TaskSpawner to reduce GitHub API rate limit consumption
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)