### PR TITLE
Add Helm values support to kelos install

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -51,13 +51,30 @@ jobs:
 
       - name: Install kelos
         run: |
-          bin/kelos install --version main --image-pull-policy Always \
-            --spawner-resource-requests cpu=100m,memory=128Mi \
-            --ghproxy-resource-requests cpu=10m,memory=64Mi \
-            --ghproxy-cache-ttl 50s \
-            --token-refresher-resource-requests cpu=50m,memory=64Mi \
-            --controller-resource-requests cpu=10m,memory=64Mi \
-            --controller-resource-limits cpu=500m,memory=128Mi
+          cat > /tmp/kelos-dev-values.yaml <<'EOF'
+          image:
+            tag: main
+            pullPolicy: Always
+          spawner:
+            resources:
+              requests: "cpu=100m,memory=128Mi"
+          ghproxy:
+            cacheTTL: 50s
+            resources:
+              requests: "cpu=10m,memory=64Mi"
+          tokenRefresher:
+            resources:
+              requests: "cpu=50m,memory=64Mi"
+          controller:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 128Mi
+          EOF
+          bin/kelos install -f /tmp/kelos-dev-values.yaml
           kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
           kubectl rollout status deployment/kelos-controller-manager -n kelos-system --timeout=120s
           kubectl rollout restart deployment -l kelos.dev/component=ghproxy -n "${KELOS_NAMESPACE}"

--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ kelos install
 
 This installs the Kelos controller and CRDs into the `kelos-system` namespace.
 
+For chart-native customization, pass Helm values to `kelos install`:
+
+```bash
+kelos install -f values.yaml
+kelos install --set webhookServer.sources.github.enabled=true
+```
+
+`kelos install` manages CRDs separately, so `crds.install` must be omitted or set to `false`.
+For the full values schema and advanced examples, see [the Helm chart README](internal/manifests/charts/kelos/README.md).
+
 Verify the installation:
 
 ```bash

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -351,15 +351,26 @@ The `kelos` CLI lets you manage the full lifecycle without writing YAML.
 
 ### `kelos install` Flags
 
-- `--version`: Override the image tag used for controller and bundled agent images
+- `--values, -f`: Load Helm values from a YAML file; repeat to merge multiple files, or use `-` to read from stdin
+- `--set`: Set chart values with Helm `key=value` syntax
+- `--set-string`: Set string chart values with Helm `key=value` syntax
+- `--set-file`: Set chart values from file contents with Helm `key=path` syntax
+- `--version`: Override the image tag used for controller and bundled agent images; shorthand for `image.tag`
 - `--image-pull-policy`: Set `imagePullPolicy` on controller-managed images
 - `--disable-heartbeat`: Do not install the telemetry heartbeat CronJob
 - `--spawner-resource-requests`: Resource requests for spawner containers as comma-separated `name=value` pairs
 - `--spawner-resource-limits`: Resource limits for spawner containers as comma-separated `name=value` pairs
+- `--ghproxy-resource-requests`: Resource requests for workspace ghproxy containers as comma-separated `name=value` pairs
+- `--ghproxy-resource-limits`: Resource limits for workspace ghproxy containers as comma-separated `name=value` pairs
+- `--ghproxy-allowed-upstreams`: Comma-separated list of allowed upstream base URLs for ghproxy
+- `--ghproxy-cache-ttl`: Cache TTL for workspace ghproxy instances
 - `--token-refresher-resource-requests`: Resource requests for token refresher sidecars as comma-separated `name=value` pairs, for example `cpu=100m,memory=128Mi`
 - `--token-refresher-resource-limits`: Resource limits for token refresher sidecars as comma-separated `name=value` pairs, for example `cpu=200m,memory=256Mi`
 - `--controller-resource-requests`: Resource requests for the controller container as comma-separated `name=value` pairs, for example `cpu=10m,memory=64Mi`
 - `--controller-resource-limits`: Resource limits for the controller container as comma-separated `name=value` pairs, for example `cpu=500m,memory=128Mi`
+
+`kelos install` renders the embedded Helm chart but still manages CRDs separately, so `crds.install` must be omitted or set to `false`.
+When the same key is set multiple ways, precedence is: chart defaults, then `--values` files, then compatibility install flags, then explicit `--set`, `--set-string`, and `--set-file` overrides.
 
 ### `kelos run` Flags
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/strvals"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,9 +33,38 @@ import (
 
 const fieldManager = "kelos"
 
+type helmValuesOptions struct {
+	imageTag                       *string
+	pullPolicy                     string
+	disableHeartbeat               bool
+	spawnerResourceRequests        string
+	spawnerResourceLimits          string
+	ghproxyResourceRequests        string
+	ghproxyResourceLimits          string
+	tokenRefresherResourceRequests string
+	tokenRefresherResourceLimits   string
+	controllerResourceRequests     string
+	controllerResourceLimits       string
+	ghproxyAllowedUpstreams        string
+	ghproxyCacheTTL                string
+}
+
+type installValuesOptions struct {
+	defaultImageTag string
+	valuesFiles     []string
+	setValues       []string
+	setStringValues []string
+	setFileValues   []string
+	flagValues      helmValuesOptions
+}
+
 func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 	var dryRun bool
 	var flagVersion string
+	var valuesFiles []string
+	var setValues []string
+	var setStringValues []string
+	var setFileValues []string
 	var imagePullPolicy string
 	var disableHeartbeat bool
 	var spawnerResourceRequests string
@@ -52,25 +83,37 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 		Short: "Install kelos CRDs and controller into the cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			installVersion := version.Version
 			if flagVersion != "" {
-				version.Version = flagVersion
+				installVersion = flagVersion
 			}
 
-			vals := disableChartCRDs(buildHelmValuesWithGHProxyResources(
-				version.Version,
-				imagePullPolicy,
-				disableHeartbeat,
-				spawnerResourceRequests,
-				spawnerResourceLimits,
-				ghproxyResourceRequests,
-				ghproxyResourceLimits,
-				tokenRefresherResourceRequests,
-				tokenRefresherResourceLimits,
-				controllerResourceRequests,
-				controllerResourceLimits,
-				ghproxyAllowedUpstreams,
-				ghproxyCacheTTL,
-			))
+			vals, err := buildInstallValues(cmd.InOrStdin(), installValuesOptions{
+				defaultImageTag: installVersion,
+				valuesFiles:     valuesFiles,
+				setValues:       setValues,
+				setStringValues: setStringValues,
+				setFileValues:   setFileValues,
+				flagValues: helmValuesOptions{
+					imageTag:                       nonEmptyStringPtr(flagVersion),
+					pullPolicy:                     imagePullPolicy,
+					disableHeartbeat:               disableHeartbeat,
+					spawnerResourceRequests:        spawnerResourceRequests,
+					spawnerResourceLimits:          spawnerResourceLimits,
+					ghproxyResourceRequests:        ghproxyResourceRequests,
+					ghproxyResourceLimits:          ghproxyResourceLimits,
+					tokenRefresherResourceRequests: tokenRefresherResourceRequests,
+					tokenRefresherResourceLimits:   tokenRefresherResourceLimits,
+					controllerResourceRequests:     controllerResourceRequests,
+					controllerResourceLimits:       controllerResourceLimits,
+					ghproxyAllowedUpstreams:        ghproxyAllowedUpstreams,
+					ghproxyCacheTTL:                ghproxyCacheTTL,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
 			controllerManifest, err := helmchart.Render(manifests.ChartFS, vals)
 			if err != nil {
 				return fmt.Errorf("rendering chart: %w", err)
@@ -106,7 +149,7 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 				return fmt.Errorf("installing CRDs: %w", err)
 			}
 
-			fmt.Fprintf(os.Stdout, "Installing kelos controller (version: %s)\n", version.Version)
+			fmt.Fprintf(os.Stdout, "Installing kelos controller (version: %s)\n", installVersion)
 			if err := applyManifests(ctx, dc, dyn, controllerManifest); err != nil {
 				return fmt.Errorf("installing controller: %w", err)
 			}
@@ -117,6 +160,10 @@ func newInstallCommand(cfg *ClientConfig) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print the manifests that would be applied without installing")
+	cmd.Flags().StringArrayVarP(&valuesFiles, "values", "f", nil, "specify values in a YAML file (use '-' to read from stdin)")
+	cmd.Flags().StringArrayVar(&setValues, "set", nil, "set chart values on the command line (key1=val1,key2=val2)")
+	cmd.Flags().StringArrayVar(&setStringValues, "set-string", nil, "set string chart values on the command line (key1=val1,key2=val2)")
+	cmd.Flags().StringArrayVar(&setFileValues, "set-file", nil, "set chart values from files (key1=path1,key2=path2)")
 	cmd.Flags().StringVar(&flagVersion, "version", "", "override the version used for image tags (defaults to the binary version)")
 	cmd.Flags().StringVar(&imagePullPolicy, "image-pull-policy", "", "set imagePullPolicy on controller containers (e.g. Always, IfNotPresent, Never)")
 	cmd.Flags().BoolVar(&disableHeartbeat, "disable-heartbeat", false, "do not install the telemetry heartbeat CronJob")
@@ -140,38 +187,62 @@ func buildHelmValues(ver string, pullPolicy string, disableHeartbeat bool, spawn
 }
 
 func buildHelmValuesWithGHProxyResources(ver string, pullPolicy string, disableHeartbeat bool, spawnerResourceRequests string, spawnerResourceLimits string, ghproxyResourceRequests string, ghproxyResourceLimits string, tokenRefresherResourceRequests string, tokenRefresherResourceLimits string, controllerResourceRequests string, controllerResourceLimits string, ghproxyAllowedUpstreams string, ghproxyCacheTTL string) map[string]interface{} {
-	imageVals := map[string]interface{}{
-		"tag": ver,
+	return buildHelmValuesFromOptions(helmValuesOptions{
+		imageTag:                       ptr.To(ver),
+		pullPolicy:                     pullPolicy,
+		disableHeartbeat:               disableHeartbeat,
+		spawnerResourceRequests:        spawnerResourceRequests,
+		spawnerResourceLimits:          spawnerResourceLimits,
+		ghproxyResourceRequests:        ghproxyResourceRequests,
+		ghproxyResourceLimits:          ghproxyResourceLimits,
+		tokenRefresherResourceRequests: tokenRefresherResourceRequests,
+		tokenRefresherResourceLimits:   tokenRefresherResourceLimits,
+		controllerResourceRequests:     controllerResourceRequests,
+		controllerResourceLimits:       controllerResourceLimits,
+		ghproxyAllowedUpstreams:        ghproxyAllowedUpstreams,
+		ghproxyCacheTTL:                ghproxyCacheTTL,
+	})
+}
+
+func buildHelmValuesFromOptions(opts helmValuesOptions) map[string]interface{} {
+	vals := map[string]interface{}{}
+
+	imageVals := map[string]interface{}{}
+	if opts.imageTag != nil {
+		imageVals["tag"] = *opts.imageTag
 	}
-	if pullPolicy != "" {
-		imageVals["pullPolicy"] = pullPolicy
+	if opts.pullPolicy != "" {
+		imageVals["pullPolicy"] = opts.pullPolicy
 	}
-	vals := map[string]interface{}{
-		"image": imageVals,
+	if len(imageVals) > 0 {
+		vals["image"] = imageVals
 	}
-	if disableHeartbeat {
+
+	if opts.disableHeartbeat {
 		vals["telemetry"] = map[string]interface{}{
 			"enabled": false,
 		}
 	}
+
 	spawnerResources := map[string]interface{}{}
-	if spawnerResourceRequests != "" {
-		spawnerResources["requests"] = spawnerResourceRequests
+	if opts.spawnerResourceRequests != "" {
+		spawnerResources["requests"] = opts.spawnerResourceRequests
 	}
-	if spawnerResourceLimits != "" {
-		spawnerResources["limits"] = spawnerResourceLimits
+	if opts.spawnerResourceLimits != "" {
+		spawnerResources["limits"] = opts.spawnerResourceLimits
 	}
 	if len(spawnerResources) > 0 {
 		vals["spawner"] = map[string]interface{}{
 			"resources": spawnerResources,
 		}
 	}
+
 	ghproxyResources := map[string]interface{}{}
-	if ghproxyResourceRequests != "" {
-		ghproxyResources["requests"] = ghproxyResourceRequests
+	if opts.ghproxyResourceRequests != "" {
+		ghproxyResources["requests"] = opts.ghproxyResourceRequests
 	}
-	if ghproxyResourceLimits != "" {
-		ghproxyResources["limits"] = ghproxyResourceLimits
+	if opts.ghproxyResourceLimits != "" {
+		ghproxyResources["limits"] = opts.ghproxyResourceLimits
 	}
 	if len(ghproxyResources) > 0 {
 		ghproxyVals, _ := vals["ghproxy"].(map[string]interface{})
@@ -182,11 +253,11 @@ func buildHelmValuesWithGHProxyResources(ver string, pullPolicy string, disableH
 		vals["ghproxy"] = ghproxyVals
 	}
 	tokenRefresherResources := map[string]interface{}{}
-	if tokenRefresherResourceRequests != "" {
-		tokenRefresherResources["requests"] = tokenRefresherResourceRequests
+	if opts.tokenRefresherResourceRequests != "" {
+		tokenRefresherResources["requests"] = opts.tokenRefresherResourceRequests
 	}
-	if tokenRefresherResourceLimits != "" {
-		tokenRefresherResources["limits"] = tokenRefresherResourceLimits
+	if opts.tokenRefresherResourceLimits != "" {
+		tokenRefresherResources["limits"] = opts.tokenRefresherResourceLimits
 	}
 	if len(tokenRefresherResources) > 0 {
 		vals["tokenRefresher"] = map[string]interface{}{
@@ -194,34 +265,163 @@ func buildHelmValuesWithGHProxyResources(ver string, pullPolicy string, disableH
 		}
 	}
 	controllerResources := map[string]interface{}{}
-	if controllerResourceRequests != "" {
-		controllerResources["requests"] = parseResourceString(controllerResourceRequests)
+	if opts.controllerResourceRequests != "" {
+		controllerResources["requests"] = parseResourceString(opts.controllerResourceRequests)
 	}
-	if controllerResourceLimits != "" {
-		controllerResources["limits"] = parseResourceString(controllerResourceLimits)
+	if opts.controllerResourceLimits != "" {
+		controllerResources["limits"] = parseResourceString(opts.controllerResourceLimits)
 	}
 	if len(controllerResources) > 0 {
 		vals["controller"] = map[string]interface{}{
 			"resources": controllerResources,
 		}
 	}
-	if ghproxyAllowedUpstreams != "" {
+	if opts.ghproxyAllowedUpstreams != "" {
 		ghproxyVals, _ := vals["ghproxy"].(map[string]interface{})
 		if ghproxyVals == nil {
 			ghproxyVals = map[string]interface{}{}
 		}
-		ghproxyVals["allowedUpstreams"] = ghproxyAllowedUpstreams
+		ghproxyVals["allowedUpstreams"] = opts.ghproxyAllowedUpstreams
 		vals["ghproxy"] = ghproxyVals
 	}
-	if ghproxyCacheTTL != "" {
+	if opts.ghproxyCacheTTL != "" {
 		ghproxyVals, _ := vals["ghproxy"].(map[string]interface{})
 		if ghproxyVals == nil {
 			ghproxyVals = map[string]interface{}{}
 		}
-		ghproxyVals["cacheTTL"] = ghproxyCacheTTL
+		ghproxyVals["cacheTTL"] = opts.ghproxyCacheTTL
 		vals["ghproxy"] = ghproxyVals
 	}
 	return vals
+}
+
+func buildInstallValues(stdin io.Reader, opts installValuesOptions) (map[string]interface{}, error) {
+	vals := map[string]interface{}{}
+	stdinConsumed := false
+
+	for _, path := range opts.valuesFiles {
+		fileVals, err := loadValuesFile(path, stdin, &stdinConsumed)
+		if err != nil {
+			return nil, err
+		}
+		vals = chartutil.MergeTables(fileVals, vals)
+	}
+
+	vals = chartutil.MergeTables(buildHelmValuesFromOptions(opts.flagValues), vals)
+
+	for _, setArg := range opts.setValues {
+		if err := strvals.ParseInto(setArg, vals); err != nil {
+			return nil, fmt.Errorf("parsing --set %q: %w", setArg, err)
+		}
+	}
+
+	for _, setStringArg := range opts.setStringValues {
+		if err := strvals.ParseIntoString(setStringArg, vals); err != nil {
+			return nil, fmt.Errorf("parsing --set-string %q: %w", setStringArg, err)
+		}
+	}
+
+	for _, setFileArg := range opts.setFileValues {
+		if err := strvals.ParseIntoFile(setFileArg, vals, readSetFileValue); err != nil {
+			return nil, fmt.Errorf("parsing --set-file %q: %w", setFileArg, err)
+		}
+	}
+
+	if opts.defaultImageTag != "" && !hasNestedKey(vals, "image", "tag") {
+		vals = chartutil.MergeTables(map[string]interface{}{
+			"image": map[string]interface{}{
+				"tag": opts.defaultImageTag,
+			},
+		}, vals)
+	}
+
+	if err := validateInstallValues(vals); err != nil {
+		return nil, err
+	}
+
+	return disableChartCRDs(vals), nil
+}
+
+func loadValuesFile(path string, stdin io.Reader, stdinConsumed *bool) (map[string]interface{}, error) {
+	if path == "-" {
+		if *stdinConsumed {
+			return nil, fmt.Errorf("reading values from stdin: '-' can only be used once")
+		}
+		*stdinConsumed = true
+
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading values from stdin: %w", err)
+		}
+		if len(bytes.TrimSpace(data)) == 0 {
+			return map[string]interface{}{}, nil
+		}
+
+		vals, err := chartutil.ReadValues(data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing values from stdin: %w", err)
+		}
+		return vals, nil
+	}
+
+	vals, err := chartutil.ReadValuesFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading values file %q: %w", path, err)
+	}
+	return vals, nil
+}
+
+func readSetFileValue(path []rune) (interface{}, error) {
+	data, err := os.ReadFile(string(path))
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+func hasNestedKey(vals map[string]interface{}, path ...string) bool {
+	current := vals
+	for i, key := range path {
+		value, ok := current[key]
+		if !ok {
+			return false
+		}
+		if i == len(path)-1 {
+			return true
+		}
+		next, ok := value.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		current = next
+	}
+	return false
+}
+
+func validateInstallValues(vals map[string]interface{}) error {
+	crds, ok := vals["crds"]
+	if !ok {
+		return nil
+	}
+
+	crdMap, ok := crds.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("crds must be a map, got %T", crds)
+	}
+
+	installValue, ok := crdMap["install"]
+	if !ok {
+		return nil
+	}
+
+	installEnabled, ok := installValue.(bool)
+	if !ok {
+		return fmt.Errorf("crds.install must be a boolean, got %T", installValue)
+	}
+	if installEnabled {
+		return fmt.Errorf("kelos install manages CRDs separately; crds.install must be omitted or false")
+	}
+	return nil
 }
 
 func disableChartCRDs(vals map[string]interface{}) map[string]interface{} {
@@ -249,6 +449,17 @@ func parseResourceString(s string) map[string]interface{} {
 		}
 	}
 	return result
+}
+
+// nonEmptyStringPtr returns a pointer to s, or nil if s is empty. The nil
+// signal is load-bearing: it lets buildHelmValuesFromOptions distinguish
+// "user did not pass --version" (leave image.tag alone) from "user passed
+// --version with an explicit value" (override image.tag).
+func nonEmptyStringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 // kelosGVRs lists the kelos custom resource GVRs that need to be cleaned up
@@ -286,12 +497,32 @@ func newUninstallCommand(cfg *ClientConfig) *cobra.Command {
 				return fmt.Errorf("creating dynamic client: %w", err)
 			}
 
-			// Render the chart with CRDs disabled to identify controller
-			// resources to delete. Resource names and kinds do not change
-			// with values, so defaults suffice. This still renders optional
-			// resources like the telemetry CronJob, which is safe because
-			// deleteManifests ignores not-found errors.
-			controllerManifest, err := helmchart.Render(manifests.ChartFS, disableChartCRDs(nil))
+			// Render the chart with CRDs disabled to identify resources to
+			// delete. Uninstall does not persist install values, so we force
+			// optional webhookServer.sources.*.enabled on here to ensure any
+			// webhook-related RBAC and namespaced resources are included in
+			// cleanup. Only webhookServer.sources.*.enabled currently gates
+			// cluster-scoped resources; other optional flags (ingress,
+			// gateway) produce only namespaced resources that the namespace
+			// cascade reclaims when the kelos-system namespace is deleted.
+			// Any future optional feature that adds a cluster-scoped resource
+			// must be forced on here too. Deleting resources that were never
+			// installed is safe because deleteManifests ignores not-found
+			// errors.
+			controllerManifest, err := helmchart.Render(manifests.ChartFS, disableChartCRDs(map[string]interface{}{
+				"webhookServer": map[string]interface{}{
+					"sources": map[string]interface{}{
+						"github": map[string]interface{}{
+							"enabled":    true,
+							"secretName": "kelos-uninstall-placeholder",
+						},
+						"linear": map[string]interface{}{
+							"enabled":    true,
+							"secretName": "kelos-uninstall-placeholder",
+						},
+					},
+				},
+			}))
 			if err != nil {
 				return fmt.Errorf("rendering chart for uninstall: %w", err)
 			}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -506,6 +508,112 @@ func TestInstallCommand_VersionFlag(t *testing.T) {
 	}
 	if !strings.Contains(output, ":v0.5.0") {
 		t.Errorf("expected :v0.5.0 tags in output, got:\n%s", output[:min(len(output), 500)])
+	}
+}
+
+func TestInstallCommand_ValuesFileFlag(t *testing.T) {
+	dir := t.TempDir()
+	valuesPath := filepath.Join(dir, "values.yaml")
+	values := `webhookServer:
+  sources:
+    github:
+      enabled: true
+      secretName: github-webhook-secret
+`
+	if err := os.WriteFile(valuesPath, []byte(values), 0o644); err != nil {
+		t.Fatalf("writing values file: %v", err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"install", "--dry-run", "--values", valuesPath})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "name: kelos-webhook-github") {
+		t.Fatalf("expected webhook deployment in output, got:\n%s", output[:min(len(output), 500)])
+	}
+	if !strings.Contains(output, "name: github-webhook-secret") {
+		t.Fatalf("expected webhook secret name from values file in output, got:\n%s", output[:min(len(output), 500)])
+	}
+}
+
+func TestInstallCommand_ValuesFromStdin(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetIn(strings.NewReader(`webhookServer:
+  sources:
+    github:
+      enabled: true
+      secretName: stdin-webhook-secret
+`))
+	cmd.SetArgs([]string{"install", "--dry-run", "--values", "-"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "name: kelos-webhook-github") {
+		t.Fatalf("expected webhook deployment in output, got:\n%s", output[:min(len(output), 500)])
+	}
+	if !strings.Contains(output, "name: stdin-webhook-secret") {
+		t.Fatalf("expected webhook secret name from stdin values in output, got:\n%s", output[:min(len(output), 500)])
+	}
+}
+
+func TestInstallCommand_SetFileFlag(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret-name.txt")
+	if err := os.WriteFile(secretPath, []byte("file-webhook-secret"), 0o644); err != nil {
+		t.Fatalf("writing set-file input: %v", err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"install",
+		"--dry-run",
+		"--set", "webhookServer.sources.github.enabled=true",
+		"--set-file", "webhookServer.sources.github.secretName=" + secretPath,
+	})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "name: kelos-webhook-github") {
+		t.Fatalf("expected webhook deployment in output, got:\n%s", output[:min(len(output), 500)])
+	}
+	if !strings.Contains(output, "name: file-webhook-secret") {
+		t.Fatalf("expected webhook secret name from --set-file in output, got:\n%s", output[:min(len(output), 500)])
+	}
+}
+
+func TestInstallCommand_SetOverridesCompatibilityFlag(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"install",
+		"--dry-run",
+		"--image-pull-policy", "Always",
+		"--set", "image.pullPolicy=Never",
+	})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "imagePullPolicy: Never") {
+		t.Fatalf("expected --set to override compatibility flag, got:\n%s", output[:min(len(output), 500)])
+	}
+	if strings.Contains(output, "imagePullPolicy: Always") {
+		t.Fatalf("did not expect compatibility flag value to win, got:\n%s", output[:min(len(output), 500)])
 	}
 }
 
@@ -1081,6 +1189,269 @@ func TestBuildHelmValues(t *testing.T) {
 			)
 			tt.checkFn(t, vals)
 		})
+	}
+}
+
+func TestBuildInstallValues_MergesWithPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	valuesOnePath := filepath.Join(dir, "values-one.yaml")
+	valuesTwoPath := filepath.Join(dir, "values-two.yaml")
+	secretPath := filepath.Join(dir, "secret-name.txt")
+
+	valuesOne := `image:
+  tag: values-tag-1
+  pullPolicy: Never
+ghproxy:
+  cacheTTL: 10s
+webhookServer:
+  sources:
+    github:
+      enabled: true
+`
+	valuesTwo := `image:
+  tag: values-tag-2
+ghproxy:
+  cacheTTL: 20s
+`
+	if err := os.WriteFile(valuesOnePath, []byte(valuesOne), 0o644); err != nil {
+		t.Fatalf("writing first values file: %v", err)
+	}
+	if err := os.WriteFile(valuesTwoPath, []byte(valuesTwo), 0o644); err != nil {
+		t.Fatalf("writing second values file: %v", err)
+	}
+	if err := os.WriteFile(secretPath, []byte("github-secret-from-file"), 0o644); err != nil {
+		t.Fatalf("writing set-file content: %v", err)
+	}
+
+	vals, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "default-tag",
+		valuesFiles:     []string{valuesOnePath, valuesTwoPath},
+		setValues:       []string{"image.pullPolicy=IfNotPresent", "ghproxy.cacheTTL=30s"},
+		setStringValues: []string{"image.tag=set-string-tag", "ghproxy.allowedUpstreams=https://github.example.com/api/v3"},
+		setFileValues:   []string{"webhookServer.sources.github.secretName=" + secretPath},
+		flagValues: helmValuesOptions{
+			imageTag:        nonEmptyStringPtr("flag-tag"),
+			pullPolicy:      "Always",
+			ghproxyCacheTTL: "45s",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	image := vals["image"].(map[string]interface{})
+	if image["tag"] != "set-string-tag" {
+		t.Fatalf("expected image.tag from explicit override, got %v", image["tag"])
+	}
+	if image["pullPolicy"] != "IfNotPresent" {
+		t.Fatalf("expected image.pullPolicy from explicit override, got %v", image["pullPolicy"])
+	}
+
+	ghproxy := vals["ghproxy"].(map[string]interface{})
+	if ghproxy["cacheTTL"] != "30s" {
+		t.Fatalf("expected ghproxy.cacheTTL from explicit override, got %v", ghproxy["cacheTTL"])
+	}
+	if ghproxy["allowedUpstreams"] != "https://github.example.com/api/v3" {
+		t.Fatalf("expected ghproxy.allowedUpstreams from --set-string, got %v", ghproxy["allowedUpstreams"])
+	}
+
+	webhookServer := vals["webhookServer"].(map[string]interface{})
+	sources := webhookServer["sources"].(map[string]interface{})
+	github := sources["github"].(map[string]interface{})
+	if github["enabled"] != true {
+		t.Fatalf("expected webhook GitHub source enabled from values file, got %v", github["enabled"])
+	}
+	if github["secretName"] != "github-secret-from-file" {
+		t.Fatalf("expected webhook secret name from --set-file, got %v", github["secretName"])
+	}
+
+	crds := vals["crds"].(map[string]interface{})
+	if crds["install"] != false {
+		t.Fatalf("expected crds.install to be forced false, got %v", crds["install"])
+	}
+}
+
+func TestBuildInstallValues_UsesDefaultImageTagOnlyWhenUnset(t *testing.T) {
+	vals, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image := vals["image"].(map[string]interface{})
+	if image["tag"] != "v1.2.3" {
+		t.Fatalf("expected default image tag, got %v", image["tag"])
+	}
+
+	overrideVals, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		setValues:       []string{"image.tag=custom-tag"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building override values: %v", err)
+	}
+	overrideImage := overrideVals["image"].(map[string]interface{})
+	if overrideImage["tag"] != "custom-tag" {
+		t.Fatalf("expected explicit image tag to win, got %v", overrideImage["tag"])
+	}
+}
+
+func TestBuildInstallValues_ReadsValuesFromStdin(t *testing.T) {
+	vals, err := buildInstallValues(strings.NewReader(`webhookServer:
+  sources:
+    github:
+      enabled: true
+      secretName: stdin-webhook-secret
+`), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		valuesFiles:     []string{"-"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	webhookServer := vals["webhookServer"].(map[string]interface{})
+	sources := webhookServer["sources"].(map[string]interface{})
+	github := sources["github"].(map[string]interface{})
+	if github["secretName"] != "stdin-webhook-secret" {
+		t.Fatalf("expected secret name from stdin values, got %v", github["secretName"])
+	}
+}
+
+func TestBuildInstallValues_SetStringPreservesStrings(t *testing.T) {
+	vals, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		setStringValues: []string{"webhookServer.sources.github.replicas=2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	webhookServer := vals["webhookServer"].(map[string]interface{})
+	sources := webhookServer["sources"].(map[string]interface{})
+	github := sources["github"].(map[string]interface{})
+	replicas, ok := github["replicas"].(string)
+	if !ok {
+		t.Fatalf("expected replicas to remain a string, got %T", github["replicas"])
+	}
+	if replicas != "2" {
+		t.Fatalf("expected replicas string value 2, got %q", replicas)
+	}
+}
+
+func TestBuildInstallValues_RejectsCRDsInstallTrue(t *testing.T) {
+	_, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		setValues:       []string{"crds.install=true"},
+	})
+	if err == nil {
+		t.Fatal("expected crds.install=true to be rejected")
+	}
+	if !strings.Contains(err.Error(), "crds.install") {
+		t.Fatalf("expected crds.install error, got %v", err)
+	}
+}
+
+func TestBuildInstallValues_RejectsNonMapCRDs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad-crds.yaml")
+	if err := os.WriteFile(path, []byte("crds: notamap\n"), 0o644); err != nil {
+		t.Fatalf("writing values file: %v", err)
+	}
+
+	_, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		valuesFiles:     []string{path},
+	})
+	if err == nil {
+		t.Fatal("expected non-map crds to be rejected")
+	}
+	if !strings.Contains(err.Error(), "crds must be a map") {
+		t.Fatalf("expected 'crds must be a map' error, got %v", err)
+	}
+}
+
+func TestBuildInstallValues_MultipleFilesLaterWins(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.yaml")
+	secondPath := filepath.Join(dir, "second.yaml")
+	if err := os.WriteFile(firstPath, []byte("image:\n  pullPolicy: Always\n"), 0o644); err != nil {
+		t.Fatalf("writing first values file: %v", err)
+	}
+	if err := os.WriteFile(secondPath, []byte("image:\n  pullPolicy: Never\n"), 0o644); err != nil {
+		t.Fatalf("writing second values file: %v", err)
+	}
+
+	vals, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		valuesFiles:     []string{firstPath, secondPath},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image := vals["image"].(map[string]interface{})
+	if image["pullPolicy"] != "Never" {
+		t.Fatalf("expected later values file to win, got %v", image["pullPolicy"])
+	}
+}
+
+func TestBuildInstallValues_MissingValuesFile(t *testing.T) {
+	_, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		valuesFiles:     []string{filepath.Join(t.TempDir(), "does-not-exist.yaml")},
+	})
+	if err == nil {
+		t.Fatal("expected missing values file to error")
+	}
+	if !strings.Contains(err.Error(), "reading values file") {
+		t.Fatalf("expected 'reading values file' error, got %v", err)
+	}
+}
+
+func TestBuildInstallValues_InvalidYAMLValuesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.yaml")
+	if err := os.WriteFile(path, []byte("image:\n  tag: v1\n  - not yaml\n"), 0o644); err != nil {
+		t.Fatalf("writing values file: %v", err)
+	}
+
+	_, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		valuesFiles:     []string{path},
+	})
+	if err == nil {
+		t.Fatal("expected invalid YAML values file to error")
+	}
+	if !strings.Contains(err.Error(), "reading values file") {
+		t.Fatalf("expected 'reading values file' error, got %v", err)
+	}
+}
+
+func TestBuildInstallValues_DoubleStdinRejected(t *testing.T) {
+	_, err := buildInstallValues(strings.NewReader("image:\n  tag: v1\n"), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		valuesFiles:     []string{"-", "-"},
+	})
+	if err == nil {
+		t.Fatal("expected double stdin to error")
+	}
+	if !strings.Contains(err.Error(), "'-' can only be used once") {
+		t.Fatalf("expected double-stdin error, got %v", err)
+	}
+}
+
+func TestBuildInstallValues_SetStringOverridesSet(t *testing.T) {
+	vals, err := buildInstallValues(strings.NewReader(""), installValuesOptions{
+		defaultImageTag: "v1.2.3",
+		setValues:       []string{"image.tag=from-set"},
+		setStringValues: []string{"image.tag=from-set-string"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image := vals["image"].(map[string]interface{})
+	if image["tag"] != "from-set-string" {
+		t.Fatalf("expected --set-string to win over --set for same key, got %v", image["tag"])
 	}
 }
 

--- a/internal/cli/webhook_test.go
+++ b/internal/cli/webhook_test.go
@@ -122,6 +122,58 @@ func TestRenderChart_WebhookGateway(t *testing.T) {
 	}
 }
 
+func TestRenderChart_WebhookLinearOnly(t *testing.T) {
+	vals := map[string]interface{}{
+		"webhookServer": map[string]interface{}{
+			"image": "ghcr.io/kelos-dev/kelos-webhook-server",
+			"sources": map[string]interface{}{
+				"github": map[string]interface{}{
+					"enabled": false,
+				},
+				"linear": map[string]interface{}{
+					"enabled":    true,
+					"replicas":   1,
+					"secretName": "linear-webhook-secret",
+				},
+			},
+		},
+		"image": map[string]interface{}{
+			"tag": "latest",
+		},
+	}
+
+	data, err := helmchart.Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+
+	content := string(data)
+
+	expectedComponents := []string{
+		"name: kelos-webhook-linear",
+		"name: kelos-webhook-role",
+		"name: kelos-webhook-rolebinding",
+		"name: kelos-webhook",
+		"--source=linear",
+		"linear-webhook-secret",
+	}
+	for _, component := range expectedComponents {
+		if !strings.Contains(content, component) {
+			t.Errorf("expected rendered chart to contain %q", component)
+		}
+	}
+
+	unexpectedComponents := []string{
+		"name: kelos-webhook-github",
+		"--source=github",
+	}
+	for _, component := range unexpectedComponents {
+		if strings.Contains(content, component) {
+			t.Errorf("did not expect rendered chart to contain %q for linear-only webhook install", component)
+		}
+	}
+}
+
 func TestRenderChart_WebhookServersDisabled(t *testing.T) {
 	vals := map[string]interface{}{
 		"webhookServer": map[string]interface{}{

--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -229,7 +229,7 @@ subjects:
   - kind: ServiceAccount
     name: kelos-controller
     namespace: kelos-system
-{{- if .Values.webhookServer.sources.github.enabled }}
+{{- if or .Values.webhookServer.sources.github.enabled .Values.webhookServer.sources.linear.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/manifests/charts/kelos/templates/serviceaccount.yaml
+++ b/internal/manifests/charts/kelos/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: kelos-controller
   namespace: kelos-system
-{{- if .Values.webhookServer.sources.github.enabled }}
+{{- if or .Values.webhookServer.sources.github.enabled .Values.webhookServer.sources.linear.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,12 +37,17 @@ func clearNamespaceFinalizers() {
 }
 
 // deleteControllerResources removes the non-CRD resources created by install
-// without touching the CRDs, keeping the envtest environment intact.
+// without touching the CRDs, keeping the envtest environment intact. Includes
+// optional cluster-scoped webhook RBAC so tests that enable webhook sources
+// start from a clean slate and cannot satisfy assertions against stale state
+// left by a previous test.
 func deleteControllerResources() {
 	for _, obj := range []client.Object{
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "kelos-controller-rolebinding"}},
 		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "kelos-controller-role"}},
 		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "kelos-spawner-role"}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "kelos-webhook-rolebinding"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "kelos-webhook-role"}},
 	} {
 		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, obj))
 	}
@@ -178,6 +185,74 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 			Expect(args).To(ContainElement("--token-refresher-resource-requests=cpu=100m,memory=128Mi"))
 			Expect(args).To(ContainElement("--token-refresher-resource-limits=cpu=200m,memory=256Mi"))
 		})
+
+		It("Should apply Helm values file overrides", func() {
+			valuesPath := filepath.Join(GinkgoT().TempDir(), "values.yaml")
+			values := `webhookServer:
+  sources:
+    github:
+      enabled: true
+      secretName: github-webhook-secret
+`
+			Expect(os.WriteFile(valuesPath, []byte(values), 0o644)).To(Succeed())
+
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"install",
+				"--kubeconfig", kubeconfigPath,
+				"--values", valuesPath,
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			webhookDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "kelos-webhook-github",
+				Namespace: "kelos-system",
+			}, webhookDep)).To(Succeed())
+
+			env := webhookDep.Spec.Template.Spec.Containers[0].Env
+			Expect(env).NotTo(BeEmpty())
+			Expect(env[0].ValueFrom).NotTo(BeNil())
+			Expect(env[0].ValueFrom.SecretKeyRef).NotTo(BeNil())
+			Expect(env[0].ValueFrom.SecretKeyRef.Name).To(Equal("github-webhook-secret"))
+		})
+
+		It("Should support Linear-only webhook installs", func() {
+			valuesPath := filepath.Join(GinkgoT().TempDir(), "values.yaml")
+			values := `webhookServer:
+  sources:
+    linear:
+      enabled: true
+      secretName: linear-webhook-secret
+`
+			Expect(os.WriteFile(valuesPath, []byte(values), 0o644)).To(Succeed())
+
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"install",
+				"--kubeconfig", kubeconfigPath,
+				"--values", valuesPath,
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			webhookDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "kelos-webhook-linear",
+				Namespace: "kelos-system",
+			}, webhookDep)).To(Succeed())
+			Expect(webhookDep.Spec.Template.Spec.ServiceAccountName).To(Equal("kelos-webhook"))
+
+			webhookSA := &corev1.ServiceAccount{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "kelos-webhook",
+				Namespace: "kelos-system",
+			}, webhookSA)).To(Succeed())
+
+			webhookCRB := &rbacv1.ClusterRoleBinding{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: "kelos-webhook-rolebinding",
+			}, webhookCRB)).To(Succeed())
+		})
 	})
 
 	Context("kelos uninstall", func() {
@@ -274,6 +349,82 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 				err := k8sClient.List(ctx, &taskList)
 				// After CRDs are deleted, listing will fail
 				return err != nil || len(taskList.Items) == 0
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+		})
+
+		It("Should remove optional webhook RBAC", func() {
+			valuesPath := filepath.Join(GinkgoT().TempDir(), "values.yaml")
+			values := `webhookServer:
+  sources:
+    github:
+      enabled: true
+      secretName: github-webhook-secret
+`
+			Expect(os.WriteFile(valuesPath, []byte(values), 0o644)).To(Succeed())
+
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"install",
+				"--kubeconfig", kubeconfigPath,
+				"--values", valuesPath,
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			webhookCR := &rbacv1.ClusterRole{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: "kelos-webhook-role",
+			}, webhookCR)).To(Succeed())
+
+			root2 := cli.NewRootCommand()
+			root2.SetArgs([]string{"uninstall", "--kubeconfig", kubeconfigPath})
+			Expect(root2.Execute()).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-webhook-role"}, &rbacv1.ClusterRole{})
+				return apierrors.IsNotFound(err)
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-webhook-rolebinding"}, &rbacv1.ClusterRoleBinding{})
+				return apierrors.IsNotFound(err)
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+		})
+
+		It("Should remove optional webhook RBAC for Linear-only installs", func() {
+			valuesPath := filepath.Join(GinkgoT().TempDir(), "values.yaml")
+			values := `webhookServer:
+  sources:
+    linear:
+      enabled: true
+      secretName: linear-webhook-secret
+`
+			Expect(os.WriteFile(valuesPath, []byte(values), 0o644)).To(Succeed())
+
+			root := cli.NewRootCommand()
+			root.SetArgs([]string{
+				"install",
+				"--kubeconfig", kubeconfigPath,
+				"--values", valuesPath,
+			})
+			Expect(root.Execute()).To(Succeed())
+
+			webhookCR := &rbacv1.ClusterRole{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: "kelos-webhook-role",
+			}, webhookCR)).To(Succeed())
+
+			root2 := cli.NewRootCommand()
+			root2.SetArgs([]string{"uninstall", "--kubeconfig", kubeconfigPath})
+			Expect(root2.Execute()).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-webhook-role"}, &rbacv1.ClusterRole{})
+				return apierrors.IsNotFound(err)
+			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-webhook-rolebinding"}, &rbacv1.ClusterRoleBinding{})
+				return apierrors.IsNotFound(err)
 			}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds Helm-style values overrides to `kelos install` via `--values/-f`, `--set`, `--set-string`, and `--set-file`. Values merge with Helm's standard precedence:

```
chart defaults < -f files < install-specific compatibility flags < --set / --set-string / --set-file
```

This lets users set any chart value without having to add a typed CLI flag for it (the install-specific flags only cover a subset), and keeps explicit `--set` behaving the way Helm users expect.

Also fixes two bugs exposed by the values-file path:

- The chart's webhook `ClusterRole` / `ClusterRoleBinding` / `ServiceAccount` were gated on `webhookServer.sources.github.enabled` only, so Linear-only installs rendered the Linear `Deployment` without any RBAC. Both templates now gate on `or github.enabled linear.enabled`.
- `kelos uninstall` re-rendered the chart with default values to derive its delete target, so optional cluster-scoped resources (which only render when a feature flag is on) were never cleaned up. Uninstall now renders with `webhookServer.sources.{github,linear}.enabled=true` so `deleteManifests` picks them up. Namespaced resources are still reclaimed via namespace cascade as before.

`kelos install` still manages CRDs separately, so the new `-f` / `--set` path rejects `crds.install=true`, non-map `crds`, and non-bool `crds.install` with tailored errors.

Unit tests cover merge precedence, stdin handling, `--set-string` type preservation, error paths (missing file, invalid YAML, non-map `crds`, double stdin, `--set-string` overriding `--set` for the same key), and the `crds.install=true` rejection. Integration tests cover values-file installs, Linear-only installs, and uninstall cleanup of optional webhook RBAC for both GitHub and Linear variants.

#### Which issue(s) this PR is related to:

Fixes #942

#### Special notes for your reviewer:

Precedence matches Helm: explicit `--set` / `--set-string` / `--set-file` win over the install-specific compatibility flags, which in turn win over `-f` values files. Documented in `docs/reference.md`.

The uninstall render intentionally forces `webhookServer.sources.{github,linear}.enabled=true` so optional cluster-scoped RBAC is always captured in the delete set; there is an inline comment at the literal explaining which flags need to stay on the list and when to revisit. Deleting resources that were never installed is safe because `deleteManifests` ignores not-found errors.

Verified with `make verify` and `make test`. Integration tests rely on CI.

#### Does this PR introduce a user-facing change?

Yes

```release-note
Add `--values`/`-f`, `--set`, `--set-string`, and `--set-file` flags to `kelos install` for customizing the embedded Helm chart, enabling arbitrary value overrides without dedicated CLI flags.
```
