### PR TITLE
test/e2e: switch codex E2E model to gpt-5.4-mini

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -44,7 +44,7 @@ var agentConfigs = []agentTestConfig{
 		SecretName:     "codex-credentials",
 		SecretKey:      "CODEX_AUTH_JSON",
 		SecretValue:    &codexAuthJSON,
-		Model:          "gpt-5.1-codex-mini",
+		Model:          "gpt-5.4-mini",
 		EnvVar:         "CODEX_AUTH_JSON",
 	},
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The codex E2E suite currently fails because `gpt-5.1-codex-mini` is not supported when using Codex with a ChatGPT account. Switch the codex agent test config to `gpt-5.4-mini` so the suite can run against ChatGPT-account credentials.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Single-line change in `test/e2e/suite_test.go`. E2E tests are hard to run locally — verification will come from the PR's CI jobs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex E2E failures by switching the agent test model from `gpt-5.1-codex-mini` (not supported with ChatGPT accounts) to `gpt-5.4-mini`. Restores Codex E2E runs in CI using ChatGPT-account credentials.

<sup>Written for commit b66b9a2d1b749d1700c32e42a1c984f4ee11953c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

