### PR TITLE
fix: populate Branch for issue_comment webhook events on pull requests

### DIFF
--- a/internal/manifests/charts/kelos/templates/webhook-server.yaml
+++ b/internal/manifests/charts/kelos/templates/webhook-server.yaml
@@ -40,6 +40,32 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.webhookServer.sources.github.secretName }}
                   key: WEBHOOK_SECRET
+            {{- if .Values.webhookServer.sources.github.githubSecretName }}
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.webhookServer.sources.github.githubSecretName }}
+                  key: GITHUB_TOKEN
+                  optional: true
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.webhookServer.sources.github.githubSecretName }}
+                  key: appID
+                  optional: true
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.webhookServer.sources.github.githubSecretName }}
+                  key: installationID
+                  optional: true
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.webhookServer.sources.github.githubSecretName }}
+                  key: privateKey
+                  optional: true
+            {{- end }}
           ports:
             - name: webhook
               containerPort: 8443

--- a/internal/manifests/charts/kelos/values.yaml
+++ b/internal/manifests/charts/kelos/values.yaml
@@ -43,6 +43,7 @@ webhookServer:
       enabled: false
       replicas: 1
       secretName: ""
+      githubSecretName: ""
     linear:
       enabled: false
       replicas: 1

--- a/internal/webhook/github_api.go
+++ b/internal/webhook/github_api.go
@@ -1,0 +1,167 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/kelos-dev/kelos/internal/githubapp"
+)
+
+const (
+	githubTokenEnvVar          = "GITHUB_TOKEN"
+	githubAppIDEnvVar          = "GITHUB_APP_ID"
+	githubInstallationIDEnvVar = "GITHUB_APP_INSTALLATION_ID"
+	githubPrivateKeyEnvVar     = "GITHUB_APP_PRIVATE_KEY"
+)
+
+// githubHTTPClient is used for all GitHub API requests, with a reasonable
+// timeout to avoid blocking webhook processing if the API is unresponsive.
+var githubHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// githubPRBranchFetcher is the function used to fetch a PR's head branch from
+// the GitHub API. It is a package-level variable so tests can swap in a stub.
+var githubPRBranchFetcher = fetchGitHubPRBranch
+
+// githubTokenProvider resolves a GitHub API token from the environment. It
+// supports both a static GITHUB_TOKEN (PAT) and GitHub App credentials. When
+// App credentials are configured, installation tokens are cached and
+// automatically refreshed before expiry.
+var githubTokenProvider = &tokenProvider{}
+
+// githubPRResponse is the minimal structure needed to extract the head branch
+// from a GitHub pull request API response.
+type githubPRResponse struct {
+	Head struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+}
+
+// tokenProvider resolves GitHub API tokens. It prefers a static GITHUB_TOKEN
+// but falls back to GitHub App installation tokens when App credentials are
+// present. Installation tokens are cached with a safety margin before expiry.
+type tokenProvider struct {
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+// Token returns a valid GitHub API token, or "" if no credentials are configured.
+func (tp *tokenProvider) Token(ctx context.Context) (string, error) {
+	// Fast path: static PAT
+	if pat := os.Getenv(githubTokenEnvVar); pat != "" {
+		return pat, nil
+	}
+
+	// Check for GitHub App credentials
+	appID := os.Getenv(githubAppIDEnvVar)
+	installID := os.Getenv(githubInstallationIDEnvVar)
+	privateKey := os.Getenv(githubPrivateKeyEnvVar)
+	if appID == "" || installID == "" || privateKey == "" {
+		return "", nil
+	}
+
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	// Return cached token if still valid (with 5-minute safety margin)
+	if tp.token != "" && time.Now().Add(5*time.Minute).Before(tp.expiresAt) {
+		return tp.token, nil
+	}
+
+	// Generate a new installation token
+	creds, err := githubapp.ParseCredentials(map[string][]byte{
+		"appID":          []byte(appID),
+		"installationID": []byte(installID),
+		"privateKey":     []byte(privateKey),
+	})
+	if err != nil {
+		return "", fmt.Errorf("parsing GitHub App credentials: %w", err)
+	}
+
+	tc := githubapp.NewTokenClient()
+	resp, err := tc.GenerateInstallationToken(ctx, creds)
+	if err != nil {
+		return "", fmt.Errorf("generating GitHub App installation token: %w", err)
+	}
+
+	tp.token = resp.Token
+	tp.expiresAt = resp.ExpiresAt
+	return tp.token, nil
+}
+
+// fetchGitHubPRBranch fetches the head branch for a pull request using the
+// GitHub REST API. It resolves the token via the token provider, which supports
+// both GITHUB_TOKEN (PAT) and GitHub App credentials.
+// Returns ("", nil) if no credentials are configured, allowing callers to fall
+// back gracefully.
+func fetchGitHubPRBranch(ctx context.Context, prAPIURL string) (string, error) {
+	token, err := githubTokenProvider.Token(ctx)
+	if err != nil {
+		return "", err
+	}
+	return fetchGitHubPRBranchWithToken(ctx, prAPIURL, token)
+}
+
+// fetchGitHubPRBranchWithToken is the testable core of fetchGitHubPRBranch.
+// It accepts the token explicitly.
+func fetchGitHubPRBranchWithToken(ctx context.Context, prAPIURL, token string) (string, error) {
+	if token == "" {
+		return "", nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, prAPIURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating GitHub API request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := githubHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling GitHub API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var pr githubPRResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return "", fmt.Errorf("decoding GitHub API response: %w", err)
+	}
+
+	return pr.Head.Ref, nil
+}
+
+// enrichGitHubIssueCommentBranch fetches the PR's head branch from the GitHub
+// API and sets it on the event data. This is called lazily for issue_comment
+// events on pull requests, since GitHub does not include the PR's head ref in
+// the issue_comment webhook payload.
+func enrichGitHubIssueCommentBranch(ctx context.Context, log logr.Logger, eventData *GitHubEventData) {
+	if eventData.PullRequestAPIURL == "" {
+		return
+	}
+
+	branch, err := githubPRBranchFetcher(ctx, eventData.PullRequestAPIURL)
+	if err != nil {
+		log.Error(err, "Failed to fetch PR branch for issue_comment event", "prAPIURL", eventData.PullRequestAPIURL)
+		return
+	}
+	if branch == "" {
+		log.Info("No GitHub credentials configured, cannot enrich issue_comment event with PR branch")
+		return
+	}
+
+	log.Info("Enriched issue_comment event with PR branch", "branch", branch)
+	eventData.Branch = branch
+}

--- a/internal/webhook/github_api_test.go
+++ b/internal/webhook/github_api_test.go
@@ -1,0 +1,189 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestFetchGitHubPRBranchWithToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   interface{}
+		wantBranch string
+		wantErr    bool
+	}{
+		{
+			name:       "successful fetch",
+			statusCode: http.StatusOK,
+			response: map[string]interface{}{
+				"head": map[string]interface{}{
+					"ref": "feature-branch",
+				},
+			},
+			wantBranch: "feature-branch",
+		},
+		{
+			name:       "API error",
+			statusCode: http.StatusNotFound,
+			response:   map[string]string{"message": "Not Found"},
+			wantErr:    true,
+		},
+		{
+			name:       "empty head ref",
+			statusCode: http.StatusOK,
+			response: map[string]interface{}{
+				"head": map[string]interface{}{
+					"ref": "",
+				},
+			},
+			wantBranch: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") != "Bearer test-token" {
+					t.Errorf("Expected Authorization header 'Bearer test-token', got %q", r.Header.Get("Authorization"))
+				}
+				if r.Header.Get("Accept") != "application/vnd.github+json" {
+					t.Errorf("Expected Accept header 'application/vnd.github+json', got %q", r.Header.Get("Accept"))
+				}
+				w.WriteHeader(tt.statusCode)
+				json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			branch, err := fetchGitHubPRBranchWithToken(context.Background(), server.URL, "test-token")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fetchGitHubPRBranchWithToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if branch != tt.wantBranch {
+				t.Errorf("fetchGitHubPRBranchWithToken() = %q, want %q", branch, tt.wantBranch)
+			}
+		})
+	}
+}
+
+func TestFetchGitHubPRBranchWithToken_EmptyToken(t *testing.T) {
+	branch, err := fetchGitHubPRBranchWithToken(context.Background(), "http://unused", "")
+	if err != nil {
+		t.Errorf("Expected no error for empty token, got %v", err)
+	}
+	if branch != "" {
+		t.Errorf("Expected empty branch for empty token, got %q", branch)
+	}
+}
+
+func TestTokenProvider_PATPreferred(t *testing.T) {
+	t.Setenv(githubTokenEnvVar, "ghp_my_pat_token")
+	// Also set App vars to prove PAT takes precedence
+	t.Setenv(githubAppIDEnvVar, "12345")
+	t.Setenv(githubInstallationIDEnvVar, "67890")
+	t.Setenv(githubPrivateKeyEnvVar, "fake-key")
+
+	tp := &tokenProvider{}
+	token, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "ghp_my_pat_token" {
+		t.Errorf("Token() = %q, want %q", token, "ghp_my_pat_token")
+	}
+}
+
+func TestTokenProvider_NoCredentials(t *testing.T) {
+	// Ensure no env vars are set
+	t.Setenv(githubTokenEnvVar, "")
+	t.Setenv(githubAppIDEnvVar, "")
+	t.Setenv(githubInstallationIDEnvVar, "")
+	t.Setenv(githubPrivateKeyEnvVar, "")
+
+	tp := &tokenProvider{}
+	token, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "" {
+		t.Errorf("Token() = %q, want empty", token)
+	}
+}
+
+func TestTokenProvider_PartialAppCredentials(t *testing.T) {
+	// Only set some app vars — should return empty, not error
+	t.Setenv(githubTokenEnvVar, "")
+	t.Setenv(githubAppIDEnvVar, "12345")
+	t.Setenv(githubInstallationIDEnvVar, "")
+	t.Setenv(githubPrivateKeyEnvVar, "")
+
+	tp := &tokenProvider{}
+	token, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "" {
+		t.Errorf("Token() = %q, want empty for partial credentials", token)
+	}
+}
+
+func TestEnrichGitHubIssueCommentBranch(t *testing.T) {
+	// Swap in a stub fetcher
+	orig := githubPRBranchFetcher
+	defer func() { githubPRBranchFetcher = orig }()
+
+	t.Run("enriches branch from API", func(t *testing.T) {
+		githubPRBranchFetcher = func(ctx context.Context, prAPIURL string) (string, error) {
+			if prAPIURL != "https://api.github.com/repos/org/repo/pulls/42" {
+				t.Errorf("Unexpected prAPIURL: %s", prAPIURL)
+			}
+			return "my-feature-branch", nil
+		}
+
+		eventData := &GitHubEventData{
+			PullRequestAPIURL: "https://api.github.com/repos/org/repo/pulls/42",
+		}
+
+		enrichGitHubIssueCommentBranch(context.Background(), logr.Discard(), eventData)
+
+		if eventData.Branch != "my-feature-branch" {
+			t.Errorf("Expected Branch = %q, got %q", "my-feature-branch", eventData.Branch)
+		}
+	})
+
+	t.Run("no-op when PullRequestAPIURL is empty", func(t *testing.T) {
+		githubPRBranchFetcher = func(ctx context.Context, prAPIURL string) (string, error) {
+			t.Error("Fetcher should not be called when PullRequestAPIURL is empty")
+			return "", nil
+		}
+
+		eventData := &GitHubEventData{}
+		enrichGitHubIssueCommentBranch(context.Background(), logr.Discard(), eventData)
+
+		if eventData.Branch != "" {
+			t.Errorf("Expected empty Branch, got %q", eventData.Branch)
+		}
+	})
+
+	t.Run("handles no credentials gracefully", func(t *testing.T) {
+		githubPRBranchFetcher = func(ctx context.Context, prAPIURL string) (string, error) {
+			return "", nil // simulates no credentials configured
+		}
+
+		eventData := &GitHubEventData{
+			PullRequestAPIURL: "https://api.github.com/repos/org/repo/pulls/42",
+		}
+
+		enrichGitHubIssueCommentBranch(context.Background(), logr.Discard(), eventData)
+
+		if eventData.Branch != "" {
+			t.Errorf("Expected empty Branch when no credentials configured, got %q", eventData.Branch)
+		}
+	})
+}

--- a/internal/webhook/github_filter.go
+++ b/internal/webhook/github_filter.go
@@ -34,6 +34,10 @@ type GitHubEventData struct {
 	Body   string
 	URL    string
 	Branch string
+	// PullRequestAPIURL is the GitHub API URL for the pull request associated
+	// with an issue_comment event. It is extracted from issue.pull_request.url
+	// and used to lazily fetch the PR's head branch when needed.
+	PullRequestAPIURL string
 }
 
 // ParseGitHubWebhook parses a GitHub webhook payload using the go-github SDK.
@@ -126,6 +130,13 @@ func ParseGitHubWebhook(eventType string, payload []byte) (*GitHubEventData, err
 			data.Number = issue.GetNumber()
 			data.Body = issue.GetBody()
 			data.URL = issue.GetHTMLURL()
+			// When the comment is on a pull request, store the API URL so the
+			// handler can lazily fetch the PR's head branch.
+			if issue.IsPullRequest() {
+				if links := issue.GetPullRequestLinks(); links != nil {
+					data.PullRequestAPIURL = links.GetURL()
+				}
+			}
 		}
 
 	case *github.PullRequestReviewEvent:
@@ -393,6 +404,12 @@ func matchesFilter(filter v1alpha1.GitHubWebhookFilter, eventData *GitHubEventDa
 	}
 
 	return true
+}
+
+// needsBranchEnrichment returns true if the event is an issue_comment on a pull
+// request and the Branch field has not been populated yet.
+func needsBranchEnrichment(eventData *GitHubEventData) bool {
+	return eventData.Branch == "" && eventData.PullRequestAPIURL != ""
 }
 
 // ExtractGitHubWorkItem extracts template variables from GitHub webhook events for task creation.

--- a/internal/webhook/github_filter_test.go
+++ b/internal/webhook/github_filter_test.go
@@ -1027,3 +1027,109 @@ func TestMatchesGitHubEvent_RepositoryFiltering(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGitHubWebhook_IssueCommentOnPR_ExtractsPullRequestAPIURL(t *testing.T) {
+	payload := `{
+		"action": "created",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"issue": {
+			"number": 42,
+			"title": "Test PR",
+			"body": "PR body",
+			"html_url": "https://github.com/org/repo/pull/42",
+			"state": "open",
+			"pull_request": {
+				"url": "https://api.github.com/repos/org/repo/pulls/42",
+				"html_url": "https://github.com/org/repo/pull/42"
+			}
+		},
+		"comment": {"body": "/review"}
+	}`
+
+	got, err := ParseGitHubWebhook("issue_comment", []byte(payload))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+
+	if got.PullRequestAPIURL != "https://api.github.com/repos/org/repo/pulls/42" {
+		t.Errorf("PullRequestAPIURL = %q, want %q", got.PullRequestAPIURL, "https://api.github.com/repos/org/repo/pulls/42")
+	}
+	if got.Number != 42 {
+		t.Errorf("Number = %d, want 42", got.Number)
+	}
+	// Branch should be empty at parse time (enriched lazily)
+	if got.Branch != "" {
+		t.Errorf("Branch should be empty at parse time, got %q", got.Branch)
+	}
+}
+
+func TestParseGitHubWebhook_IssueCommentOnIssue_NoPullRequestAPIURL(t *testing.T) {
+	payload := `{
+		"action": "created",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"issue": {
+			"number": 10,
+			"title": "Plain Issue",
+			"body": "Issue body",
+			"html_url": "https://github.com/org/repo/issues/10",
+			"state": "open"
+		},
+		"comment": {"body": "hello"}
+	}`
+
+	got, err := ParseGitHubWebhook("issue_comment", []byte(payload))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+
+	if got.PullRequestAPIURL != "" {
+		t.Errorf("PullRequestAPIURL should be empty for plain issues, got %q", got.PullRequestAPIURL)
+	}
+}
+
+func TestNeedsBranchEnrichment(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventData *GitHubEventData
+		want      bool
+	}{
+		{
+			name: "needs enrichment - PR comment with no branch",
+			eventData: &GitHubEventData{
+				PullRequestAPIURL: "https://api.github.com/repos/org/repo/pulls/42",
+			},
+			want: true,
+		},
+		{
+			name: "no enrichment needed - branch already set",
+			eventData: &GitHubEventData{
+				Branch:            "feature-branch",
+				PullRequestAPIURL: "https://api.github.com/repos/org/repo/pulls/42",
+			},
+			want: false,
+		},
+		{
+			name: "no enrichment needed - plain issue comment",
+			eventData: &GitHubEventData{
+				PullRequestAPIURL: "",
+			},
+			want: false,
+		},
+		{
+			name:      "no enrichment needed - empty event data",
+			eventData: &GitHubEventData{},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needsBranchEnrichment(tt.eventData)
+			if got != tt.want {
+				t.Errorf("needsBranchEnrichment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -293,6 +293,13 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 
 	log.Info("Found matching TaskSpawners", "count", len(spawners))
 
+	// Lazily enrich the Branch field for issue_comment events on pull
+	// requests. The GitHub issue_comment payload does not include the PR's
+	// head ref, so we fetch it from the API once per delivery.
+	if parsed.GitHub != nil && needsBranchEnrichment(parsed.GitHub) {
+		enrichGitHubIssueCommentBranch(ctx, log, parsed.GitHub)
+	}
+
 	tasksCreated := 0
 	linearLabelsEnriched := false
 

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -495,6 +495,86 @@ func TestServeHTTP_RepositoryFilterRejectsWrongRepo(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_IssueCommentOnPR_EnrichesBranch(t *testing.T) {
+	// Swap the fetcher to return a known branch
+	orig := githubPRBranchFetcher
+	defer func() { githubPRBranchFetcher = orig }()
+	githubPRBranchFetcher = func(ctx context.Context, prAPIURL string) (string, error) {
+		return "feature-branch", nil
+	}
+
+	spawner := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-comment-spawner",
+			Namespace: "default",
+			UID:       "test-uid-branch",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubWebhook: &kelosv1alpha1.GitHubWebhook{
+					Events: []string{"issue_comment"},
+				},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type: "claude-code",
+				Credentials: kelosv1alpha1.Credentials{
+					Type: "api-key",
+				},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					Name: "test-workspace",
+				},
+				PromptTemplate: "Review PR on branch {{.Branch}}",
+			},
+		},
+	}
+
+	handler := newTestHandler(t, spawner)
+
+	payload := []byte(`{
+		"action": "created",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"issue": {
+			"number": 42,
+			"title": "Test PR",
+			"body": "PR body",
+			"html_url": "https://github.com/org/repo/pull/42",
+			"state": "open",
+			"pull_request": {
+				"url": "https://api.github.com/repos/org/repo/pulls/42",
+				"html_url": "https://github.com/org/repo/pull/42"
+			}
+		},
+		"comment": {"body": "/review"}
+	}`)
+	sig := signPayload(payload, []byte(testSecret))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set(GitHubEventHeader, "issue_comment")
+	req.Header.Set(GitHubSignatureHeader, sig)
+	req.Header.Set(GitHubDeliveryHeader, "branch-enrich-delivery")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var taskList kelosv1alpha1.TaskList
+	if err := handler.client.List(context.Background(), &taskList); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(taskList.Items) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(taskList.Items))
+	}
+
+	task := taskList.Items[0]
+	if task.Spec.Prompt != "Review PR on branch feature-branch" {
+		t.Errorf("Expected prompt with enriched branch, got %q", task.Spec.Prompt)
+	}
+}
+
 // --- Linear HTTP handler tests ---
 
 // newLinearTestHandler creates a WebhookHandler for Linear backed by a fake client.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a `issue_comment` webhook event fires on a pull request, the `{{.Branch}}` template variable is empty. This causes task creation to either fail (if the template references `{{.Branch}}` unconditionally) or create tasks without checking out the PR branch.

GitHub's `issue_comment` payload only includes `PullRequestLinks` (API URLs), not the full PR object with `head.ref`. The `PullRequestEvent` handler correctly extracts the branch, but the `IssueCommentEvent` handler never sets it.

**Fix:** When an `issue_comment` is on a pull request (`issue.IsPullRequest() == true`), lazily fetch the PR details from the GitHub API to resolve the head branch. This follows the same lazy enrichment pattern used for Linear comment label enrichment.

**Key changes:**

- **`GitHubEventData.PullRequestAPIURL`** — new field extracted during parsing from `issue.pull_request.url` when the comment is on a PR.
- **`github_api.go`** — new file with a `tokenProvider` that supports both `GITHUB_TOKEN` (PAT) and GitHub App credentials (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY`). Reuses the existing `internal/githubapp` package for installation token generation, with caching and automatic refresh.
- **`handler.go`** — lazy enrichment call fetches the PR branch once per delivery before the spawner loop, mirroring the `enrichLinearCommentLabels` pattern.
- **Helm chart** — new optional `webhookServer.sources.github.githubSecretName` value injects credentials into the webhook server pod. Supports the same secret format used by workspaces (either a `GITHUB_TOKEN` key or `appID`/`installationID`/`privateKey` keys, all optional).

#### Which issue(s) this PR is related to:

fixes: #867

#### Special notes for your reviewer:

- The `tokenProvider` prefers `GITHUB_TOKEN` over GitHub App credentials when both are configured.
- GitHub App installation tokens are cached with a 5-minute safety margin before expiry to avoid using expired tokens.
- Without credentials configured, the enrichment is a no-op (graceful degradation) — `Branch` remains empty as before.
- The Helm chart uses `optional: true` on all SecretKeyRef entries so a single secret can contain either PAT or App credentials without requiring both.

#### Does this PR introduce a user-facing change?

```release-note
Fix empty {{.Branch}} template variable for issue_comment webhook events on pull requests. The webhook server now fetches the PR's head branch from the GitHub API. Configure credentials via the new webhookServer.sources.github.githubSecretName Helm value, supporting both PAT and GitHub App authentication.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty `{{.Branch}}` for `issue_comment` events on pull requests by lazily fetching the PR’s head branch from the GitHub API using optional `GITHUB_TOKEN` or GitHub App auth. Ensures PR comment workflows template with the correct branch.

- **Bug Fixes**
  - Parse `issue.pull_request.url` into `PullRequestAPIURL`; if branch is missing, fetch once per delivery and set `Branch` before templating.
  - Token provider prefers `GITHUB_TOKEN`, falls back to GitHub App (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY`) via `internal/githubapp`, with cached installation tokens; no-op if no credentials.

- **Migration**
  - Set `webhookServer.sources.github.githubSecretName` to a Secret containing either `GITHUB_TOKEN` or `appID`/`installationID`/`privateKey`.

<sup>Written for commit a16fa180de92b3247e38effdb3985c58afba8114. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

