### PR TITLE
Remove pollInterval from cron-sourced TaskSpawners

### DIFF
--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -94,4 +94,3 @@ spec:
       - Do not create a PR if no actionable changes are found — exit cleanly instead
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back every change with a specific reference to the PR review that motivated it
-  pollInterval: 1m

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -106,4 +106,3 @@ spec:
         - Agent configuration based on PR reviews → kelos-config-update
         - Coding agent image version updates → kelos-image-update
       - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
-  pollInterval: 1m

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -101,4 +101,3 @@ spec:
         - Agent configuration based on PR reviews → kelos-config-update
         - Coding agent image version updates → kelos-image-update
       - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
-  pollInterval: 1m

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -134,4 +134,3 @@ spec:
       - If no agents need updating, exit cleanly without creating any PRs
       - Include the npm package changelog or release notes link in the PR body when available
       - For cursor, include a link to https://cursor.com/changelog in the PR body instead
-  pollInterval: 1m

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -116,4 +116,3 @@ spec:
         - Agent configuration based on PR reviews → kelos-config-update
         - Coding agent image version updates → kelos-image-update
       - If after review you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output
-  pollInterval: 1m


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Removes `pollInterval` from all cron-sourced TaskSpawner configs under `self-development/`. Cron-sourced TaskSpawners are triggered by schedule, so `pollInterval` is unnecessary.

Affected files:
- `kelos-config-update.yaml`
- `kelos-fake-strategist.yaml`
- `kelos-fake-user.yaml`
- `kelos-image-update.yaml`
- `kelos-self-update.yaml`

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove pollInterval from all cron-sourced TaskSpawner configs in self-development. These jobs run on schedules, so polling is redundant; this simplifies config and avoids confusion.

<sup>Written for commit e287f65e88ea69a0ea8480e31d37394d21ff9a90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

