### PR TITLE
Add token refresher resource install flags

### DIFF
--- a/cmd/kelos-controller/main.go
+++ b/cmd/kelos-controller/main.go
@@ -54,6 +54,8 @@ func main() {
 	var spawnerResourceLimits string
 	var tokenRefresherImage string
 	var tokenRefresherImagePullPolicy string
+	var tokenRefresherResourceRequests string
+	var tokenRefresherResourceLimits string
 	var telemetryReport bool
 	var telemetryEndpoint string
 	var telemetryEnvironment string
@@ -79,6 +81,8 @@ func main() {
 	flag.StringVar(&spawnerResourceLimits, "spawner-resource-limits", "", "Resource limits for spawner containers as comma-separated name=value pairs (e.g., cpu=1,memory=1Gi).")
 	flag.StringVar(&tokenRefresherImage, "token-refresher-image", controller.DefaultTokenRefresherImage, "The image to use for the token refresher sidecar.")
 	flag.StringVar(&tokenRefresherImagePullPolicy, "token-refresher-image-pull-policy", "", "The image pull policy for the token refresher sidecar (e.g., Always, Never, IfNotPresent).")
+	flag.StringVar(&tokenRefresherResourceRequests, "token-refresher-resource-requests", "", "Resource requests for token refresher sidecars as comma-separated name=value pairs (e.g., cpu=100m,memory=128Mi).")
+	flag.StringVar(&tokenRefresherResourceLimits, "token-refresher-resource-limits", "", "Resource limits for token refresher sidecars as comma-separated name=value pairs (e.g., cpu=200m,memory=256Mi).")
 	flag.BoolVar(&telemetryReport, "telemetry-report", false, "Run a one-shot telemetry report and exit.")
 	flag.StringVar(&telemetryEndpoint, "telemetry-endpoint", telemetry.DefaultPostHogEndpoint, "The PostHog endpoint for sending telemetry reports.")
 	flag.StringVar(&telemetryEnvironment, "telemetry-environment", "production", "The environment label for telemetry reports (e.g., production, development).")
@@ -93,7 +97,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(opts)))
 
-	// Parse spawner resource flags
+	// Parse resource flags.
 	var spawnerResources *corev1.ResourceRequirements
 	requests, err := controller.ParseResourceList(spawnerResourceRequests)
 	if err != nil {
@@ -109,6 +113,23 @@ func main() {
 		spawnerResources = &corev1.ResourceRequirements{
 			Requests: requests,
 			Limits:   limits,
+		}
+	}
+	var tokenRefresherResources *corev1.ResourceRequirements
+	tokenRefresherRequests, err := controller.ParseResourceList(tokenRefresherResourceRequests)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing --token-refresher-resource-requests: %v\n", err)
+		os.Exit(1)
+	}
+	tokenRefresherLimits, err := controller.ParseResourceList(tokenRefresherResourceLimits)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing --token-refresher-resource-limits: %v\n", err)
+		os.Exit(1)
+	}
+	if tokenRefresherRequests != nil || tokenRefresherLimits != nil {
+		tokenRefresherResources = &corev1.ResourceRequirements{
+			Requests: tokenRefresherRequests,
+			Limits:   tokenRefresherLimits,
 		}
 	}
 
@@ -190,6 +211,7 @@ func main() {
 	deploymentBuilder.SpawnerResources = spawnerResources
 	deploymentBuilder.TokenRefresherImage = tokenRefresherImage
 	deploymentBuilder.TokenRefresherImagePullPolicy = corev1.PullPolicy(tokenRefresherImagePullPolicy)
+	deploymentBuilder.TokenRefresherResources = tokenRefresherResources
 	if err = (&controller.TaskSpawnerReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -304,6 +304,16 @@ The `kelos` CLI lets you manage the full lifecycle without writing YAML.
 | `kelos suspend taskspawner <name>` | Pause a TaskSpawner (stops polling, running tasks continue) |
 | `kelos resume taskspawner <name>` | Resume a paused TaskSpawner |
 
+### `kelos install` Flags
+
+- `--version`: Override the image tag used for controller and bundled agent images
+- `--image-pull-policy`: Set `imagePullPolicy` on controller-managed images
+- `--disable-heartbeat`: Do not install the telemetry heartbeat CronJob
+- `--spawner-resource-requests`: Resource requests for spawner containers as comma-separated `name=value` pairs
+- `--spawner-resource-limits`: Resource limits for spawner containers as comma-separated `name=value` pairs
+- `--token-refresher-resource-requests`: Resource requests for token refresher sidecars as comma-separated `name=value` pairs, for example `cpu=100m,memory=128Mi`
+- `--token-refresher-resource-limits`: Resource limits for token refresher sidecars as comma-separated `name=value` pairs, for example `cpu=200m,memory=256Mi`
+
 ### `kelos run` Flags
 
 - `--prompt, -p`: Task prompt (required)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -37,6 +37,8 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 	var disableHeartbeat bool
 	var spawnerResourceRequests string
 	var spawnerResourceLimits string
+	var tokenRefresherResourceRequests string
+	var tokenRefresherResourceLimits string
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -47,7 +49,15 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 				version.Version = flagVersion
 			}
 
-			vals := buildHelmValues(version.Version, imagePullPolicy, disableHeartbeat, spawnerResourceRequests, spawnerResourceLimits)
+			vals := buildHelmValues(
+				version.Version,
+				imagePullPolicy,
+				disableHeartbeat,
+				spawnerResourceRequests,
+				spawnerResourceLimits,
+				tokenRefresherResourceRequests,
+				tokenRefresherResourceLimits,
+			)
 			controllerManifest, err := helmchart.Render(manifests.ChartFS, vals)
 			if err != nil {
 				return fmt.Errorf("rendering chart: %w", err)
@@ -99,12 +109,14 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().BoolVar(&disableHeartbeat, "disable-heartbeat", false, "do not install the telemetry heartbeat CronJob")
 	cmd.Flags().StringVar(&spawnerResourceRequests, "spawner-resource-requests", "", "resource requests for spawner containers (e.g., cpu=250m,memory=512Mi)")
 	cmd.Flags().StringVar(&spawnerResourceLimits, "spawner-resource-limits", "", "resource limits for spawner containers (e.g., cpu=1,memory=1Gi)")
+	cmd.Flags().StringVar(&tokenRefresherResourceRequests, "token-refresher-resource-requests", "", "resource requests for token refresher sidecars (e.g., cpu=100m,memory=128Mi)")
+	cmd.Flags().StringVar(&tokenRefresherResourceLimits, "token-refresher-resource-limits", "", "resource limits for token refresher sidecars (e.g., cpu=200m,memory=256Mi)")
 
 	return cmd
 }
 
 // buildHelmValues constructs the values map for Helm chart rendering from CLI flags.
-func buildHelmValues(ver string, pullPolicy string, disableHeartbeat bool, spawnerResourceRequests string, spawnerResourceLimits string) map[string]interface{} {
+func buildHelmValues(ver string, pullPolicy string, disableHeartbeat bool, spawnerResourceRequests string, spawnerResourceLimits string, tokenRefresherResourceRequests string, tokenRefresherResourceLimits string) map[string]interface{} {
 	imageVals := map[string]interface{}{
 		"tag": ver,
 	}
@@ -124,6 +136,12 @@ func buildHelmValues(ver string, pullPolicy string, disableHeartbeat bool, spawn
 	}
 	if spawnerResourceLimits != "" {
 		vals["spawnerResourceLimits"] = spawnerResourceLimits
+	}
+	if tokenRefresherResourceRequests != "" {
+		vals["tokenRefresherResourceRequests"] = tokenRefresherResourceRequests
+	}
+	if tokenRefresherResourceLimits != "" {
+		vals["tokenRefresherResourceLimits"] = tokenRefresherResourceLimits
 	}
 	return vals
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -149,7 +149,7 @@ func TestParseManifests_EmbeddedCRDs(t *testing.T) {
 
 func renderDefaultChart(t *testing.T) []byte {
 	t.Helper()
-	vals := buildHelmValues("v0.0.0-test", "", false, "", "")
+	vals := buildHelmValues("v0.0.0-test", "", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -178,7 +178,7 @@ func TestRenderChart_DefaultValues(t *testing.T) {
 }
 
 func TestRenderChart_VersionSubstitution(t *testing.T) {
-	vals := buildHelmValues("v0.5.0", "", false, "", "")
+	vals := buildHelmValues("v0.5.0", "", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -192,7 +192,7 @@ func TestRenderChart_VersionSubstitution(t *testing.T) {
 }
 
 func TestRenderChart_ImageArgs(t *testing.T) {
-	vals := buildHelmValues("v0.3.0", "", false, "", "")
+	vals := buildHelmValues("v0.3.0", "", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -213,7 +213,7 @@ func TestRenderChart_ImageArgs(t *testing.T) {
 }
 
 func TestRenderChart_ImagePullPolicy(t *testing.T) {
-	vals := buildHelmValues("v0.1.0", "Always", false, "", "")
+	vals := buildHelmValues("v0.1.0", "Always", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -236,7 +236,7 @@ func TestRenderChart_ImagePullPolicy(t *testing.T) {
 }
 
 func TestRenderChart_NoPullPolicyByDefault(t *testing.T) {
-	vals := buildHelmValues("latest", "", false, "", "")
+	vals := buildHelmValues("latest", "", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -250,7 +250,7 @@ func TestRenderChart_NoPullPolicyByDefault(t *testing.T) {
 }
 
 func TestRenderChart_DisableHeartbeat(t *testing.T) {
-	vals := buildHelmValues("latest", "", true, "", "")
+	vals := buildHelmValues("latest", "", true, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -277,7 +277,7 @@ func TestRenderChart_DisableHeartbeat(t *testing.T) {
 }
 
 func TestRenderChart_EnableHeartbeat(t *testing.T) {
-	vals := buildHelmValues("latest", "", false, "", "")
+	vals := buildHelmValues("latest", "", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -471,6 +471,36 @@ func TestInstallCommand_SpawnerResourceLimitsFlag(t *testing.T) {
 	}
 }
 
+func TestInstallCommand_TokenRefresherResourceRequestsFlag(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--dry-run", "--token-refresher-resource-requests", "cpu=100m,memory=128Mi"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "--token-refresher-resource-requests=cpu=100m,memory=128Mi") {
+		t.Errorf("expected --token-refresher-resource-requests arg in output")
+	}
+}
+
+func TestInstallCommand_TokenRefresherResourceLimitsFlag(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--dry-run", "--token-refresher-resource-limits", "cpu=200m,memory=256Mi"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "--token-refresher-resource-limits=cpu=200m,memory=256Mi") {
+		t.Errorf("expected --token-refresher-resource-limits arg in output")
+	}
+}
+
 func TestInstallCommand_NoSpawnerResourcesByDefault(t *testing.T) {
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{"install", "--dry-run"})
@@ -489,8 +519,26 @@ func TestInstallCommand_NoSpawnerResourcesByDefault(t *testing.T) {
 	}
 }
 
+func TestInstallCommand_NoTokenRefresherResourcesByDefault(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--dry-run"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(output, "--token-refresher-resource-requests") {
+		t.Error("expected no --token-refresher-resource-requests when not set")
+	}
+	if strings.Contains(output, "--token-refresher-resource-limits") {
+		t.Error("expected no --token-refresher-resource-limits when not set")
+	}
+}
+
 func TestRenderChart_SpawnerResources(t *testing.T) {
-	vals := buildHelmValues("latest", "", false, "cpu=250m,memory=512Mi", "cpu=1,memory=1Gi")
+	vals := buildHelmValues("latest", "", false, "cpu=250m,memory=512Mi", "cpu=1,memory=1Gi", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -503,8 +551,22 @@ func TestRenderChart_SpawnerResources(t *testing.T) {
 	}
 }
 
+func TestRenderChart_TokenRefresherResources(t *testing.T) {
+	vals := buildHelmValues("latest", "", false, "", "", "cpu=100m,memory=128Mi", "cpu=200m,memory=256Mi")
+	data, err := helmchart.Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	if !bytes.Contains(data, []byte("--token-refresher-resource-requests=cpu=100m,memory=128Mi")) {
+		t.Error("expected --token-refresher-resource-requests in rendered output")
+	}
+	if !bytes.Contains(data, []byte("--token-refresher-resource-limits=cpu=200m,memory=256Mi")) {
+		t.Error("expected --token-refresher-resource-limits in rendered output")
+	}
+}
+
 func TestRenderChart_NoSpawnerResourcesByDefault(t *testing.T) {
-	vals := buildHelmValues("latest", "", false, "", "")
+	vals := buildHelmValues("latest", "", false, "", "", "", "")
 	data, err := helmchart.Render(manifests.ChartFS, vals)
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
@@ -514,6 +576,20 @@ func TestRenderChart_NoSpawnerResourcesByDefault(t *testing.T) {
 	}
 	if bytes.Contains(data, []byte("spawner-resource-limits")) {
 		t.Error("expected no spawner-resource-limits when not set")
+	}
+}
+
+func TestRenderChart_NoTokenRefresherResourcesByDefault(t *testing.T) {
+	vals := buildHelmValues("latest", "", false, "", "", "", "")
+	data, err := helmchart.Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	if bytes.Contains(data, []byte("token-refresher-resource-requests")) {
+		t.Error("expected no token-refresher-resource-requests when not set")
+	}
+	if bytes.Contains(data, []byte("token-refresher-resource-limits")) {
+		t.Error("expected no token-refresher-resource-limits when not set")
 	}
 }
 
@@ -646,13 +722,15 @@ func TestWaitForCustomResourceDeletion_RespectsContextCancellation(t *testing.T)
 
 func TestBuildHelmValues(t *testing.T) {
 	tests := []struct {
-		name                    string
-		version                 string
-		pullPolicy              string
-		disableHeartbeat        bool
-		spawnerResourceRequests string
-		spawnerResourceLimits   string
-		checkFn                 func(t *testing.T, vals map[string]interface{})
+		name                           string
+		version                        string
+		pullPolicy                     string
+		disableHeartbeat               bool
+		spawnerResourceRequests        string
+		spawnerResourceLimits          string
+		tokenRefresherResourceRequests string
+		tokenRefresherResourceLimits   string
+		checkFn                        func(t *testing.T, vals map[string]interface{})
 	}{
 		{
 			name:    "default values",
@@ -673,6 +751,12 @@ func TestBuildHelmValues(t *testing.T) {
 				}
 				if _, ok := vals["spawnerResourceLimits"]; ok {
 					t.Error("expected no spawnerResourceLimits when empty")
+				}
+				if _, ok := vals["tokenRefresherResourceRequests"]; ok {
+					t.Error("expected no tokenRefresherResourceRequests when empty")
+				}
+				if _, ok := vals["tokenRefresherResourceLimits"]; ok {
+					t.Error("expected no tokenRefresherResourceLimits when empty")
 				}
 			},
 		},
@@ -718,10 +802,38 @@ func TestBuildHelmValues(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:                           "with token refresher resource requests",
+			version:                        "latest",
+			tokenRefresherResourceRequests: "cpu=100m,memory=128Mi",
+			checkFn: func(t *testing.T, vals map[string]interface{}) {
+				if vals["tokenRefresherResourceRequests"] != "cpu=100m,memory=128Mi" {
+					t.Errorf("expected tokenRefresherResourceRequests=cpu=100m,memory=128Mi, got %v", vals["tokenRefresherResourceRequests"])
+				}
+			},
+		},
+		{
+			name:                         "with token refresher resource limits",
+			version:                      "latest",
+			tokenRefresherResourceLimits: "cpu=200m,memory=256Mi",
+			checkFn: func(t *testing.T, vals map[string]interface{}) {
+				if vals["tokenRefresherResourceLimits"] != "cpu=200m,memory=256Mi" {
+					t.Errorf("expected tokenRefresherResourceLimits=cpu=200m,memory=256Mi, got %v", vals["tokenRefresherResourceLimits"])
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vals := buildHelmValues(tt.version, tt.pullPolicy, tt.disableHeartbeat, tt.spawnerResourceRequests, tt.spawnerResourceLimits)
+			vals := buildHelmValues(
+				tt.version,
+				tt.pullPolicy,
+				tt.disableHeartbeat,
+				tt.spawnerResourceRequests,
+				tt.spawnerResourceLimits,
+				tt.tokenRefresherResourceRequests,
+				tt.tokenRefresherResourceLimits,
+			)
 			tt.checkFn(t, vals)
 		})
 	}

--- a/internal/controller/taskspawner_deployment_builder.go
+++ b/internal/controller/taskspawner_deployment_builder.go
@@ -36,6 +36,7 @@ type DeploymentBuilder struct {
 	SpawnerResources              *corev1.ResourceRequirements
 	TokenRefresherImage           string
 	TokenRefresherImagePullPolicy corev1.PullPolicy
+	TokenRefresherResources       *corev1.ResourceRequirements
 }
 
 // NewDeploymentBuilder creates a new DeploymentBuilder.
@@ -153,7 +154,7 @@ func (b *DeploymentBuilder) buildPodParts(ts *kelosv1alpha1.TaskSpawner, workspa
 				}
 
 				restartPolicyAlways := corev1.ContainerRestartPolicyAlways
-				initContainers = append(initContainers, corev1.Container{
+				refresherContainer := corev1.Container{
 					Name:            "token-refresher",
 					Image:           b.TokenRefresherImage,
 					ImagePullPolicy: b.TokenRefresherImagePullPolicy,
@@ -170,7 +171,11 @@ func (b *DeploymentBuilder) buildPodParts(ts *kelosv1alpha1.TaskSpawner, workspa
 							ReadOnly:  true,
 						},
 					},
-				})
+				}
+				if b.TokenRefresherResources != nil {
+					refresherContainer.Resources = *b.TokenRefresherResources
+				}
+				initContainers = append(initContainers, refresherContainer)
 			} else {
 				// PAT: inject GITHUB_TOKEN from secret
 				envVars = append(envVars, corev1.EnvVar{

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -418,6 +418,56 @@ func TestDeploymentBuilder_GitHubAppGitHubCom(t *testing.T) {
 	}
 }
 
+func TestDeploymentBuilder_TokenRefresherResources(t *testing.T) {
+	builder := NewDeploymentBuilder()
+	builder.TokenRefresherResources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	ts := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type:         "claude-code",
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
+			},
+		},
+	}
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
+			Name: "github-app-creds",
+		},
+	}
+
+	deploy := builder.Build(ts, workspace, true)
+	refresher := deploy.Spec.Template.Spec.InitContainers[0]
+	spawner := deploy.Spec.Template.Spec.Containers[0]
+
+	if refresher.Resources.Requests.Cpu().String() != "100m" {
+		t.Errorf("expected token-refresher cpu request 100m, got %s", refresher.Resources.Requests.Cpu().String())
+	}
+	if refresher.Resources.Limits.Memory().String() != "256Mi" {
+		t.Errorf("expected token-refresher memory limit 256Mi, got %s", refresher.Resources.Limits.Memory().String())
+	}
+	if len(spawner.Resources.Requests) != 0 || len(spawner.Resources.Limits) != 0 {
+		t.Errorf("expected spawner resources to remain empty, got requests=%v limits=%v", spawner.Resources.Requests, spawner.Resources.Limits)
+	}
+}
+
 func TestDeploymentBuilder_PAT(t *testing.T) {
 	builder := NewDeploymentBuilder()
 	ts := &kelosv1alpha1.TaskSpawner{
@@ -2386,6 +2436,56 @@ func TestDeploymentBuilder_CronJob_SpawnerResources(t *testing.T) {
 	}
 }
 
+func TestDeploymentBuilder_CronJob_TokenRefresherResources(t *testing.T) {
+	builder := NewDeploymentBuilder()
+	builder.TokenRefresherResources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("100m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	ts := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Cron: &kelosv1alpha1.Cron{
+					Schedule: "*/5 * * * *",
+				},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type:         "claude-code",
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
+			},
+		},
+	}
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
+			Name: "github-app-creds",
+		},
+	}
+
+	cronJob := builder.BuildCronJob(ts, workspace, true)
+	refresher := cronJob.Spec.JobTemplate.Spec.Template.Spec.InitContainers[0]
+	spawner := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+	if refresher.Resources.Requests.Cpu().String() != "100m" {
+		t.Errorf("expected token-refresher cpu request 100m on CronJob, got %s", refresher.Resources.Requests.Cpu().String())
+	}
+	if refresher.Resources.Limits.Memory().String() != "256Mi" {
+		t.Errorf("expected token-refresher memory limit 256Mi on CronJob, got %s", refresher.Resources.Limits.Memory().String())
+	}
+	if len(spawner.Resources.Requests) != 0 || len(spawner.Resources.Limits) != 0 {
+		t.Errorf("expected spawner resources to remain empty on CronJob, got requests=%v limits=%v", spawner.Resources.Requests, spawner.Resources.Limits)
+	}
+}
+
 func TestDeploymentBuilder_SpawnerResources_TokenRefresherUnaffected(t *testing.T) {
 	builder := NewDeploymentBuilder()
 	builder.SpawnerResources = &corev1.ResourceRequirements{
@@ -2536,5 +2636,149 @@ func TestUpdateCronJob_ResourcesDrift(t *testing.T) {
 	spawner := updated.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 	if spawner.Resources.Requests.Cpu().String() != "100m" {
 		t.Errorf("expected cpu request 100m after drift update, got %s", spawner.Resources.Requests.Cpu().String())
+	}
+}
+
+func TestUpdateDeployment_TokenRefresherResourcesDrift(t *testing.T) {
+	builder := NewDeploymentBuilder()
+	ts := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type:         "claude-code",
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
+			},
+		},
+	}
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
+			Name: "github-app-creds",
+		},
+	}
+
+	deploy := builder.Build(ts, workspace, true)
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ts, deploy).
+		WithStatusSubresource(ts).
+		Build()
+
+	builder.TokenRefresherResources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("100m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	r := &TaskSpawnerReconciler{
+		Client:            cl,
+		Scheme:            scheme,
+		DeploymentBuilder: builder,
+	}
+
+	ctx := context.Background()
+	if err := r.updateDeployment(ctx, ts, deploy, workspace, true, 1); err != nil {
+		t.Fatalf("updateDeployment error: %v", err)
+	}
+
+	var updated appsv1.Deployment
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(deploy), &updated); err != nil {
+		t.Fatalf("getting deployment: %v", err)
+	}
+
+	refresher := updated.Spec.Template.Spec.InitContainers[0]
+	if refresher.Resources.Requests.Cpu().String() != "100m" {
+		t.Errorf("expected token-refresher cpu request 100m after drift update, got %s", refresher.Resources.Requests.Cpu().String())
+	}
+	if refresher.Resources.Limits.Memory().String() != "256Mi" {
+		t.Errorf("expected token-refresher memory limit 256Mi after drift update, got %s", refresher.Resources.Limits.Memory().String())
+	}
+}
+
+func TestUpdateCronJob_TokenRefresherResourcesDrift(t *testing.T) {
+	builder := NewDeploymentBuilder()
+	ts := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spawner",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				Cron: &kelosv1alpha1.Cron{
+					Schedule: "*/5 * * * *",
+				},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type:         "claude-code",
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "ws"},
+			},
+		},
+	}
+	workspace := &kelosv1alpha1.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		SecretRef: &kelosv1alpha1.SecretReference{
+			Name: "github-app-creds",
+		},
+	}
+
+	cronJob := builder.BuildCronJob(ts, workspace, true)
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+	utilruntime.Must(kelosv1alpha1.AddToScheme(scheme))
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ts, cronJob).
+		WithStatusSubresource(ts).
+		Build()
+
+	builder.TokenRefresherResources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("100m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	r := &TaskSpawnerReconciler{
+		Client:            cl,
+		Scheme:            scheme,
+		DeploymentBuilder: builder,
+	}
+
+	ctx := context.Background()
+	if err := r.updateCronJob(ctx, ts, cronJob, workspace, true, false); err != nil {
+		t.Fatalf("updateCronJob error: %v", err)
+	}
+
+	var updated batchv1.CronJob
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(cronJob), &updated); err != nil {
+		t.Fatalf("getting CronJob: %v", err)
+	}
+
+	refresher := updated.Spec.JobTemplate.Spec.Template.Spec.InitContainers[0]
+	if refresher.Resources.Requests.Cpu().String() != "100m" {
+		t.Errorf("expected token-refresher cpu request 100m after drift update, got %s", refresher.Resources.Requests.Cpu().String())
+	}
+	if refresher.Resources.Limits.Memory().String() != "256Mi" {
+		t.Errorf("expected token-refresher memory limit 256Mi after drift update, got %s", refresher.Resources.Limits.Memory().String())
 	}
 }

--- a/internal/manifests/charts/kelos/templates/deployment.yaml
+++ b/internal/manifests/charts/kelos/templates/deployment.yaml
@@ -64,6 +64,12 @@ spec:
             {{- if .Values.image.pullPolicy }}
             - --token-refresher-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
+            {{- if .Values.tokenRefresherResourceRequests }}
+            - --token-refresher-resource-requests={{ .Values.tokenRefresherResourceRequests }}
+            {{- end }}
+            {{- if .Values.tokenRefresherResourceLimits }}
+            - --token-refresher-resource-limits={{ .Values.tokenRefresherResourceLimits }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/internal/manifests/charts/kelos/values.yaml
+++ b/internal/manifests/charts/kelos/values.yaml
@@ -15,3 +15,5 @@ spawnerImage: ghcr.io/kelos-dev/kelos-spawner
 spawnerResourceRequests: ""
 spawnerResourceLimits: ""
 tokenRefresherImage: ghcr.io/kelos-dev/kelos-token-refresher
+tokenRefresherResourceRequests: ""
+tokenRefresherResourceLimits: ""

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -157,6 +157,27 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 			root2.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
 			Expect(root2.Execute()).To(Succeed())
 		})
+
+		It("Should forward token refresher resource flags to the controller deployment", func() {
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"install",
+				"--kubeconfig", kubeconfigPath,
+				"--token-refresher-resource-requests", "cpu=100m,memory=128Mi",
+				"--token-refresher-resource-limits", "cpu=200m,memory=256Mi",
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "kelos-controller-manager",
+				Namespace: "kelos-system",
+			}, dep)).To(Succeed())
+
+			args := dep.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElement("--token-refresher-resource-requests=cpu=100m,memory=128Mi"))
+			Expect(args).To(ContainElement("--token-refresher-resource-limits=cpu=200m,memory=256Mi"))
+		})
 	})
 
 	Context("kelos uninstall", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `kelos install` support for token refresher resource requests and limits, and threads those values through the chart and controller so GitHub App token refresher sidecars receive the configured resources. Also adds unit and integration coverage plus CLI reference docs.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Verifies dry-run and chart rendering for the new install flags
- Verifies Deployment and CronJob token refresher resource wiring and reconciliation drift handling
- Tests run: `make test`, `make test-integration`, `make verify`

#### Does this PR introduce a user-facing change?

Yes

```release-note
Added `kelos install --token-refresher-resource-requests` and `--token-refresher-resource-limits` so GitHub App token refresher sidecars can be configured with CPU and memory resources.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds resource flags to `kelos install` so you can set CPU/memory requests and limits for GitHub App token refresher sidecars. Values flow through the Helm chart into the controller and are applied to TaskSpawner Deployments and CronJobs.

- **New Features**
  - Added `--token-refresher-resource-requests` and `--token-refresher-resource-limits` to `kelos install` (e.g., `cpu=100m,memory=128Mi`).
  - New Helm values `tokenRefresherResourceRequests` and `tokenRefresherResourceLimits`; rendered into controller args.
  - Controller parses these flags and sets `ResourceRequirements` on the token refresher init container; handles drift on Deployments and CronJobs.
  - Tests cover dry-run output, chart rendering, resource wiring, and reconciliation; CLI reference docs updated.

<sup>Written for commit 6333221eac8ba3b4635ed0c2ed1a3c13d03b1f98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

