### PR TITLE
Fix triage spawner to trigger on opened issues without needs-actor

### DIFF
--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -11,8 +11,6 @@ spec:
       filters:
         - event: issues
           action: opened
-          labels:
-            - needs-actor
           excludeLabels:
             - triage-accepted
           state: open


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The kelos-triage TaskSpawner's `opened` filter required the `needs-actor` label to be present. However, newly opened issues won't have that label yet, so the triage never fired on issue creation. This removes the `labels: [needs-actor]` requirement from the `opened` filter so the spawner triggers on any opened issue that doesn't already have `triage-accepted`.

The `labeled` and `reopened` filters still require `needs-actor`, which is correct for those subsequent events.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the triage TaskSpawner to run on any newly opened issue that doesn’t already have `triage-accepted`, even if `needs-actor` isn’t present. Removes the `needs-actor` requirement from the `opened` filter; `labeled` and `reopened` filters remain unchanged.

<sup>Written for commit 21bdf27e9ab56366223952f32f599921631003de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

