### PR TITLE
fix: enrich Linear Comment webhook payloads with issue description

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -280,6 +280,15 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 
 	log.Info("Processing webhook event", "resourceID", parsed.ID, "title", parsed.Title)
 
+	// Unconditionally enrich Linear Comment events with issue details
+	// (labels + description) before evaluating spawner filters. Linear does
+	// not include these fields in Comment webhook payloads, which causes
+	// label filtering to miss and template rendering to crash. This is a
+	// single cheap GraphQL call per delivery.
+	if parsed.Linear != nil {
+		enrichLinearCommentIssue(ctx, log, parsed.Linear)
+	}
+
 	// Get all TaskSpawners that match this source type
 	spawners, err := h.getMatchingSpawners(ctx)
 	if err != nil {
@@ -294,7 +303,6 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 	log.Info("Found matching TaskSpawners", "count", len(spawners))
 
 	tasksCreated := 0
-	linearLabelsEnriched := false
 
 	for _, spawner := range spawners {
 		spawnerLog := log.WithValues("spawner", spawner.Name, "namespace", spawner.Namespace)
@@ -317,17 +325,6 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 					"reason", "Webhook accepted but task creation skipped due to concurrency limits")
 				continue // Skip this spawner, continue with others
 			}
-		}
-
-		// Lazily enrich labels for Linear Comment events. Linear does not
-		// include issue labels in Comment webhook payloads, so when a
-		// spawner filters Comments by labels we fetch them from the API.
-		// Lazily enrich labels once per delivery. We set the flag after the
-		// call so that a transient API failure does not silently skip label
-		// filtering for all remaining spawners in this loop.
-		if parsed.Linear != nil && !linearLabelsEnriched && spawnerNeedsLinearLabels(spawner, parsed.Linear) {
-			enrichLinearCommentLabels(ctx, spawnerLog, parsed.Linear)
-			linearLabelsEnriched = true
 		}
 
 		// Check if this webhook matches the spawner's filters

--- a/internal/webhook/linear_api.go
+++ b/internal/webhook/linear_api.go
@@ -20,9 +20,10 @@ const (
 // timeout to avoid blocking webhook processing if the API is unresponsive.
 var linearHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
-// linearIssueLabelsQuery is the GraphQL query to fetch labels for an issue.
-const linearIssueLabelsQuery = `query IssueLabels($id: String!) {
+// linearIssueDetailsQuery is the GraphQL query to fetch labels and description for an issue.
+const linearIssueDetailsQuery = `query IssueDetails($id: String!) {
   issue(id: $id) {
+    description
     labels {
       nodes {
         name
@@ -39,7 +40,8 @@ type linearGraphQLRequest struct {
 type linearGraphQLResponse struct {
 	Data struct {
 		Issue struct {
-			Labels struct {
+			Description *string `json:"description"`
+			Labels      struct {
 				Nodes []struct {
 					Name string `json:"name"`
 				} `json:"nodes"`
@@ -51,24 +53,30 @@ type linearGraphQLResponse struct {
 	} `json:"errors,omitempty"`
 }
 
-// fetchLinearIssueLabels fetches labels for a Linear issue by ID using the
-// GraphQL API. The API key is read from the LINEAR_API_KEY environment variable.
-// Returns nil (no error) if the env var is not set, allowing callers to fall
-// back to whatever labels are in the webhook payload.
-func fetchLinearIssueLabels(ctx context.Context, issueID string) ([]string, error) {
-	apiKey := os.Getenv(linearAPIKeyEnvVar)
-	return fetchLinearIssueLabelsFromURL(ctx, defaultLinearAPIURL, apiKey, issueID)
+// linearIssueDetails holds the enriched fields returned by the Linear API.
+type linearIssueDetails struct {
+	Labels      []string
+	Description *string // nil when the API did not return a description
 }
 
-// fetchLinearIssueLabelsFromURL is the testable core of fetchLinearIssueLabels.
+// fetchLinearIssueDetails fetches labels and description for a Linear issue by
+// ID using the GraphQL API. The API key is read from the LINEAR_API_KEY
+// environment variable. Returns nil (no error) if the env var is not set,
+// allowing callers to fall back to whatever data is in the webhook payload.
+func fetchLinearIssueDetails(ctx context.Context, issueID string) (*linearIssueDetails, error) {
+	apiKey := os.Getenv(linearAPIKeyEnvVar)
+	return fetchLinearIssueDetailsFromURL(ctx, defaultLinearAPIURL, apiKey, issueID)
+}
+
+// fetchLinearIssueDetailsFromURL is the testable core of fetchLinearIssueDetails.
 // It accepts the API URL and key explicitly.
-func fetchLinearIssueLabelsFromURL(ctx context.Context, apiURL, apiKey, issueID string) ([]string, error) {
+func fetchLinearIssueDetailsFromURL(ctx context.Context, apiURL, apiKey, issueID string) (*linearIssueDetails, error) {
 	if apiKey == "" {
 		return nil, nil
 	}
 
 	reqBody := linearGraphQLRequest{
-		Query: linearIssueLabelsQuery,
+		Query: linearIssueDetailsQuery,
 		Variables: map[string]interface{}{
 			"id": issueID,
 		},
@@ -106,9 +114,11 @@ func fetchLinearIssueLabelsFromURL(ctx context.Context, apiURL, apiKey, issueID 
 		return nil, fmt.Errorf("Linear API error: %s", gqlResp.Errors[0].Message)
 	}
 
-	var labels []string
-	for _, node := range gqlResp.Data.Issue.Labels.Nodes {
-		labels = append(labels, node.Name)
+	details := &linearIssueDetails{
+		Description: gqlResp.Data.Issue.Description,
 	}
-	return labels, nil
+	for _, node := range gqlResp.Data.Issue.Labels.Nodes {
+		details.Labels = append(details.Labels, node.Name)
+	}
+	return details, nil
 }

--- a/internal/webhook/linear_api_test.go
+++ b/internal/webhook/linear_api_test.go
@@ -8,20 +8,23 @@ import (
 	"testing"
 )
 
-func TestFetchLinearIssueLabels(t *testing.T) {
+func TestFetchLinearIssueDetails(t *testing.T) {
+	desc := "A detailed description"
 	tests := []struct {
-		name       string
-		response   linearGraphQLResponse
-		statusCode int
-		wantLabels []string
-		wantErr    bool
+		name            string
+		response        linearGraphQLResponse
+		statusCode      int
+		wantLabels      []string
+		wantDescription *string
+		wantErr         bool
 	}{
 		{
-			name: "successful response with labels",
+			name: "successful response with labels and description",
 			response: linearGraphQLResponse{
 				Data: struct {
 					Issue struct {
-						Labels struct {
+						Description *string `json:"description"`
+						Labels      struct {
 							Nodes []struct {
 								Name string `json:"name"`
 							} `json:"nodes"`
@@ -29,12 +32,14 @@ func TestFetchLinearIssueLabels(t *testing.T) {
 					} `json:"issue"`
 				}{
 					Issue: struct {
-						Labels struct {
+						Description *string `json:"description"`
+						Labels      struct {
 							Nodes []struct {
 								Name string `json:"name"`
 							} `json:"nodes"`
 						} `json:"labels"`
 					}{
+						Description: &desc,
 						Labels: struct {
 							Nodes []struct {
 								Name string `json:"name"`
@@ -50,15 +55,17 @@ func TestFetchLinearIssueLabels(t *testing.T) {
 					},
 				},
 			},
-			statusCode: http.StatusOK,
-			wantLabels: []string{"bug", "priority:high"},
+			statusCode:      http.StatusOK,
+			wantLabels:      []string{"bug", "priority:high"},
+			wantDescription: &desc,
 		},
 		{
-			name: "empty labels",
+			name: "empty labels and nil description",
 			response: linearGraphQLResponse{
 				Data: struct {
 					Issue struct {
-						Labels struct {
+						Description *string `json:"description"`
+						Labels      struct {
 							Nodes []struct {
 								Name string `json:"name"`
 							} `json:"nodes"`
@@ -66,8 +73,9 @@ func TestFetchLinearIssueLabels(t *testing.T) {
 					} `json:"issue"`
 				}{},
 			},
-			statusCode: http.StatusOK,
-			wantLabels: nil,
+			statusCode:      http.StatusOK,
+			wantLabels:      nil,
+			wantDescription: nil,
 		},
 		{
 			name:       "API error status",
@@ -120,20 +128,34 @@ func TestFetchLinearIssueLabels(t *testing.T) {
 			}))
 			defer server.Close()
 
-			labels, err := fetchLinearIssueLabelsFromURL(context.Background(), server.URL, "test-api-key", "issue-123")
+			details, err := fetchLinearIssueDetailsFromURL(context.Background(), server.URL, "test-api-key", "issue-123")
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("fetchLinearIssueLabels() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("fetchLinearIssueDetails() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr {
-				if len(labels) != len(tt.wantLabels) {
-					t.Errorf("fetchLinearIssueLabels() = %v, want %v", labels, tt.wantLabels)
+				if details == nil {
+					t.Fatal("fetchLinearIssueDetails() returned nil details")
+				}
+				if len(details.Labels) != len(tt.wantLabels) {
+					t.Errorf("fetchLinearIssueDetails() labels = %v, want %v", details.Labels, tt.wantLabels)
 					return
 				}
-				for i, label := range labels {
+				for i, label := range details.Labels {
 					if label != tt.wantLabels[i] {
-						t.Errorf("fetchLinearIssueLabels()[%d] = %v, want %v", i, label, tt.wantLabels[i])
+						t.Errorf("fetchLinearIssueDetails() labels[%d] = %v, want %v", i, label, tt.wantLabels[i])
+					}
+				}
+				if tt.wantDescription == nil {
+					if details.Description != nil {
+						t.Errorf("fetchLinearIssueDetails() description = %v, want nil", *details.Description)
+					}
+				} else {
+					if details.Description == nil {
+						t.Errorf("fetchLinearIssueDetails() description = nil, want %v", *tt.wantDescription)
+					} else if *details.Description != *tt.wantDescription {
+						t.Errorf("fetchLinearIssueDetails() description = %v, want %v", *details.Description, *tt.wantDescription)
 					}
 				}
 			}
@@ -141,13 +163,13 @@ func TestFetchLinearIssueLabels(t *testing.T) {
 	}
 }
 
-func TestFetchLinearIssueLabels_NoAPIKey(t *testing.T) {
+func TestFetchLinearIssueDetails_NoAPIKey(t *testing.T) {
 	// When no API key is provided, should return nil, nil
-	labels, err := fetchLinearIssueLabelsFromURL(context.Background(), "http://unused", "", "issue-123")
+	details, err := fetchLinearIssueDetailsFromURL(context.Background(), "http://unused", "", "issue-123")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if labels != nil {
-		t.Errorf("Expected nil labels, got %v", labels)
+	if details != nil {
+		t.Errorf("Expected nil details, got %v", details)
 	}
 }

--- a/internal/webhook/linear_filter.go
+++ b/internal/webhook/linear_filter.go
@@ -193,47 +193,22 @@ func matchesLinearFilter(filter *v1alpha1.LinearWebhookFilter, eventData *Linear
 	return true
 }
 
-// spawnerNeedsLinearLabels returns true if the spawner has any filter that
-// uses Labels or ExcludeLabels and the parsed event is a Comment whose issue
-// labels are missing from the payload (the common case for Linear Comment
-// webhooks).
-func spawnerNeedsLinearLabels(spawner *v1alpha1.TaskSpawner, eventData *LinearEventData) bool {
+// linearDetailsFetcher is the function used to fetch issue details (labels and
+// description) from the Linear API. It is a package-level variable so tests
+// can swap in a stub.
+var linearDetailsFetcher = fetchLinearIssueDetails
+
+// enrichLinearCommentIssue fetches labels and description from the Linear API
+// for Comment events and injects them into the parsed payload so that
+// downstream label filtering and template rendering work correctly. This is
+// called unconditionally for all Comment events — it is cheap (single GraphQL
+// call) and prevents template crashes when prompts reference fields like
+// {{.Payload.data.issue.description}}.
+func enrichLinearCommentIssue(ctx context.Context, log logr.Logger, eventData *LinearEventData) {
 	if eventData.Type != "Comment" {
-		return false
+		return
 	}
 
-	lw := spawner.Spec.When.LinearWebhook
-	if lw == nil {
-		return false
-	}
-
-	// Check if any Comment-scoped (or unscoped) filter uses label-based filtering
-	for _, f := range lw.Filters {
-		if f.Type != "" && !strings.EqualFold(f.Type, "Comment") {
-			continue
-		}
-		if len(f.Labels) > 0 || len(f.ExcludeLabels) > 0 {
-			// Only enrich if issue labels are absent from the payload
-			dataObj, _ := eventData.Payload["data"].(map[string]interface{})
-			if dataObj == nil {
-				return true
-			}
-			labels := extractLabels(dataObj)
-			return labels == nil
-		}
-	}
-
-	return false
-}
-
-// linearLabelFetcher is the function used to fetch issue labels from the
-// Linear API. It is a package-level variable so tests can swap in a stub.
-var linearLabelFetcher = fetchLinearIssueLabels
-
-// enrichLinearCommentLabels fetches labels from the Linear API for Comment
-// events and injects them into the parsed payload at data.issue.labels so
-// that downstream label filtering works.
-func enrichLinearCommentLabels(ctx context.Context, log logr.Logger, eventData *LinearEventData) {
 	dataObj, _ := eventData.Payload["data"].(map[string]interface{})
 	if dataObj == nil {
 		return
@@ -242,7 +217,7 @@ func enrichLinearCommentLabels(ctx context.Context, log logr.Logger, eventData *
 	// Extract the parent issue ID from data.issue.id
 	issue, _ := dataObj["issue"].(map[string]interface{})
 	if issue == nil {
-		log.Info("Comment webhook has no issue object, cannot enrich labels")
+		log.Info("Comment webhook has no issue object, cannot enrich")
 		return
 	}
 
@@ -254,35 +229,40 @@ func enrichLinearCommentLabels(ctx context.Context, log logr.Logger, eventData *
 		issueID = fmt.Sprintf("%.0f", id)
 	}
 	if issueID == "" {
-		log.Info("Comment webhook has no issue ID, cannot enrich labels")
+		log.Info("Comment webhook has no issue ID, cannot enrich")
 		return
 	}
 
-	labels, err := linearLabelFetcher(ctx, issueID)
+	details, err := linearDetailsFetcher(ctx, issueID)
 	if err != nil {
-		log.Error(err, "Failed to fetch Linear issue labels", "issueID", issueID)
+		log.Error(err, "Failed to fetch Linear issue details", "issueID", issueID)
 		return
 	}
-	if labels == nil {
-		// LINEAR_API_KEY not set — label-based filtering on Comment events will
-		// not work because Linear does not include issue labels in Comment
-		// webhook payloads.
-		log.Info("LINEAR_API_KEY not set, cannot enrich Comment event with issue labels from Linear API")
+	if details == nil {
+		// LINEAR_API_KEY not set — enrichment cannot proceed.
+		log.Info("LINEAR_API_KEY not set, cannot enrich Comment event with issue details from Linear API")
 		return
 	}
 
-	log.Info("Enriched Comment event with issue labels from Linear API", "issueID", issueID, "labels", labels)
+	log.Info("Enriched Comment event with issue details from Linear API", "issueID", issueID, "labels", details.Labels)
 
 	// Inject labels into data.issue.labels as []interface{} matching the
 	// format that extractLabels/matchesLinearFilter expect.
-	labelObjs := make([]interface{}, len(labels))
-	for i, name := range labels {
+	labelObjs := make([]interface{}, len(details.Labels))
+	for i, name := range details.Labels {
 		labelObjs[i] = map[string]interface{}{"name": name}
 	}
 	issue["labels"] = labelObjs
 
 	// Also update the convenience field on LinearEventData
-	eventData.Labels = labels
+	eventData.Labels = details.Labels
+
+	// Inject description only if not already present in the payload
+	if details.Description != nil {
+		if _, exists := issue["description"]; !exists {
+			issue["description"] = *details.Description
+		}
+	}
 }
 
 // ExtractLinearWorkItem converts Linear webhook data to template variables.

--- a/internal/webhook/linear_filter_test.go
+++ b/internal/webhook/linear_filter_test.go
@@ -1380,168 +1380,9 @@ func TestExtractLinearWorkItem(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func TestSpawnerNeedsLinearLabels(t *testing.T) {
-	tests := []struct {
-		name    string
-		spawner *v1alpha1.TaskSpawner
-		payload string
-		want    bool
-	}{
-		{
-			name: "comment event with typed label filter and no labels in payload",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Type: "Comment", Labels: []string{"bug"}},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1","title":"Test"}}}`,
-			want:    true,
-		},
-		{
-			name: "comment event with unscoped label filter and no labels in payload",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Labels: []string{"bug"}},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1","title":"Test"}}}`,
-			want:    true,
-		},
-		{
-			name: "comment event with excludeLabels filter and no labels in payload",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Type: "Comment", ExcludeLabels: []string{"wontfix"}},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1","title":"Test"}}}`,
-			want:    true,
-		},
-		{
-			name: "comment event with labels already in payload",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Type: "Comment", Labels: []string{"bug"}},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1","labels":[{"name":"bug"}]}}}`,
-			want:    false,
-		},
-		{
-			name: "comment event with no label filter",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Type: "Comment", Action: "create"},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1"}}}`,
-			want:    false,
-		},
-		{
-			name: "issue event is not enriched",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Issue"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Type: "Issue", Labels: []string{"bug"}},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Issue","action":"create","data":{"id":"i1","title":"Test"}}`,
-			want:    false,
-		},
-		{
-			name: "issue-scoped label filter does not trigger enrichment for Comment",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Issue", "Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Type: "Issue", Labels: []string{"bug"}},
-								{Type: "Comment", Action: "create"},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1"}}}`,
-			want:    false,
-		},
-		{
-			name: "unscoped label filter triggers enrichment for Comment",
-			spawner: &v1alpha1.TaskSpawner{
-				Spec: v1alpha1.TaskSpawnerSpec{
-					When: v1alpha1.When{
-						LinearWebhook: &v1alpha1.LinearWebhook{
-							Types: []string{"Issue", "Comment"},
-							Filters: []v1alpha1.LinearWebhookFilter{
-								{Labels: []string{"bug"}},
-							},
-						},
-					},
-				},
-			},
-			payload: `{"type":"Comment","action":"create","data":{"id":"c1","issue":{"id":"i1"}}}`,
-			want:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			eventData, err := ParseLinearWebhook([]byte(tt.payload))
-			if err != nil {
-				t.Fatalf("ParseLinearWebhook() error = %v", err)
-			}
-			got := spawnerNeedsLinearLabels(tt.spawner, eventData)
-			if got != tt.want {
-				t.Errorf("spawnerNeedsLinearLabels() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestEnrichLinearCommentLabels(t *testing.T) {
-	// Set up a mock Linear API server that returns labels for the issue
+func TestEnrichLinearCommentIssue(t *testing.T) {
+	desc := "A detailed description of the issue"
+	// Set up a mock Linear API server that returns labels and description
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req linearGraphQLRequest
 		json.NewDecoder(r.Body).Decode(&req)
@@ -1549,6 +1390,7 @@ func TestEnrichLinearCommentLabels(t *testing.T) {
 		resp := map[string]interface{}{
 			"data": map[string]interface{}{
 				"issue": map[string]interface{}{
+					"description": desc,
 					"labels": map[string]interface{}{
 						"nodes": []map[string]interface{}{
 							{"name": "bug"},
@@ -1562,11 +1404,11 @@ func TestEnrichLinearCommentLabels(t *testing.T) {
 	}))
 	defer server.Close()
 
-	origFetcher := linearLabelFetcher
-	linearLabelFetcher = func(ctx context.Context, issueID string) ([]string, error) {
-		return fetchLinearIssueLabelsFromURL(ctx, server.URL, "test-key", issueID)
+	origFetcher := linearDetailsFetcher
+	linearDetailsFetcher = func(ctx context.Context, issueID string) (*linearIssueDetails, error) {
+		return fetchLinearIssueDetailsFromURL(ctx, server.URL, "test-key", issueID)
 	}
-	defer func() { linearLabelFetcher = origFetcher }()
+	defer func() { linearDetailsFetcher = origFetcher }()
 
 	payload := `{
 		"type":"Comment",
@@ -1586,7 +1428,7 @@ func TestEnrichLinearCommentLabels(t *testing.T) {
 		t.Fatalf("ParseLinearWebhook() error = %v", err)
 	}
 
-	enrichLinearCommentLabels(context.Background(), logr.Discard(), eventData)
+	enrichLinearCommentIssue(context.Background(), logr.Discard(), eventData)
 
 	// Check that labels were injected into the payload
 	dataObj := eventData.Payload["data"].(map[string]interface{})
@@ -1612,14 +1454,106 @@ func TestEnrichLinearCommentLabels(t *testing.T) {
 	if len(eventData.Labels) != 2 || eventData.Labels[0] != "bug" || eventData.Labels[1] != "priority:high" {
 		t.Errorf("Expected eventData.Labels = [bug priority:high], got %v", eventData.Labels)
 	}
+
+	// Check that description was injected
+	gotDesc, ok := issue["description"].(string)
+	if !ok {
+		t.Fatal("Expected description to be injected into issue")
+	}
+	if gotDesc != desc {
+		t.Errorf("Expected description %q, got %q", desc, gotDesc)
+	}
 }
 
-func TestEnrichLinearCommentLabels_MatchesFilterAfterEnrichment(t *testing.T) {
+func TestEnrichLinearCommentIssue_PreservesExistingDescription(t *testing.T) {
+	apiDesc := "Description from API"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"issue": map[string]interface{}{
+					"description": apiDesc,
+					"labels": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{"name": "bug"},
+						},
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	origFetcher := linearDetailsFetcher
+	linearDetailsFetcher = func(ctx context.Context, issueID string) (*linearIssueDetails, error) {
+		return fetchLinearIssueDetailsFromURL(ctx, server.URL, "test-key", issueID)
+	}
+	defer func() { linearDetailsFetcher = origFetcher }()
+
+	// Payload already has a description — it should NOT be overwritten
+	payload := `{
+		"type":"Comment",
+		"action":"create",
+		"data":{
+			"id":"comment-123",
+			"body":"Test comment",
+			"issue":{
+				"id":"issue-456",
+				"title":"Parent issue",
+				"description":"Existing description"
+			}
+		}
+	}`
+
+	eventData, err := ParseLinearWebhook([]byte(payload))
+	if err != nil {
+		t.Fatalf("ParseLinearWebhook() error = %v", err)
+	}
+
+	enrichLinearCommentIssue(context.Background(), logr.Discard(), eventData)
+
+	dataObj := eventData.Payload["data"].(map[string]interface{})
+	issue := dataObj["issue"].(map[string]interface{})
+
+	gotDesc, ok := issue["description"].(string)
+	if !ok {
+		t.Fatal("Expected description in issue")
+	}
+	if gotDesc != "Existing description" {
+		t.Errorf("Expected existing description to be preserved, got %q", gotDesc)
+	}
+}
+
+func TestEnrichLinearCommentIssue_SkipsNonCommentEvents(t *testing.T) {
+	called := false
+	origFetcher := linearDetailsFetcher
+	linearDetailsFetcher = func(ctx context.Context, issueID string) (*linearIssueDetails, error) {
+		called = true
+		return &linearIssueDetails{Labels: []string{"bug"}}, nil
+	}
+	defer func() { linearDetailsFetcher = origFetcher }()
+
+	payload := `{"type":"Issue","action":"create","data":{"id":"i1","title":"Test"}}`
+	eventData, err := ParseLinearWebhook([]byte(payload))
+	if err != nil {
+		t.Fatalf("ParseLinearWebhook() error = %v", err)
+	}
+
+	enrichLinearCommentIssue(context.Background(), logr.Discard(), eventData)
+
+	if called {
+		t.Error("Expected enrichment to be skipped for non-Comment events")
+	}
+}
+
+func TestEnrichLinearCommentIssue_MatchesFilterAfterEnrichment(t *testing.T) {
+	desc := "Issue description"
 	// End-to-end test: Comment payload without labels -> enrich -> filter matches
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]interface{}{
 			"data": map[string]interface{}{
 				"issue": map[string]interface{}{
+					"description": desc,
 					"labels": map[string]interface{}{
 						"nodes": []map[string]interface{}{
 							{"name": "bug"},
@@ -1633,11 +1567,11 @@ func TestEnrichLinearCommentLabels_MatchesFilterAfterEnrichment(t *testing.T) {
 	}))
 	defer server.Close()
 
-	origFetcher := linearLabelFetcher
-	linearLabelFetcher = func(ctx context.Context, issueID string) ([]string, error) {
-		return fetchLinearIssueLabelsFromURL(ctx, server.URL, "test-key", issueID)
+	origFetcher := linearDetailsFetcher
+	linearDetailsFetcher = func(ctx context.Context, issueID string) (*linearIssueDetails, error) {
+		return fetchLinearIssueDetailsFromURL(ctx, server.URL, "test-key", issueID)
 	}
-	defer func() { linearLabelFetcher = origFetcher }()
+	defer func() { linearDetailsFetcher = origFetcher }()
 
 	config := &v1alpha1.LinearWebhook{
 		Types: []string{"Comment"},
@@ -1672,7 +1606,7 @@ func TestEnrichLinearCommentLabels_MatchesFilterAfterEnrichment(t *testing.T) {
 	}
 
 	// Enrich
-	enrichLinearCommentLabels(context.Background(), logr.Discard(), eventData)
+	enrichLinearCommentIssue(context.Background(), logr.Discard(), eventData)
 
 	// After enrichment — filter should match
 	matched, err = MatchesLinearEvent(config, eventData)
@@ -1681,5 +1615,12 @@ func TestEnrichLinearCommentLabels_MatchesFilterAfterEnrichment(t *testing.T) {
 	}
 	if !matched {
 		t.Error("Expected match after enrichment")
+	}
+
+	// Verify description was also injected
+	dataObj := eventData.Payload["data"].(map[string]interface{})
+	issue := dataObj["issue"].(map[string]interface{})
+	if issue["description"] != desc {
+		t.Errorf("Expected description %q, got %v", desc, issue["description"])
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Linear Comment webhooks include `data.issue.id`, `data.issue.identifier`, `data.issue.title`, and `data.issue.url` — but **not** `data.issue.description`. This causes Go template rendering to crash with `map has no entry for key "description"` when spawner prompt templates reference `{{.Payload.data.issue.description}}`.

This fix extends the existing label enrichment (from PR #866 ) to also fetch the issue description from the Linear GraphQL API. Both fields are now fetched in a single API call, and enrichment is unconditional for all Comment events — preventing a class of template errors cheaply.

**Changes:**
- Extended the Linear GraphQL query to fetch `description` alongside `labels`
- Made Comment event enrichment unconditional (moved before the spawner loop, no longer gated on `spawnerNeedsLinearLabels`)
- Description is only injected if not already present in the payload (preserves existing values)
- Removed now-unused `spawnerNeedsLinearLabels` function

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The enrichment is now unconditional for Comment events. This means a Linear API call happens for every Comment webhook even if no spawner uses label filtering. This is intentional — it's cheap (single GraphQL call) and prevents template crashes.

#### Does this PR introduce a user-facing change?

```release-note
Fixed template rendering crash for Linear Comment webhooks by enriching payloads with issue description from the Linear API.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes template crashes for Linear Comment webhooks by enriching payloads with the issue description (and labels) via a single GraphQL call before filtering. All Comment events now get consistent data to avoid missing fields in templates.

- **Bug Fixes**
  - Fetch issue description and labels in one GraphQL call and inject into `data.issue`; only add description if absent.
  - Run enrichment unconditionally for Comment events before spawner filters to prevent label-based mismatches and template errors.
  - Introduced `fetchLinearIssueDetails`, updated tests, and removed the unused `spawnerNeedsLinearLabels`.

<sup>Written for commit 09bcfb9d2819bb8c03884ef8375572b86ac49b7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

