### PR TITLE
feat: add Helm chart publishing workflow to release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,3 +79,43 @@ jobs:
           gh release upload "$VERSION" --clobber \
             bin/kelos-* \
             bin/checksums.txt
+
+  publish-helm-chart:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 3.20.1
+
+      - name: Determine version
+        id: version
+        run: |
+          # Extract version without 'v' prefix (e.g., v1.2.3 -> 1.2.3)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        run: |
+          helm registry login ghcr.io \
+            -u ${{ github.actor }} \
+            -p ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p /tmp/charts
+          helm package internal/manifests/charts/kelos \
+            --version ${{ steps.version.outputs.version }} \
+            --app-version ${{ github.ref_name }} \
+            --destination /tmp/charts
+
+      - name: Push Helm chart to GHCR
+        run: |
+          helm push /tmp/charts/kelos-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/kelos-dev/charts


### PR DESCRIPTION
#### What type of PR is this?

feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs
/kind feature
-->

#### What this PR does / why we need it:

Github action that releases the helm chart to separate heln 
repo

#### Which issue(s) this PR is related to:

Fixes #805
Fixes #781

<!--
Fixes #<issue number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

none

#### Does this PR introduce a user-facing change?
users can now install kelos using the official helm chart repo
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
users can now install kelos with helm: "helm install kelos oci://ghcr.io/kelos-dev/charts/kelos"
```
