### PR TITLE
Tune self-update history queries

### DIFF
--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -72,8 +72,8 @@ spec:
 
       1. **Prompt Tuning**
          - Review prompts in all TaskSpawner definitions (`self-development/*.yaml`)
-         - Compare prompts against actual agent behavior by checking recent PRs and issues created by agents
-           (`gh pr list --label generated-by-kelos --limit 20`, `gh issue list --label generated-by-kelos --limit 20`)
+         - Compare prompts against actual agent behavior by checking recent merged/closed PRs and issues created by agents
+           (`gh pr list --state merged --label generated-by-kelos --limit 20`, `gh issue list --state all --label generated-by-kelos --limit 20`)
          - Identify prompts that produce low-quality output, miss edge cases, or lack clarity
          - Propose improved prompt wording backed by evidence from past agent runs
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the self-update prompt tuning guidance so it reviews merged PR history and all generated issues instead of only the default open PR/issue lists. This gives the self-update agent access to completed and closed evidence when looking for prompt-quality patterns.

#### Which issue(s) this PR is related to:

Fixes #1047

#### Special notes for your reviewer:

Validation:
- `python3` YAML parse of `self-development/kelos-self-update.yaml` passed
- `git diff --check` passed
- `make verify` could not run because `go` is not installed in this environment (`make: go: No such file or directory`)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the self-update prompt audit to read merged PRs and all issues instead of only open items, improving evidence for tuning. Updates `self-development/kelos-self-update.yaml` to use `gh pr list --state merged` and `gh issue list --state all`, fixing #1047.

<sup>Written for commit 921b2b1248671349cc6bc068fbccad9d1188135a. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1049?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

