### PR TITLE
Set spawner and token-refresher resource requests in deploy-dev

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Install kelos
         run: |
-          bin/kelos install --version main --image-pull-policy Always
+          bin/kelos install --version main --image-pull-policy Always \
+            --spawner-resource-requests cpu=100m,memory=128Mi \
+            --token-refresher-resource-requests cpu=50m,memory=64Mi
           kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
           kubectl rollout status deployment/kelos-controller-manager -n kelos-system --timeout=120s
           kubectl rollout restart deployment -l app.kubernetes.io/component=spawner -n "${KELOS_NAMESPACE}"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Sets resource requests for spawner and token-refresher containers in the deploy-dev workflow:
- Spawner: cpu=100m, memory=128Mi
- Token refresher: cpu=50m, memory=64Mi

#### Which issue(s) this PR is related to:

Fixes #754

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set resource requests in deploy-dev for the spawner (CPU 100m, memory 128Mi) and token-refresher (CPU 50m, memory 64Mi) to ensure predictable scheduling and reduce restarts.
Implemented via new `--spawner-resource-requests` and `--token-refresher-resource-requests` flags in the `bin/kelos install` step.

<sup>Written for commit de1917feea96cfe2d1ecc2bcd2ca3068ee4340f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

