### PR TITLE
Increase self-development task TTLs

### DIFF
--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -57,7 +57,7 @@ spec:
       name: kelos-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -47,7 +47,7 @@ spec:
       name: kelos-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -37,7 +37,7 @@ spec:
       name: kelos-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -56,7 +56,7 @@ spec:
       name: kelos-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -20,7 +20,7 @@ spec:
       name: kelos-agent
     model: sonnet
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -27,7 +27,7 @@ spec:
       name: kelos-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -61,7 +61,7 @@ spec:
       name: kelos-agent
     model: opus
     type: claude-code
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
       secretRef:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Increases the self-development TaskSpawner task TTLs from 1 hour to 10 days for the webhook-driven agents so failed tasks remain available for debugging.

Aligns these manifests with the existing 10-day retention already used by the cron-based self-development agents.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This only changes files under `self-development/`.

Validation run:
- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased TaskSpawner task TTL from 1 hour to 10 days for webhook-driven self-development agents. This keeps failed tasks available for debugging and aligns retention with the cron-based self-development agents.

<sup>Written for commit 88e6e9a6476c20f3c6435c801798b403e42b60b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

