### PR TITLE
fix: use fetch-depth 2 for fork e2e merge ref checkout

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
           persist-credentials: ${{ inputs.persist-credentials }}
+          fetch-depth: 2
 
       - name: Validate checked-out commit matches approved SHA
         if: inputs.expected-sha != ''


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The fork-e2e workflow checks out `refs/pull/N/merge` and validates that the merge commit's second parent matches the approved PR head SHA. With the default `fetch-depth: 1`, `git show --format=%P` does not report parent SHAs for the shallow merge commit, causing the validation to always fail with "Checked-out ref is not a merge commit".

Setting `fetch-depth: 2` fetches the merge commit along with its parents, making the validation work correctly.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Reproduced in:
- https://github.com/kelos-dev/kelos/actions/runs/23800724580
- https://github.com/kelos-dev/kelos/actions/runs/23800823492
- https://github.com/kelos-dev/kelos/actions/runs/23800971165

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure fork E2E merge-ref validation works by fetching parent SHAs. Set `actions/checkout` to `fetch-depth: 2` when checking out `refs/pull/N/merge`, preventing false "not a merge commit" errors and allowing the approved head SHA check to pass.

<sup>Written for commit b8f81f6e42f47dcf0b0bca86910bd209ea3c80db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

