### PR TITLE
feat: deploy github webhook server in dev environment

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -73,14 +73,25 @@ jobs:
               limits:
                 cpu: 500m
                 memory: 128Mi
+          webhookServer:
+            sources:
+              github:
+                enabled: true
+                secretName: github-webhook-secret
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
           EOF
           bin/kelos install -f /tmp/kelos-dev-values.yaml
           kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
           kubectl rollout status deployment/kelos-controller-manager -n kelos-system --timeout=120s
           kubectl rollout restart deployment -l kelos.dev/component=ghproxy -n "${KELOS_NAMESPACE}"
           kubectl rollout restart deployment -l kelos.dev/component=spawner -n "${KELOS_NAMESPACE}"
+          kubectl rollout restart deployment/kelos-webhook-github -n kelos-system
           kubectl rollout status deployment -l kelos.dev/component=ghproxy -n "${KELOS_NAMESPACE}" --timeout=120s
           kubectl rollout status deployment -l kelos.dev/component=spawner -n "${KELOS_NAMESPACE}" --timeout=120s
+          kubectl rollout status deployment/kelos-webhook-github -n kelos-system --timeout=120s
 
       - name: Apply PodMonitoring
         run: |
@@ -135,6 +146,23 @@ jobs:
               matchLabels:
                 kelos.dev/name: kelos
                 kelos.dev/component: ghproxy
+            endpoints:
+              - port: metrics
+                interval: 30s
+          ---
+          apiVersion: monitoring.googleapis.com/v1
+          kind: PodMonitoring
+          metadata:
+            name: kelos-webhook-github
+            namespace: kelos-system
+            labels:
+              app.kubernetes.io/name: kelos
+              app.kubernetes.io/component: webhook-github
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: kelos
+                app.kubernetes.io/component: webhook-github
             endpoints:
               - port: metrics
                 interval: 30s

--- a/internal/webhook/github_filter.go
+++ b/internal/webhook/github_filter.go
@@ -429,19 +429,10 @@ func ExtractGitHubWorkItem(eventData *GitHubEventData) map[string]interface{} {
 		"Kind":  "webhook",
 	}
 
-	// Add number, body, URL if available
-	if eventData.Number > 0 {
-		vars["Number"] = eventData.Number
-	}
-	if eventData.Body != "" {
-		vars["Body"] = eventData.Body
-	}
-	if eventData.URL != "" {
-		vars["URL"] = eventData.URL
-	}
-	if eventData.Branch != "" {
-		vars["Branch"] = eventData.Branch
-	}
+	vars["Number"] = eventData.Number
+	vars["Body"] = eventData.Body
+	vars["URL"] = eventData.URL
+	vars["Branch"] = eventData.Branch
 
 	return vars
 }

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -35,19 +35,19 @@ metadata:
   name: kelos-reviewer
 spec:
   when:
-    githubPullRequests:
-      state: open
-      commentPolicy:
-        triggerComment: /kelos review
-        excludeComments:
-          - /kelos needs-input
-        allowedUsers:
-          - gjkim42
-          - kelos-bot[bot]
-      draft: false
-      reporting:
-        enabled: true
-      pollInterval: 1m
+    githubWebhook:
+      repository: "kelos-dev/kelos"
+      events:
+        - "issue_comment"
+      filters:
+        - event: "issue_comment"
+          action: "created"
+          bodyContains: "/kelos review"
+          author: "gjkim42"
+        - event: "issue_comment"
+          action: "created"
+          bodyContains: "/kelos review"
+          author: "kelos-bot[bot]"
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Deploys the GitHub webhook server in the dev environment using the new helm values file install flow and converts kelos-reviewer to a webhook-based TaskSpawner.

- Pass `webhookServer` config through `/tmp/kelos-dev-values.yaml` instead of CLI flags
- Add rollout restart, status check, and PodMonitoring for `kelos-webhook-github` in `kelos-system`
- Convert `kelos-reviewer` from polling (`githubPullRequests`) to webhook-based (`issue_comment` events filtered by allowed authors)
- Fix `ExtractGitHubWorkItem` to always include `Number`, `Body`, `URL`, and `Branch` in template vars so unconditional `{{.Branch}}` references don't fail with "map has no entry for key"

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The webhook server deploys to `kelos-system` namespace and requires a secret named `github-webhook-secret` with a `WEBHOOK_SECRET` key
- The kelos-reviewer triggers on `issue_comment` events with `/kelos review` in the body, filtered by author (`gjkim42`, `kelos-bot[bot]`)
- Branch enrichment for issue_comment events on PRs is already handled on main (#867)

#### Does this PR introduce a user-facing change?

```release-note
Fix webhook template rendering to always include standard variables (Number, Body, URL, Branch) so prompt templates with unconditional references don't fail.
```