### PR TITLE
self-development: remove labeled filters that cause duplicate task spawns

### DIFF
--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -17,13 +17,6 @@ spec:
             - triage-accepted
           state: open
         - event: issues
-          action: labeled
-          labels:
-            - needs-actor
-          excludeLabels:
-            - triage-accepted
-          state: open
-        - event: issues
           action: reopened
           labels:
             - needs-actor

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -40,7 +40,6 @@ spec:
       repository: kelos-dev/kelos
       events:
         - issue_comment
-        - issues
       filters:
         - event: issue_comment
           action: created
@@ -56,16 +55,6 @@ spec:
             - actor/kelos
           state: open
           author: kelos-bot[bot]
-        - event: issues
-          action: labeled
-          labels:
-            - actor/kelos
-          state: open
-        - event: issues
-          action: reopened
-          labels:
-            - actor/kelos
-          state: open
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `issues/labeled` webhook action fires once per label added, so
TaskSpawners using it as a filter can be triggered multiple times for
the same issue when several labels are applied at once.

- **kelos-triage**: Removed the `labeled` filter. The existing `opened`
  filter already covers new issues created with `needs-actor`.
- **kelos-workers**: Removed the `issues` event filters entirely.
  Workers should only be triggered by explicit `/kelos pick-up`
  comments, not automatically on issue creation or reopening.

Both spawners retain the `reopened` filter where applicable (kelos-triage).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```