### PR TITLE
docs: introduce kelos skill in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,15 @@ Or pass `--secret` to `kelos run` with a pre-created secret (api-key is the defa
 
 </details>
 
+> **Kelos Skill** — Not sure where to start? Kelos ships with a [skill](skill/) that teaches AI coding agents how to author and operate Kelos resources. Copy `skill/` into your project and ask your agent:
+>
+> ```
+> Using the /kelos skill, set up a TaskSpawner that watches GitHub issues
+> labeled "bug" and auto-creates Tasks to fix them.
+> ```
+>
+> The agent will generate the correct manifests, apply them, and troubleshoot any issues on your behalf.
+
 ## Examples
 
 ### Auto-fix GitHub issues with TaskSpawner


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Adds a callout in the README that introduces the first-party kelos skill. This guides users to copy `skill/` into their project so any AI coding agent can help them author, apply, and troubleshoot Kelos resources.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a README callout for the first‑party Kelos skill, pointing users to copy `skill/` into their project to use with AI coding agents for authoring and operating Kelos resources. Includes a sample prompt to create a TaskSpawner that watches GitHub "bug" issues and auto‑creates Tasks.

<sup>Written for commit c54e41b097cf87fe611420e57768b662486211ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

