### PR TITLE
Migrate self-development to webhook-based TaskSpawners

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -49,6 +49,30 @@ jobs:
           location: ${{ env.GKE_CLUSTER_LOCATION }}
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Apply github-webhook-secret
+        env:
+          KELOS_WEBHOOK_SECRET: ${{ secrets.KELOS_WEBHOOK_SECRET }}
+          KELOS_GITHUB_APP_ID: ${{ secrets.KELOS_GITHUB_APP_ID }}
+          KELOS_GITHUB_APP_INSTALLATION_ID: ${{ secrets.KELOS_GITHUB_APP_INSTALLATION_ID }}
+          KELOS_GITHUB_APP_PRIVATE_KEY: ${{ secrets.KELOS_GITHUB_APP_PRIVATE_KEY }}
+        run: |
+          # Apply the full github-webhook-secret from repo secrets so the
+          # workflow is self-sufficient and the secret state is portable to
+          # other clusters. Holds both the HMAC WEBHOOK_SECRET and the
+          # GitHub App credentials the webhook server uses to resolve
+          # .Branch for issue_comment events on pull requests.
+          KEY_FILE=$(mktemp)
+          trap 'rm -f "$KEY_FILE"' EXIT
+          printf '%s' "$KELOS_GITHUB_APP_PRIVATE_KEY" > "$KEY_FILE"
+          kubectl create secret generic github-webhook-secret \
+            --namespace kelos-system \
+            --from-literal=WEBHOOK_SECRET="$KELOS_WEBHOOK_SECRET" \
+            --from-literal=appID="$KELOS_GITHUB_APP_ID" \
+            --from-literal=installationID="$KELOS_GITHUB_APP_INSTALLATION_ID" \
+            --from-file=privateKey="$KEY_FILE" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f -
+
       - name: Install kelos
         run: |
           cat > /tmp/kelos-dev-values.yaml <<'EOF'
@@ -73,14 +97,33 @@ jobs:
               limits:
                 cpu: 500m
                 memory: 128Mi
+          # NOTE: webhookServer.gateway is intentionally left at chart default
+          # (disabled). The dev cluster already has a Gateway
+          # (kelos-webhook-gateway) and HTTPRoute (kelos-webhook-route) applied
+          # out of band — they use GKE CertMap via
+          # networking.gke.io/certmap annotation, which the chart's gateway
+          # template cannot express. Managing them via helm would fight the
+          # out-of-band config, so they stay manual.
+          webhookServer:
+            sources:
+              github:
+                enabled: true
+                secretName: github-webhook-secret
+                githubSecretName: github-webhook-secret
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
           EOF
           bin/kelos install -f /tmp/kelos-dev-values.yaml
           kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
           kubectl rollout status deployment/kelos-controller-manager -n kelos-system --timeout=120s
           kubectl rollout restart deployment -l kelos.dev/component=ghproxy -n "${KELOS_NAMESPACE}"
           kubectl rollout restart deployment -l kelos.dev/component=spawner -n "${KELOS_NAMESPACE}"
+          kubectl rollout restart deployment/kelos-webhook-github -n kelos-system
           kubectl rollout status deployment -l kelos.dev/component=ghproxy -n "${KELOS_NAMESPACE}" --timeout=120s
           kubectl rollout status deployment -l kelos.dev/component=spawner -n "${KELOS_NAMESPACE}" --timeout=120s
+          kubectl rollout status deployment/kelos-webhook-github -n kelos-system --timeout=120s
 
       - name: Apply PodMonitoring
         run: |
@@ -135,6 +178,23 @@ jobs:
               matchLabels:
                 kelos.dev/name: kelos
                 kelos.dev/component: ghproxy
+            endpoints:
+              - port: metrics
+                interval: 30s
+          ---
+          apiVersion: monitoring.googleapis.com/v1
+          kind: PodMonitoring
+          metadata:
+            name: kelos-webhook-github
+            namespace: kelos-system
+            labels:
+              app.kubernetes.io/name: kelos
+              app.kubernetes.io/component: webhook-github
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: kelos
+                app.kubernetes.io/component: webhook-github
             endpoints:
               - port: metrics
                 interval: 30s

--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -1,0 +1,106 @@
+package examples
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	sigyaml "sigs.k8s.io/yaml"
+
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+)
+
+func TestSelfDevelopmentGitHubSpawnersUseWebhooks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		file   string
+		events []string
+	}{
+		{file: "kelos-workers.yaml", events: []string{"issue_comment", "issues"}},
+		{file: "kelos-planner.yaml", events: []string{"issue_comment"}},
+		{file: "kelos-reviewer.yaml", events: []string{"issue_comment"}},
+		{file: "kelos-pr-responder.yaml", events: []string{"issue_comment", "pull_request_review"}},
+		{file: "kelos-squash-commits.yaml", events: []string{"issue_comment"}},
+		{file: "kelos-triage.yaml", events: []string{"issues"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			ts := readSelfDevelopmentTaskSpawner(t, tt.file)
+
+			if ts.Spec.When.GitHubWebhook == nil {
+				t.Fatalf("expected %s to use githubWebhook", tt.file)
+			}
+			if ts.Spec.When.GitHubIssues != nil {
+				t.Fatalf("expected %s to stop using githubIssues", tt.file)
+			}
+			if ts.Spec.When.GitHubPullRequests != nil {
+				t.Fatalf("expected %s to stop using githubPullRequests", tt.file)
+			}
+
+			if got := ts.Spec.When.GitHubWebhook.Repository; got != "kelos-dev/kelos" {
+				t.Fatalf("expected %s repository to be kelos-dev/kelos, got %q", tt.file, got)
+			}
+			if !reflect.DeepEqual(ts.Spec.When.GitHubWebhook.Events, tt.events) {
+				t.Fatalf("expected %s events %v, got %v", tt.file, tt.events, ts.Spec.When.GitHubWebhook.Events)
+			}
+			if len(ts.Spec.When.GitHubWebhook.Filters) == 0 {
+				t.Fatalf("expected %s to define webhook filters", tt.file)
+			}
+		})
+	}
+}
+
+func readSelfDevelopmentTaskSpawner(t *testing.T, file string) *kelosv1alpha1.TaskSpawner {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "self-development", file)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	reader := yamlutil.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	for {
+		doc, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading YAML document from %s: %v", path, err)
+		}
+
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		var meta struct {
+			Kind string `yaml:"kind"`
+		}
+		if err := sigyaml.Unmarshal(doc, &meta); err != nil {
+			t.Fatalf("decoding document metadata from %s: %v", path, err)
+		}
+		if meta.Kind != "TaskSpawner" {
+			continue
+		}
+
+		var ts kelosv1alpha1.TaskSpawner
+		if err := sigyaml.Unmarshal(doc, &ts); err != nil {
+			t.Fatalf("decoding TaskSpawner from %s: %v", path, err)
+		}
+		return &ts
+	}
+
+	t.Fatalf("no TaskSpawner found in %s", path)
+	return nil
+}

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -49,7 +49,27 @@ The token needs these permissions:
 - `repo` (full control of private repositories)
 - `workflow` (if your repo uses GitHub Actions)
 
-### 3. Agent Credentials Secret
+### 3. GitHub Webhook Secret and Delivery
+
+The issue and pull request TaskSpawners in this directory are webhook-driven.
+Create a secret with the shared webhook secret GitHub will use:
+
+```bash
+kubectl create secret generic github-webhook-secret \
+  --from-literal=WEBHOOK_SECRET=<your-github-webhook-secret>
+```
+
+Then:
+- Enable the GitHub webhook server in your Kelos deployment (see `examples/helm-values-webhook.yaml` or `examples/webhook-gateway-values.yaml`)
+- Expose `https://<your-domain>/webhook/github` over HTTPS
+- Configure a repository webhook that uses the same secret
+- Subscribe the repository webhook to `issues`, `issue_comment`, and `pull_request_review`
+
+Webhook TaskSpawners only react to **new** events after deployment. If an issue
+or PR was already in a matching state before the webhook server went live,
+retrigger it with a fresh comment or relabel after deployment.
+
+### 4. Agent Credentials Secret
 
 Create a secret with your AI agent credentials:
 
@@ -73,7 +93,7 @@ Picks up open GitHub issues labeled `actor/kelos` and creates autonomous agent t
 
 | | |
 |---|---|
-| **Trigger** | GitHub Issues with `actor/kelos` label |
+| **Trigger** | GitHub issue comment/label webhooks for issues labeled `actor/kelos` |
 | **Model** | Opus |
 | **Concurrency** | 3 |
 
@@ -95,7 +115,7 @@ Reacts to `/kelos plan` comments on open issues. Investigates the issue, inspect
 
 | | |
 |---|---|
-| **Trigger** | GitHub Issues with `/kelos plan` comment |
+| **Trigger** | GitHub `issue_comment` webhook with `/kelos plan` |
 | **Model** | Opus |
 | **Concurrency** | 2 |
 
@@ -103,13 +123,11 @@ Reacts to `/kelos plan` comments on open issues. Investigates the issue, inspect
 - Reads the issue body, all comments, linked issues/PRs, and relevant source code
 - Posts a single planning comment with: plan assessment, implementation steps, acceptance criteria, and open questions/risks
 - If the issue already contains a solid plan, normalizes it into a canonical step list instead of inventing a new one
-- Ends every response with `/kelos needs-input` to pause further automation
 - A later `/kelos plan` comment retriggers planning after more discussion or scope changes
 
 **Handoff flow:**
 1. `/kelos plan` — requests or refreshes an implementation plan
-2. `/kelos needs-input` — pauses further automation after planning
-3. `/kelos pick-up` — maintainer hands off to workers when ready
+2. `/kelos pick-up` — maintainer hands off to workers when ready
 
 **Deploy:**
 ```bash
@@ -122,7 +140,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review`.
 
 | | |
 |---|---|
-| **Trigger** | GitHub Pull Requests with `/kelos review` comment |
+| **Trigger** | GitHub PR comment webhook with `/kelos review` |
 | **Model** | Opus |
 | **Concurrency** | 3 |
 
@@ -136,8 +154,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review`.
 
 **Handoff flow:**
 1. `/kelos review` — requests a code review on the PR
-2. `/kelos needs-input` — pauses further automation after review is posted
-3. `/kelos review` — maintainer can retrigger review after changes are pushed
+2. `/kelos review` — maintainer can retrigger review after changes are pushed
 
 **Deploy:**
 ```bash
@@ -150,7 +167,7 @@ Picks up open GitHub pull requests labeled `generated-by-kelos` when a reviewer 
 
 | | |
 |---|---|
-| **Trigger** | GitHub Pull Requests with `generated-by-kelos` label and `changes requested` review state |
+| **Trigger** | GitHub PR review/comment webhooks on `generated-by-kelos` pull requests |
 | **Model** | Opus |
 | **Concurrency** | 2 |
 
@@ -158,8 +175,7 @@ Picks up open GitHub pull requests labeled `generated-by-kelos` when a reviewer 
 - Reuses the existing PR branch instead of starting over
 - Reads review comments and PR conversation before making incremental changes
 - Lets the maintainer stay on the PR page for the common review-feedback loop
-- Requires `/kelos pick-up` PR comment to be picked up
-- Uses `/kelos needs-input` PR comments to pause when human input is required
+- Requires `/kelos pick-up` PR comment or review body to be picked up
 
 **Deploy:**
 ```bash
@@ -172,7 +188,7 @@ Picks up open GitHub issues labeled `needs-actor` and performs automated triage.
 
 | | |
 |---|---|
-| **Trigger** | GitHub Issues with `needs-actor` label |
+| **Trigger** | GitHub issue opened/labeled/reopened webhooks with `needs-actor` |
 | **Model** | Opus |
 | **Concurrency** | 8 |
 
@@ -184,7 +200,7 @@ Picks up open GitHub issues labeled `needs-actor` and performs automated triage.
 5. Assesses priority (`priority/important-soon`, `priority/important-longterm`, `priority/backlog`)
 6. Recommends an actor — assigns `actor/kelos` if the issue has clear scope and verifiable criteria, otherwise assigns `actor/human`. `kind/api` issues always get `actor/human` and are **not** marked `triage-accepted`, because new user-facing APIs must be reviewed and discussed with a maintainer before any PR is opened.
 
-Posts a single triage comment with its findings, adds the `kelos/needs-input` label (to prevent re-triage), and posts a `/kelos needs-input` comment (to prevent workers from picking up the issue before maintainer review).
+Posts a single triage comment with its findings and adds the `kelos/needs-input` label to prevent re-triage.
 
 **Deploy:**
 ```bash
@@ -311,40 +327,48 @@ To adapt these examples for your own repository:
    - Change `spec.taskTemplate.workspaceRef.name` to match your Workspace resource
    - Or update the Workspace to point to your repository
 
-2. **Adjust the issue filters:**
+2. **Update the webhook repository and filters:**
    ```yaml
    spec:
      when:
-       githubIssues:
-         labels: [your-label]        # Issues to pick up
-         excludeLabels: [wontfix]    # Issues to skip
-         state: open                 # open, closed, or all
+       githubWebhook:
+         repository: your-org/your-repo
+         events: [issue_comment]
+         filters:
+           - event: issue_comment
+             action: created
+             bodyContains: /kelos pick-up
+             labels: [your-label]
+             state: open
    ```
 
 3. **Customize the prompt:**
    - Edit `spec.taskTemplate.promptTemplate` to match your workflow
    - Available template variables (Go `text/template` syntax):
 
-   | Variable | Description | GitHub Issues | Cron |
-   |----------|-------------|---------------|------|
+   | Variable | Description | GitHub Webhook | Cron |
+   |----------|-------------|----------------|------|
    | `{{.ID}}` | Unique identifier for the work item | Issue/PR number as string (e.g., `"42"`) | Date-time string (e.g., `"20260207-0900"`) |
    | `{{.Number}}` | Issue or PR number | Issue/PR number (e.g., `42`) | `0` |
    | `{{.Title}}` | Title of the work item | Issue/PR title | Trigger time (RFC3339) |
    | `{{.Body}}` | Body text of the work item | Issue/PR body | Empty |
    | `{{.URL}}` | URL to the source item | GitHub HTML URL | Empty |
-   | `{{.Labels}}` | Comma-separated labels | Issue/PR labels | Empty |
-   | `{{.Comments}}` | Concatenated comments | Issue/PR comments | Empty |
-   | `{{.Kind}}` | Type of work item | `"Issue"` or `"PR"` | `"Issue"` |
+   | `{{.Event}}` | GitHub webhook event type | `issue_comment`, `issues`, `pull_request_review`, etc. | Empty |
+   | `{{.Action}}` | GitHub webhook action | `created`, `labeled`, `submitted`, etc. | Empty |
+   | `{{.Sender}}` | GitHub username that triggered the webhook | GitHub login | Empty |
+   | `{{.Branch}}` | Branch name when present in the webhook payload | Usually PR head branch or push branch | Empty |
+   | `{{.Kind}}` | Type of work item | `"webhook"` | `"Issue"` |
    | `{{.Time}}` | Trigger time (RFC3339) | Empty | Cron tick time (e.g., `"2026-02-07T09:00:00Z"`) |
    | `{{.Schedule}}` | Cron schedule expression | Empty | Schedule string (e.g., `"0 * * * *"`) |
 
-4. **Set the polling interval** (per-source):
-   ```yaml
-   spec:
-     when:
-       githubIssues:
-         pollInterval: 5m  # How often to check for new issues
-   ```
+   The webhook-based self-development agents re-read the latest issue or PR
+   state with `gh` before acting, so they do not depend on aggregated
+   `{{.Comments}}`, `{{.ReviewComments}}`, or `{{.ReviewState}}` variables.
+
+4. **Remember the trigger is event-driven:**
+   - Webhook spawners do not poll or backfill old work items
+   - Retrigger an existing issue or PR with a fresh comment or relabel after deployment
+   - Duplicate a filter if you need to allow multiple specific GitHub usernames
 
 5. **Choose the right model:**
    ```yaml
@@ -355,21 +379,15 @@ To adapt these examples for your own repository:
 
 ## Feedback Loop Pattern
 
-The key pattern in these examples uses `triggerComment` and `excludeComments` to create an autonomous feedback loop:
+The key pattern in these examples is webhook-triggered handoff plus runtime re-validation:
 
-1. A maintainer posts a `/kelos pick-up` comment to approve an issue for agent work
-2. Agent picks up the issue, investigates, creates/updates a PR, and self-reviews
-3. If the agent needs human input, it posts a `/kelos needs-input` comment
-4. The maintainer can re-trigger the agent by posting the trigger comment again
+1. GitHub delivers an `issue_comment`, `issues`, or `pull_request_review` webhook
+2. The matching TaskSpawner creates a Task immediately from that event
+3. The agent re-reads the latest issue or PR state with `gh` before acting, so asynchronous label updates are respected
+4. If the agent needs human input, it posts a plain-English status comment describing what happened
+5. A fresh `/kelos pick-up`, `/kelos plan`, `/kelos review`, or relabel event retriggers automation later
 
-The planner uses the same pattern with a different trigger:
-
-1. A maintainer posts `/kelos plan` on an issue to request an implementation plan
-2. The planner investigates the issue and codebase, then posts a structured plan
-3. The plan comment ends with `/kelos needs-input`, pausing further automation
-4. A later `/kelos plan` comment retriggers planning after more discussion or scope changes
-
-This allows agents to work fully autonomously while keeping a maintainer approval gate, without requiring any external GitHub Actions or label management.
+Each run is a discrete webhook event, so no "pause" comment is needed to prevent re-pickup of stale state — the bot's own replies don't match the trigger substrings and cannot retrigger the spawner.
 
 ## Troubleshooting
 
@@ -377,7 +395,10 @@ This allows agents to work fully autonomously while keeping a maintainer approva
 - Check the TaskSpawner status: `kubectl get taskspawner <name> -o yaml`
 - Verify the Workspace exists: `kubectl get workspace`
 - Ensure credentials are correctly configured: `kubectl get secret kelos-credentials`
-- Check TaskSpawner logs: `kubectl logs deployment/kelos-controller-manager -n kelos-system`
+- Ensure the GitHub webhook server is enabled and the `github-webhook-secret` exists
+- Check webhook server logs: `kubectl logs -l app.kubernetes.io/component=webhook-github`
+- Review the repository webhook's recent deliveries in GitHub
+- If the issue or PR matched before you deployed the webhook server, retrigger it with a new comment or relabel
 
 **Tasks failing immediately:**
 - Verify the agent credentials are valid

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -26,18 +26,21 @@ metadata:
   name: kelos-planner
 spec:
   when:
-    githubIssues:
-      state: open
-      commentPolicy:
-        triggerComment: "/kelos plan"
-        excludeComments:
-          - "/kelos needs-input"
-        allowedUsers:
-          - gjkim42
-          - kelos-bot[bot]
-      reporting:
-        enabled: true
-      pollInterval: 1m
+    githubWebhook:
+      repository: kelos-dev/kelos
+      events:
+        - issue_comment
+      filters:
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos plan
+          state: open
+          author: gjkim42
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos plan
+          state: open
+          author: kelos-bot[bot]
   maxConcurrency: 2
   taskTemplate:
     workspaceRef:
@@ -69,15 +72,21 @@ spec:
       or change labels.
 
       ---
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
       Issue #{{.Number}}: {{.Title}}
       {{.Body}}
-      {{if .Comments}}
-      Comments:
-      {{.Comments}}
-      {{end}}
       ---
 
       ## Your tasks
+
+      ### 0. Confirm the target is an issue
+      If `gh pr view {{.Number}}` succeeds, this comment was posted on a pull request.
+      Exit without posting anything in that case.
 
       ### 1. Refresh issue context
       Re-read the latest issue state and all comments:
@@ -125,14 +134,11 @@ spec:
       ## Open Questions & Risks
 
       - <Question or risk, if any — or "None identified">
-
-      /kelos needs-input
       ```
 
       ## Rules
 
       - Do NOT open PRs, push code, or modify any files
       - Do NOT change labels or assignees
-      - Do NOT trigger other automation (except the `/kelos needs-input` line above)
+      - Do NOT trigger other automation
       - Post exactly one comment per run
-      - The comment MUST end with a standalone `/kelos needs-input` line

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -4,21 +4,33 @@ metadata:
   name: kelos-pr-responder
 spec:
   when:
-    githubPullRequests:
-      labels:
-        - generated-by-kelos
-      state: open
-      commentPolicy:
-        triggerComment: /kelos pick-up
-        excludeComments:
-          - /kelos needs-input
-        allowedUsers:
-          - gjkim42
-          - kelos-bot[bot]
-      draft: false
-      reporting:
-        enabled: true
-      pollInterval: 1m
+    githubWebhook:
+      repository: kelos-dev/kelos
+      events:
+        - issue_comment
+        - pull_request_review
+      filters:
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos pick-up
+          labels:
+            - generated-by-kelos
+          state: open
+          author: gjkim42
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos pick-up
+          labels:
+            - generated-by-kelos
+          state: open
+          author: kelos-bot[bot]
+        - event: pull_request_review
+          action: submitted
+          bodyContains: /kelos pick-up
+          labels:
+            - generated-by-kelos
+          state: open
+          draft: false
   maxConcurrency: 2
   taskTemplate:
     workspaceRef:
@@ -55,23 +67,18 @@ spec:
     promptTemplate: |
       You are a coding agent updating an existing PR in response to review feedback.
 
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
       Pull request:
       - PR #{{.Number}}: {{.Title}}
       - URL: {{.URL}}
-      - Branch: {{.Branch}}
-      - Review state: {{.ReviewState}}
-
-      {{if .ReviewComments}}
-      Inline review comments:
-      {{.ReviewComments}}
-      {{end}}
-      {{if .Comments}}
-      PR conversation:
-      {{.Comments}}
-      {{end}}
 
       Task:
-      - 0. Set up your working branch. Kelos has already checked out {{.Branch}} for you. Run this exactly:
+      - 1. Kelos has already checked out the PR head branch. Rebase onto main before making changes:
         ```
         git fetch --unshallow || true
         if git remote get-url upstream >/dev/null 2>&1; then
@@ -82,16 +89,16 @@ spec:
           git rebase origin/main
         fi
         ```
-      - 1. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments). If `KELOS_UPSTREAM_REPO` is set, use it with `gh pr ... --repo "$KELOS_UPSTREAM_REPO"` and target that repo in `gh api`.
-      - 2. Read ALL comments on the linked issue referenced by the PR body. First determine the linked issue number from the PR body, then run `gh issue view <linked-issue-number> --comments`. If `KELOS_UPSTREAM_REPO` is set, use `--repo "$KELOS_UPSTREAM_REPO"`.
-      - 3. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
-      - 4. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work.
-      - 5. Commit and push your changes to origin {{.Branch}}.
-      - 6. /review the PR to verify your changes address the feedback. If changes are needed, make them, run `make verify` and `make test`, commit and push, then /review again. Repeat until the review passes.
-      - 7. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #123` or `Closes #123`). Do not embed the issue number in natural language. Ensure the PR has labels "generated-by-kelos" and "ok-to-test" (use `gh pr edit {{.Number}} --add-label generated-by-kelos --add-label ok-to-test` if missing). If `KELOS_UPSTREAM_REPO` is set, include `--repo "$KELOS_UPSTREAM_REPO"`.
-      - 8. After pushing, actively check CI status with `gh pr checks {{.Number}}` (if `KELOS_UPSTREAM_REPO` is set, add `--repo "$KELOS_UPSTREAM_REPO"`). If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
+      - 2. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments). If `KELOS_UPSTREAM_REPO` is set, use it with `gh pr ... --repo "$KELOS_UPSTREAM_REPO"` and target that repo in `gh api`.
+      - 3. Read ALL comments on the linked issue referenced by the PR body. First determine the linked issue number from the PR body, then run `gh issue view <linked-issue-number> --comments`. If `KELOS_UPSTREAM_REPO` is set, use `--repo "$KELOS_UPSTREAM_REPO"`.
+      - 4. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
+      - 5. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work. If there is nothing actionable to change, exit without code changes or comments.
+      - 6. Commit and push your changes to origin on the PR head branch (use `git push origin HEAD`).
+      - 7. /review the PR to verify your changes address the feedback. If changes are needed, make them, run `make verify` and `make test`, commit and push, then /review again. Repeat until the review passes.
+      - 8. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #123` or `Closes #123`). Do not embed the issue number in natural language. Ensure the PR has labels "generated-by-kelos" and "ok-to-test" (use `gh pr edit {{.Number}} --add-label generated-by-kelos --add-label ok-to-test` if missing). If `KELOS_UPSTREAM_REPO` is set, include `--repo "$KELOS_UPSTREAM_REPO"`.
+      - 9. After pushing, actively check CI status with `gh pr checks {{.Number}}` (if `KELOS_UPSTREAM_REPO` is set, add `--repo "$KELOS_UPSTREAM_REPO"`). If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
 
       Post-checklist:
-      - If the PR is ready for human review, you need more information, or you cannot make progress, post a PR comment whose first line is `/kelos needs-input` and explain why below it. Maintainers can resume the PR later with `/kelos pick-up`. When all review feedback was already addressed in previous commits and no new comments require action, keep the explanation brief (e.g. "All review feedback was addressed in previous commits. Ready for re-review.") instead of repeating a full status breakdown. Never post duplicate or near-identical status messages.
+      - If the PR is ready for human review, you need more information, or you cannot make progress, post a plain-English PR comment explaining the current state. Maintainers can resume the PR later with `/kelos pick-up`. When all review feedback was already addressed in previous commits and no new comments require action, keep the explanation brief (e.g. "All review feedback was addressed in previous commits. Ready for re-review.") instead of repeating a full status breakdown. Never post duplicate or near-identical status messages.
       - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
         - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -35,19 +35,21 @@ metadata:
   name: kelos-reviewer
 spec:
   when:
-    githubPullRequests:
-      state: open
-      commentPolicy:
-        triggerComment: /kelos review
-        excludeComments:
-          - /kelos needs-input
-        allowedUsers:
-          - gjkim42
-          - kelos-bot[bot]
-      draft: false
-      reporting:
-        enabled: true
-      pollInterval: 1m
+    githubWebhook:
+      repository: kelos-dev/kelos
+      events:
+        - issue_comment
+      filters:
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos review
+          state: open
+          author: gjkim42
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos review
+          state: open
+          author: kelos-bot[bot]
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:
@@ -79,39 +81,38 @@ spec:
       using `gh pr review`. You do NOT write code, push changes, or modify any files.
 
       ---
-      PR #{{.Number}}: {{.Title}}
-      URL: {{.URL}}
-      Branch: {{.Branch}}
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
 
+      PR #{{.Number}}: {{.Title}}
       {{.Body}}
-      {{if .Comments}}
-      PR conversation:
-      {{.Comments}}
-      {{end}}
       ---
 
       ## Your tasks
 
-      ### 0. Set up full history
-      Run this before reviewing:
+      ### 1. Set up full history
+      Kelos has already checked out the PR head branch. Fetch full history before reviewing:
         ```
         git fetch --unshallow || true
         git fetch origin main
         ```
 
-      ### 1. Understand the context
+      ### 2. Understand the context
       - Read the PR description and all comments: `gh pr view {{.Number}} --comments`
       - If the PR references an issue, read the issue and its comments:
         `gh issue view <issue-number> --comments`
       - Understand the motivation and scope of the change
 
-      ### 2. Review the diff
+      ### 3. Review the diff
       Review the code:
       - Read the full diff: `git diff origin/main...HEAD`
       - For each changed file, read the surrounding context to understand how the
         changes fit into the existing codebase
 
-      ### 3. Check the following areas
+      ### 4. Check the following areas
 
       **Correctness**:
       - Does the code do what the PR/issue describes?
@@ -141,7 +142,7 @@ spec:
       - Changes are minimal and focused — no unrelated refactoring
       - Naming is clear and consistent with the codebase
 
-      ### 4. Submit the review
+      ### 5. Submit the review
       Submit a review using `gh pr review {{.Number}}`:
 
       - If the PR looks good with no or only minor nits:
@@ -168,8 +169,6 @@ spec:
 
       ## Suggestions (optional)
       - <Non-blocking improvement ideas>
-
-      /kelos needs-input
       ```
 
       For inline comments on specific lines, use:
@@ -185,7 +184,6 @@ spec:
       - Do NOT merge or close the PR
       - Do NOT change labels
       - Submit exactly one review per run
-      - The review body MUST end with a standalone `/kelos needs-input` line
       - Be specific: reference file paths and line numbers
       - Be constructive: explain why something is a problem and suggest a fix
       - Distinguish between blocking issues (request changes) and optional nits (approve with comments)

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -82,7 +82,7 @@ spec:
 
       2. **Configuration Alignment**
          - Check that resource requests/limits, models, TTLs, and other settings are appropriate
-         - Verify that labels, excludeLabels, and filters are correct and consistent
+         - Verify that webhook repositories, events, labels, excludeLabels, and filters are correct and consistent
          - Ensure AgentConfig instructions in `agentconfig.yaml` match the project's current conventions in `CLAUDE.md`
          - Look for inconsistencies between TaskSpawners that should share the same configuration
 

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -4,18 +4,16 @@ metadata:
   name: kelos-squash-commits
 spec:
   when:
-    githubPullRequests:
-      state: open
-      commentPolicy:
-        triggerComment: /kelos squash-commits
-        excludeComments:
-          - /kelos squash-commits-done
-        allowedUsers:
-          - gjkim42
-          - kelos-bot[bot]
-      reporting:
-        enabled: true
-      pollInterval: 1m
+    githubWebhook:
+      repository: kelos-dev/kelos
+      events:
+        - issue_comment
+      filters:
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos squash-commits
+          state: open
+          author: gjkim42
   maxConcurrency: 1
   taskTemplate:
     workspaceRef:
@@ -50,12 +48,17 @@ spec:
     promptTemplate: |
       You are a coding agent. Your only task is to rebase and squash commits on a PR branch.
 
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
       Pull request:
       - PR #{{.Number}}: {{.Title}}
-      - Branch: {{.Branch}}
 
       Steps:
-      1. Fetch full history:
+      1. Kelos has already checked out the PR head branch. Fetch full history:
          ```
          git fetch --unshallow || true
          git fetch origin main
@@ -81,7 +84,7 @@ spec:
 
       5. Force push the result:
          ```
-         git push --force-with-lease origin {{.Branch}}
+         git push --force-with-lease origin HEAD
          ```
 
       6. Update the PR description if needed:
@@ -92,7 +95,7 @@ spec:
          - Extract the linked issue number from the PR body (look for `Closes #N`, `Fixes #N`, etc.)
          - Run: `gh issue edit <issue-number> --add-label kelos/needs-input`
 
-      8. Post a comment on PR #{{.Number}} whose first line is `/kelos squash-commits-done` to signal completion.
+      8. Post a comment on PR #{{.Number}} whose first line is `Squash complete.` to signal completion.
 
       Important:
       - Do NOT start any new development work

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -4,17 +4,32 @@ metadata:
   name: kelos-triage
 spec:
   when:
-    githubIssues:
-      types:
+    githubWebhook:
+      repository: kelos-dev/kelos
+      events:
         - issues
-      state: open
-      labels:
-        - needs-actor
-      excludeLabels:
-        - triage-accepted
-      reporting:
-        enabled: true
-      pollInterval: 1m
+      filters:
+        - event: issues
+          action: opened
+          labels:
+            - needs-actor
+          excludeLabels:
+            - triage-accepted
+          state: open
+        - event: issues
+          action: labeled
+          labels:
+            - needs-actor
+          excludeLabels:
+            - triage-accepted
+          state: open
+        - event: issues
+          action: reopened
+          labels:
+            - needs-actor
+          excludeLabels:
+            - triage-accepted
+          state: open
   maxConcurrency: 8
   taskTemplate:
     workspaceRef:
@@ -45,12 +60,14 @@ spec:
       assess priority, recommend an actor, and post a single triage comment using `gh`.
 
       ---
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
       Issue #{{.Number}}: {{.Title}}
       {{.Body}}
-      {{if .Comments}}
-      Comments:
-      {{.Comments}}
-      {{end}}
       ---
 
       ## Your tasks

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -36,24 +36,36 @@ metadata:
   name: kelos-workers
 spec:
   when:
-    githubIssues:
-      labels:
-        - actor/kelos
-      commentPolicy:
-        triggerComment: "/kelos pick-up"
-        excludeComments:
-          - "/kelos needs-input"
-        allowedUsers:
-          - gjkim42
-          - kelos-bot[bot]
-      reporting:
-        enabled: true
-      priorityLabels:
-        - priority/critical-urgent
-        - priority/important-soon
-        - priority/important-longterm
-        - priority/backlog
-      pollInterval: 1m
+    githubWebhook:
+      repository: kelos-dev/kelos
+      events:
+        - issue_comment
+        - issues
+      filters:
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos pick-up
+          labels:
+            - actor/kelos
+          state: open
+          author: gjkim42
+        - event: issue_comment
+          action: created
+          bodyContains: /kelos pick-up
+          labels:
+            - actor/kelos
+          state: open
+          author: kelos-bot[bot]
+        - event: issues
+          action: labeled
+          labels:
+            - actor/kelos
+          state: open
+        - event: issues
+          action: reopened
+          labels:
+            - actor/kelos
+          state: open
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:
@@ -93,39 +105,48 @@ spec:
       - update an existing PR to fix the issue
       - comment on the issue or the PR if you cannot fix it
 
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
       Task:
-      - 0. Set up your working branch. Run this exactly:
+      - 0. Refresh the latest issue state:
+        - Re-read the issue and all comments: `gh issue view {{.Number}} --comments`
+        - If `gh pr view {{.Number}}` succeeds, this webhook came from a pull request comment. Exit without doing any work.
+      - 1. Set up your working branch. Run this exactly:
         ```
         git fetch --unshallow || true; git fetch origin main; git rebase origin/main
         ```
-      - 1. Check if a PR already exists for branch kelos-task-{{.Number}}.
+      - 2. Check if a PR already exists for branch kelos-task-{{.Number}}.
 
       If a PR already exists:
-      - 2a. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments).
+      - 3a. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments).
         - Also read ALL comments on the linked issue (gh issue view {{.Number}} --comments), not just the PR.
-      - 3a. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
-      - 4a. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work.
-      - 5a. Commit and push your changes to origin kelos-task-{{.Number}}.
-      - 6a. /review the PR to verify your changes address the feedback. If changes are needed, make them, run `make verify` and `make test`, commit and push, then /review again. Repeat until the review passes.
-      - 7a. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #{{.Number}}` or `Closes #{{.Number}}`). Do not embed the issue number in natural language. Ensure the PR has labels "generated-by-kelos" and "ok-to-test" (use `gh pr edit {{.Number}} --add-label generated-by-kelos --add-label ok-to-test` if missing).
-      - 8a. After pushing, actively check CI status with `gh pr checks`. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
+      - 4a. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
+      - 5a. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work.
+      - 6a. Commit and push your changes to origin kelos-task-{{.Number}}.
+      - 7a. /review the PR to verify your changes address the feedback. If changes are needed, make them, run `make verify` and `make test`, commit and push, then /review again. Repeat until the review passes.
+      - 8a. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #{{.Number}}` or `Closes #{{.Number}}`). Do not embed the issue number in natural language. Ensure the PR has labels "generated-by-kelos" and "ok-to-test" (use `gh pr edit kelos-task-{{.Number}} --add-label generated-by-kelos --add-label ok-to-test` if missing).
+      - 9a. After pushing, actively check CI status with `gh pr checks`. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
 
       If no PR exists:
-      - 2b. Investigate the issue #{{.Number}}.
+      - 3b. Investigate the issue #{{.Number}}.
         - Read ALL comments on the issue (gh issue view {{.Number}} --comments), including maintainer feedback and linked issues/PRs.
         - If previous PRs for this issue were closed, read their reviews to understand why before choosing your approach.
         - Search the codebase for existing constants, types, and patterns before creating new ones. Do not duplicate definitions.
         - Only implement what the issue explicitly asks for. If you discover related improvements, create separate issues for them.
-      - 3b. Create a commit that fixes the issue.
-      - 4b. Push your branch to origin kelos-task-{{.Number}}.
-      - 5b. Create a PR with labels "generated-by-kelos" and "ok-to-test" (use `gh pr create --label generated-by-kelos --label ok-to-test`), then /review it. If changes are needed, make them, run `make verify` and `make test`, commit and push, then /review again. Repeat until the review passes.
-      - 6b. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #{{.Number}}` or `Closes #{{.Number}}`). Do not embed the issue number in natural language.
-      - 7b. After pushing, actively check CI status with `gh pr checks`. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
+      - 4b. Create a commit that fixes the issue.
+      - 5b. Push your branch to origin kelos-task-{{.Number}}.
+      - 6b. Create a PR with labels "generated-by-kelos" and "ok-to-test" (use `gh pr create --label generated-by-kelos --label ok-to-test`), then /review it. If changes are needed, make them, run `make verify` and `make test`, commit and push, then /review again. Repeat until the review passes.
+      - 7b. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #{{.Number}}` or `Closes #{{.Number}}`). Do not embed the issue number in natural language.
+      - 8b. After pushing, actively check CI status with `gh pr checks`. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
 
       Post-checklist:
-      - Post a `/kelos needs-input` comment on the issue (gh issue comment {{.Number}} --body "/kelos needs-input") and leave a comment for the reason if any of the following applies:
-        - The PR is ready for review, please take a look.
-        - Commented on the issue or the PR for more information.
+      - Post a plain-English status comment on the issue (`gh issue comment {{.Number}} --body "..."`) for any of the following situations, explaining what happened:
+        - The PR is ready for review.
+        - You commented on the issue or the PR for more information.
         - You cannot make any progress on the issue, explain why.
       - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
         - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

#### What this PR does / why we need it:

Two commits on top of `main`:

1. **Deploy GitHub webhook server in dev environment** (`.github/workflows/deploy-dev.yaml`) — enable `webhookServer.sources.github` via the new `kelos install -f` helm values flow so the webhook-based self-development TaskSpawners have a delivery endpoint in the dev cluster. A new preceding workflow step renders the full `github-webhook-secret` (HMAC `WEBHOOK_SECRET` + GitHub App `appID` / `installationID` / `privateKey`) from repo secrets and applies it via `kubectl apply -f -`, so the deploy is portable to another cluster without any pre-existing in-cluster secret. `githubSecretName` points at the same consolidated secret. Adds rollout restart + PodMonitoring for the `kelos-webhook-github` Deployment.

2. **Migrate self-development spawners to GitHub webhooks** (`self-development/*.yaml`, `self-development/README.md`, `internal/examples/self_development_test.go`) — replace the `githubIssues` / `githubPullRequests` polling sources in `kelos-workers`, `kelos-planner`, `kelos-reviewer`, `kelos-pr-responder`, `kelos-squash-commits`, and `kelos-triage` with `githubWebhook`. Cron-based spawners (fake-user, fake-strategist, config-update, self-update, image-update) are unchanged.

   Key design choices in the migration:
   - Lean on the webhook filter for state/label/draft gating instead of duplicating those checks in the prompts.
   - Drop the `/kelos needs-input` control command from the worker, planner, reviewer, and pr-responder prompts. It was a polling-era workaround to prevent re-pickup of stale state; webhook deliveries are discrete events and the bot's own replies don't match the trigger substrings, so the pause signal has no functional role. The `kelos/needs-input` label used by triage is a separate re-triage gate and stays.
   - Set `taskTemplate.branch: "{{.Branch}}"` on reviewer, pr-responder, and squash-commits so kelos checks out the real PR head and TaskReconciler can serialize concurrent writers via `task.spec.branch`.
   - `kelos-pr-responder` triggers on both `issue_comment` (with `/kelos pick-up`) and `pull_request_review` (submitted with `/kelos pick-up` in the review body) so a human review-change request that includes the trigger phrase resumes the loop.
   - `kelos-squash-commits` changes its completion marker to `Squash complete.` so the bot's own comment can't re-match the `/kelos squash-commits` trigger substring. The bot is also removed from the author filter as defense in depth.

   Adds `internal/examples/self_development_test.go` as a regression test that fails CI if any migrated spawner reverts to polling or drops the expected event/filter configuration.

#### Which issue(s) this PR is related to:

N/A

Related but not fixed in this PR:
- #963 — self-development README is missing setup for GitHub App credentials inside the webhook secret. The deploy-dev workflow handles this via repo secrets, but users deploying manually still need docs.
- #964 — webhook server conditionally omits `.Branch` from template vars, breaking task creation with `missingkey=error`. Upstream fix required for the `branch: "{{.Branch}}"` idiom to work on fresh clusters without GitHub App credentials configured.

#### Special notes for your reviewer:

- Existing matching issues and PRs will not backfill after deploy. They need a fresh `/kelos pick-up`, `/kelos plan`, `/kelos review`, or relabel event to retrigger.
- The workflow depends on four new repository secrets: `KELOS_WEBHOOK_SECRET`, `KELOS_GITHUB_APP_ID`, `KELOS_GITHUB_APP_INSTALLATION_ID`, `KELOS_GITHUB_APP_PRIVATE_KEY`. These must be set before the next `deploy-dev` run.
- `webhookServer.gateway` is intentionally left at chart default. The dev cluster already has a Gateway (`kelos-webhook-gateway`) and HTTPRoute (`kelos-webhook-route`) applied out of band that rely on GKE Certificate Manager via the `networking.gke.io/certmap` annotation with no inline `tls.certificateRefs`, which the chart's gateway template cannot express. Managing them via helm would fight the working out-of-band config. There's a pointer comment in the values block to this effect.
- `task.spec.branch` is TaskReconciler's per-branch writer lock, which is why all PR-scoped spawners use `{{.Branch}}` rather than a synthetic name — concurrent spawners targeting the same PR head must share the lock.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
