### PR TITLE
Add PR author to generated release notes

### DIFF
--- a/hack/release-notes/main.go
+++ b/hack/release-notes/main.go
@@ -42,10 +42,15 @@ var categories = []category{
 	{Label: "kind/docs", Heading: "Documentation"},
 }
 
-// prData mirrors the JSON returned by `gh pr view --json body,labels`.
+// prData mirrors the JSON returned by `gh pr view --json author,body,labels`.
 type prData struct {
+	Author prAuthor  `json:"author"`
 	Body   string    `json:"body"`
 	Labels []prLabel `json:"labels"`
+}
+
+type prAuthor struct {
+	Login string `json:"login"`
 }
 
 type prLabel struct {
@@ -97,7 +102,7 @@ func main() {
 			labelSet[l.Name] = true
 		}
 
-		formatted := formatNote(note, pr)
+		formatted := formatNote(note, pr, data.Author.Login)
 		matched := false
 		for _, cat := range categories {
 			if labelSet[cat.Label] {
@@ -186,9 +191,9 @@ func parsePRNumbers(gitLogOutput string) []string {
 	return numbers
 }
 
-// fetchPR retrieves the body and labels of a PR via the GitHub CLI.
+// fetchPR retrieves the author, body, and labels of a PR via the GitHub CLI.
 func fetchPR(number string) (*prData, error) {
-	out, err := runCommand("gh", "pr", "view", number, "--json", "body,labels")
+	out, err := runCommand("gh", "pr", "view", number, "--json", "author,body,labels")
 	if err != nil {
 		return nil, err
 	}
@@ -227,12 +232,17 @@ func IsNone(note string) bool {
 	return strings.EqualFold(strings.TrimSpace(note), "none")
 }
 
-// formatNote formats a release note with a PR reference.
-func formatNote(note, pr string) []string {
+// formatNote formats a release note with a PR reference and author handle.
+func formatNote(note, pr, author string) []string {
+	suffix := fmt.Sprintf("(#%s", pr)
+	if author != "" {
+		suffix += ", @" + author
+	}
+	suffix += ")"
 	var lines []string
 	for _, line := range strings.Split(note, "\n") {
 		if line != "" {
-			lines = append(lines, fmt.Sprintf("- %s (#%s)", line, pr))
+			lines = append(lines, fmt.Sprintf("- %s %s", line, suffix))
 		}
 	}
 	return lines

--- a/hack/release-notes/main_test.go
+++ b/hack/release-notes/main_test.go
@@ -137,28 +137,38 @@ func TestIsNone(t *testing.T) {
 
 func TestFormatNote(t *testing.T) {
 	tests := []struct {
-		name string
-		note string
-		pr   string
-		want []string
+		name   string
+		note   string
+		pr     string
+		author string
+		want   []string
 	}{
 		{
-			name: "single line",
-			note: "Added a feature",
-			pr:   "42",
-			want: []string{"- Added a feature (#42)"},
+			name:   "single line with author",
+			note:   "Added a feature",
+			pr:     "42",
+			author: "octocat",
+			want:   []string{"- Added a feature (#42, @octocat)"},
 		},
 		{
-			name: "multi-line",
-			note: "Fixed bug A\nFixed bug B",
-			pr:   "99",
-			want: []string{"- Fixed bug A (#99)", "- Fixed bug B (#99)"},
+			name:   "multi-line with author",
+			note:   "Fixed bug A\nFixed bug B",
+			pr:     "99",
+			author: "octocat",
+			want:   []string{"- Fixed bug A (#99, @octocat)", "- Fixed bug B (#99, @octocat)"},
+		},
+		{
+			name:   "missing author falls back to PR only",
+			note:   "Added a feature",
+			pr:     "42",
+			author: "",
+			want:   []string{"- Added a feature (#42)"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatNote(tt.note, tt.pr)
+			got := formatNote(tt.note, tt.pr, tt.author)
 			if len(got) != len(tt.want) {
 				t.Fatalf("formatNote() returned %d lines, want %d", len(got), len(tt.want))
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `release-notes` generator under `hack/release-notes/` now includes the PR author's GitHub handle alongside the PR number in each release-note line, so readers can see at a glance who contributed each change.

Example output:

- Before: `- Added a feature (#42)`
- After: `- Added a feature (#42, @octocat)`

The author is fetched via `gh pr view --json author,body,labels`. If the author is unavailable for any reason, the format falls back to the prior `(#<pr>)` form.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Unit tests in `hack/release-notes/main_test.go` were updated to cover the new author suffix and the empty-author fallback.

#### Does this PR introduce a user-facing change?

```release-note
Generated release notes now include the PR author's GitHub handle alongside the PR number (e.g. `(#42, @octocat)`).
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PR author handles to generated release notes so readers can see who contributed each change. Falls back to the previous format when the author is unavailable.

- **New Features**
  - Append `@<login>` next to the PR number in each release-note line (e.g., `(#42, @octocat)`), with a fallback to `(#<pr>)`.
  - Fetch authors via `gh pr view --json author,body,labels`; updated formatter to accept an author and tests to cover suffix and fallback.

<sup>Written for commit f8e4ab1dd3721ce89f3602c53cf3f16913a020cc. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1055?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

