### PR TITLE
Run PR E2E directly from CI and Fork E2E

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,25 +5,36 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   merge_group:
-  workflow_dispatch:
-    inputs:
-      ok-to-test:
-        description: Run e2e tests
-        type: boolean
-        default: false
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}${{
-      github.event.action == 'labeled' && '-labeled' || ''
-    }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  set-pr-e2e-pending:
+    if: >-
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set pending PR E2E status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'pr-e2e',
+              description: 'Waiting for test-e2e to complete',
+              target_url: context.payload.pull_request.html_url,
+            })
+
   build:
-    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +47,6 @@ jobs:
         run: make build
 
   verify:
-    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +59,6 @@ jobs:
         run: make verify
 
   test:
-    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +71,6 @@ jobs:
         run: make test
 
   test-integration:
-    if: github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +84,10 @@ jobs:
 
   test-e2e:
     if: >-
-      github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.ok-to-test) || (contains(github.event.pull_request.labels.*.name, 'ok-to-test') && github.event.pull_request.head.repo.full_name == github.repository)
+      github.event_name == 'push' || github.event_name == 'merge_group' || (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     permissions:
       contents: read
       issues: read
@@ -84,3 +95,86 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+
+  report-pr-e2e-status:
+    if: >-
+      always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - set-pr-e2e-pending
+      - test-e2e
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      statuses: write
+    steps:
+      - name: Report PR E2E status
+        uses: actions/github-script@v7
+        env:
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          CURRENT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TEST_E2E_RESULT: ${{ needs.test-e2e.result }}
+          WORKFLOW_EVENT: pull_request
+          WORKFLOW_NAME: CI
+        with:
+          script: |
+            const currentRunId = Number(process.env.CURRENT_RUN_ID)
+            const currentRunAttempt = Number(process.env.CURRENT_RUN_ATTEMPT)
+            const prHeadSha = process.env.PR_HEAD_SHA
+            const result = process.env.TEST_E2E_RESULT
+
+            if (result === 'skipped') {
+              core.info('test-e2e was skipped, leaving pr-e2e unchanged')
+              return
+            }
+
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: process.env.WORKFLOW_EVENT,
+              head_sha: prHeadSha,
+              per_page: 100,
+            })
+
+            const latestRun = runs.workflow_runs
+              .filter((run) => run.name === process.env.WORKFLOW_NAME)
+              .sort((left, right) => {
+                const createdDiff = Date.parse(right.created_at) - Date.parse(left.created_at)
+                if (createdDiff !== 0) return createdDiff
+                if (left.id !== right.id) return right.id - left.id
+                return (right.run_attempt || 1) - (left.run_attempt || 1)
+              })[0]
+
+            if (!latestRun) {
+              core.info(`No ${process.env.WORKFLOW_NAME} workflow runs found for ${prHeadSha}`)
+              return
+            }
+
+            if (latestRun.id !== currentRunId || (latestRun.run_attempt || 1) !== currentRunAttempt) {
+              core.info(`Skipping stale status update from run ${currentRunId} attempt ${currentRunAttempt}`)
+              return
+            }
+
+            let state = 'pending'
+            let description = 'Waiting for test-e2e to complete'
+
+            if (result === 'success') {
+              state = 'success'
+              description = 'test-e2e succeeded'
+            } else if (result === 'failure' || result === 'cancelled') {
+              state = 'failure'
+              description = `test-e2e ${result}`
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: prHeadSha,
+              state,
+              context: 'pr-e2e',
+              description,
+              target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            })

--- a/.github/workflows/fork-e2e.yaml
+++ b/.github/workflows/fork-e2e.yaml
@@ -1,27 +1,93 @@
 name: Fork E2E
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: PR number to test
-        required: true
-        type: number
-      head_sha:
-        description: Approved HEAD SHA of the fork PR
-        required: true
-        type: string
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: fork-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
+  set-pr-e2e-pending:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set pending PR E2E status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'pr-e2e',
+              description: 'Waiting for Fork E2E to complete',
+              target_url: context.payload.pull_request.html_url,
+            })
+
   fork-e2e:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
     permissions:
       contents: read
       issues: read
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
-      checkout-ref: refs/pull/${{ inputs.pr_number }}/merge
+      checkout-ref: refs/pull/${{ github.event.pull_request.number }}/merge
       persist-credentials: false
-      expected-head-sha: ${{ inputs.head_sha }}
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      expected-head-sha: ${{ github.event.pull_request.head.sha }}
+      use-environment-secrets: true
+      environment-name: ok-to-test
+
+  report-pr-e2e-status:
+    if: >-
+      always() && github.event.pull_request.head.repo.full_name != github.repository
+    needs:
+      - set-pr-e2e-pending
+      - fork-e2e
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      statuses: write
+    steps:
+      - name: Report PR E2E status
+        uses: actions/github-script@v7
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FORK_E2E_RESULT: ${{ needs.fork-e2e.result }}
+        with:
+          script: |
+            const result = process.env.FORK_E2E_RESULT
+            const prHeadSha = process.env.PR_HEAD_SHA
+
+            let state = 'pending'
+            let description = 'Waiting for Fork E2E to complete'
+
+            if (result === 'success') {
+              state = 'success'
+              description = 'Fork E2E succeeded'
+            } else if (result === 'failure' || result === 'cancelled') {
+              state = 'failure'
+              description = `Fork E2E ${result}`
+            } else if (result === 'skipped') {
+              core.info('Fork E2E was skipped, leaving pr-e2e unchanged')
+              return
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: prHeadSha,
+              state,
+              context: 'pr-e2e',
+              description,
+              target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            })

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -19,21 +19,30 @@ on:
         description: If set, validate the checked-out merge commit includes this PR head SHA
         type: string
         default: ''
+      use-environment-secrets:
+        description: Whether to load secrets from a GitHub environment
+        type: boolean
+        default: false
+      environment-name:
+        description: GitHub environment name to use when loading environment secrets
+        type: string
+        default: ''
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
-        required: true
+        required: false
       CODEX_AUTH_JSON:
-        required: true
+        required: false
 
 jobs:
   e2e:
+    if: ${{ !inputs.use-environment-secrets }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       # TaskSpawner E2E injects github.token into make test-e2e and calls the
       # GitHub Issues API to discover issues and comments.
       issues: read
-    steps:
+    steps: &e2e_steps
       - uses: actions/checkout@v4
         if: inputs.checkout-ref == ''
         with:
@@ -45,6 +54,21 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
           persist-credentials: ${{ inputs.persist-credentials }}
           fetch-depth: 2
+
+      - name: Validate E2E secrets
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is required"
+            exit 1
+          fi
+
+          if [ -z "$CODEX_AUTH_JSON" ]; then
+            echo "::error::CODEX_AUTH_JSON is required"
+            exit 1
+          fi
 
       - name: Validate checked-out commit matches approved SHA
         if: inputs.expected-sha != ''
@@ -115,3 +139,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           KELOS_BIN: ${{ github.workspace }}/bin/kelos
         run: make test-e2e
+
+  e2e-with-environment:
+    if: ${{ inputs.use-environment-secrets }}
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment-name }}
+    permissions:
+      contents: read
+      # TaskSpawner E2E injects github.token into make test-e2e and calls the
+      # GitHub Issues API to discover issues and comments.
+      issues: read
+    steps: *e2e_steps


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Runs same-repo PR E2E from CI, runs fork PR E2E from a pull_request_target workflow gated by the ok-to-test environment, and publishes a single required pr-e2e status directly from the workflow that actually ran the test.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Fork PR E2E now uses per-PR concurrency and relies on environment approval rather than manual dispatch. The reusable E2E workflow validates required secrets immediately after checkout. After merge, branch protection should require the pr-e2e status once it has appeared at least once.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```
