### PR TITLE
feat: log cache misses in ghproxy

### DIFF
--- a/cmd/ghproxy/main.go
+++ b/cmd/ghproxy/main.go
@@ -235,6 +235,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	statusCode = resp.StatusCode
 	if r.Method == http.MethodGet {
 		cacheResult = "miss"
+		log.Info("Cache miss", "path", r.URL.RequestURI(), "upstream", upstream, "status", resp.StatusCode, "resource", resource)
 	}
 	w.WriteHeader(resp.StatusCode)
 	w.Write(body)

--- a/cmd/ghproxy/main_test.go
+++ b/cmd/ghproxy/main_test.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kelos-dev/kelos/internal/source"
 )
@@ -328,6 +333,52 @@ func TestCacheKeyVariesByAcceptNotAuthorization(t *testing.T) {
 	}
 	if key1 != cacheKey(defaultUpstream, "/repos/o/r/issues", "application/json") {
 		t.Fatal("expected cache key to be stable for identical inputs")
+	}
+}
+
+func TestProxy_LogsCacheMiss(t *testing.T) {
+	var buf bytes.Buffer
+	ctrl.SetLogger(zap.New(zap.WriteTo(&buf), zap.UseDevMode(true)))
+
+	now := time.Unix(1700000000, 0)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	p := newProxy([]string{upstream.URL}, time.Minute)
+	p.now = func() time.Time { return now }
+	proxyServer := httptest.NewServer(p)
+	defer proxyServer.Close()
+
+	doGET := func() {
+		req, _ := http.NewRequest("GET", proxyServer.URL+"/repos/owner/repo/issues", nil)
+		req.Header.Set(source.UpstreamBaseURLHeader, upstream.URL)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+
+	// First request is a cache miss — should log.
+	doGET()
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "Cache miss") {
+		t.Errorf("expected cache miss log on first request, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "/repos/owner/repo/issues") {
+		t.Errorf("expected log to contain request path, got: %s", logOutput)
+	}
+
+	// Second request within TTL is a fresh hit — no additional miss log.
+	buf.Reset()
+	now = now.Add(10 * time.Second)
+	doGET()
+	if strings.Contains(buf.String(), "Cache miss") {
+		t.Error("unexpected cache miss log for fresh cache hit")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an info-level log line when ghproxy encounters a cache miss on a GET request and forwards it to the upstream GitHub API. The log includes the request path, upstream URL, response status code, and resource type, making it easier to observe which API calls are actually hitting GitHub.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The log is only emitted for GET cache misses (not for fresh hits, revalidated hits, or non-GET requests which bypass the cache entirely).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an info-level log when `ghproxy` encounters a GET cache miss, including the request path, upstream URL, response status, and resource, to show which calls reach the GitHub API. Adds a test to verify the miss is logged on the first GET and not for cache hits or non-GET requests.

<sup>Written for commit c1fbc44fc2490dfcfe45d45ec1c360b080ab583b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

