### PR TITLE
Add CLAUDE_CODE_EFFORT_LEVEL=max to opus-model self-development workflows

### DIFF
--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -27,6 +27,8 @@ spec:
         limits:
           ephemeral-storage: "2Gi"
       env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
         - name: GIT_AUTHOR_NAME
           value: "Gunju Kim"
         - name: GIT_AUTHOR_EMAIL

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -57,6 +57,9 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
+      env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
     agentConfigRef:
       name: kelos-fake-strategist-agent
     promptTemplate: |

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -57,6 +57,9 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
+      env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
     agentConfigRef:
       name: kelos-planner-agent
     promptTemplate: |

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -39,6 +39,8 @@ spec:
         limits:
           ephemeral-storage: "4Gi"
       env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
         - name: GIT_AUTHOR_NAME
           value: "Gunju Kim"
         - name: GIT_AUTHOR_EMAIL

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -67,6 +67,9 @@ spec:
           ephemeral-storage: "4Gi"
         limits:
           ephemeral-storage: "4Gi"
+      env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
     branch: "{{.Branch}}"
     agentConfigRef:
       name: kelos-reviewer-agent

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -57,6 +57,9 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
+      env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
     agentConfigRef:
       name: kelos-self-update-agent
     promptTemplate: |

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -34,6 +34,9 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
+      env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
     agentConfigRef:
       name: kelos-dev-agent
     promptTemplate: |

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -74,6 +74,8 @@ spec:
         limits:
           ephemeral-storage: "4Gi"
       env:
+        - name: CLAUDE_CODE_EFFORT_LEVEL
+          value: "max"
         - name: GIT_AUTHOR_NAME
           value: "Gunju Kim"
         - name: GIT_AUTHOR_EMAIL

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -24,6 +24,9 @@ spec:
         ephemeral-storage: "2Gi"
       limits:
         ephemeral-storage: "2Gi"
+    env:
+      - name: CLAUDE_CODE_EFFORT_LEVEL
+        value: "max"
   prompt: |
     You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
     Your goal is to find new and better ways to use Kelos — expanding its reach, improving its workflows, and identifying opportunities for growth.


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Adds `CLAUDE_CODE_EFFORT_LEVEL=max` environment variable to all self-development TaskSpawner workflows that use the opus model, enabling max effort mode for these agents.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Only opus-model workflows are updated. Sonnet-model workflows (kelos-fake-user, kelos-squash-commits, kelos-image-update) are intentionally excluded.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable max-effort mode for all opus-based self-development agents by setting `CLAUDE_CODE_EFFORT_LEVEL=max` in their TaskSpawner workflows. Sonnet-based workflows are intentionally unchanged.

<sup>Written for commit 24b337c786ecd795e87de6ed0042ca1c8e1fb47a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

