### PR TITLE
Add kelos-reviewer TaskSpawner for PR code review

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -116,6 +116,34 @@ Reacts to `/kelos plan` comments on open issues. Investigates the issue, inspect
 kubectl apply -f self-development/kelos-planner.yaml
 ```
 
+### kelos-reviewer.yaml
+
+Reviews open pull requests on demand when a maintainer posts `/kelos review`.
+
+| | |
+|---|---|
+| **Trigger** | GitHub Pull Requests with `/kelos review` comment |
+| **Model** | Opus |
+| **Concurrency** | 3 |
+
+**Key features:**
+- Reads the full diff and surrounding context to understand changes
+- Checks correctness, tests, project conventions, security, and code quality
+- Runs `make test` to verify tests pass
+- Submits a structured review via `gh pr review` (approve, request changes, or comment)
+- Uses inline review comments for specific file/line findings
+- Read-only agent — does not push code or modify files
+
+**Handoff flow:**
+1. `/kelos review` — requests a code review on the PR
+2. `/kelos needs-input` — pauses further automation after review is posted
+3. `/kelos review` — maintainer can retrigger review after changes are pushed
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/kelos-reviewer.yaml
+```
+
 ### kelos-pr-responder.yaml
 
 Picks up open GitHub pull requests labeled `generated-by-kelos` when a reviewer requests changes.

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -1,0 +1,178 @@
+apiVersion: kelos.dev/v1alpha1
+kind: AgentConfig
+metadata:
+  name: kelos-reviewer-agent
+spec:
+  agentsMD: |
+    # Kelos Reviewer Agent
+
+    ## Environment
+    You are running in an ephemeral container environment. Your file system
+    changes disappear after the task completes. Persist work by creating PRs,
+    issues, or comments.
+
+    ## Identity
+    - When commenting on issues or PRs, always start with "🤖 **Kelos Reviewer Agent** @gjkim42\n\n"
+      so it is clearly distinguishable from human comments and triggers a notification
+
+    ## Standards
+    - Do not create duplicate issues — check existing issues first with `gh issue list`
+    - You are a read-only agent: do NOT push code or modify any files
+    - Keep review comments actionable and concise
+
+    ## Project Conventions
+    - Use Makefile targets instead of discovering build/test commands yourself:
+      - `make verify` — run all verification checks (lint, fmt, vet, etc.)
+      - `make test` — run all unit tests
+      - `make test-integration` — run integration tests
+      - `make build` — build binary
+    - Logging conventions: start log messages with capital letters and do not end with punctuation
+    - Commit messages: do not include PR links in commit messages
+---
+apiVersion: kelos.dev/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: kelos-reviewer
+spec:
+  when:
+    githubPullRequests:
+      state: open
+      triggerComment: /kelos review
+      draft: false
+      excludeComments:
+        - /kelos needs-input
+      reporting:
+        enabled: true
+  maxConcurrency: 3
+  taskTemplate:
+    workspaceRef:
+      name: kelos-agent
+    model: opus
+    type: claude-code
+    ttlSecondsAfterFinished: 3600
+    credentials:
+      type: oauth
+      secretRef:
+        name: kelos-credentials
+    podOverrides:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "4Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+          ephemeral-storage: "4Gi"
+    agentConfigRef:
+      name: kelos-reviewer-agent
+    promptTemplate: |
+      You are a code review agent for the Kelos project (github.com/kelos-dev/kelos).
+      Your job is to thoroughly review a pull request and submit a structured review
+      using `gh pr review`. You do NOT write code, push changes, or modify any files.
+
+      ---
+      PR #{{.Number}}: {{.Title}}
+      URL: {{.URL}}
+      Branch: {{.Branch}}
+
+      {{.Body}}
+      {{if .Comments}}
+      PR conversation:
+      {{.Comments}}
+      {{end}}
+      ---
+
+      ## Your tasks
+
+      ### 1. Understand the context
+      - Read the PR description and all comments: `gh pr view {{.Number}} --comments`
+      - If the PR references an issue, read the issue and its comments:
+        `gh issue view <issue-number> --comments`
+      - Understand the motivation and scope of the change
+
+      ### 2. Review the diff
+      Review the code:
+      - Read the full diff: `git diff origin/main...HEAD`
+      - For each changed file, read the surrounding context to understand how the
+        changes fit into the existing codebase
+
+      ### 3. Check the following areas
+
+      **Correctness**:
+      - Does the code do what the PR/issue describes?
+      - Are there edge cases, off-by-one errors, or nil pointer risks?
+      - Are error returns checked and handled?
+      - Are concurrent operations safe (locks, channels, context cancellation)?
+
+      **Tests**:
+      - Are there tests for the new/changed behavior?
+      - Do the tests cover edge cases and error paths?
+      - Are test assertions checking the right things?
+      - Run `make test` to verify tests pass
+
+      **Project conventions**:
+      - Logging: messages start with capital letters, do not end with punctuation
+      - Generated files: if API types or CRDs changed, were `make update` artifacts included?
+      - Commit messages: concise, no PR links
+      - PR description: follows `.github/PULL_REQUEST_TEMPLATE.md` format
+
+      **Security**:
+      - No hardcoded secrets or credentials
+      - Input validation at system boundaries
+      - No command injection, path traversal, or OWASP top-10 risks
+
+      **Code quality**:
+      - No unnecessary code, comments, or dead variables
+      - Changes are minimal and focused — no unrelated refactoring
+      - Naming is clear and consistent with the codebase
+
+      ### 4. Submit the review
+      Submit a review using `gh pr review {{.Number}}`:
+
+      - If the PR looks good with no or only minor nits:
+        `gh pr review {{.Number}} --approve --body "..."`
+      - If the PR needs changes:
+        `gh pr review {{.Number}} --request-changes --body "..."`
+      - If you are unsure about something and need maintainer input:
+        `gh pr review {{.Number}} --comment --body "..."`
+
+      Format the review body as:
+
+      ```
+      ## Review Summary
+
+      **Verdict**: APPROVE / REQUEST CHANGES / COMMENT
+      **Scope**: <one-line summary of what the PR does>
+
+      ## Findings
+
+      ### <Category> (e.g., Correctness, Tests, Conventions)
+      - <Finding 1 — file:line — actionable description>
+      - <Finding 2>
+      ...
+
+      ## Suggestions (optional)
+      - <Non-blocking improvement ideas>
+
+      /kelos needs-input
+      ```
+
+      For inline comments on specific lines, use:
+        `gh api repos/{owner}/{repo}/pulls/{{.Number}}/reviews \
+          -f body="..." \
+          -f event="<APPROVE|REQUEST_CHANGES|COMMENT>" \
+          -f 'comments=[{"path":"file.go","line":42,"body":"comment"}]'`
+      The `event` value MUST match your chosen verdict (APPROVE, REQUEST_CHANGES, or COMMENT).
+
+      ## Rules
+
+      - Do NOT push code, create commits, or modify any files
+      - Do NOT merge or close the PR
+      - Do NOT change labels
+      - Submit exactly one review per run
+      - The review body MUST end with a standalone `/kelos needs-input` line
+      - Be specific: reference file paths and line numbers
+      - Be constructive: explain why something is a problem and suggest a fix
+      - Distinguish between blocking issues (request changes) and optional nits (approve with comments)
+  pollInterval: 1m


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a new `kelos-reviewer` TaskSpawner that reviews pull requests on demand. A maintainer posts `/kelos review` on any open PR to trigger an automated code review. The agent checks correctness, tests, project conventions, security, and code quality, then submits a structured review via `gh pr review`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The reviewer agent is read-only — it does not push code or modify files. It uses the same `/kelos needs-input` pause pattern as the planner and pr-responder.

Changes in v2:
- Removed manual `git fetch`/`git checkout` instructions from the prompt since kelos handles workspace setup automatically
- Fixed hardcoded `REQUEST_CHANGES` event in the inline review example to use the appropriate event matching the chosen verdict

#### Does this PR introduce a user-facing change?

```release-note
NONE
```