### PR TITLE
Set pr-e2e status on merge_group commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,23 +15,26 @@ concurrency:
 jobs:
   set-pr-e2e-pending:
     if: >-
-      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       statuses: write
     steps:
       - name: Set pending PR E2E status
         uses: actions/github-script@v7
+        env:
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          TARGET_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
         with:
           script: |
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
+              sha: process.env.TARGET_SHA,
               state: 'pending',
               context: 'pr-e2e',
               description: 'Waiting for test-e2e to complete',
-              target_url: context.payload.pull_request.html_url,
+              target_url: process.env.TARGET_URL,
             })
 
   build:
@@ -96,7 +99,10 @@ jobs:
 
   report-pr-e2e-status:
     if: >-
-      always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      always() && (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        || github.event_name == 'merge_group'
+      )
     needs:
       - set-pr-e2e-pending
       - test-e2e
@@ -113,15 +119,15 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           TEST_E2E_RESULT: ${{ needs.test-e2e.result }}
-          WORKFLOW_EVENT: pull_request
+          WORKFLOW_EVENT: ${{ github.event_name }}
           WORKFLOW_NAME: CI
         with:
           script: |
             const currentRunId = Number(process.env.CURRENT_RUN_ID)
             const currentRunAttempt = Number(process.env.CURRENT_RUN_ATTEMPT)
-            const prHeadSha = process.env.PR_HEAD_SHA
+            const targetSha = process.env.TARGET_SHA
             const result = process.env.TEST_E2E_RESULT
 
             if (result === 'skipped') {
@@ -133,7 +139,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               event: process.env.WORKFLOW_EVENT,
-              head_sha: prHeadSha,
+              head_sha: targetSha,
               per_page: 100,
             })
 
@@ -147,7 +153,7 @@ jobs:
               })[0]
 
             if (!latestRun) {
-              core.info(`No ${process.env.WORKFLOW_NAME} workflow runs found for ${prHeadSha}`)
+              core.info(`No ${process.env.WORKFLOW_NAME} workflow runs found for ${targetSha}`)
               return
             }
 
@@ -170,7 +176,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: prHeadSha,
+              sha: targetSha,
               state,
               context: 'pr-e2e',
               description,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After #937, `pr-e2e` became a required status check for the merge queue. But the `set-pr-e2e-pending` and `report-pr-e2e-status` jobs in `ci.yaml` only ran on `pull_request` events, so the status was never set on merge_group commits. Because the merge queue creates a new merge commit with a different SHA than the PR head, PRs stalled in the queue waiting for a `pr-e2e` status that would never arrive. This affected both forked PRs and same-repo PRs.

This PR expands both jobs to also fire on `merge_group` events, falling back to `github.event.merge_group.head_sha` and the workflow run URL when no `pull_request` payload is available, and uses `github.event_name` for the stale-run lookup instead of the hardcoded `pull_request` filter.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verified by inspecting a currently stuck merge_group run: the ci.yaml run on the merge_group commit shows `set-pr-e2e-pending` and `report-pr-e2e-status` as SKIPPED, and the merge_group commit only carries a `license/cla` status — no `pr-e2e`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `pr-e2e` statuses on `merge_group` commits so merge queue runs don’t stall. Extends CI to set and report the status for both `pull_request` and `merge_group` events.

- **Bug Fixes**
  - Run `set-pr-e2e-pending` and `report-pr-e2e-status` on `merge_group` events.
  - Fallback to `github.event.merge_group.head_sha` and the workflow run URL when no `pull_request` payload exists.
  - Use `github.event_name` for stale-run lookup instead of a hardcoded `pull_request` filter.

<sup>Written for commit 12af40abbb5f7bd60b3095d061e00ff9b27354b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

