### PR TITLE
Remove actor/kelos label requirement from kelos-workers

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -12,7 +12,7 @@ Each TaskSpawner references an `AgentConfig` that defines git identity, comment 
 
 | TaskSpawner | Trigger | Model | Description |
 |---|---|---|---|
-| **kelos-workers** | Webhook: issue comment/label (`actor/kelos`) | Opus | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
+| **kelos-workers** | Webhook: issue comment `/kelos pick-up` | Opus | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
 | **kelos-planner** | Webhook: issue comment `/kelos plan` | Opus | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
 | **kelos-reviewer** | Webhook: PR comment `/kelos review` | Opus | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
 | **kelos-api-reviewer** | Webhook: issue/PR comment `/kelos api-review` | Opus | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
@@ -27,11 +27,11 @@ Each TaskSpawner references an `AgentConfig` that defines git identity, comment 
 
 ### kelos-workers.yaml
 
-Picks up open GitHub issues labeled `actor/kelos` and creates autonomous agent tasks to fix them.
+Picks up open GitHub issues when a maintainer posts `/kelos pick-up` and creates autonomous agent tasks to fix them.
 
 | | |
 |---|---|
-| **Trigger** | GitHub issue comment/label webhooks for issues labeled `actor/kelos` |
+| **Trigger** | GitHub `issue_comment` webhook with `/kelos pick-up` |
 | **Model** | Opus |
 | **Concurrency** | 3 |
 

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -44,15 +44,11 @@ spec:
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
-          labels:
-            - actor/kelos
           state: open
           author: gjkim42
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
-          labels:
-            - actor/kelos
           state: open
           author: kelos-bot[bot]
   maxConcurrency: 3


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `kelos-workers` TaskSpawner gated pick-up on the `actor/kelos` label in
addition to the `/kelos pick-up` comment. Since `/kelos pick-up` from an
authorized author (`gjkim42` or `kelos-bot[bot]`) is already a sufficient
trigger, the extra label requirement is unnecessary friction.

This PR drops the `labels: [actor/kelos]` filter from both webhook filter
entries and updates the README to match.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The triage flow still applies `actor/kelos`, but workers no longer require
it — the comment-based gate (`/kelos pick-up`) plus author allowlist is
the authoritative trigger.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `actor/kelos` label gate from `kelos-workers`; it now triggers only when an authorized maintainer comments `/kelos pick-up`. This reduces friction and updates both config and README to match the comment-based trigger.

<sup>Written for commit 21b62622d27cfa3fefb5b440ae50b24edd2a1746. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1054?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

