### PR TITLE
Add ghproxy upstream request metric

### DIFF
--- a/cmd/ghproxy/main.go
+++ b/cmd/ghproxy/main.go
@@ -118,6 +118,10 @@ type responsePayload struct {
 	headers     map[string]string
 }
 
+func recordUpstreamRequest(method, statusCode, resource, reason string) {
+	githubAPIUpstreamRequestsTotal.WithLabelValues(method, statusCode, resource, reason).Inc()
+}
+
 func (p *proxy) fetchResponse(log logr.Logger, upstream string, key string, r *http.Request) (*responsePayload, error) {
 	if r.Method == http.MethodGet {
 		p.mu.RLock()
@@ -153,6 +157,7 @@ func (p *proxy) fetchResponse(log logr.Logger, upstream string, key string, r *h
 // doNonGET handles non-GET requests, forwarding the original request body
 // and context directly to upstream without singleflight coalescing.
 func (p *proxy) doNonGET(upstream string, r *http.Request) (*responsePayload, error) {
+	resource := source.ClassifyResource(r.URL.Path)
 	target, err := url.Parse(upstream + r.URL.RequestURI())
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream URL: %w", err)
@@ -174,9 +179,11 @@ func (p *proxy) doNonGET(upstream string, r *http.Request) (*responsePayload, er
 
 	resp, err := p.upstream.Do(outReq)
 	if err != nil {
+		recordUpstreamRequest(r.Method, "error", resource, "skip")
 		return nil, fmt.Errorf("upstream request failed: %w", err)
 	}
 	defer resp.Body.Close()
+	recordUpstreamRequest(r.Method, strconv.Itoa(resp.StatusCode), resource, "skip")
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -205,6 +212,11 @@ func (p *proxy) doGETUpstream(log logr.Logger, upstream, key, requestURI string,
 	p.mu.RLock()
 	entry := p.cache[key]
 	p.mu.RUnlock()
+	resource := source.ClassifyResource(requestURI)
+	reason := "miss"
+	if entry != nil {
+		reason = "revalidate"
+	}
 
 	target, err := url.Parse(upstream + requestURI)
 	if err != nil {
@@ -235,9 +247,11 @@ func (p *proxy) doGETUpstream(log logr.Logger, upstream, key, requestURI string,
 
 	resp, err := p.upstream.Do(outReq)
 	if err != nil {
+		recordUpstreamRequest(http.MethodGet, "error", resource, reason)
 		return nil, fmt.Errorf("upstream request failed: %w", err)
 	}
 	defer resp.Body.Close()
+	recordUpstreamRequest(http.MethodGet, strconv.Itoa(resp.StatusCode), resource, reason)
 
 	if resp.StatusCode == http.StatusNotModified && entry != nil {
 		refreshed := *entry
@@ -280,7 +294,7 @@ func (p *proxy) doGETUpstream(log logr.Logger, upstream, key, requestURI string,
 		}
 	}
 
-	log.Info("Cache miss", "key", key, "status", resp.StatusCode, "resource", source.ClassifyResource(requestURI))
+	log.Info("Cache miss", "key", key, "status", resp.StatusCode, "resource", resource)
 	return &responsePayload{
 		statusCode:  resp.StatusCode,
 		cacheResult: "miss",

--- a/cmd/ghproxy/metrics.go
+++ b/cmd/ghproxy/metrics.go
@@ -12,8 +12,19 @@ var (
 		},
 		[]string{"method", "status_code", "resource", "cache"},
 	)
+
+	githubAPIUpstreamRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kelos_ghproxy_github_api_upstream_requests_total",
+			Help: "Total number of upstream GitHub API requests made by ghproxy",
+		},
+		[]string{"method", "status_code", "resource", "reason"},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(githubAPIRequestsTotal)
+	prometheus.MustRegister(
+		githubAPIRequestsTotal,
+		githubAPIUpstreamRequestsTotal,
+	)
 }

--- a/cmd/ghproxy/metrics_test.go
+++ b/cmd/ghproxy/metrics_test.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +27,7 @@ func TestProxy_RecordsMetrics(t *testing.T) {
 	defer proxyServer.Close()
 
 	before := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
+	upstreamBefore := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
 
 	req, _ := http.NewRequest("GET", proxyServer.URL+"/repos/owner/repo/issues", nil)
 	req.Header.Set(source.UpstreamBaseURLHeader, upstream.URL)
@@ -36,8 +39,12 @@ func TestProxy_RecordsMetrics(t *testing.T) {
 	resp.Body.Close()
 
 	after := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
+	upstreamAfter := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
 	if after != before+1 {
 		t.Errorf("expected miss counter to increment by 1, got delta %f", after-before)
+	}
+	if upstreamAfter != upstreamBefore+1 {
+		t.Errorf("expected upstream miss counter to increment by 1, got delta %f", upstreamAfter-upstreamBefore)
 	}
 }
 
@@ -70,18 +77,23 @@ func TestProxy_RecordsFreshCacheHitMetric(t *testing.T) {
 
 	freshHitBefore := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "fresh_hit"))
 	missBefore := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
+	upstreamMissBefore := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
 
 	doGET()
 	doGET()
 
 	freshHitAfter := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "fresh_hit"))
 	missAfter := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
+	upstreamMissAfter := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
 
 	if missAfter != missBefore+1 {
 		t.Errorf("expected 1 miss, got delta %f", missAfter-missBefore)
 	}
 	if freshHitAfter != freshHitBefore+1 {
 		t.Errorf("expected 1 fresh_hit, got delta %f", freshHitAfter-freshHitBefore)
+	}
+	if upstreamMissAfter != upstreamMissBefore+1 {
+		t.Errorf("expected 1 upstream miss, got delta %f", upstreamMissAfter-upstreamMissBefore)
 	}
 }
 
@@ -118,6 +130,8 @@ func TestProxy_RecordsRevalidatedCacheHitMetric(t *testing.T) {
 
 	hitBefore := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "revalidated_hit"))
 	missBefore := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
+	upstreamMissBefore := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
+	upstreamRevalidateBefore := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "304", "pulls", "revalidate"))
 
 	// First request: cache miss.
 	doGET()
@@ -127,12 +141,20 @@ func TestProxy_RecordsRevalidatedCacheHitMetric(t *testing.T) {
 
 	hitAfter := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "revalidated_hit"))
 	missAfter := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
+	upstreamMissAfter := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "pulls", "miss"))
+	upstreamRevalidateAfter := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "304", "pulls", "revalidate"))
 
 	if missAfter != missBefore+1 {
 		t.Errorf("expected 1 miss, got delta %f", missAfter-missBefore)
 	}
 	if hitAfter != hitBefore+1 {
 		t.Errorf("expected 1 hit, got delta %f", hitAfter-hitBefore)
+	}
+	if upstreamMissAfter != upstreamMissBefore+1 {
+		t.Errorf("expected 1 upstream miss, got delta %f", upstreamMissAfter-upstreamMissBefore)
+	}
+	if upstreamRevalidateAfter != upstreamRevalidateBefore+1 {
+		t.Errorf("expected 1 upstream revalidate, got delta %f", upstreamRevalidateAfter-upstreamRevalidateBefore)
 	}
 	if reqCount != 2 {
 		t.Errorf("expected 2 upstream requests, got %d", reqCount)
@@ -151,6 +173,7 @@ func TestProxy_RecordsNonGETSkipMetric(t *testing.T) {
 	defer proxyServer.Close()
 
 	before := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("POST", "201", "issues", "skip"))
+	upstreamBefore := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("POST", "201", "issues", "skip"))
 
 	req, _ := http.NewRequest("POST", proxyServer.URL+"/repos/owner/repo/issues", nil)
 	resp, err := http.DefaultClient.Do(req)
@@ -160,7 +183,83 @@ func TestProxy_RecordsNonGETSkipMetric(t *testing.T) {
 	resp.Body.Close()
 
 	after := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("POST", "201", "issues", "skip"))
+	upstreamAfter := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("POST", "201", "issues", "skip"))
 	if after != before+1 {
 		t.Errorf("expected non-GET skip counter to increment by 1, got delta %f", after-before)
+	}
+	if upstreamAfter != upstreamBefore+1 {
+		t.Errorf("expected upstream non-GET skip counter to increment by 1, got delta %f", upstreamAfter-upstreamBefore)
+	}
+}
+
+func TestProxy_RecordsSingleflightAsOneUpstreamRequest(t *testing.T) {
+	gate := make(chan struct{})
+	upstreamStarted := make(chan struct{})
+	var upstreamStartedOnce sync.Once
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamStartedOnce.Do(func() {
+			close(upstreamStarted)
+		})
+		<-gate
+		w.Header().Set("ETag", `"v1"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"number":1}]`))
+	}))
+	defer upstream.Close()
+
+	p := newProxy(upstream.URL, time.Minute, nil)
+	const concurrency = 5
+	releaseProxy := make(chan struct{})
+	var releaseProxyOnce sync.Once
+	var arrived atomic.Int32
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if arrived.Add(1) == concurrency {
+			releaseProxyOnce.Do(func() {
+				close(releaseProxy)
+			})
+		}
+		<-releaseProxy
+		p.ServeHTTP(w, r)
+	}))
+	defer proxyServer.Close()
+
+	proxiedMissBefore := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
+	proxiedFreshHitBefore := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "issues", "fresh_hit"))
+	upstreamBefore := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
+
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", proxyServer.URL+"/repos/owner/repo/issues", nil)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("request failed: %v", err)
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+
+	select {
+	case <-upstreamStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream request")
+	}
+	close(gate)
+	wg.Wait()
+
+	proxiedMissAfter := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
+	proxiedFreshHitAfter := testutil.ToFloat64(githubAPIRequestsTotal.WithLabelValues("GET", "200", "issues", "fresh_hit"))
+	upstreamAfter := testutil.ToFloat64(githubAPIUpstreamRequestsTotal.WithLabelValues("GET", "200", "issues", "miss"))
+
+	proxiedDelta := (proxiedMissAfter - proxiedMissBefore) + (proxiedFreshHitAfter - proxiedFreshHitBefore)
+	if proxiedDelta != concurrency {
+		t.Errorf("expected %d proxied requests across miss and fresh_hit, got delta %f", concurrency, proxiedDelta)
+	}
+	if upstreamAfter != upstreamBefore+1 {
+		t.Errorf("expected 1 upstream miss request, got delta %f", upstreamAfter-upstreamBefore)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a dedicated ghproxy metric for actual upstream GitHub API calls so dashboards can distinguish client-facing proxy traffic from real outbound requests when cache hits or singleflight coalescing are involved.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Existing `kelos_ghproxy_github_api_requests_total` remains request-facing.
- New `kelos_ghproxy_github_api_upstream_requests_total` counts actual outbound calls with `reason=miss|revalidate|skip`.
- Added tests covering cache miss, fresh hit, revalidation, non-GET, and singleflight coalescing.

#### Does this PR introduce a user-facing change?

```release-note
ghproxy now exposes `kelos_ghproxy_github_api_upstream_requests_total` to count actual upstream GitHub API calls separately from proxied request volume, including miss, revalidation, and non-GET passthrough paths.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new metric to track actual upstream GitHub API calls, separate from proxied traffic, and adds a stable singleflight test to verify one upstream request under concurrency.

- **New Features**
  - Exposes `kelos_ghproxy_github_api_upstream_requests_total` with labels: `method`, `status_code`, `resource`, `reason` (`miss|revalidate|skip`), using `status_code="error"` on failures.
  - Instruments GET misses and revalidations, non-GET passthroughs, and singleflight paths; classifies resources consistently; keeps `kelos_ghproxy_github_api_requests_total` unchanged.

- **Migration**
  - Update dashboards/alerts to use `kelos_ghproxy_github_api_upstream_requests_total` for actual GitHub API usage.

<sup>Written for commit ef9a61d1725e677078da6030215a091e8b5ecccf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

