### PR TITLE
revert: roll back claude-code to 2.1.87

### DIFF
--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -27,7 +27,7 @@ RUN ARCH=$(dpkg --print-architecture) \
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-ARG CLAUDE_CODE_VERSION=2.1.88
+ARG CLAUDE_CODE_VERSION=2.1.87
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 COPY claude-code/kelos_entrypoint.sh /kelos_entrypoint.sh


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Rolls back the claude-code image from 2.1.88 to 2.1.87.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Roll back `@anthropic-ai/claude-code` in the Docker image from 2.1.88 to 2.1.87 to restore the previous stable version.
Updates the Dockerfile `CLAUDE_CODE_VERSION` ARG to 2.1.87.

<sup>Written for commit 40de17d8088cf26b974a40c8e5b5fdd16f192214. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

