### PR TITLE
Route kind/api issues to actor/human in triage

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -177,12 +177,12 @@ Picks up open GitHub issues labeled `needs-actor` and performs automated triage.
 | **Concurrency** | 8 |
 
 **For each issue, the agent:**
-1. Classifies with exactly one `kind/*` label (`kind/bug`, `kind/feature`, `kind/api`, `kind/docs`)
+1. Classifies with exactly one `kind/*` label (`kind/bug`, `kind/feature`, `kind/api`, `kind/docs`). `kind/api` covers any change that introduces or modifies a user-facing API surface — CRD fields, CLI commands or flags, webhooks, etc.
 2. Checks if the issue has already been fixed by a merged PR or recent commit
 3. Checks if the issue references outdated APIs, flags, or features
 4. Detects duplicate issues
 5. Assesses priority (`priority/important-soon`, `priority/important-longterm`, `priority/backlog`)
-6. Recommends an actor — assigns `actor/kelos` if the issue has clear scope and verifiable criteria, otherwise leaves `needs-actor` for human decision
+6. Recommends an actor — assigns `actor/kelos` if the issue has clear scope and verifiable criteria, otherwise assigns `actor/human`. `kind/api` issues always get `actor/human` because new user-facing APIs must be reviewed and discussed with a maintainer before any PR is opened.
 
 Posts a single triage comment with its findings, adds the `kelos/needs-input` label (to prevent re-triage), and posts a `/kelos needs-input` comment (to prevent workers from picking up the issue before maintainer review).
 

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -59,7 +59,9 @@ spec:
       Read the issue carefully and apply exactly one `kind/*` label:
         - `kind/bug` — something is broken or behaving incorrectly
         - `kind/feature` — a request for new functionality
-        - `kind/api` — related to API changes or additions
+        - `kind/api` — introduces or changes a user-facing API surface:
+          CRD fields, CLI commands or flags, webhooks, or any other
+          interface the user interacts with
         - `kind/docs` — documentation improvement or fix
 
       Apply the label:
@@ -103,7 +105,12 @@ spec:
       ### 6. Recommend actor
       Determine whether this issue can be handled autonomously by Kelos's worker agent:
 
-      Assign `actor/kelos` if ALL of these are true:
+      Assign `actor/human` if the issue is `kind/api`. New user-facing API
+      surface (CRD fields, CLI commands or flags, webhooks, etc) must be
+      reviewed and discussed with a maintainer before any PR is opened, so
+      these are never handled autonomously.
+
+      Otherwise, assign `actor/kelos` if ALL of these are true:
         - The issue describes a concrete code change, documentation fix, test improvement,
           or configuration update with clear scope
         - The acceptance criteria are objectively verifiable (tests pass, docs are accurate,
@@ -111,7 +118,7 @@ spec:
         - It does NOT require: new CRD design decisions, breaking API changes,
           infrastructure/cluster access, subjective design choices, or external service setup
 
-      Leave `needs-actor` if ANY of these are true:
+      Otherwise, assign `actor/human` if ANY of these are true:
         - The issue requires architectural decisions or community input
         - The scope is ambiguous or open-ended
         - It depends on external systems Kelos cannot access
@@ -131,7 +138,7 @@ spec:
 
       **Kind**: <kind label applied>
       **Priority**: <priority label applied> — <one-line justification>
-      **Actor**: `actor/kelos` or `needs human` — <one-line justification>
+      **Actor**: `actor/kelos` or `actor/human` — <one-line justification>
 
       **Status**: STILL VALID / ALREADY FIXED / OUTDATED / DUPLICATE
 
@@ -148,8 +155,8 @@ spec:
       If recommending `actor/kelos`:
         `gh issue edit {{.Number}} --add-label triage-accepted --add-label actor/kelos --remove-label needs-triage --remove-label needs-actor`
 
-      If leaving `needs-actor`:
-        `gh issue edit {{.Number}} --add-label triage-accepted --remove-label needs-triage`
+      If recommending `actor/human`:
+        `gh issue edit {{.Number}} --add-label triage-accepted --add-label actor/human --remove-label needs-triage --remove-label needs-actor`
 
       The `triage-accepted` label prevents re-triage.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the `kelos-triage` TaskSpawner prompt so that issues introducing new user-facing API surface are always routed to a human maintainer instead of being picked up autonomously by the worker agent.

- Clarifies the `kind/api` classification to explicitly cover CRD fields, CLI commands or flags, webhooks, and other user-facing interfaces.
- Adds a hard rule in the actor recommendation step: any `kind/api` issue is assigned `actor/human`, because new APIs must be reviewed and discussed with a maintainer before a PR is opened.
- Replaces the previous "leave `needs-actor`" fallthrough with an explicit `actor/human` assignment so the triage lifecycle always ends in a concrete actor label. The `actor/*` prefix already satisfies the `needs-actor` sync rule in `.github/workflows/label.yaml`.
- Updates `self-development/README.md` to document the new routing.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The `actor/human` label already exists on the repo, so no label provisioning is required.
- Only files under `self-development/` change, so per `CLAUDE.md` this is `/kind cleanup` with a `NONE` release note.
- `self-development/kelos-action/triage.yaml` is intentionally left alone — its classification set does not include `kind/api`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always route `kind/api` issues to `actor/human` in triage so new user-facing APIs are reviewed by a maintainer. Clarifies `kind/api` scope (CRD fields, CLI commands/flags, webhooks) and replaces the `needs-actor` fallback with an explicit `actor/human`; updates `self-development/README.md` accordingly.

<sup>Written for commit 4b06fb9c07937e3ffa1a4c1df5e1d83cd2adf721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

