### PR TITLE
feat(api): add agentConfigRefs for composable multi-layer AgentConfig…

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -89,6 +89,8 @@ type PodOverrides struct {
 }
 
 // TaskSpec defines the desired state of Task.
+//
+// +kubebuilder:validation:XValidation:rule="!(has(self.agentConfigRef) && has(self.agentConfigRefs))",message="agentConfigRef and agentConfigRefs are mutually exclusive"
 type TaskSpec struct {
 	// Type specifies the agent type (e.g., claude-code).
 	// +kubebuilder:validation:Required
@@ -121,6 +123,14 @@ type TaskSpec struct {
 	// AgentConfigRef references an AgentConfig resource.
 	// +optional
 	AgentConfigRef *AgentConfigReference `json:"agentConfigRef,omitempty"`
+
+	// AgentConfigRefs references an ordered list of AgentConfig resources.
+	// Configs are merged in order: agentsMD is concatenated, plugins/skills
+	// are appended, mcpServers are appended with later entries winning on
+	// name collision. Mutually exclusive with AgentConfigRef.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	AgentConfigRefs []AgentConfigReference `json:"agentConfigRefs,omitempty"`
 
 	// DependsOn lists Task names that must succeed before this Task starts.
 	// +optional

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -533,6 +533,8 @@ type TaskTemplateMetadata struct {
 }
 
 // TaskTemplate defines the template for spawned Tasks.
+//
+// +kubebuilder:validation:XValidation:rule="!(has(self.agentConfigRef) && has(self.agentConfigRefs))",message="agentConfigRef and agentConfigRefs are mutually exclusive"
 type TaskTemplate struct {
 	// Type specifies the agent type (e.g., claude-code).
 	// +kubebuilder:validation:Required
@@ -565,6 +567,15 @@ type TaskTemplate struct {
 	// When set, spawned Tasks inherit this agent config reference.
 	// +optional
 	AgentConfigRef *AgentConfigReference `json:"agentConfigRef,omitempty"`
+
+	// AgentConfigRefs references an ordered list of AgentConfig resources.
+	// Configs are merged in order: agentsMD is concatenated, plugins/skills
+	// are appended, mcpServers are appended with later entries winning on
+	// name collision. Mutually exclusive with AgentConfigRef.
+	// When set, spawned Tasks inherit this agent config reference list.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	AgentConfigRefs []AgentConfigReference `json:"agentConfigRefs,omitempty"`
 
 	// DependsOn lists Task names that spawned Tasks depend on.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -943,6 +943,11 @@ func (in *TaskSpec) DeepCopyInto(out *TaskSpec) {
 		*out = new(AgentConfigReference)
 		**out = **in
 	}
+	if in.AgentConfigRefs != nil {
+		in, out := &in.AgentConfigRefs, &out.AgentConfigRefs
+		*out = make([]AgentConfigReference, len(*in))
+		copy(*out, *in)
+	}
 	if in.DependsOn != nil {
 		in, out := &in.DependsOn, &out.DependsOn
 		*out = make([]string, len(*in))
@@ -1018,6 +1023,11 @@ func (in *TaskTemplate) DeepCopyInto(out *TaskTemplate) {
 		in, out := &in.AgentConfigRef, &out.AgentConfigRef
 		*out = new(AgentConfigReference)
 		**out = **in
+	}
+	if in.AgentConfigRefs != nil {
+		in, out := &in.AgentConfigRefs, &out.AgentConfigRefs
+		*out = make([]AgentConfigReference, len(*in))
+		copy(*out, *in)
 	}
 	if in.DependsOn != nil {
 		in, out := &in.DependsOn, &out.DependsOn

--- a/cmd/kelos-spawner/main_test.go
+++ b/cmd/kelos-spawner/main_test.go
@@ -637,6 +637,47 @@ func TestRunCycleWithSource_AgentConfigRefForwarded(t *testing.T) {
 	}
 }
 
+func TestRunCycleWithSource_AgentConfigRefsForwarded(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	ts.Spec.TaskTemplate.AgentConfigRefs = []kelosv1alpha1.AgentConfigReference{
+		{Name: "base-config"},
+		{Name: "role-config"},
+	}
+	cl, key := setupTest(t, ts)
+
+	src := &fakeSource{
+		items: []source.WorkItem{
+			{ID: "1", Title: "Item 1"},
+		},
+	}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var taskList kelosv1alpha1.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(taskList.Items))
+	}
+
+	task := taskList.Items[0]
+	if task.Spec.AgentConfigRef != nil {
+		t.Error("Expected AgentConfigRef to be nil when AgentConfigRefs is used")
+	}
+	if len(task.Spec.AgentConfigRefs) != 2 {
+		t.Fatalf("Expected 2 AgentConfigRefs, got %d", len(task.Spec.AgentConfigRefs))
+	}
+	if task.Spec.AgentConfigRefs[0].Name != "base-config" {
+		t.Errorf("Expected AgentConfigRefs[0].Name %q, got %q", "base-config", task.Spec.AgentConfigRefs[0].Name)
+	}
+	if task.Spec.AgentConfigRefs[1].Name != "role-config" {
+		t.Errorf("Expected AgentConfigRefs[1].Name %q, got %q", "role-config", task.Spec.AgentConfigRefs[1].Name)
+	}
+}
+
 func TestRunCycleWithSource_PodOverridesForwarded(t *testing.T) {
 	ts := newTaskSpawner("spawner", "default", nil)
 	ts.Spec.TaskTemplate.PodOverrides = &kelosv1alpha1.PodOverrides{

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -43,7 +43,13 @@ func printTaskTable(w io.Writer, tasks []kelosv1alpha1.Task, allNamespaces bool)
 			workspace = t.Spec.WorkspaceRef.Name
 		}
 		agentConfig := "-"
-		if t.Spec.AgentConfigRef != nil {
+		if len(t.Spec.AgentConfigRefs) > 0 {
+			names := make([]string, len(t.Spec.AgentConfigRefs))
+			for i, ref := range t.Spec.AgentConfigRefs {
+				names[i] = ref.Name
+			}
+			agentConfig = strings.Join(names, ",")
+		} else if t.Spec.AgentConfigRef != nil {
 			agentConfig = t.Spec.AgentConfigRef.Name
 		}
 		dur := taskDuration(&t.Status)
@@ -83,7 +89,13 @@ func printTaskDetail(w io.Writer, t *kelosv1alpha1.Task) {
 	if t.Spec.WorkspaceRef != nil {
 		printField(w, "Workspace", t.Spec.WorkspaceRef.Name)
 	}
-	if t.Spec.AgentConfigRef != nil {
+	if len(t.Spec.AgentConfigRefs) > 0 {
+		names := make([]string, len(t.Spec.AgentConfigRefs))
+		for i, ref := range t.Spec.AgentConfigRefs {
+			names[i] = ref.Name
+		}
+		printField(w, "Agent Configs", strings.Join(names, ", "))
+	} else if t.Spec.AgentConfigRef != nil {
 		printField(w, "Agent Config", t.Spec.AgentConfigRef.Name)
 	}
 	if t.Spec.TTLSecondsAfterFinished != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -35,23 +35,23 @@ func resolveCredentialValue(v string) string {
 
 func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	var (
-		prompt         string
-		promptFile     string
-		agentType      string
-		secret         string
-		credentialType string
-		model          string
-		image          string
-		name           string
-		watch          bool
-		workspace      string
-		dryRun         bool
-		yes            bool
-		timeout        string
-		envFlags       []string
-		agentConfigRef string
-		dependsOn      []string
-		branch         string
+		prompt          string
+		promptFile      string
+		agentType       string
+		secret          string
+		credentialType  string
+		model           string
+		image           string
+		name            string
+		watch           bool
+		workspace       string
+		dryRun          bool
+		yes             bool
+		timeout         string
+		envFlags        []string
+		agentConfigRefs []string
+		dependsOn       []string
+		branch          string
 	)
 
 	cmd := &cobra.Command{
@@ -75,7 +75,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 					workspace = c.Workspace.Name
 				}
 				if !cmd.Flags().Changed("agent-config") && c.AgentConfig != "" {
-					agentConfigRef = c.AgentConfig
+					agentConfigRefs = []string{c.AgentConfig}
 				}
 			}
 
@@ -258,9 +258,15 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				}
 			}
 
-			if agentConfigRef != "" {
+			if len(agentConfigRefs) == 1 {
 				task.Spec.AgentConfigRef = &kelosv1alpha1.AgentConfigReference{
-					Name: agentConfigRef,
+					Name: agentConfigRefs[0],
+				}
+			} else if len(agentConfigRefs) > 1 {
+				for _, name := range agentConfigRefs {
+					task.Spec.AgentConfigRefs = append(task.Spec.AgentConfigRefs, kelosv1alpha1.AgentConfigReference{
+						Name: name,
+					})
 				}
 			}
 
@@ -332,7 +338,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompts")
 	cmd.Flags().StringVar(&timeout, "timeout", "", "maximum execution time for the agent (e.g. 30m, 1h)")
 	cmd.Flags().StringArrayVar(&envFlags, "env", nil, "additional environment variables for the agent (NAME=VALUE)")
-	cmd.Flags().StringVar(&agentConfigRef, "agent-config", "", "name of AgentConfig resource to use")
+	cmd.Flags().StringArrayVar(&agentConfigRefs, "agent-config", nil, "name of AgentConfig resource(s) to use (repeatable)")
 	cmd.Flags().StringArrayVar(&dependsOn, "depends-on", nil, "Task names this task depends on (repeatable)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Git branch to work on")
 

--- a/internal/controller/agentconfig_merge.go
+++ b/internal/controller/agentconfig_merge.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"strings"
+
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+)
+
+// MergeAgentConfigs merges multiple AgentConfigSpecs in order.
+// agentsMD values are concatenated with "\n\n", plugins and skills are
+// appended, and mcpServers are appended with later entries winning on
+// name collision. Returns nil if the input slice is empty.
+func MergeAgentConfigs(configs []kelosv1alpha1.AgentConfigSpec) *kelosv1alpha1.AgentConfigSpec {
+	if len(configs) == 0 {
+		return nil
+	}
+	if len(configs) == 1 {
+		result := configs[0]
+		return &result
+	}
+
+	merged := kelosv1alpha1.AgentConfigSpec{}
+
+	var mdParts []string
+	for _, c := range configs {
+		if c.AgentsMD != "" {
+			mdParts = append(mdParts, c.AgentsMD)
+		}
+	}
+	merged.AgentsMD = strings.Join(mdParts, "\n\n")
+
+	for _, c := range configs {
+		merged.Plugins = append(merged.Plugins, c.Plugins...)
+	}
+
+	for _, c := range configs {
+		merged.Skills = append(merged.Skills, c.Skills...)
+	}
+
+	seen := make(map[string]int)
+	for _, c := range configs {
+		for _, server := range c.MCPServers {
+			if idx, exists := seen[server.Name]; exists {
+				merged.MCPServers[idx] = server
+			} else {
+				seen[server.Name] = len(merged.MCPServers)
+				merged.MCPServers = append(merged.MCPServers, server)
+			}
+		}
+	}
+
+	return &merged
+}
+
+// ResolveAgentConfigRefs returns the effective list of AgentConfigReference
+// values from a TaskSpec, normalizing the singular AgentConfigRef into a
+// single-element list for backward compatibility.
+func ResolveAgentConfigRefs(spec *kelosv1alpha1.TaskSpec) []kelosv1alpha1.AgentConfigReference {
+	if len(spec.AgentConfigRefs) > 0 {
+		return spec.AgentConfigRefs
+	}
+	if spec.AgentConfigRef != nil {
+		return []kelosv1alpha1.AgentConfigReference{*spec.AgentConfigRef}
+	}
+	return nil
+}

--- a/internal/controller/agentconfig_merge_test.go
+++ b/internal/controller/agentconfig_merge_test.go
@@ -1,0 +1,242 @@
+package controller
+
+import (
+	"testing"
+
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+)
+
+func TestMergeAgentConfigs_Empty(t *testing.T) {
+	if got := MergeAgentConfigs(nil); got != nil {
+		t.Errorf("Expected nil, got %+v", got)
+	}
+	if got := MergeAgentConfigs([]kelosv1alpha1.AgentConfigSpec{}); got != nil {
+		t.Errorf("Expected nil, got %+v", got)
+	}
+}
+
+func TestMergeAgentConfigs_Single(t *testing.T) {
+	input := kelosv1alpha1.AgentConfigSpec{
+		AgentsMD: "# Instructions",
+		Plugins:  []kelosv1alpha1.PluginSpec{{Name: "p1"}},
+		Skills:   []kelosv1alpha1.SkillsShSpec{{Source: "owner/repo"}},
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
+			{Name: "server1", Type: "stdio", Command: "cmd"},
+		},
+	}
+	got := MergeAgentConfigs([]kelosv1alpha1.AgentConfigSpec{input})
+	if got == nil {
+		t.Fatal("Expected non-nil result")
+	}
+	if got.AgentsMD != "# Instructions" {
+		t.Errorf("AgentsMD = %q, want %q", got.AgentsMD, "# Instructions")
+	}
+	if len(got.Plugins) != 1 || got.Plugins[0].Name != "p1" {
+		t.Errorf("Plugins = %+v, want [{Name: p1}]", got.Plugins)
+	}
+	if len(got.Skills) != 1 || got.Skills[0].Source != "owner/repo" {
+		t.Errorf("Skills = %+v, want [{Source: owner/repo}]", got.Skills)
+	}
+	if len(got.MCPServers) != 1 || got.MCPServers[0].Name != "server1" {
+		t.Errorf("MCPServers = %+v, want [{Name: server1}]", got.MCPServers)
+	}
+}
+
+func TestMergeAgentConfigs_AgentsMDConcatenation(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{AgentsMD: "# Config A"},
+		{AgentsMD: "# Config B"},
+	}
+	got := MergeAgentConfigs(configs)
+	want := "# Config A\n\n# Config B"
+	if got.AgentsMD != want {
+		t.Errorf("AgentsMD = %q, want %q", got.AgentsMD, want)
+	}
+}
+
+func TestMergeAgentConfigs_AgentsMDSkipsEmpty(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{AgentsMD: ""},
+		{AgentsMD: "# Config B"},
+	}
+	got := MergeAgentConfigs(configs)
+	if got.AgentsMD != "# Config B" {
+		t.Errorf("AgentsMD = %q, want %q", got.AgentsMD, "# Config B")
+	}
+}
+
+func TestMergeAgentConfigs_PluginsAppended(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{Plugins: []kelosv1alpha1.PluginSpec{{Name: "p1"}}},
+		{Plugins: []kelosv1alpha1.PluginSpec{{Name: "p2"}, {Name: "p3"}}},
+	}
+	got := MergeAgentConfigs(configs)
+	if len(got.Plugins) != 3 {
+		t.Fatalf("len(Plugins) = %d, want 3", len(got.Plugins))
+	}
+	names := []string{got.Plugins[0].Name, got.Plugins[1].Name, got.Plugins[2].Name}
+	want := []string{"p1", "p2", "p3"}
+	for i := range names {
+		if names[i] != want[i] {
+			t.Errorf("Plugins[%d].Name = %q, want %q", i, names[i], want[i])
+		}
+	}
+}
+
+func TestMergeAgentConfigs_SkillsAppended(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{Skills: []kelosv1alpha1.SkillsShSpec{{Source: "a/b"}}},
+		{Skills: []kelosv1alpha1.SkillsShSpec{{Source: "c/d"}}},
+	}
+	got := MergeAgentConfigs(configs)
+	if len(got.Skills) != 2 {
+		t.Fatalf("len(Skills) = %d, want 2", len(got.Skills))
+	}
+	if got.Skills[0].Source != "a/b" || got.Skills[1].Source != "c/d" {
+		t.Errorf("Skills = %+v", got.Skills)
+	}
+}
+
+func TestMergeAgentConfigs_MCPServersAppended(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{MCPServers: []kelosv1alpha1.MCPServerSpec{{Name: "s1", Type: "stdio"}}},
+		{MCPServers: []kelosv1alpha1.MCPServerSpec{{Name: "s2", Type: "http"}}},
+	}
+	got := MergeAgentConfigs(configs)
+	if len(got.MCPServers) != 2 {
+		t.Fatalf("len(MCPServers) = %d, want 2", len(got.MCPServers))
+	}
+	if got.MCPServers[0].Name != "s1" || got.MCPServers[1].Name != "s2" {
+		t.Errorf("MCPServers = %+v", got.MCPServers)
+	}
+}
+
+func TestMergeAgentConfigs_MCPServersLaterWins(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{MCPServers: []kelosv1alpha1.MCPServerSpec{{Name: "shared", Type: "stdio", Command: "old"}}},
+		{MCPServers: []kelosv1alpha1.MCPServerSpec{{Name: "shared", Type: "http", URL: "http://new"}}},
+	}
+	got := MergeAgentConfigs(configs)
+	if len(got.MCPServers) != 1 {
+		t.Fatalf("len(MCPServers) = %d, want 1", len(got.MCPServers))
+	}
+	if got.MCPServers[0].Type != "http" || got.MCPServers[0].URL != "http://new" {
+		t.Errorf("MCPServers[0] = %+v, want http type with new URL", got.MCPServers[0])
+	}
+}
+
+func TestMergeAgentConfigs_MCPServersOrderPreserved(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{MCPServers: []kelosv1alpha1.MCPServerSpec{
+			{Name: "a", Type: "stdio", Command: "a1"},
+			{Name: "b", Type: "stdio", Command: "b1"},
+		}},
+		{MCPServers: []kelosv1alpha1.MCPServerSpec{
+			{Name: "c", Type: "http", URL: "http://c"},
+			{Name: "a", Type: "http", URL: "http://a2"},
+		}},
+	}
+	got := MergeAgentConfigs(configs)
+	if len(got.MCPServers) != 3 {
+		t.Fatalf("len(MCPServers) = %d, want 3", len(got.MCPServers))
+	}
+	// Order: a (first seen, overwritten), b, c
+	if got.MCPServers[0].Name != "a" || got.MCPServers[0].Type != "http" {
+		t.Errorf("MCPServers[0] = %+v, want a/http (later wins)", got.MCPServers[0])
+	}
+	if got.MCPServers[1].Name != "b" {
+		t.Errorf("MCPServers[1].Name = %q, want %q", got.MCPServers[1].Name, "b")
+	}
+	if got.MCPServers[2].Name != "c" {
+		t.Errorf("MCPServers[2].Name = %q, want %q", got.MCPServers[2].Name, "c")
+	}
+}
+
+func TestMergeAgentConfigs_ThreeConfigs(t *testing.T) {
+	configs := []kelosv1alpha1.AgentConfigSpec{
+		{
+			AgentsMD: "## Environment",
+			Plugins:  []kelosv1alpha1.PluginSpec{{Name: "base"}},
+			MCPServers: []kelosv1alpha1.MCPServerSpec{
+				{Name: "shared", Type: "stdio", Command: "v1"},
+			},
+		},
+		{
+			AgentsMD: "## Standards",
+			Skills:   []kelosv1alpha1.SkillsShSpec{{Source: "org/skills"}},
+		},
+		{
+			AgentsMD: "## Identity",
+			Plugins:  []kelosv1alpha1.PluginSpec{{Name: "role"}},
+			MCPServers: []kelosv1alpha1.MCPServerSpec{
+				{Name: "shared", Type: "http", URL: "http://v2"},
+				{Name: "extra", Type: "sse", URL: "http://extra"},
+			},
+		},
+	}
+	got := MergeAgentConfigs(configs)
+
+	wantMD := "## Environment\n\n## Standards\n\n## Identity"
+	if got.AgentsMD != wantMD {
+		t.Errorf("AgentsMD = %q, want %q", got.AgentsMD, wantMD)
+	}
+	if len(got.Plugins) != 2 || got.Plugins[0].Name != "base" || got.Plugins[1].Name != "role" {
+		t.Errorf("Plugins = %+v", got.Plugins)
+	}
+	if len(got.Skills) != 1 || got.Skills[0].Source != "org/skills" {
+		t.Errorf("Skills = %+v", got.Skills)
+	}
+	if len(got.MCPServers) != 2 {
+		t.Fatalf("len(MCPServers) = %d, want 2", len(got.MCPServers))
+	}
+	if got.MCPServers[0].Name != "shared" || got.MCPServers[0].Type != "http" {
+		t.Errorf("MCPServers[0] = %+v, want shared/http", got.MCPServers[0])
+	}
+	if got.MCPServers[1].Name != "extra" {
+		t.Errorf("MCPServers[1].Name = %q, want %q", got.MCPServers[1].Name, "extra")
+	}
+}
+
+func TestResolveAgentConfigRefs_NeitherSet(t *testing.T) {
+	spec := &kelosv1alpha1.TaskSpec{}
+	if got := ResolveAgentConfigRefs(spec); got != nil {
+		t.Errorf("Expected nil, got %+v", got)
+	}
+}
+
+func TestResolveAgentConfigRefs_SingularSet(t *testing.T) {
+	spec := &kelosv1alpha1.TaskSpec{
+		AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "single"},
+	}
+	got := ResolveAgentConfigRefs(spec)
+	if len(got) != 1 || got[0].Name != "single" {
+		t.Errorf("Expected [{Name: single}], got %+v", got)
+	}
+}
+
+func TestResolveAgentConfigRefs_PluralSet(t *testing.T) {
+	spec := &kelosv1alpha1.TaskSpec{
+		AgentConfigRefs: []kelosv1alpha1.AgentConfigReference{
+			{Name: "first"},
+			{Name: "second"},
+		},
+	}
+	got := ResolveAgentConfigRefs(spec)
+	if len(got) != 2 || got[0].Name != "first" || got[1].Name != "second" {
+		t.Errorf("Expected [first, second], got %+v", got)
+	}
+}
+
+func TestResolveAgentConfigRefs_PluralTakesPrecedence(t *testing.T) {
+	spec := &kelosv1alpha1.TaskSpec{
+		AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "singular"},
+		AgentConfigRefs: []kelosv1alpha1.AgentConfigReference{
+			{Name: "plural1"},
+			{Name: "plural2"},
+		},
+	}
+	got := ResolveAgentConfigRefs(spec)
+	if len(got) != 2 || got[0].Name != "plural1" {
+		t.Errorf("Expected plural to take precedence, got %+v", got)
+	}
+}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -244,20 +244,25 @@ func (r *TaskReconciler) createJob(ctx context.Context, task *kelosv1alpha1.Task
 	}
 
 	var agentConfig *kelosv1alpha1.AgentConfigSpec
-	if task.Spec.AgentConfigRef != nil {
-		var ac kelosv1alpha1.AgentConfig
-		if err := r.Get(ctx, client.ObjectKey{
-			Namespace: task.Namespace,
-			Name:      task.Spec.AgentConfigRef.Name,
-		}, &ac); err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("AgentConfig not found yet, requeuing", "agentConfig", task.Spec.AgentConfigRef.Name)
-				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+	if refs := ResolveAgentConfigRefs(&task.Spec); len(refs) > 0 {
+		var specs []kelosv1alpha1.AgentConfigSpec
+		for _, ref := range refs {
+			var ac kelosv1alpha1.AgentConfig
+			if err := r.Get(ctx, client.ObjectKey{
+				Namespace: task.Namespace,
+				Name:      ref.Name,
+			}, &ac); err != nil {
+				if apierrors.IsNotFound(err) {
+					logger.Info("AgentConfig not found yet, requeuing", "agentConfig", ref.Name)
+					return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+				}
+				logger.Error(err, "Unable to fetch AgentConfig", "agentConfig", ref.Name)
+				return ctrl.Result{}, err
 			}
-			logger.Error(err, "Unable to fetch AgentConfig", "agentConfig", task.Spec.AgentConfigRef.Name)
-			return ctrl.Result{}, err
+			specs = append(specs, ac.Spec)
 		}
-		agentConfig = &ac.Spec
+
+		agentConfig = MergeAgentConfigs(specs)
 
 		if len(agentConfig.MCPServers) > 0 {
 			resolved, err := r.resolveMCPServerSecrets(ctx, task.Namespace, agentConfig.MCPServers)

--- a/internal/manifests/charts/kelos/templates/crds/task-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/task-crd.yaml
@@ -69,6 +69,24 @@ spec:
                 required:
                 - name
                 type: object
+              agentConfigRefs:
+                description: |-
+                  AgentConfigRefs references an ordered list of AgentConfig resources.
+                  Configs are merged in order: agentsMD is concatenated, plugins/skills
+                  are appended, mcpServers are appended with later entries winning on
+                  name collision. Mutually exclusive with AgentConfigRef.
+                items:
+                  description: AgentConfigReference refers to an AgentConfig resource
+                    by name.
+                  properties:
+                    name:
+                      description: Name is the name of the AgentConfig resource.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                minItems: 1
+                type: array
               branch:
                 description: |-
                   Branch is the git branch this Task works on. When set, an init
@@ -421,6 +439,8 @@ spec:
             x-kubernetes-validations:
             - message: Task spec is immutable after creation
               rule: self == oldSelf
+            - message: agentConfigRef and agentConfigRefs are mutually exclusive
+              rule: '!(has(self.agentConfigRef) && has(self.agentConfigRefs))'
           status:
             description: TaskStatus defines the observed state of Task.
             properties:

--- a/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
@@ -110,6 +110,25 @@ spec:
                     required:
                     - name
                     type: object
+                  agentConfigRefs:
+                    description: |-
+                      AgentConfigRefs references an ordered list of AgentConfig resources.
+                      Configs are merged in order: agentsMD is concatenated, plugins/skills
+                      are appended, mcpServers are appended with later entries winning on
+                      name collision. Mutually exclusive with AgentConfigRef.
+                      When set, spawned Tasks inherit this agent config reference list.
+                    items:
+                      description: AgentConfigReference refers to an AgentConfig resource
+                        by name.
+                      properties:
+                        name:
+                          description: Name is the name of the AgentConfig resource.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    minItems: 1
+                    type: array
                   branch:
                     description: |-
                       Branch is the git branch spawned Tasks should work on.
@@ -498,6 +517,9 @@ spec:
                 - credentials
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: agentConfigRef and agentConfigRefs are mutually exclusive
+                  rule: '!(has(self.agentConfigRef) && has(self.agentConfigRefs))'
               when:
                 description: When defines the conditions that trigger task spawning.
                 properties:

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -293,6 +293,24 @@ spec:
                 required:
                 - name
                 type: object
+              agentConfigRefs:
+                description: |-
+                  AgentConfigRefs references an ordered list of AgentConfig resources.
+                  Configs are merged in order: agentsMD is concatenated, plugins/skills
+                  are appended, mcpServers are appended with later entries winning on
+                  name collision. Mutually exclusive with AgentConfigRef.
+                items:
+                  description: AgentConfigReference refers to an AgentConfig resource
+                    by name.
+                  properties:
+                    name:
+                      description: Name is the name of the AgentConfig resource.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                minItems: 1
+                type: array
               branch:
                 description: |-
                   Branch is the git branch this Task works on. When set, an init
@@ -645,6 +663,8 @@ spec:
             x-kubernetes-validations:
             - message: Task spec is immutable after creation
               rule: self == oldSelf
+            - message: agentConfigRef and agentConfigRefs are mutually exclusive
+              rule: '!(has(self.agentConfigRef) && has(self.agentConfigRefs))'
           status:
             description: TaskStatus defines the observed state of Task.
             properties:
@@ -797,6 +817,25 @@ spec:
                     required:
                     - name
                     type: object
+                  agentConfigRefs:
+                    description: |-
+                      AgentConfigRefs references an ordered list of AgentConfig resources.
+                      Configs are merged in order: agentsMD is concatenated, plugins/skills
+                      are appended, mcpServers are appended with later entries winning on
+                      name collision. Mutually exclusive with AgentConfigRef.
+                      When set, spawned Tasks inherit this agent config reference list.
+                    items:
+                      description: AgentConfigReference refers to an AgentConfig resource
+                        by name.
+                      properties:
+                        name:
+                          description: Name is the name of the AgentConfig resource.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    minItems: 1
+                    type: array
                   branch:
                     description: |-
                       Branch is the git branch spawned Tasks should work on.
@@ -1185,6 +1224,9 @@ spec:
                 - credentials
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: agentConfigRef and agentConfigRefs are mutually exclusive
+                  rule: '!(has(self.agentConfigRef) && has(self.agentConfigRefs))'
               when:
                 description: When defines the conditions that trigger task spawning.
                 properties:

--- a/internal/taskbuilder/builder.go
+++ b/internal/taskbuilder/builder.go
@@ -88,6 +88,9 @@ func (tb *TaskBuilder) BuildTask(
 	if taskTemplate.AgentConfigRef != nil {
 		task.Spec.AgentConfigRef = taskTemplate.AgentConfigRef
 	}
+	if len(taskTemplate.AgentConfigRefs) > 0 {
+		task.Spec.AgentConfigRefs = taskTemplate.AgentConfigRefs
+	}
 	if len(taskTemplate.DependsOn) > 0 {
 		task.Spec.DependsOn = taskTemplate.DependsOn
 	}

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -3509,4 +3509,95 @@ var _ = Describe("Task Controller", func() {
 			}
 		})
 	})
+
+	Context("When creating a Task with multiple AgentConfigs", func() {
+		It("Should merge AgentConfigs and create a Job with concatenated agentsMD", func() {
+			By("Creating a namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-task-multi-agentconfig",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+			By("Creating a Secret with API key")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "anthropic-api-key",
+					Namespace: ns.Name,
+				},
+				StringData: map[string]string{
+					"ANTHROPIC_API_KEY": "test-api-key",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating base AgentConfig")
+			baseConfig := &kelosv1alpha1.AgentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "base-config",
+					Namespace: ns.Name,
+				},
+				Spec: kelosv1alpha1.AgentConfigSpec{
+					AgentsMD: "## Environment\nShared environment instructions",
+				},
+			}
+			Expect(k8sClient.Create(ctx, baseConfig)).Should(Succeed())
+
+			By("Creating role AgentConfig")
+			roleConfig := &kelosv1alpha1.AgentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "role-config",
+					Namespace: ns.Name,
+				},
+				Spec: kelosv1alpha1.AgentConfigSpec{
+					AgentsMD: "## Identity\nWorker agent role",
+				},
+			}
+			Expect(k8sClient.Create(ctx, roleConfig)).Should(Succeed())
+
+			By("Creating a Task referencing both AgentConfigs")
+			task := &kelosv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "task-multi-agentconfig",
+					Namespace: ns.Name,
+				},
+				Spec: kelosv1alpha1.TaskSpec{
+					Type:   "claude-code",
+					Prompt: "Test multi agentconfig merge",
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeAPIKey,
+						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					},
+					AgentConfigRefs: []kelosv1alpha1.AgentConfigReference{
+						{Name: "base-config"},
+						{Name: "role-config"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
+
+			By("Verifying a Job is created")
+			createdJob := &batchv1.Job{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: task.Name, Namespace: ns.Name}, createdJob)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying KELOS_AGENTS_MD contains merged content")
+			container := createdJob.Spec.Template.Spec.Containers[0]
+			var agentsMD string
+			for _, env := range container.Env {
+				if env.Name == "KELOS_AGENTS_MD" {
+					agentsMD = env.Value
+					break
+				}
+			}
+			Expect(agentsMD).To(ContainSubstring("## Environment"))
+			Expect(agentsMD).To(ContainSubstring("Shared environment instructions"))
+			Expect(agentsMD).To(ContainSubstring("## Identity"))
+			Expect(agentsMD).To(ContainSubstring("Worker agent role"))
+			Expect(strings.Index(agentsMD, "## Environment")).To(BeNumerically("<", strings.Index(agentsMD, "## Identity")))
+		})
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs
/kind feature
-->

/kind feature

#### What this PR does / why we need it:
Add an ordered list field `agentConfigRefs` alongside the existing singular `agentConfigRef` on Task and TaskTemplate types. Multiple AgentConfigs are merged in order at task creation time: agentsMD is concatenated, plugins/skills are appended, and mcpServers are appended with later entries winning on name collision.

This eliminates duplicated instructions across AgentConfigs in multi-agent deployments by enabling composition — shared config lives in a base AgentConfig while role-specific layers add only their delta.


#### Which issue(s) this PR is related to:

<!--
Fixes #<issue number>

If there is no associated issue, then write "N/A".
-->
Fixes #693
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
feat: Adds support for agentConfigReferences allowing for a list to be built up and shared across taskSpawners
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for composing multiple AgentConfigs via a new agentConfigRefs list on Tasks and TaskTemplates. The controller merges configs in order to reduce duplication in multi-agent setups.

- **New Features**
  - Added Task/TaskTemplate `.spec.agentConfigRefs` (ordered list), mutually exclusive with `agentConfigRef` via CRD XValidation.
  - Controller merges in order: `agentsMD` concatenated, `plugins`/`skills` appended, `mcpServers` appended with later names overriding; singular or list is normalized.
  - CLI: `kelos run --agent-config` is repeatable; one value maps to `agentConfigRef`, multiple to `agentConfigRefs`. Printers show multiple names.
  - Spawner and `TaskBuilder` forward lists; CRDs and install manifests updated; unit, merge, and integration tests added.

- **Migration**
  - No breaking changes; existing `agentConfigRef` continues to work.
  - To compose configs, set `spec.agentConfigRefs` or pass `--agent-config` multiple times. Ensure only one of `agentConfigRef` or `agentConfigRefs` is set.

<sup>Written for commit 3a4f04722a746a81128df115a34afd26f9b5c8d4. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1014?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

