### PR TITLE
Remove CPU and memory limits from self-development tasks

### DIFF
--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -25,8 +25,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
       env:
         - name: GIT_AUTHOR_NAME

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -56,8 +56,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
       name: kelos-fake-strategist-agent

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -56,8 +56,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
       name: kelos-fake-user-agent

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -45,8 +45,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
       env:
         - name: GIT_AUTHOR_NAME

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -56,8 +56,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
       name: kelos-planner-agent

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -37,8 +37,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "4Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "4Gi"
       env:
         - name: GIT_AUTHOR_NAME

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -66,8 +66,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "4Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "4Gi"
     agentConfigRef:
       name: kelos-reviewer-agent

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -56,8 +56,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
       name: kelos-self-update-agent

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -34,8 +34,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "4Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "4Gi"
       env:
         - name: GIT_AUTHOR_NAME

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -33,8 +33,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "2Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "2Gi"
     agentConfigRef:
       name: kelos-dev-agent

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -72,8 +72,6 @@ spec:
           memory: "512Mi"
           ephemeral-storage: "4Gi"
         limits:
-          cpu: "1"
-          memory: "2Gi"
           ephemeral-storage: "4Gi"
       env:
         - name: GIT_AUTHOR_NAME

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -23,8 +23,6 @@ spec:
         memory: "512Mi"
         ephemeral-storage: "2Gi"
       limits:
-        cpu: "1"
-        memory: "2Gi"
         ephemeral-storage: "2Gi"
   prompt: |
     You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Removes CPU and memory limits from all self-development TaskSpawner and Task pod overrides, keeping only ephemeral-storage limits. This allows agent pods to burst beyond their requested CPU/memory when node resources are available, improving performance for resource-intensive operations like builds and tests.

Resource requests are preserved for scheduling purposes.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed CPU and memory limits from self-development TaskSpawner and Task pods, keeping only ephemeral-storage limits. Pods can now burst above requested CPU/memory when nodes have headroom to speed up builds and tests; requests are unchanged for scheduling.

<sup>Written for commit 02728a8efad1f2429b7240cdf762ae306de4a230. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

