### PR TITLE
Add cwd to AgentConfig.mcpServers[] for stdio working directory

### DIFF
--- a/api/v1alpha1/agentconfig_types.go
+++ b/api/v1alpha1/agentconfig_types.go
@@ -126,6 +126,15 @@ type MCPServerSpec struct {
 	// for overlapping keys.
 	// +optional
 	EnvFrom *SecretValuesSource `json:"envFrom,omitempty"`
+
+	// WorkingDir is the working directory in which a stdio MCP server
+	// command is spawned. Only used when type is "stdio". Useful for
+	// servers that must run from a specific project root (for example,
+	// "php artisan boost:mcp" requires the Laravel project root as cwd).
+	// Relative paths are resolved by the agent against its own current
+	// working directory; absolute paths are recommended.
+	// +optional
+	WorkingDir string `json:"cwd,omitempty"`
 }
 
 // SecretValuesSource selects a Secret to populate values from.

--- a/api/v1alpha1/agentconfig_types.go
+++ b/api/v1alpha1/agentconfig_types.go
@@ -134,7 +134,7 @@ type MCPServerSpec struct {
 	// Relative paths are resolved by the agent against its own current
 	// working directory; absolute paths are recommended.
 	// +optional
-	WorkingDir string `json:"cwd,omitempty"`
+	WorkingDir string `json:"workingDir,omitempty"`
 }
 
 // SecretValuesSource selects a Secret to populate values from.

--- a/codex/kelos_entrypoint.sh
+++ b/codex/kelos_entrypoint.sh
@@ -71,6 +71,7 @@ for (const [name, s] of Object.entries(servers)) {
   toml += `[mcp_servers.${JSON.stringify(name)}]\n`;
   if (s.command) toml += `command = ${JSON.stringify(s.command)}\n`;
   if (s.args && s.args.length) toml += `args = ${JSON.stringify(s.args)}\n`;
+  if (s.cwd) toml += `cwd = ${JSON.stringify(s.cwd)}\n`;
   if (s.url) toml += `url = ${JSON.stringify(s.url)}\n`;
   if (s.headers) {
     const h = Object.entries(s.headers).map(([k,v]) => `${JSON.stringify(k)} = ${JSON.stringify(v)}`).join(", ");

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -109,6 +109,7 @@ GitHub Apps are preferred over PATs for production use because they offer fine-g
 | `spec.mcpServers[].url` | Server endpoint (http/sse only) | No |
 | `spec.mcpServers[].headers` | HTTP headers (http/sse only) | No |
 | `spec.mcpServers[].env` | Environment variables for server process (stdio only) | No |
+| `spec.mcpServers[].cwd` | Working directory in which the stdio command is spawned (stdio only); useful for servers that must run from a specific project root (e.g., `php artisan boost:mcp` from a Laravel root) | No |
 
 ## TaskSpawner
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -109,7 +109,7 @@ GitHub Apps are preferred over PATs for production use because they offer fine-g
 | `spec.mcpServers[].url` | Server endpoint (http/sse only) | No |
 | `spec.mcpServers[].headers` | HTTP headers (http/sse only) | No |
 | `spec.mcpServers[].env` | Environment variables for server process (stdio only) | No |
-| `spec.mcpServers[].cwd` | Working directory in which the stdio command is spawned (stdio only); useful for servers that must run from a specific project root (e.g., `php artisan boost:mcp` from a Laravel root) | No |
+| `spec.mcpServers[].workingDir` | Working directory in which the stdio command is spawned (stdio only); useful for servers that must run from a specific project root (e.g., `php artisan boost:mcp` from a Laravel root) | No |
 
 ## TaskSpawner
 

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -817,6 +817,7 @@ type mcpServerJSON struct {
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
+	Cwd     string            `json:"cwd,omitempty"`
 }
 
 // buildMCPServersJSON converts MCPServerSpec entries into a JSON string
@@ -840,6 +841,7 @@ func buildMCPServersJSON(servers []kelosv1alpha1.MCPServerSpec) (string, error) 
 			URL:     s.URL,
 			Headers: s.Headers,
 			Env:     s.Env,
+			Cwd:     s.WorkingDir,
 		}
 		mcpMap[s.Name] = entry
 	}

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -3180,68 +3180,86 @@ func TestBuildJob_AgentConfigMCPServers(t *testing.T) {
 }
 
 func TestBuildJob_AgentConfigMCPServersStdioCwd(t *testing.T) {
-	builder := NewJobBuilder()
-	task := &kelosv1alpha1.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-mcp-cwd",
-			Namespace: "default",
-		},
-		Spec: kelosv1alpha1.TaskSpec{
-			Type:   AgentTypeClaudeCode,
-			Prompt: "Fix issue",
-			Credentials: kelosv1alpha1.Credentials{
-				Type:      kelosv1alpha1.CredentialTypeAPIKey,
-				SecretRef: &kelosv1alpha1.SecretReference{Name: "my-secret"},
-			},
-		},
+	// The MCP env var is wired identically for every agent type that
+	// supports MCP; per-agent translation of the `cwd` field happens in
+	// each agent's entrypoint script (Object.assign for claude-code,
+	// cursor, gemini; field-by-field TOML emission for codex). This test
+	// pins the Go-side contract: the same KELOS_MCP_SERVERS payload, with
+	// `cwd` populated, is delivered to every agent type.
+	agentTypes := []string{
+		AgentTypeClaudeCode,
+		AgentTypeCodex,
+		AgentTypeCursor,
+		AgentTypeGemini,
+		AgentTypeOpenCode,
 	}
 
-	agentConfig := &kelosv1alpha1.AgentConfigSpec{
-		MCPServers: []kelosv1alpha1.MCPServerSpec{
-			{
-				Name:       "laravel-boost",
-				Type:       "stdio",
-				Command:    "php",
-				Args:       []string{"artisan", "boost:mcp"},
-				WorkingDir: "/workspace/repo",
-			},
-		},
-	}
+	for _, agentType := range agentTypes {
+		t.Run(agentType, func(t *testing.T) {
+			builder := NewJobBuilder()
+			task := &kelosv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mcp-cwd",
+					Namespace: "default",
+				},
+				Spec: kelosv1alpha1.TaskSpec{
+					Type:   agentType,
+					Prompt: "Fix issue",
+					Credentials: kelosv1alpha1.Credentials{
+						Type:      kelosv1alpha1.CredentialTypeAPIKey,
+						SecretRef: &kelosv1alpha1.SecretReference{Name: "my-secret"},
+					},
+				},
+			}
 
-	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
-	if err != nil {
-		t.Fatalf("Build() returned error: %v", err)
-	}
+			agentConfig := &kelosv1alpha1.AgentConfigSpec{
+				MCPServers: []kelosv1alpha1.MCPServerSpec{
+					{
+						Name:       "laravel-boost",
+						Type:       "stdio",
+						Command:    "php",
+						Args:       []string{"artisan", "boost:mcp"},
+						WorkingDir: "/workspace/repo",
+					},
+				},
+			}
 
-	container := job.Spec.Template.Spec.Containers[0]
-	var mcpJSON string
-	for _, env := range container.Env {
-		if env.Name == "KELOS_MCP_SERVERS" {
-			mcpJSON = env.Value
-		}
-	}
-	if mcpJSON == "" {
-		t.Fatal("Expected KELOS_MCP_SERVERS env var to be set")
-	}
+			job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
+			if err != nil {
+				t.Fatalf("Build() returned error: %v", err)
+			}
 
-	var parsed struct {
-		MCPServers map[string]struct {
-			Type    string   `json:"type"`
-			Command string   `json:"command"`
-			Args    []string `json:"args"`
-			Cwd     string   `json:"cwd"`
-		} `json:"mcpServers"`
-	}
-	if err := json.Unmarshal([]byte(mcpJSON), &parsed); err != nil {
-		t.Fatalf("Failed to parse KELOS_MCP_SERVERS JSON: %v", err)
-	}
+			container := job.Spec.Template.Spec.Containers[0]
+			var mcpJSON string
+			for _, env := range container.Env {
+				if env.Name == "KELOS_MCP_SERVERS" {
+					mcpJSON = env.Value
+				}
+			}
+			if mcpJSON == "" {
+				t.Fatal("Expected KELOS_MCP_SERVERS env var to be set")
+			}
 
-	boost, ok := parsed.MCPServers["laravel-boost"]
-	if !ok {
-		t.Fatal("Expected 'laravel-boost' MCP server entry")
-	}
-	if boost.Cwd != "/workspace/repo" {
-		t.Errorf("Expected cwd '/workspace/repo', got %q", boost.Cwd)
+			var parsed struct {
+				MCPServers map[string]struct {
+					Type    string   `json:"type"`
+					Command string   `json:"command"`
+					Args    []string `json:"args"`
+					Cwd     string   `json:"cwd"`
+				} `json:"mcpServers"`
+			}
+			if err := json.Unmarshal([]byte(mcpJSON), &parsed); err != nil {
+				t.Fatalf("Failed to parse KELOS_MCP_SERVERS JSON: %v", err)
+			}
+
+			boost, ok := parsed.MCPServers["laravel-boost"]
+			if !ok {
+				t.Fatal("Expected 'laravel-boost' MCP server entry")
+			}
+			if boost.Cwd != "/workspace/repo" {
+				t.Errorf("Expected cwd '/workspace/repo', got %q", boost.Cwd)
+			}
+		})
 	}
 }
 

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -3179,6 +3179,121 @@ func TestBuildJob_AgentConfigMCPServers(t *testing.T) {
 	}
 }
 
+func TestBuildJob_AgentConfigMCPServersStdioCwd(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mcp-cwd",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix issue",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
+			{
+				Name:       "laravel-boost",
+				Type:       "stdio",
+				Command:    "php",
+				Args:       []string{"artisan", "boost:mcp"},
+				WorkingDir: "/workspace/repo",
+			},
+		},
+	}
+
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+	var mcpJSON string
+	for _, env := range container.Env {
+		if env.Name == "KELOS_MCP_SERVERS" {
+			mcpJSON = env.Value
+		}
+	}
+	if mcpJSON == "" {
+		t.Fatal("Expected KELOS_MCP_SERVERS env var to be set")
+	}
+
+	var parsed struct {
+		MCPServers map[string]struct {
+			Type    string   `json:"type"`
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+			Cwd     string   `json:"cwd"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal([]byte(mcpJSON), &parsed); err != nil {
+		t.Fatalf("Failed to parse KELOS_MCP_SERVERS JSON: %v", err)
+	}
+
+	boost, ok := parsed.MCPServers["laravel-boost"]
+	if !ok {
+		t.Fatal("Expected 'laravel-boost' MCP server entry")
+	}
+	if boost.Cwd != "/workspace/repo" {
+		t.Errorf("Expected cwd '/workspace/repo', got %q", boost.Cwd)
+	}
+}
+
+func TestBuildJob_AgentConfigMCPServersCwdOmittedWhenUnset(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mcp-no-cwd",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix issue",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+
+	agentConfig := &kelosv1alpha1.AgentConfigSpec{
+		MCPServers: []kelosv1alpha1.MCPServerSpec{
+			{
+				Name:    "no-cwd",
+				Type:    "stdio",
+				Command: "echo",
+				Args:    []string{"hello"},
+			},
+		},
+	}
+
+	job, err := builder.Build(task, nil, agentConfig, task.Spec.Prompt)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+	var mcpJSON string
+	for _, env := range container.Env {
+		if env.Name == "KELOS_MCP_SERVERS" {
+			mcpJSON = env.Value
+		}
+	}
+	if mcpJSON == "" {
+		t.Fatal("Expected KELOS_MCP_SERVERS env var to be set")
+	}
+
+	if strings.Contains(mcpJSON, `"cwd"`) {
+		t.Errorf("Expected cwd key to be omitted when WorkingDir is unset, got: %s", mcpJSON)
+	}
+}
+
 func TestBuildJob_AgentConfigMCPServersWithHTTPHeaders(t *testing.T) {
 	builder := NewJobBuilder()
 	task := &kelosv1alpha1.Task{

--- a/internal/manifests/charts/kelos/templates/crds/agentconfig-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/agentconfig-crd.yaml
@@ -68,6 +68,15 @@ spec:
                         Command is the executable to run for stdio transport.
                         Required when type is "stdio".
                       type: string
+                    cwd:
+                      description: |-
+                        WorkingDir is the working directory in which a stdio MCP server
+                        command is spawned. Only used when type is "stdio". Useful for
+                        servers that must run from a specific project root (for example,
+                        "php artisan boost:mcp" requires the Laravel project root as cwd).
+                        Relative paths are resolved by the agent against its own current
+                        working directory; absolute paths are recommended.
+                      type: string
                     env:
                       additionalProperties:
                         type: string

--- a/internal/manifests/charts/kelos/templates/crds/agentconfig-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/agentconfig-crd.yaml
@@ -68,15 +68,6 @@ spec:
                         Command is the executable to run for stdio transport.
                         Required when type is "stdio".
                       type: string
-                    cwd:
-                      description: |-
-                        WorkingDir is the working directory in which a stdio MCP server
-                        command is spawned. Only used when type is "stdio". Useful for
-                        servers that must run from a specific project root (for example,
-                        "php artisan boost:mcp" requires the Laravel project root as cwd).
-                        Relative paths are resolved by the agent against its own current
-                        working directory; absolute paths are recommended.
-                      type: string
                     env:
                       additionalProperties:
                         type: string
@@ -149,6 +140,15 @@ spec:
                       description: |-
                         URL is the server endpoint for http or sse transport.
                         Required when type is "http" or "sse".
+                      type: string
+                    workingDir:
+                      description: |-
+                        WorkingDir is the working directory in which a stdio MCP server
+                        command is spawned. Only used when type is "stdio". Useful for
+                        servers that must run from a specific project root (for example,
+                        "php artisan boost:mcp" requires the Laravel project root as cwd).
+                        Relative paths are resolved by the agent against its own current
+                        working directory; absolute paths are recommended.
                       type: string
                   required:
                   - name

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -65,6 +65,15 @@ spec:
                         Command is the executable to run for stdio transport.
                         Required when type is "stdio".
                       type: string
+                    cwd:
+                      description: |-
+                        WorkingDir is the working directory in which a stdio MCP server
+                        command is spawned. Only used when type is "stdio". Useful for
+                        servers that must run from a specific project root (for example,
+                        "php artisan boost:mcp" requires the Laravel project root as cwd).
+                        Relative paths are resolved by the agent against its own current
+                        working directory; absolute paths are recommended.
+                      type: string
                     env:
                       additionalProperties:
                         type: string

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -65,15 +65,6 @@ spec:
                         Command is the executable to run for stdio transport.
                         Required when type is "stdio".
                       type: string
-                    cwd:
-                      description: |-
-                        WorkingDir is the working directory in which a stdio MCP server
-                        command is spawned. Only used when type is "stdio". Useful for
-                        servers that must run from a specific project root (for example,
-                        "php artisan boost:mcp" requires the Laravel project root as cwd).
-                        Relative paths are resolved by the agent against its own current
-                        working directory; absolute paths are recommended.
-                      type: string
                     env:
                       additionalProperties:
                         type: string
@@ -146,6 +137,15 @@ spec:
                       description: |-
                         URL is the server endpoint for http or sse transport.
                         Required when type is "http" or "sse".
+                      type: string
+                    workingDir:
+                      description: |-
+                        WorkingDir is the working directory in which a stdio MCP server
+                        command is spawned. Only used when type is "stdio". Useful for
+                        servers that must run from a specific project root (for example,
+                        "php artisan boost:mcp" requires the Laravel project root as cwd).
+                        Relative paths are resolved by the agent against its own current
+                        working directory; absolute paths are recommended.
                       type: string
                   required:
                   - name


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an optional `cwd` field to `AgentConfig.mcpServers[]` so callers can pin the working directory of stdio MCP servers.

Stdio MCP servers run with whatever CWD the agent process happens to be in. That's fine for most servers, but breaks servers that must execute from a specific project root. Laravel Boost is the canonical example: `php artisan boost:mcp` only works when CWD is the Laravel project root. Without `cwd`, callers have to patch the repo's `.mcp.json` at runtime to inject a `cd /workspace/repo && exec` wrapper, which is a file-write side effect inside the workspace that's easy to get wrong.

The field is plumbed through `buildMCPServersJSON` into the `.mcp.json`-shaped JSON exposed via `KELOS_MCP_SERVERS`. The claude-code, cursor, and gemini entrypoints pick it up transparently because they merge the inner `mcpServers` map into the agent's user-scoped config via `Object.assign`. The codex entrypoint converts the JSON to TOML field-by-field, so this PR also adds `cwd` to its TOML emission alongside the other stdio fields.

`cwd` is omitted from the rendered JSON when `WorkingDir` is unset, so existing configs are unaffected.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The field is documented as stdio-only. For `http`/`sse` servers the field is still serialized if set, but the agent transports for those types ignore it.
- claude-code already honors `cwd` on stdio MCP entries per its MCP schema, so no claude-side change is needed.
- Two new unit tests cover the field passing through to the rendered JSON and being omitted when unset.

#### Does this PR introduce a user-facing change?

```release-note
Add `cwd` to `AgentConfig.mcpServers[]` to set the working directory of a stdio MCP server. Useful for servers that must run from a specific project root, e.g. `php artisan boost:mcp` from a Laravel project root.
```