### PR TITLE
fix: populate SpawnerRef fields for Task owner references

### DIFF
--- a/cmd/kelos-spawner/main.go
+++ b/cmd/kelos-spawner/main.go
@@ -349,7 +349,10 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 			&ts.Spec.TaskTemplate,
 			templateVars,
 			&taskbuilder.SpawnerRef{
-				Name: ts.Name,
+				Name:       ts.Name,
+				UID:        string(ts.UID),
+				APIVersion: kelosv1alpha1.GroupVersion.String(),
+				Kind:       "TaskSpawner",
 			},
 		)
 		if err != nil {

--- a/cmd/kelos-spawner/main_test.go
+++ b/cmd/kelos-spawner/main_test.go
@@ -94,6 +94,7 @@ func newTaskSpawner(name, namespace string, maxConcurrency *int32) *kelosv1alpha
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
 		},
 		Spec: kelosv1alpha1.TaskSpawnerSpec{
 			When: kelosv1alpha1.When{
@@ -296,6 +297,53 @@ func TestRunCycleWithSource_NoMaxConcurrency(t *testing.T) {
 	}
 	if len(taskList.Items) != 3 {
 		t.Errorf("Expected 3 tasks, got %d", len(taskList.Items))
+	}
+}
+
+func TestRunCycleWithSource_OwnerReferenceSet(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	cl, key := setupTest(t, ts)
+
+	src := &fakeSource{
+		items: []source.WorkItem{
+			{ID: "1", Title: "Item 1"},
+		},
+	}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var taskList kelosv1alpha1.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(taskList.Items))
+	}
+
+	task := taskList.Items[0]
+	if len(task.OwnerReferences) != 1 {
+		t.Fatalf("Expected 1 owner reference, got %d", len(task.OwnerReferences))
+	}
+	ref := task.OwnerReferences[0]
+	if ref.APIVersion != kelosv1alpha1.GroupVersion.String() {
+		t.Errorf("Expected APIVersion %s, got %s", kelosv1alpha1.GroupVersion.String(), ref.APIVersion)
+	}
+	if ref.Kind != "TaskSpawner" {
+		t.Errorf("Expected Kind TaskSpawner, got %s", ref.Kind)
+	}
+	if ref.Name != "spawner" {
+		t.Errorf("Expected Name spawner, got %s", ref.Name)
+	}
+	if ref.UID != ts.UID {
+		t.Errorf("Expected UID %s, got %s", ts.UID, ref.UID)
+	}
+	if ref.Controller == nil || !*ref.Controller {
+		t.Error("Expected Controller=true")
+	}
+	if ref.BlockOwnerDeletion != nil {
+		t.Errorf("Expected BlockOwnerDeletion to be nil, got %v", *ref.BlockOwnerDeletion)
 	}
 }
 

--- a/internal/taskbuilder/builder.go
+++ b/internal/taskbuilder/builder.go
@@ -143,14 +143,12 @@ func (tb *TaskBuilder) BuildTask(
 		task.Labels["kelos.dev/taskspawner"] = spawnerRef.Name
 
 		isController := true
-		blockOwnerDeletion := true
 		task.OwnerReferences = append(task.OwnerReferences, metav1.OwnerReference{
-			APIVersion:         spawnerRef.APIVersion,
-			Kind:               spawnerRef.Kind,
-			Name:               spawnerRef.Name,
-			UID:                types.UID(spawnerRef.UID),
-			Controller:         &isController,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			APIVersion: spawnerRef.APIVersion,
+			Kind:       spawnerRef.Kind,
+			Name:       spawnerRef.Name,
+			UID:        types.UID(spawnerRef.UID),
+			Controller: &isController,
 		})
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PR #851 introduced `taskbuilder.BuildTask` with `SpawnerRef` but the spawner call site in `runCycleWithSourceCore` only set `Name`, leaving `APIVersion`, `Kind`, and `UID` empty. Kubernetes rejects owner references with empty required fields, causing all Task creation from TaskSpawners to fail with:

```
Task.kelos.dev "kelos-workers-861" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: "": version must not be empty, metadata.ownerReferences.kind: Invalid value: "": must not be empty, metadata.ownerReferences.uid: Invalid value: "": must not be empty]
```

Also removes `BlockOwnerDeletion` from the owner reference since neither the spawner nor webhook RBAC role has `delete` on `taskspawners` or `update` on `taskspawners/finalizers`, which Kubernetes requires for that field.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The webhook handler in #851 correctly fills all SpawnerRef fields. This was missed in the spawner path only. The `BlockOwnerDeletion` issue affects both paths.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```