### PR TITLE
Fix template render errors when optional GitHub keys are absent

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -142,8 +142,8 @@ spec:
     promptTemplate: |
       A {{.Event}} event ({{.Action}}) was triggered by @{{.Sender}}.
 
-      {{if .Title}}Title: {{.Title}}{{end}}
-      {{if .URL}}URL: {{.URL}}{{end}}
+      {{with index . "Title"}}Title: {{.}}{{end}}
+      {{with index . "URL"}}URL: {{.}}{{end}}
 
       Please investigate and take appropriate action.
     branch: "webhook-{{.Event}}-{{.ID}}"

--- a/examples/10-taskspawner-github-webhook/README.md
+++ b/examples/10-taskspawner-github-webhook/README.md
@@ -80,8 +80,8 @@ promptTemplate: |
   Action: {{.Action}}
   Triggered by: {{.Sender}}
 
-  {{if .Title}}Title: {{.Title}}{{end}}
-  {{if .URL}}URL: {{.URL}}{{end}}
+  {{with index . "Title"}}Title: {{.}}{{end}}
+  {{with index . "URL"}}URL: {{.}}{{end}}
 
   Please investigate and take appropriate action.
 

--- a/examples/10-taskspawner-github-webhook/taskspawner.yaml
+++ b/examples/10-taskspawner-github-webhook/taskspawner.yaml
@@ -71,7 +71,7 @@ spec:
 
     # Template for the task prompt
     promptTemplate: |
-      # GitHub {{.Event | title}} Event: {{.Action}}
+      # GitHub {{.Event}} Event: {{.Action}}
 
       A GitHub webhook event has been triggered that requires attention.
 
@@ -82,22 +82,22 @@ spec:
       {{- if .Title}}
       - **Title**: {{.Title}}
       {{- end}}
-      {{- if .URL}}
-      - **URL**: {{.URL}}
+      {{- with index . "URL"}}
+      - **URL**: {{.}}
       {{- end}}
-      {{- if .Branch}}
-      - **Branch**: {{.Branch}}
+      {{- with index . "Branch"}}
+      - **Branch**: {{.}}
       {{- end}}
 
       {{- if eq .Event "issues"}}
       ## Issue Description
-      {{.Body}}
+      {{with index . "Body"}}{{.}}{{end}}
 
       ## Task
       Please review this issue and provide an initial analysis or triage.
       {{- else if eq .Event "pull_request"}}
       ## Pull Request Description
-      {{.Body}}
+      {{with index . "Body"}}{{.}}{{end}}
 
       ## Task
       Please review this pull request and provide feedback on the code changes.

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -73,7 +73,7 @@ spec:
           ephemeral-storage: "4Gi"
         limits:
           ephemeral-storage: "4Gi"
-    branch: "{{if .Branch}}{{.Branch}}{{else}}main{{end}}"
+    branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     agentConfigRef:
       name: kelos-api-reviewer-agent
     promptTemplate: |


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The webhook task builder renders templates with `Option("missingkey=error")` (`internal/taskbuilder/builder.go:160`), and `ExtractGitHubWorkItem` (`internal/webhook/github_filter.go:447-460`) omits `Number`/`Body`/`URL`/`Branch` keys when their values are empty. Direct access like `{{if .Branch}}` therefore errors at render time on events that lack the key — blocking task creation, not falling through.

This was hit live: a `/kelos api-review` comment on issue #1051 fired the webhook, matched `kelos-api-reviewer`'s filter, then failed task creation with `template: branch:1:5: executing "branch" at <.Branch>: map has no entry for key "Branch"`.

Fix: switch the affected templates to `{{with index . "Foo"}}{{.}}{{else}}…{{end}}`. `index` returns the zero value for missing keys instead of erroring, and `with` handles the empty case.

Files touched:
- `self-development/kelos-api-reviewer.yaml` — root cause; the `branch` template now renders `main` for issue events instead of erroring.
- `examples/10-taskspawner-github-webhook/taskspawner.yaml` — same `{{if .Branch}}` / `{{if .URL}}` / `{{.Body}}` patterns in the canonical webhook example. Also drops `{{.Event | title}}`, since `title` is not registered in the renderer's FuncMap and would fail to parse.
- `examples/10-taskspawner-github-webhook/README.md` and `docs/integration.md` — corresponding doc snippets converted to the safe pattern.

The bare `{{.Branch}}` usages in `kelos-reviewer.yaml`, `kelos-pr-responder.yaml`, and `kelos-squash-commits.yaml` are intentionally left alone — those spawners are only ever invoked on PRs in practice.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The original `kelos-api-reviewer.yaml` fix has been verified end-to-end against issue #1051 (webhook delivery `e68cb0e0-43ce-11f1-9c33-6a3b71dd531a`).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes template render errors when optional GitHub fields are missing by using safe lookups, so tasks no longer fail on issue events. Updates examples and docs to match the safe pattern.

- **Bug Fixes**
  - Switched to `{{with index . "Foo"}}` for `Branch`, `URL`, and `Body` to avoid `missingkey=error`.
  - In `self-development/kelos-api-reviewer.yaml`, `branch` now falls back to `main` when `Branch` is absent.
  - Updated `examples/10-taskspawner-github-webhook` and docs to the safe pattern; removed `{{.Event | title}}` (not in renderer `FuncMap`).

<sup>Written for commit 6010dd131ab5bdfc2c522c61e6d3ff2eb1b3d1a8. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1053?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

