### PR TITLE
Unset CLAUDE_CODE_EFFORT_LEVEL in self-development workflows

### DIFF
--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -70,9 +70,6 @@ spec:
           ephemeral-storage: "4Gi"
         limits:
           ephemeral-storage: "4Gi"
-      env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
     branch: "{{if .Branch}}{{.Branch}}{{else}}main{{end}}"
     agentConfigRef:
       name: kelos-api-reviewer-agent

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -27,8 +27,6 @@ spec:
         limits:
           ephemeral-storage: "2Gi"
       env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
         - name: GIT_AUTHOR_NAME
           value: "Gunju Kim"
         - name: GIT_AUTHOR_EMAIL

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -57,9 +57,6 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
-      env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
     agentConfigRef:
       name: kelos-fake-strategist-agent
     promptTemplate: |

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -60,9 +60,6 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
-      env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
     agentConfigRef:
       name: kelos-planner-agent
     promptTemplate: |

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -51,8 +51,6 @@ spec:
         limits:
           ephemeral-storage: "4Gi"
       env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
         - name: GIT_AUTHOR_NAME
           value: "Gunju Kim"
         - name: GIT_AUTHOR_EMAIL

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -72,9 +72,6 @@ spec:
           ephemeral-storage: "4Gi"
         limits:
           ephemeral-storage: "4Gi"
-      env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
     branch: "{{.Branch}}"
     agentConfigRef:
       name: kelos-reviewer-agent

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -57,9 +57,6 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
-      env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
     agentConfigRef:
       name: kelos-self-update-agent
     promptTemplate: |

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -40,9 +40,6 @@ spec:
           ephemeral-storage: "2Gi"
         limits:
           ephemeral-storage: "2Gi"
-      env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
     agentConfigRef:
       name: kelos-dev-agent
     promptTemplate: |

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -75,8 +75,6 @@ spec:
         limits:
           ephemeral-storage: "4Gi"
       env:
-        - name: CLAUDE_CODE_EFFORT_LEVEL
-          value: "max"
         - name: GIT_AUTHOR_NAME
           value: "Gunju Kim"
         - name: GIT_AUTHOR_EMAIL

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -24,9 +24,6 @@ spec:
         ephemeral-storage: "2Gi"
       limits:
         ephemeral-storage: "2Gi"
-    env:
-      - name: CLAUDE_CODE_EFFORT_LEVEL
-        value: "max"
   prompt: |
     You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
     Your goal is to find new and better ways to use Kelos — expanding its reach, improving its workflows, and identifying opportunities for growth.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the explicit `CLAUDE_CODE_EFFORT_LEVEL=max` env var override from every TaskSpawner under `self-development/` and from the `fake-strategist-task` Task template so they fall back to the default effort level. For files where this was the only env var, the now-empty `env:` block is dropped; for files with other env vars (config-update, pr-responder, workers), only the two effort lines are removed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unset `CLAUDE_CODE_EFFORT_LEVEL=max` across self-development TaskSpawners and the `fake-strategist` task to use the default effort level and keep behavior consistent. Removed now-empty `env:` blocks where this was the only variable; kept other env vars (e.g., `GIT_AUTHOR_*`) in `kelos-config-update`, `kelos-pr-responder`, and `kelos-workers`.

<sup>Written for commit d1c0a10294014f93f0f3fd0cdc76e3effcca2936. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1034?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

