### PR TITLE
feat(webhooks): parse out commenter relevant fields when receiving a github webhook

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -383,7 +383,7 @@ All `promptTemplate` and `branch` fields support Go `text/template` syntax. Avai
 | `{{.ID}}` | Issue number (string) | PR number (string) | Issue/PR number or commit ID | Issue key (e.g., `ENG-42`) | Linear resource ID | Mapped `id` field (required) | Date-time string |
 | `{{.Number}}` | Issue number (int) | PR number (int) | Issue/PR number | `0` | Empty | Empty | `0` |
 | `{{.Title}}` | Issue title | PR title | Issue/PR title | Issue summary | Resource title | Mapped `title` field (if present) | Trigger time (RFC3339) |
-| `{{.Body}}` | Issue body | PR body | Issue/PR/comment body | Issue description | Empty | Mapped `body` field (if present) | Empty |
+| `{{.Body}}` | Issue body | PR body | Issue/PR body | Issue description | Empty | Mapped `body` field (if present) | Empty |
 | `{{.URL}}` | Issue URL | PR URL | Issue/PR URL | Issue URL | Empty | Mapped `url` field (if present) | Empty |
 | `{{.Labels}}` | Comma-separated | Comma-separated | Empty | Comma-separated | Comma-separated | Empty | Empty |
 | `{{.Comments}}` | Issue comments | PR comments | Empty | Issue comments | Empty | Empty | Empty |
@@ -402,6 +402,8 @@ All `promptTemplate` and `branch` fields support Go `text/template` syntax. Avai
 | `{{.Type}}` | Empty | Empty | Empty | Empty | Resource type (e.g., `"Issue"`, `"Comment"`) | Empty | Empty |
 | `{{.State}}` | Empty | Empty | Empty | Empty | Workflow state (e.g., `"Todo"`, `"In Progress"`) | Empty | Empty |
 | `{{.IssueID}}` | Empty | Empty | Empty | Empty | Parent issue ID (Comment events only) | Empty | Empty |
+| `{{.CommentBody}}` | Empty | Empty | Comment/review body (`issue_comment`, `pull_request_review`, `pull_request_review_comment`) | Empty | Empty | Empty | Empty |
+| `{{.CommentURL}}` | Empty | Empty | Comment/review HTML URL (`issue_comment`, `pull_request_review`, `pull_request_review_comment`) | Empty | Empty | Empty | Empty |
 | `{{.Time}}` | Empty | Empty | Empty | Empty | Empty | Empty | Trigger time (RFC3339) |
 
 > **Generic Webhook only:** any additional keys you declare in `fieldMapping` are also exposed as top-level variables. For example, `fieldMapping: {severity: "$.level"}` makes `{{.severity}}` available in templates.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -207,7 +207,7 @@ The `promptTemplate` field uses Go `text/template` syntax. Available variables d
 | `{{.ID}}` | Unique identifier | Issue/PR number as string (e.g., `"42"`) | Pull request number as string | Issue/PR number or commit ID | Linear resource ID | Mapped `id` field (required) | Date-time string (e.g., `"20260207-0900"`) |
 | `{{.Number}}` | Issue or PR number | Issue/PR number (e.g., `42`) | Pull request number | Issue/PR number (when available) | Empty | Empty | `0` |
 | `{{.Title}}` | Title of the work item | Issue/PR title | Pull request title | Issue/PR title or "Push to &lt;branch&gt;" | Resource title | Mapped `title` field (if present) | Trigger time (RFC3339) |
-| `{{.Body}}` | Body text | Issue/PR body | Pull request body | Issue/PR/comment body | Empty | Mapped `body` field (if present) | Empty |
+| `{{.Body}}` | Body text | Issue/PR body | Pull request body | Issue/PR body | Empty | Mapped `body` field (if present) | Empty |
 | `{{.URL}}` | URL to the source item | GitHub HTML URL | GitHub PR URL | Issue/PR HTML URL | Empty | Mapped `url` field (if present) | Empty |
 | `{{.Labels}}` | Comma-separated labels | Issue/PR labels | Pull request labels | Empty | Issue labels | Empty | Empty |
 | `{{.Comments}}` | Concatenated comments | Issue/PR comments | PR conversation comments | Empty | Empty | Empty | Empty |
@@ -226,6 +226,8 @@ The `promptTemplate` field uses Go `text/template` syntax. Available variables d
 | `{{.Type}}` | Resource type | Empty | Empty | Empty | Resource type (e.g., `"Issue"`, `"Comment"`) | Empty | Empty |
 | `{{.State}}` | Workflow state | Empty | Empty | Empty | Current state name (e.g., `"Todo"`, `"In Progress"`) | Empty | Empty |
 | `{{.IssueID}}` | Parent issue ID | Empty | Empty | Empty | Parent issue ID (Comment events only) | Empty | Empty |
+| `{{.CommentBody}}` | Comment or review body | Empty | Empty | Comment/review body (`issue_comment`, `pull_request_review`, `pull_request_review_comment` events) | Empty | Empty | Empty |
+| `{{.CommentURL}}` | Comment or review URL | Empty | Empty | Comment/review HTML URL (`issue_comment`, `pull_request_review`, `pull_request_review_comment` events) | Empty | Empty | Empty |
 | `{{.Time}}` | Trigger time (RFC3339) | Empty | Empty | Empty | Empty | Empty | Cron tick time (e.g., `"2026-02-07T09:00:00Z"`) |
 | `{{.Schedule}}` | Cron schedule expression | Empty | Empty | Empty | Empty | Empty | Schedule string (e.g., `"0 * * * *"`) |
 

--- a/internal/webhook/github_filter.go
+++ b/internal/webhook/github_filter.go
@@ -35,6 +35,10 @@ type GitHubEventData struct {
 	Body   string
 	URL    string
 	Branch string
+	// Comment-specific fields for issue_comment, pull_request_review,
+	// and pull_request_review_comment events.
+	CommentBody string
+	CommentURL  string
 	// ChangedFiles lists file paths modified by the event.
 	// For push events, populated from the payload. For PR events, lazily
 	// fetched from the GitHub API when a webhook filter uses FilePatterns.
@@ -132,6 +136,10 @@ func ParseGitHubWebhook(eventType string, payload []byte) (*GitHubEventData, err
 	case *github.IssueCommentEvent:
 		data.Action = e.GetAction()
 		data.Sender = e.GetSender().GetLogin()
+		if comment := e.GetComment(); comment != nil {
+			data.CommentBody = comment.GetBody()
+			data.CommentURL = comment.GetHTMLURL()
+		}
 		if issue := e.GetIssue(); issue != nil {
 			data.ID = fmt.Sprintf("%d", issue.GetNumber())
 			data.Title = issue.GetTitle()
@@ -150,6 +158,10 @@ func ParseGitHubWebhook(eventType string, payload []byte) (*GitHubEventData, err
 	case *github.PullRequestReviewEvent:
 		data.Action = e.GetAction()
 		data.Sender = e.GetSender().GetLogin()
+		if review := e.GetReview(); review != nil {
+			data.CommentBody = review.GetBody()
+			data.CommentURL = review.GetHTMLURL()
+		}
 		if pr := e.GetPullRequest(); pr != nil {
 			data.ID = fmt.Sprintf("%d", pr.GetNumber())
 			data.Title = pr.GetTitle()
@@ -164,6 +176,10 @@ func ParseGitHubWebhook(eventType string, payload []byte) (*GitHubEventData, err
 	case *github.PullRequestReviewCommentEvent:
 		data.Action = e.GetAction()
 		data.Sender = e.GetSender().GetLogin()
+		if comment := e.GetComment(); comment != nil {
+			data.CommentBody = comment.GetBody()
+			data.CommentURL = comment.GetHTMLURL()
+		}
 		if pr := e.GetPullRequest(); pr != nil {
 			data.ID = fmt.Sprintf("%d", pr.GetNumber())
 			data.Title = pr.GetTitle()
@@ -457,6 +473,12 @@ func ExtractGitHubWorkItem(eventData *GitHubEventData) map[string]interface{} {
 	}
 	if eventData.Branch != "" {
 		vars["Branch"] = eventData.Branch
+	}
+	if eventData.CommentBody != "" {
+		vars["CommentBody"] = eventData.CommentBody
+	}
+	if eventData.CommentURL != "" {
+		vars["CommentURL"] = eventData.CommentURL
 	}
 
 	return vars

--- a/internal/webhook/github_filter_test.go
+++ b/internal/webhook/github_filter_test.go
@@ -1282,6 +1282,129 @@ func TestParseGitHubWebhook_IssueCommentOnPR_ExtractsPullRequestAPIURL(t *testin
 	}
 }
 
+func TestParseGitHubWebhook_IssueComment_ExtractsCommentFields(t *testing.T) {
+	payload := `{
+		"action": "created",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"issue": {
+			"number": 42,
+			"title": "Test PR",
+			"body": "PR body",
+			"html_url": "https://github.com/org/repo/pull/42",
+			"state": "open"
+		},
+		"comment": {
+			"body": "/review please",
+			"html_url": "https://github.com/org/repo/pull/42#issuecomment-123",
+			"user": {"login": "commenter"}
+		}
+	}`
+
+	got, err := ParseGitHubWebhook("issue_comment", []byte(payload))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+	if got.CommentBody != "/review please" {
+		t.Errorf("CommentBody = %q, want %q", got.CommentBody, "/review please")
+	}
+	if got.CommentURL != "https://github.com/org/repo/pull/42#issuecomment-123" {
+		t.Errorf("CommentURL = %q, want %q", got.CommentURL, "https://github.com/org/repo/pull/42#issuecomment-123")
+	}
+}
+
+func TestParseGitHubWebhook_PullRequestReviewComment_ExtractsCommentFields(t *testing.T) {
+	payload := `{
+		"action": "created",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"pull_request": {
+			"number": 99,
+			"title": "Fix bug",
+			"body": "Fixes the bug",
+			"html_url": "https://github.com/org/repo/pull/99",
+			"head": {"ref": "fix-branch"}
+		},
+		"comment": {
+			"body": "nit: rename this variable",
+			"html_url": "https://github.com/org/repo/pull/99#discussion_r456",
+			"user": {"login": "reviewer"}
+		}
+	}`
+
+	got, err := ParseGitHubWebhook("pull_request_review_comment", []byte(payload))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+	if got.CommentBody != "nit: rename this variable" {
+		t.Errorf("CommentBody = %q, want %q", got.CommentBody, "nit: rename this variable")
+	}
+	if got.CommentURL != "https://github.com/org/repo/pull/99#discussion_r456" {
+		t.Errorf("CommentURL = %q, want %q", got.CommentURL, "https://github.com/org/repo/pull/99#discussion_r456")
+	}
+}
+
+func TestParseGitHubWebhook_PullRequestReview_ExtractsCommentFields(t *testing.T) {
+	payload := `{
+		"action": "submitted",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"pull_request": {
+			"number": 50,
+			"title": "Add feature",
+			"body": "New feature",
+			"html_url": "https://github.com/org/repo/pull/50",
+			"head": {"ref": "feat-branch"}
+		},
+		"review": {
+			"body": "LGTM with minor comments",
+			"html_url": "https://github.com/org/repo/pull/50#pullrequestreview-789",
+			"user": {"login": "lead-reviewer"}
+		}
+	}`
+
+	got, err := ParseGitHubWebhook("pull_request_review", []byte(payload))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+	if got.CommentBody != "LGTM with minor comments" {
+		t.Errorf("CommentBody = %q, want %q", got.CommentBody, "LGTM with minor comments")
+	}
+	if got.CommentURL != "https://github.com/org/repo/pull/50#pullrequestreview-789" {
+		t.Errorf("CommentURL = %q, want %q", got.CommentURL, "https://github.com/org/repo/pull/50#pullrequestreview-789")
+	}
+}
+
+func TestExtractGitHubWorkItemCommentFields(t *testing.T) {
+	eventData := &GitHubEventData{
+		Event:       "pull_request_review_comment",
+		CommentBody: "nit: rename this",
+		CommentURL:  "https://github.com/org/repo/pull/99#discussion_r456",
+	}
+
+	vars := ExtractGitHubWorkItem(eventData)
+	if vars["CommentBody"] != "nit: rename this" {
+		t.Errorf("CommentBody = %v, want %q", vars["CommentBody"], "nit: rename this")
+	}
+	if vars["CommentURL"] != "https://github.com/org/repo/pull/99#discussion_r456" {
+		t.Errorf("CommentURL = %v, want %q", vars["CommentURL"], "https://github.com/org/repo/pull/99#discussion_r456")
+	}
+}
+
+func TestExtractGitHubWorkItemNoCommentFields(t *testing.T) {
+	eventData := &GitHubEventData{
+		Event: "push",
+	}
+
+	vars := ExtractGitHubWorkItem(eventData)
+	if _, ok := vars["CommentBody"]; ok {
+		t.Error("CommentBody should not be set for non-comment events")
+	}
+	if _, ok := vars["CommentURL"]; ok {
+		t.Error("CommentURL should not be set for non-comment events")
+	}
+}
+
 func TestParseGitHubWebhook_IssueCommentOnIssue_NoPullRequestAPIURL(t *testing.T) {
 	payload := `{
 		"action": "created",


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs
/kind feature
-->

/kind feature

#### What this PR does / why we need it:

Extracts comment-specific fields (CommentBody, CommentURL) from GitHub webhook payloads for issue_comment, pull_request_review, and pull_request_review_comment events and exposes them as template variables for TaskSpawner prompt templates.

Previously, these fields were never parsed or included in the template variables map, causing prompt template execution to fail when a spawner referenced comment-specific variables.

CommentAuthor was intentionally omitted because the existing Sender field already captures the same user who triggered the webhook event.

#### Which issue(s) this PR is related to:

<!--
Fixes #<issue number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

The Sender field (which was already populated) represents the user who triggered the webhook event, which is the same as the comment author. CommentBody and CommentURL provide access to the comment content and link, which are distinct from the parent issue/PR Body and URL.

Also updates the template variable tables in docs/reference.md and docs/integration.md to document the new variables.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
Add CommentBody and CommentURL template variables for GitHub comment webhook events (issue_comment, pull_request_review, pull_request_review_comment).
```