### PR TITLE
Migrate TaskSpawners to commentPolicy with allowedUsers

### DIFF
--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -28,9 +28,13 @@ spec:
   when:
     githubIssues:
       state: open
-      triggerComment: "/kelos plan"
-      excludeComments:
-        - "/kelos needs-input"
+      commentPolicy:
+        triggerComment: "/kelos plan"
+        excludeComments:
+          - "/kelos needs-input"
+        allowedUsers:
+          - gjkim42
+          - kelos-bot[bot]
       reporting:
         enabled: true
   maxConcurrency: 2

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -8,10 +8,14 @@ spec:
       labels:
         - generated-by-kelos
       state: open
-      triggerComment: /kelos pick-up
+      commentPolicy:
+        triggerComment: /kelos pick-up
+        excludeComments:
+          - /kelos needs-input
+        allowedUsers:
+          - gjkim42
+          - kelos-bot[bot]
       draft: false
-      excludeComments:
-        - /kelos needs-input
       reporting:
         enabled: true
   maxConcurrency: 2

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -37,10 +37,14 @@ spec:
   when:
     githubPullRequests:
       state: open
-      triggerComment: /kelos review
+      commentPolicy:
+        triggerComment: /kelos review
+        excludeComments:
+          - /kelos needs-input
+        allowedUsers:
+          - gjkim42
+          - kelos-bot[bot]
       draft: false
-      excludeComments:
-        - /kelos needs-input
       reporting:
         enabled: true
   maxConcurrency: 3

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -6,9 +6,13 @@ spec:
   when:
     githubPullRequests:
       state: open
-      triggerComment: /kelos squash-commits
-      excludeComments:
-        - /kelos squash-commits-done
+      commentPolicy:
+        triggerComment: /kelos squash-commits
+        excludeComments:
+          - /kelos squash-commits-done
+        allowedUsers:
+          - gjkim42
+          - kelos-bot[bot]
       reporting:
         enabled: true
   maxConcurrency: 1

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -39,9 +39,13 @@ spec:
     githubIssues:
       labels:
         - actor/kelos
-      triggerComment: "/kelos pick-up"
-      excludeComments:
-        - "/kelos needs-input"
+      commentPolicy:
+        triggerComment: "/kelos pick-up"
+        excludeComments:
+          - "/kelos needs-input"
+        allowedUsers:
+          - gjkim42
+          - kelos-bot[bot]
       reporting:
         enabled: true
       priorityLabels:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -82,9 +82,16 @@ An AgentConfig injects reusable instructions and tools into Tasks:
 
 A TaskSpawner auto-creates Tasks from external sources:
 
-- `spec.when.githubIssues`: Discover from GitHub (labels, state, assignee, author, trigger/exclude comments, priority labels)
+- `spec.when.githubIssues`: Discover from GitHub issues (labels, state, assignee, author, commentPolicy, priority labels)
+- `spec.when.githubPullRequests`: Discover from GitHub PRs (labels, state, reviewState, author, draft, commentPolicy, priority labels)
 - `spec.when.cron`: Trigger on a cron schedule
 - `spec.when.jira`: Discover from Jira (project, JQL filter, secret with `JIRA_TOKEN`)
+- `spec.when.githubIssues.commentPolicy` / `spec.when.githubPullRequests.commentPolicy`: Comment-based workflow control with authorization
+  - `triggerComment`: Command that must appear for the item to be included (e.g., "/kelos pick-up")
+  - `excludeComments`: Commands that exclude items; when combined with triggerComment, the most recent authorized command wins
+  - `allowedUsers`: Restrict comment control to specific GitHub usernames
+  - `allowedTeams`: Restrict to GitHub teams in `org/team-slug` format
+  - `minimumPermission`: Require at least this repo permission (`read`, `triage`, `write`, `maintain`, `admin`)
 - `spec.taskTemplate`: Template for spawned Tasks (same fields as Task spec)
   - `promptTemplate` and `branch` support Go `text/template` variables: `{{.ID}}`, `{{.Number}}`, `{{.Title}}`, `{{.Body}}`, `{{.URL}}`, `{{.Labels}}`, `{{.Comments}}`, `{{.Kind}}`, `{{.Time}}`, `{{.Schedule}}`
 - `spec.pollInterval`: Polling frequency (default `5m`)

--- a/skill/references/taskspawner.yaml
+++ b/skill/references/taskspawner.yaml
@@ -84,7 +84,7 @@ spec:
   pollInterval: 5m
   maxConcurrency: 3
 ---
-# TaskSpawner with comment-based triggers and priority labels
+# TaskSpawner with comment-based triggers, authorization, and priority labels
 apiVersion: kelos.dev/v1alpha1
 kind: TaskSpawner
 metadata:
@@ -94,9 +94,13 @@ spec:
     githubIssues:
       labels:
         - agent-ready
-      triggerComment: "/kelos pick-up"
-      excludeComments:
-        - "/kelos needs-input"
+      commentPolicy:
+        triggerComment: "/kelos pick-up"
+        excludeComments:
+          - "/kelos needs-input"
+        allowedUsers:
+          - my-github-username
+        minimumPermission: write
       priorityLabels:
         - priority/critical-urgent
         - priority/important-soon


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates all self-development TaskSpawners from deprecated top-level `triggerComment`/`excludeComments` fields to the new `commentPolicy` struct introduced in #702. Adds `allowedUsers` authorization to restrict comment control to `gjkim42` and `kelos-bot[bot]`.

Also updates the kelos skill documentation (`SKILL.md` and `references/taskspawner.yaml`) to document `commentPolicy` and `githubPullRequests`, removing references to legacy fields.

**TaskSpawners updated:**
- kelos-workers
- kelos-planner
- kelos-reviewer
- kelos-pr-responder
- kelos-squash-commits

**Skill updates:**
- Added `commentPolicy` field documentation with all sub-fields
- Added `githubPullRequests` source documentation
- Updated reference example to use `commentPolicy` with `allowedUsers` and `minimumPermission`

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The 6 cron/label-only TaskSpawners (kelos-triage, kelos-self-update, kelos-image-update, kelos-config-update, kelos-fake-strategist, kelos-fake-user) don't use comment triggers and need no changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate all self-development TaskSpawners to the new commentPolicy and restrict command control to `gjkim42` and `kelos-bot[bot]`. Removes deprecated triggerComment/excludeComments and updates docs and examples.

- **Refactors**
  - Replace triggerComment/excludeComments with commentPolicy in `kelos-workers`, `kelos-planner`, `kelos-reviewer`, `kelos-pr-responder`, and `kelos-squash-commits`.
  - Add allowedUsers to limit who can trigger/exclude via comments (`gjkim42`, `kelos-bot[bot]`).
  - Update `SKILL.md` and `references/taskspawner.yaml` to document `commentPolicy` and `githubPullRequests`, removing legacy fields.

<sup>Written for commit 625ab53457bf190c40f74180833f589aba910295. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

