### PR TITLE
Use secrets: inherit to fix environment secrets in reusable E2E

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,9 +92,7 @@ jobs:
       contents: read
       issues: read
     uses: ./.github/workflows/reusable-e2e.yaml
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+    secrets: inherit
 
   report-pr-e2e-status:
     if: >-

--- a/.github/workflows/fork-e2e.yaml
+++ b/.github/workflows/fork-e2e.yaml
@@ -43,6 +43,7 @@ jobs:
       expected-head-sha: ${{ github.event.pull_request.head.sha }}
       use-environment-secrets: true
       environment-name: ok-to-test
+    secrets: inherit
 
   report-pr-e2e-status:
     if: >-

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -27,11 +27,7 @@ on:
         description: GitHub environment name to use when loading environment secrets
         type: string
         default: ''
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN:
-        required: false
-      CODEX_AUTH_JSON:
-        required: false
+
 
 jobs:
   e2e:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes fork PR E2E failing at the "Validate E2E secrets" step because declared `workflow_call` secrets shadow environment secrets of the same name in reusable workflows.

Removes the explicit `secrets:` declarations from `reusable-e2e.yaml` and switches both callers (`ci.yaml`, `fork-e2e.yaml`) to `secrets: inherit`, so the `e2e-with-environment` job can access secrets from the `ok-to-test` environment.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The failed run: https://github.com/kelos-dev/kelos/actions/runs/24219120177/job/70706385404?pr=939

Root cause: when a reusable workflow declares secrets in `on.workflow_call.secrets`, those declarations take precedence over environment secrets with the same name. Since `fork-e2e.yaml` didn't pass secrets explicitly (relying on the environment), they resolved to empty.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fork PR E2E failures at the "Validate E2E secrets" step by inheriting environment secrets in the reusable workflow. Callers now use `secrets: inherit` so `ok-to-test` secrets reach `e2e-with-environment`.

- **Bug Fixes**
  - Removed `on.workflow_call.secrets` from `reusable-e2e.yaml` to avoid shadowing environment secrets.
  - Switched `ci.yaml` and `fork-e2e.yaml` to `secrets: inherit`.

<sup>Written for commit 6af66f23eb00443959bbdb223577de596117d935. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

