### PR TITLE
Split CLI install methods into separate code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,15 @@ This creates a single-node cluster and configures your kubeconfig automatically.
 
 ### 1. Install the CLI
 
-```bash
-# Install using the script
-curl -fsSL https://raw.githubusercontent.com/kelos-dev/kelos/main/hack/install.sh | bash
+Install using the script:
 
-# Or by using Homebrew
+```bash
+curl -fsSL https://raw.githubusercontent.com/kelos-dev/kelos/main/hack/install.sh | bash
+```
+
+Or using Homebrew:
+
+```bash
 brew tap kelos-dev/tap
 brew install kelos
 ```


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Separates the two CLI install methods (install script and Homebrew) in the README's "Install the CLI" section into distinct labeled code blocks. The previous single block used comments to distinguish them, which read awkwardly and made copy-paste error-prone.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Docs-only change; no functional impact.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated CLI installation methods in the README into two labeled code blocks (install script and Homebrew) to improve readability and prevent copy-paste mistakes. Docs-only change; no functional impact.

<sup>Written for commit 8d16fe2c24fefd11458543bf8fadecf35eb55176. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

