### PR TITLE
Add multi-architecture support for Docker images and workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,27 +10,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  determine-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Determine version
         id: version
         run: |
@@ -40,40 +24,97 @@ jobs:
             echo "version=main" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build images
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: make image VERSION="$VERSION"
+  build-images:
+    needs: determine-version
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Push images
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: make push VERSION="$VERSION"
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-      - name: Push latest tags for releases
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: make image IMAGE_PLATFORMS=linux/${{ matrix.arch }} PUSH=true VERSION="$VERSION-${{ matrix.arch }}"
+
+  merge-manifests:
+    needs: [determine-version, build-images]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifests
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: make manifest IMAGE_PLATFORMS=linux/amd64,linux/arm64 VERSION="$VERSION"
+
+      - name: Create and push latest manifests
         if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          make image VERSION=latest
-          make push VERSION=latest
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: make manifest IMAGE_PLATFORMS=linux/amd64,linux/arm64 VERSION=latest SOURCE_VERSION="$VERSION"
+
+  release-artifacts:
+    needs: [determine-version, merge-manifests]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Build CLI binaries
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.determine-version.outputs.version }}
         run: make release-binaries VERSION="$VERSION"
 
       - name: Generate release notes
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.determine-version.outputs.version }}
         run: go run ./hack/release-notes "$VERSION" > /tmp/release-notes.md
 
       - name: Upload CLI binaries to GitHub release
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.determine-version.outputs.version }}
         run: |
           gh release create "$VERSION" --verify-tag --draft --title "$VERSION" --notes-file /tmp/release-notes.md || true
           gh release upload "$VERSION" --clobber \
@@ -83,7 +124,7 @@ jobs:
   publish-helm-chart:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: release
+    needs: release-artifacts
     permissions:
       contents: read
       packages: write

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Image configuration
 REGISTRY ?= ghcr.io/kelos-dev
 VERSION ?= latest
-IMAGE_DIRS ?= cmd/kelos-controller cmd/kelos-spawner cmd/kelos-token-refresher cmd/kelos-webhook-server cmd/ghproxy claude-code codex gemini opencode cursor
+IMAGE_DIRS ?= cmd/kelos-controller cmd/kelos-spawner cmd/kelos-token-refresher cmd/ghproxy cmd/kelos-webhook-server claude-code codex gemini opencode cursor
+LOCAL_ARCH ?= $(shell go env GOARCH)
 
 # Version injection for the kelos CLI – only set ldflags when an explicit
 # version is given so that dev builds fall through to runtime/debug info.
@@ -79,20 +80,39 @@ build: ## Build binaries (use WHAT=cmd/kelos to build specific binary).
 run: ## Run a controller from your host.
 	go run ./cmd/kelos-controller
 
+IMAGE_PLATFORMS ?= linux/$(LOCAL_ARCH)
+IMAGE_ARCHES = $(shell echo "$(IMAGE_PLATFORMS)" | tr ',' '\n' | cut -d'/' -f2 | tr '\n' ' ')
+PUSH ?= false
+
 .PHONY: image
-image: ## Build docker images (use WHAT to build specific image).
+image: ## Build docker images (use WHAT, IMAGE_PLATFORMS, PUSH=true to customize).
 	@for dir in $(filter cmd/%,$(or $(WHAT),$(IMAGE_DIRS))); do \
-		GOOS=linux GOARCH=amd64 $(MAKE) build WHAT=$$dir; \
+		name=$$(basename $$dir); \
+		for arch in $(IMAGE_ARCHES); do \
+			GOOS=linux GOARCH=$$arch $(MAKE) build WHAT=$$dir; \
+			mv bin/$$name bin/$${name}-linux-$$arch; \
+		done; \
 	done
-	@GOOS=linux GOARCH=amd64 $(MAKE) build WHAT=cmd/kelos-capture
+	@for arch in $(IMAGE_ARCHES); do \
+		GOOS=linux GOARCH=$$arch $(MAKE) build WHAT=cmd/kelos-capture; \
+		mv bin/kelos-capture bin/kelos-capture-linux-$$arch; \
+	done
 	@for dir in $(or $(WHAT),$(IMAGE_DIRS)); do \
-		docker build -t $(REGISTRY)/$$(basename $$dir):$(VERSION) -f $$dir/Dockerfile .; \
+		docker buildx build --platform $(IMAGE_PLATFORMS) \
+			$(if $(filter true,$(PUSH)),--push,--load) \
+			-t $(REGISTRY)/$$(basename $$dir):$(VERSION) \
+			-f $$dir/Dockerfile .; \
 	done
 
-.PHONY: push
-push: ## Push docker images (use WHAT to push specific image).
+.PHONY: manifest
+SOURCE_VERSION ?= $(VERSION)
+
+manifest: ## Create and push multi-arch manifest from per-arch images (use WHAT, IMAGE_PLATFORMS, SOURCE_VERSION).
 	@for dir in $(or $(WHAT),$(IMAGE_DIRS)); do \
-		docker push $(REGISTRY)/$$(basename $$dir):$(VERSION); \
+		name=$$(basename $$dir); \
+		docker buildx imagetools create \
+			-t $(REGISTRY)/$$name:$(VERSION) \
+			$(foreach arch,$(IMAGE_ARCHES),$(REGISTRY)/$$name:$(SOURCE_VERSION)-$(arch) ); \
 	done
 
 RELEASE_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -33,7 +33,8 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 COPY claude-code/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/kelos-capture /kelos/kelos-capture
+ARG TARGETARCH
+COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude

--- a/cmd/ghproxy/Dockerfile
+++ b/cmd/ghproxy/Dockerfile
@@ -1,5 +1,6 @@
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
-COPY bin/ghproxy .
+COPY bin/ghproxy-linux-${TARGETARCH} ghproxy
 USER 65532:65532
 ENTRYPOINT ["/ghproxy"]

--- a/cmd/kelos-controller/Dockerfile
+++ b/cmd/kelos-controller/Dockerfile
@@ -1,5 +1,6 @@
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-controller .
+COPY bin/kelos-controller-linux-${TARGETARCH} kelos-controller
 USER 65532:65532
 ENTRYPOINT ["/kelos-controller"]

--- a/cmd/kelos-spawner/Dockerfile
+++ b/cmd/kelos-spawner/Dockerfile
@@ -1,5 +1,6 @@
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-spawner .
+COPY bin/kelos-spawner-linux-${TARGETARCH} kelos-spawner
 USER 65532:65532
 ENTRYPOINT ["/kelos-spawner"]

--- a/cmd/kelos-token-refresher/Dockerfile
+++ b/cmd/kelos-token-refresher/Dockerfile
@@ -1,25 +1,6 @@
-# Build stage
-FROM golang:1.25 AS builder
-
-WORKDIR /workspace
-
-# Copy go mod files
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy source
-COPY . .
-
-# Build
-RUN make build WHAT=cmd/kelos-token-refresher
-
-# Runtime stage
 FROM gcr.io/distroless/static:nonroot
-
+ARG TARGETARCH
 WORKDIR /
-
-COPY --from=builder /workspace/bin/kelos-token-refresher .
-
+COPY bin/kelos-token-refresher-linux-${TARGETARCH} kelos-token-refresher
 USER 65532:65532
-
 ENTRYPOINT ["/kelos-token-refresher"]

--- a/cmd/kelos-webhook-server/Dockerfile
+++ b/cmd/kelos-webhook-server/Dockerfile
@@ -1,5 +1,6 @@
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-webhook-server .
+COPY bin/kelos-webhook-server-linux-${TARGETARCH} kelos-webhook-server
 USER 65532:65532
 ENTRYPOINT ["/kelos-webhook-server"]

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -33,7 +33,8 @@ RUN npm install -g @openai/codex@${CODEX_VERSION}
 COPY codex/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/kelos-capture /kelos/kelos-capture
+ARG TARGETARCH
+COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.codex && chown -R agent:agent /home/agent

--- a/cursor/Dockerfile
+++ b/cursor/Dockerfile
@@ -30,7 +30,8 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 COPY cursor/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/kelos-capture /kelos/kelos-capture
+ARG TARGETARCH
+COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent

--- a/gemini/Dockerfile
+++ b/gemini/Dockerfile
@@ -33,7 +33,8 @@ RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION}
 COPY gemini/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/kelos-capture /kelos/kelos-capture
+ARG TARGETARCH
+COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -33,7 +33,8 @@ RUN npm install -g opencode-ai@${OPENCODE_VERSION}
 COPY opencode/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-COPY bin/kelos-capture /kelos/kelos-capture
+ARG TARGETARCH
+COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.opencode && chown -R agent:agent /home/agent


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds arm64 support for all Docker images. Supersedes #841 with additional fixes for Dockerfiles that were missed (`ghproxy`, `kelos-webhook-server`, `kelos-token-refresher`).

Changes:
- Split CI release workflow into parallel per-arch builds on native runners (no QEMU)
- Add `IMAGE_PLATFORMS`, `PUSH`, `LOCAL_ARCH` Makefile variables and `manifest` target
- Update all Dockerfiles to use `ARG TARGETARCH` for arch-specific binary copies
- Remove `make push` in favor of `PUSH=true` with buildx
- Add `SOURCE_VERSION` to `manifest` target for correct `latest` tag creation

#### Which issue(s) this PR is related to:
Fixes #840
Supersedes #841

#### Special notes for your reviewer:
Compared to #841, this PR additionally fixes:
- `ghproxy` and `kelos-webhook-server` Dockerfiles (were missing `ARG TARGETARCH`, builds would fail)
- `kelos-token-refresher` Dockerfile (replaced redundant multi-stage build with consistent single-stage pattern)

#### Does this PR introduce a user-facing change?

```release-note
Added multi-architecture (amd64/arm64) support for container images
```