### PR TITLE
fix: validate that --prompt is not empty in axon run

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -100,6 +100,9 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 					return fmt.Errorf("prompt file is empty")
 				}
 			}
+			if strings.TrimSpace(prompt) == "" {
+				return fmt.Errorf("--prompt must not be empty")
+			}
 
 			// Auto-create secret from token if no explicit secret is set.
 			if secret == "" && cfg.Config != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds client-side validation to reject empty or whitespace-only `--prompt` values in `axon run`. Previously, `axon run -p "" --secret dummy` was silently accepted and would only fail at the Kubernetes API level after a network round-trip.

The fix adds a `strings.TrimSpace` check after all prompt resolution (both `--prompt` and `--prompt-file`) to catch this early with a clear error message.

#### Which issue(s) this PR is related to:

Fixes #199

#### Special notes for your reviewer:

The validation is placed after the `--prompt-file` resolution block so it catches both direct `--prompt ""` and empty file content.

#### Does this PR introduce a user-facing change?

```release-note
The `axon run` command now rejects empty or whitespace-only `--prompt` values with a clear error message instead of creating an invalid Task.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty or whitespace-only prompts in `axon run` by trimming and validating `--prompt` after `--prompt-file` resolution, failing fast with a clear error instead of creating an invalid Task.

<sup>Written for commit 13476fe6c03521c13f79d0556994488ab5213816. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

