### PR TITLE
feat: add Homebrew formula and update workflow for automatic formula …

### DIFF
--- a/.github/workflows/update-homebrew-formula.yaml
+++ b/.github/workflows/update-homebrew-formula.yaml
@@ -1,0 +1,40 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: kelos-dev/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: homebrew-tap
+
+      - name: Copy formula template to tap repo
+        run: cp Formula/kelos.rb homebrew-tap/Formula/kelos.rb
+
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: bash hack/update-homebrew-formula.sh "$TAG_NAME" homebrew-tap
+
+      - name: Commit and push Homebrew formula update
+        working-directory: homebrew-tap
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          git config user.name "kelos-dev[bot]"
+          git config user.email "kelos-dev@users.noreply.github.com"
+          git add Formula/kelos.rb
+          git commit -m "chore: update Homebrew formula for ${TAG_NAME}" || true
+          git push

--- a/Formula/kelos.rb
+++ b/Formula/kelos.rb
@@ -1,0 +1,40 @@
+class Kelos < Formula
+  desc "Orchestrate autonomous AI coding agents on Kubernetes"
+  homepage "https://github.com/kelos-dev/kelos"
+  license "Apache-2.0"
+
+  version "VERSION_PLACEHOLDER"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/kelos-dev/kelos/releases/download/v#{version}/kelos-darwin-amd64"
+      sha256 "SHA256_MACOS_AMD64_PLACEHOLDER"
+    end
+    on_arm do
+      url "https://github.com/kelos-dev/kelos/releases/download/v#{version}/kelos-darwin-arm64"
+      sha256 "SHA256_MACOS_ARM64_PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/kelos-dev/kelos/releases/download/v#{version}/kelos-linux-amd64"
+      sha256 "SHA256_LINUX_AMD64_PLACEHOLDER"
+    end
+    on_arm do
+      url "https://github.com/kelos-dev/kelos/releases/download/v#{version}/kelos-linux-arm64"
+      sha256 "SHA256_LINUX_ARM64_PLACEHOLDER"
+    end
+  end
+
+  def install
+    # Homebrew downloads the binary with the URL's filename,
+    # so we just rename it and install
+    bin.install Dir.glob("kelos-*").first => "kelos"
+  end
+
+  test do
+    output = shell_output("#{bin}/kelos version")
+    assert_match(/\d+\.\d+\.\d+/, output)
+  end
+end

--- a/README.md
+++ b/README.md
@@ -143,7 +143,12 @@ This creates a single-node cluster and configures your kubeconfig automatically.
 ### 1. Install the CLI
 
 ```bash
+# Install using the script
 curl -fsSL https://raw.githubusercontent.com/kelos-dev/kelos/main/hack/install.sh | bash
+
+# Or by using Homebrew
+brew tap kelos-dev/tap
+brew install kelos
 ```
 
 <details>

--- a/hack/update-homebrew-formula.sh
+++ b/hack/update-homebrew-formula.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Script to update the Homebrew formula with checksums from a GitHub release
+# Usage: ./hack/update-homebrew-formula.sh v1.2.3 [/path/to/tap-repo]
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <version> [tap-repo-path]" >&2
+  exit 1
+fi
+
+VERSION="$1"
+TAP_DIR="${2:-.}"
+REPO="kelos-dev/kelos"
+CHECKSUMS_FILE="/tmp/checksums.txt"
+
+trap 'rm -f /tmp/checksums.txt' EXIT
+
+echo "Fetching checksums for ${VERSION}..."
+
+# Download checksums
+gh release download "${VERSION}" \
+  --repo "${REPO}" \
+  --pattern "checksums.txt" \
+  --dir /tmp
+
+# Parse checksums
+declare -A SHAS
+while IFS= read -r line; do
+  sha=$(echo "$line" | awk '{print $1}')
+  filename=$(echo "$line" | awk '{print $2}')
+
+  # Extract arch from filename (e.g., kelos-linux-amd64 -> linux-amd64)
+  arch="${filename#kelos-}"
+
+  SHAS["$arch"]="$sha"
+done <"$CHECKSUMS_FILE"
+
+# Verify we have all required checksums
+required_archs=("darwin-amd64" "darwin-arm64" "linux-amd64" "linux-arm64")
+for arch in "${required_archs[@]}"; do
+  if [[ -z "${SHAS["$arch"]:-}" ]]; then
+    echo "Error: Missing checksum for $arch" >&2
+    exit 1
+  fi
+done
+
+# Update formula
+FORMULA_FILE="${TAP_DIR}/Formula/kelos.rb"
+
+# Strip leading 'v' so Homebrew gets a bare version number (e.g., 1.2.3 not v1.2.3)
+BARE_VERSION="${VERSION#v}"
+# Note: sed -i without a backup suffix requires GNU sed. This script is intended to run
+# in CI on Ubuntu. On macOS, use `sed -i '' ...` or install gnu-sed via Homebrew.
+sed -i "s/version \"VERSION_PLACEHOLDER\"/version \"${BARE_VERSION}\"/" "$FORMULA_FILE"
+sed -i "s/sha256 \"SHA256_MACOS_AMD64_PLACEHOLDER\"/sha256 \"${SHAS["darwin-amd64"]}\"/" "$FORMULA_FILE"
+sed -i "s/sha256 \"SHA256_MACOS_ARM64_PLACEHOLDER\"/sha256 \"${SHAS["darwin-arm64"]}\"/" "$FORMULA_FILE"
+sed -i "s/sha256 \"SHA256_LINUX_AMD64_PLACEHOLDER\"/sha256 \"${SHAS["linux-amd64"]}\"/" "$FORMULA_FILE"
+sed -i "s/sha256 \"SHA256_LINUX_ARM64_PLACEHOLDER\"/sha256 \"${SHAS["linux-arm64"]}\"/" "$FORMULA_FILE"
+
+echo "✓ Updated $FORMULA_FILE with version $VERSION"
+echo "  Checksums:"
+for arch in "${required_archs[@]}"; do
+  echo "    $arch: ${SHAS["$arch"]}"
+done


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds Homebrew installation support for Kelos, allowing users to install and manage Kelos via:
```
brew tap kelos-dev/tap
brew install kelos
```
This improves the installation experience and makes Kelos discoverable through a widely-used package manager.

This PR includes:
- Automated formula updates in GitHub Actions during release workflow
- Platform detection for macOS (Intel/ARM64) and Linux (x86_64/ARM64)
- Installation and version tests

The formula is automatically updated with correct checksums and version on every release, requiring no manual intervention.

#### Which issue(s) this PR is related to:

Fixes #817

#### Special notes for your reviewer:

- The GitHub Actions workflow automatically skips duplicate builds when the bot commits formula updates (using `if: github.actor != 'kelos-dev[bot]'`)
- Binaries must be built and checksummed in the release job before the formula update step
- Formula uses placeholders that are replaced at release time with actual checksums
- The `update-homebrew-formula.sh` script handles downloading checksums from the GitHub release and updating the formula

#### Does this PR introduce a user-facing change?

Yes - a new installation method.

```release-note
Add Homebrew installation support: users can now install Kelos via `brew tap kelos-dev/tap && brew install kelos`
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Homebrew support so users can install `kelos` with `brew tap kelos-dev/tap && brew install kelos`. The formula auto-updates on new releases and supports macOS (Intel/ARM) and Linux (AMD64/ARM64).

- **New Features**
  - Added `Formula/kelos.rb` with per-OS/arch URLs; version and SHAs filled at release; includes a `kelos version` test; README updated with brew install steps.
  - New workflow runs on release to update `kelos-dev/homebrew-tap`: copies the formula, runs `hack/update-homebrew-formula.sh <tag>`, then commits and pushes. The script downloads `checksums.txt`, verifies required arches, strips the leading `v`, and updates version/SHAs.

<sup>Written for commit f1c9737282ed981697fe8b031e6a18a641da3dc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



