### PR TITLE
Trim verbose self-development section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,74 +43,11 @@ Kelos is built on four resources:
 3. **AgentConfigs** — Reusable bundles of agent instructions (`AGENTS.md`, `CLAUDE.md`), plugins (skills and agents), and MCP servers.
 4. **TaskSpawners** — Orchestration engines that react to external triggers (GitHub, Cron) to automatically manage agent lifecycles.
 
-<details>
-<summary>TaskSpawner — Automatic Task Creation from External Sources</summary>
-
-TaskSpawner watches external sources (e.g., GitHub Issues) and automatically creates Tasks for each discovered item.
-
-```
-                    polls         new issues
- TaskSpawner ─────────────▶ GitHub Issues
-      │        ◀─────────────
-      │
-      ├──creates──▶ Task: fix-bugs-1
-      └──creates──▶ Task: fix-bugs-2
-```
-
-</details>
-
 ## Kelos Developing Kelos
 
 Kelos develops itself. TaskSpawners run 24/7, each handling a different part of the development lifecycle — fully autonomous.
 
-<img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/a205f0c6-9eb4-4001-8ee6-5c8ab187fbea" />
-
-| TaskSpawner | Trigger | Model | Description |
-|---|---|---|---|
-| **kelos-workers** | GitHub Issues (`actor/kelos`) | Opus | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
-| **kelos-pr-responder** | GitHub Pull Requests (`generated-by-kelos`, `changes_requested`) | Opus | Re-engages on PR review feedback and updates the existing branch incrementally |
-| **kelos-planner** | GitHub Issues (`/kelos plan` comment) | Opus | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
-| **kelos-triage** | GitHub Issues (`needs-actor`) | Opus | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
-| **kelos-fake-user** | Cron (daily 09:00 UTC) | Sonnet | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
-| **kelos-fake-strategist** | Cron (every 12 hours) | Opus | Explores new use cases, workflow improvements, and integration opportunities |
-| **kelos-self-update** | Cron (daily 06:00 UTC) | Opus | Reviews and tunes prompts, configs, and workflow files — the pipeline improves itself |
-| **kelos-config-update** | Cron (daily 18:00 UTC) | Opus | Reviews recent PR feedback and updates agent configuration (conventions, prompts, configs) accordingly |
-| **kelos-image-update** | Cron (daily 03:00 UTC) | Sonnet | Checks for newer agent image versions (Claude Code, Codex, Gemini, etc.) and creates PRs to update them |
-| **kelos-reviewer** | GitHub Pull Requests (`/kelos review` comment) | Opus | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
-| **kelos-squash-commits** | GitHub Pull Requests (`/kelos squash-commits` comment) | Sonnet | Rebases and squashes PR branch commits into a single clean commit |
-
-Here's a trimmed snippet of `kelos-workers.yaml` — enough to show the pattern:
-
-```yaml
-apiVersion: kelos.dev/v1alpha1
-kind: TaskSpawner
-metadata:
-  name: kelos-workers
-spec:
-  when:
-    githubIssues:
-      labels: [actor/kelos]
-      excludeLabels: [kelos/needs-input]
-      priorityLabels:
-        - priority/critical-urgent
-        - priority/important-soon
-      pollInterval: 1m
-  maxConcurrency: 3
-  taskTemplate:
-    model: opus
-    type: claude-code
-    branch: "kelos-task-{{.Number}}"
-    promptTemplate: |
-      You are a coding agent. You either
-      - create a PR to fix the issue
-      - update an existing PR to fix the issue
-      - comment on the issue or the PR if you cannot fix it
-      ...
-```
-
-The key pattern is `excludeLabels: [kelos/needs-input]` — this creates a feedback loop where the agent works autonomously until it needs human input, then pauses. Removing the label re-queues the issue on the next poll.
-
-See the full manifest at [`self-development/kelos-workers.yaml`](self-development/kelos-workers.yaml) and the [`self-development/` README](self-development/README.md) for setup instructions.
+See the [`self-development/` README](self-development/README.md) for the full pipeline: manifests, triggers, models, and setup instructions.
 
 ## Why Kelos?
 

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -8,84 +8,22 @@ This directory contains real-world orchestration patterns used by the Kelos proj
 
 Each TaskSpawner references an `AgentConfig` that defines git identity, comment signatures, and standard constraints. Some agents (triage, pr-responder, squash-commits, config-update) share the base `agentconfig.yaml` (`kelos-dev-agent`), while others (workers, planner, fake-user, fake-strategist, self-update, image-update) define their own `AgentConfig` inline.
 
-## Prerequisites
-
-Before deploying these examples, you need to create the following resources:
-
-### 1. Workspace Resource
-
-Create a Workspace that points to your repository:
-
-```yaml
-apiVersion: kelos.dev/v1alpha1
-kind: Workspace
-metadata:
-  name: kelos-agent
-spec:
-  repo: https://github.com/your-org/your-repo.git
-  ref: main
-  secretRef:
-    name: github-token  # For pushing branches and creating PRs
-  # Or use GitHub App authentication (recommended for production/org use):
-  # secretRef:
-  #   name: github-app-creds
-  # Create the GitHub App secret with:
-  #   kubectl create secret generic github-app-creds \
-  #     --from-literal=appID=12345 \
-  #     --from-literal=installationID=67890 \
-  #     --from-file=privateKey=my-app.private-key.pem
-```
-
-### 2. GitHub Token Secret
-
-Create a secret with your GitHub token (needed for `gh` CLI and git authentication):
-
-```bash
-kubectl create secret generic github-token \
-  --from-literal=GITHUB_TOKEN=<your-github-token>
-```
-
-The token needs these permissions:
-- `repo` (full control of private repositories)
-- `workflow` (if your repo uses GitHub Actions)
-
-### 3. GitHub Webhook Secret and Delivery
-
-The issue and pull request TaskSpawners in this directory are webhook-driven.
-Create a secret with the shared webhook secret GitHub will use:
-
-```bash
-kubectl create secret generic github-webhook-secret \
-  --from-literal=WEBHOOK_SECRET=<your-github-webhook-secret>
-```
-
-Then:
-- Enable the GitHub webhook server in your Kelos deployment (see `examples/helm-values-webhook.yaml` or `examples/webhook-gateway-values.yaml`)
-- Expose `https://<your-domain>/webhook/github` over HTTPS
-- Configure a repository webhook that uses the same secret
-- Subscribe the repository webhook to `issues`, `issue_comment`, and `pull_request_review`
-
-Webhook TaskSpawners only react to **new** events after deployment. If an issue
-or PR was already in a matching state before the webhook server went live,
-retrigger it with a fresh comment or relabel after deployment.
-
-### 4. Agent Credentials Secret
-
-Create a secret with your AI agent credentials:
-
-**For OAuth (Claude Code):**
-```bash
-kubectl create secret generic kelos-credentials \
-  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-claude-oauth-token>
-```
-
-**For API Key:**
-```bash
-kubectl create secret generic kelos-credentials \
-  --from-literal=ANTHROPIC_API_KEY=<your-api-key>
-```
-
 ## TaskSpawners
+
+| TaskSpawner | Trigger | Model | Description |
+|---|---|---|---|
+| **kelos-workers** | Webhook: issue comment/label (`actor/kelos`) | Opus | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
+| **kelos-planner** | Webhook: issue comment `/kelos plan` | Opus | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
+| **kelos-reviewer** | Webhook: PR comment `/kelos review` | Opus | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
+| **kelos-api-reviewer** | Webhook: issue/PR comment `/kelos api-review` | Opus | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
+| **kelos-pr-responder** | Webhook: PR review/comment on `generated-by-kelos` PRs | Opus | Re-engages on PR review feedback and updates the existing branch incrementally |
+| **kelos-triage** | Webhook: issue opened/labeled/reopened (`needs-actor`) | Opus | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
+| **kelos-fake-user** | Cron (daily 09:00 UTC) | Sonnet | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
+| **kelos-fake-strategist** | Cron (every 12 hours) | Opus | Explores new use cases, workflow improvements, and integration opportunities |
+| **kelos-config-update** | Cron (daily 18:00 UTC) | Opus | Reviews recent PR feedback and updates agent configuration (conventions, prompts, configs) accordingly |
+| **kelos-self-update** | Cron (daily 06:00 UTC) | Opus | Reviews and tunes prompts, configs, and workflow files — the pipeline improves itself |
+| **kelos-image-update** | Cron (daily 03:00 UTC) | Sonnet | Checks for newer agent image versions (Claude Code, Codex, Gemini, etc.) and creates PRs to update them |
+| **kelos-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Sonnet | Rebases and squashes PR branch commits into a single clean commit |
 
 ### kelos-workers.yaml
 
@@ -348,6 +286,106 @@ Creates at most one PR per agent. Skips agents that are already up to date or al
 kubectl apply -f self-development/kelos-image-update.yaml
 ```
 
+### kelos-squash-commits.yaml
+
+Rebases and squashes PR branch commits into a single clean commit when a maintainer posts `/kelos squash-commits`.
+
+| | |
+|---|---|
+| **Trigger** | GitHub PR comment webhook with `/kelos squash-commits` |
+| **Model** | Sonnet |
+| **Concurrency** | 1 |
+
+**Key features:**
+- Rebases the PR branch on `origin/main` and squashes all commits after the merge base into one
+- Amends the squashed commit message based on the linked issue and PR description when needed
+- Force-pushes with `--force-with-lease`
+- Updates the PR description to match the squashed change, preserving the `Closes #N` reference
+- Adds `kelos/needs-input` to the linked issue to signal the PR is ready for re-review
+- Does not start new development work or modify source code
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/kelos-squash-commits.yaml
+```
+
+## Prerequisites
+
+Before deploying these examples, you need to create the following resources:
+
+### 1. Workspace Resource
+
+Create a Workspace that points to your repository:
+
+```yaml
+apiVersion: kelos.dev/v1alpha1
+kind: Workspace
+metadata:
+  name: kelos-agent
+spec:
+  repo: https://github.com/your-org/your-repo.git
+  ref: main
+  secretRef:
+    name: github-token  # For pushing branches and creating PRs
+  # Or use GitHub App authentication (recommended for production/org use):
+  # secretRef:
+  #   name: github-app-creds
+  # Create the GitHub App secret with:
+  #   kubectl create secret generic github-app-creds \
+  #     --from-literal=appID=12345 \
+  #     --from-literal=installationID=67890 \
+  #     --from-file=privateKey=my-app.private-key.pem
+```
+
+### 2. GitHub Token Secret
+
+Create a secret with your GitHub token (needed for `gh` CLI and git authentication):
+
+```bash
+kubectl create secret generic github-token \
+  --from-literal=GITHUB_TOKEN=<your-github-token>
+```
+
+The token needs these permissions:
+- `repo` (full control of private repositories)
+- `workflow` (if your repo uses GitHub Actions)
+
+### 3. GitHub Webhook Secret and Delivery
+
+The issue and pull request TaskSpawners in this directory are webhook-driven.
+Create a secret with the shared webhook secret GitHub will use:
+
+```bash
+kubectl create secret generic github-webhook-secret \
+  --from-literal=WEBHOOK_SECRET=<your-github-webhook-secret>
+```
+
+Then:
+- Enable the GitHub webhook server in your Kelos deployment (see `examples/helm-values-webhook.yaml` or `examples/webhook-gateway-values.yaml`)
+- Expose `https://<your-domain>/webhook/github` over HTTPS
+- Configure a repository webhook that uses the same secret
+- Subscribe the repository webhook to `issues`, `issue_comment`, and `pull_request_review`
+
+Webhook TaskSpawners only react to **new** events after deployment. If an issue
+or PR was already in a matching state before the webhook server went live,
+retrigger it with a fresh comment or relabel after deployment.
+
+### 4. Agent Credentials Secret
+
+Create a secret with your AI agent credentials:
+
+**For OAuth (Claude Code):**
+```bash
+kubectl create secret generic kelos-credentials \
+  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-claude-oauth-token>
+```
+
+**For API Key:**
+```bash
+kubectl create secret generic kelos-credentials \
+  --from-literal=ANTHROPIC_API_KEY=<your-api-key>
+```
+
 ## Customizing for Your Repository
 
 To adapt these examples for your own repository:
@@ -414,7 +452,7 @@ The key pattern in these examples is webhook-triggered handoff plus runtime re-v
 2. The matching TaskSpawner creates a Task immediately from that event
 3. The agent re-reads the latest issue or PR state with `gh` before acting, so asynchronous label updates are respected
 4. If the agent needs human input, it posts a plain-English status comment describing what happened
-5. A fresh `/kelos pick-up`, `/kelos plan`, `/kelos review`, `/kelos api-review`, or relabel event retriggers automation later
+5. A fresh `/kelos pick-up`, `/kelos plan`, `/kelos review`, `/kelos api-review`, `/kelos squash-commits`, or relabel event retriggers automation later
 
 Each run is a discrete webhook event, so no "pause" comment is needed to prevent re-pickup of stale state — the bot's own replies don't match the trigger substrings and cannot retrigger the spawner.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

The `Kelos Developing Kelos` section in the main README was getting long — a table of 11 TaskSpawners, a YAML snippet, and commentary — duplicating content that already lives in `self-development/README.md`. This PR replaces that block with a short intro paragraph and a pointer to the dedicated README, keeping the main README focused on the primary `Quick Start` → `Examples` → `Reference` flow.

The section heading, TOC entry, and existing `#kelos-developing-kelos` anchor links are preserved, so inbound links (including the one in `Orchestration Patterns`) still resolve.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

No content was lost — the removed table/YAML/image are already in `self-development/README.md`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the “Kelos Developing Kelos” section in the main README to a single pointer to `self-development/README.md`, preserving the header/TOC/anchor and removing the outdated polling diagram. Expanded `self-development/README.md` with an overview table of all 12 webhook‑driven TaskSpawners (now includes `kelos-api-reviewer`), a new `kelos-squash-commits` doc with behavior and deploy steps, and added its `/kelos squash-commits` trigger to the feedback loop.

<sup>Written for commit 60aeb7f259d75354ccb0c4e92e1d41ede98ac5db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

