### PR TITLE
Remove actor permission check from label workflow

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -63,40 +63,31 @@ jobs:
           script: |
             const eventName = context.eventName
             let body = ''
-            let actor = ''
             let issueNumber = 0
 
             if (eventName === 'issue_comment' || eventName === 'pull_request_review_comment') {
               body = context.payload.comment?.body || ''
-              actor = context.payload.comment?.user?.login || ''
               issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || 0
             } else if (eventName === 'pull_request_review') {
               body = context.payload.review?.body || ''
-              actor = context.payload.review?.user?.login || ''
               issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || 0
             } else if (eventName === 'issues') {
               body = context.payload.issue?.body || ''
-              actor = context.payload.issue?.user?.login || ''
               issueNumber = context.payload.issue?.number || 0
             } else if (eventName === 'pull_request_target') {
               body = context.payload.pull_request?.body || ''
-              actor = context.payload.pull_request?.user?.login || ''
               issueNumber = context.payload.pull_request?.number || 0
             } else {
               core.setFailed(`Unsupported event for label workflow: ${eventName}`)
               return
             }
 
-            // Keep body and actor tied to the same event source so a review,
-            // comment, issue, or PR body cannot inherit another object's
-            // commands or author.
             const strippedBody = body.replace(/<!--[\s\S]*?-->/g, '')
             const hasCommand =
               /^\s*\/(?:remove-)?(?:kind|priority|actor)\s+.+$/m.test(strippedBody) ||
               /^\s*\/(?:remove-)?triage-accepted\s*$/m.test(strippedBody)
 
             core.setOutput('body', body)
-            core.setOutput('actor', actor)
             core.setOutput('issue_number', String(issueNumber))
             core.setOutput('has_command', hasCommand ? 'true' : 'false')
 
@@ -104,26 +95,10 @@ jobs:
               core.info('No label commands found in selected source body')
               return
             }
-
-            if (!actor) {
-              core.setFailed('Could not determine actor for label command')
-              return
-            }
             if (!issueNumber) {
               core.setFailed('Could not determine issue number for label command')
               return
             }
-      - name: Check permission
-        if: steps.context.outputs.has_command == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ steps.context.outputs.actor }}/permission" -q .permission)
-          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
-            echo "User ${{ steps.context.outputs.actor }} does not have write permission (permission=$PERMISSION)"
-            exit 1
-          fi
-
       - name: Apply labels
         if: steps.context.outputs.has_command == 'true'
         uses: actions/github-script@v7


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Removes the actor permission check from the label workflow. The check was calling `gh api repos/.../collaborators/<actor>/permission` and failing the workflow whenever the actor lacked `admin` or `write` permission. This caused frequent workflow failures for bot-authored PRs (e.g. automated image update PRs) and external contributors whose PR bodies contained `/kind` commands from the template.

Label operations are low-risk and easily reversible. The workflow's `GITHUB_TOKEN` is already scoped to `issues: write` and `pull-requests: write`, so it cannot do anything destructive. Dropping the per-actor authorization step matches the behavior of similar projects (e.g. Kubernetes prow) that let any contributor use label commands.

Also cleans up the now-unused `actor` variable and its failure check from the "Resolve command context" step.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the per-actor permission check from the label workflow to stop failures on bot-authored and external contributor PRs using `/kind` commands. Also removed the unused `actor` plumbing in the context step.

- **Bug Fixes**
  - Dropped the collaborator permission API call so label commands work for bots and external contributors.
  - Removed the unused `actor` output and its failure check from "Resolve command context".

<sup>Written for commit cfdabb66105ffdc9f065b61b9fa936920c47c42b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

