### PR TITLE
Strengthen API design guidance in agent prompts

### DIFF
--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -131,6 +131,11 @@ spec:
 
       ### 4. Check the following areas
 
+      > **CRD fields are effectively permanent.** Once a field ships in a CRD,
+      > removing or renaming it is a breaking change for every existing object
+      > and client. Review each new field as if it cannot be deleted later —
+      > scrutinize the name, type, semantics, and shape before approving.
+
       **Kubernetes API conventions** (ref: https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md):
       - Are field names camelCase in Go and camelCase in JSON tags?
       - Are optional fields marked with `+optional` and use pointer types or `omitempty`?
@@ -162,11 +167,39 @@ spec:
       - If CRD or API types changed, were `make update` artifacts included in the PR?
 
       **Naming and documentation**:
-      - Are type and field names clear and consistent with existing API?
+      - Does the feature/type name accurately describe what it does, and will
+        it still make sense as the feature evolves? A wrong name is hard to
+        fix once shipped.
+      - Are field and type names consistent with existing Kelos CRDs under
+        `api/`? Look for similar concepts already named — reuse the same term
+        instead of inventing a synonym.
+      - Are names consistent with Kubernetes native resources (Pod, Deployment,
+        Job, etc.) and well-known CRDs when the concept is analogous? For
+        example, prefer `template`, `selector`, `replicas`, `conditions`,
+        `phase`, `observedGeneration` where the semantics match the upstream
+        meaning. Do not reuse those names with different semantics.
       - Do all exported types and fields have godoc comments?
       - Are comments descriptive of the field's purpose and behavior?
       - Do field names follow Kubernetes conventions (e.g., `xxxRef` for references,
         `xxxName` for names, `xxxSeconds` for duration-in-seconds)?
+
+      **Extensibility / future-proofing**:
+      - Is the field shape expandable? Prefer a struct (object) over a bare
+        scalar or bool when more knobs are likely later — e.g.,
+        `policy: { type: X }` instead of `policyType: X`, so additional
+        sub-fields can be added without a new top-level field.
+      - For lists of choices, prefer a named-string enum over a bool, so new
+        values can be added later without introducing a second flag.
+      - For things that may need per-item configuration (sources, targets,
+        rules), use a list of structs rather than a list of scalars.
+      - Avoid "stringly-typed" free-form fields (a single string encoding
+        multiple values) when a structured field would let the API grow.
+      - Watch for fields that bake in a current implementation detail and
+        will be hard to generalize (e.g., a name that implies a specific
+        backend, units, or algorithm).
+      - If a similar field already exists elsewhere in the API, can the new
+        use case be expressed by extending that field instead of adding a
+        parallel one?
 
       **Defaulting and conversion**:
       - Are defaults set via kubebuilder markers or webhook defaulting?

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -99,6 +99,32 @@ spec:
       concrete plan. Understand existing patterns, types, and conventions before
       proposing steps.
 
+      ### 3a. If the plan involves API / CRD changes
+      CRD fields are effectively permanent — once shipped, they cannot be
+      removed or renamed without breaking existing objects and clients.
+      When the issue requires adding or changing types under `api/`, the plan
+      MUST resolve these before implementation, not after:
+
+      - **Name.** Propose the exact field/type name. Check whether the name
+        will still describe the feature accurately as it evolves. Reuse names
+        already used in Kelos CRDs (grep `api/`) for the same concept; reuse
+        Kubernetes-native names (`template`, `selector`, `replicas`,
+        `conditions`, `phase`, `observedGeneration`) only when the semantics
+        match upstream.
+      - **Shape / extensibility.** Prefer a struct over a bare scalar or
+        bool when more knobs are likely later (e.g. `policy: { type: X }`
+        instead of `policyType: X`). Prefer a named-string enum over a
+        bool for mode/strategy fields. Prefer list-of-struct over
+        list-of-scalar for items that may need per-item config. Avoid
+        stringly-typed fields encoding multiple values.
+      - **Compatibility.** Spell out whether the change is additive,
+        whether old clients can still ignore it, and whether any defaulting
+        / conversion is needed.
+      - **Open questions.** If naming or shape is unresolved, surface it in
+        **Open Questions & Risks** rather than baking a guess into the plan.
+
+      Recommend running `/kelos api-review` on the resulting PR.
+
       ### 4. Assess the current plan
       Determine whether the issue already contains a solid implementation plan:
         - If YES: normalize it into a concise canonical step list. Do not invent

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -114,6 +114,22 @@ spec:
 
       ### 4. Check the following areas
 
+      > **CRD / API types are special.** If the diff touches `api/` (CRD types,
+      > kubebuilder markers, generated CRD YAML), the deep API-design review
+      > belongs to `/kelos api-review`. Do not duplicate that checklist here.
+      > Still flag the obvious permanence risks during this review:
+      > - New fields whose **name** is misleading, inconsistent with existing
+      >   Kelos CRDs, or clashes with Kubernetes-native semantics
+      >   (`template`, `selector`, `replicas`, `conditions`, `phase`,
+      >   `observedGeneration`).
+      > - Field shapes that will be hard to extend (bare scalar/bool where a
+      >   struct is likely needed, stringly-typed encodings, names that bake
+      >   in a current backend or unit).
+      > - Removal or rename of an existing field, or a silent change in
+      >   semantics — these are breaking.
+      > For deeper checks, recommend the author run `/kelos api-review` instead
+      > of expanding this review.
+
       **Correctness**:
       - Does the code do what the PR/issue describes?
       - Are there edge cases, off-by-one errors, or nil pointer risks?


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

CRD fields are effectively permanent — once shipped, removing or renaming them breaks every existing object and client. Tighten the self-development agent prompts so name choice, consistency with existing Kelos CRDs and Kubernetes-native resources, and forward-extensibility of the field shape are addressed up front rather than at code review time.

- `self-development/kelos-api-reviewer.yaml` — add a CRD-permanence callout at the top of the review checklist, expand the naming-and-documentation section with consistency checks against existing Kelos CRDs and Kubernetes natives (`template`, `selector`, `replicas`, `conditions`, `phase`, `observedGeneration`), and add a new "Extensibility / future-proofing" subsection (struct-over-scalar, enum-over-bool, list-of-struct, watch for names that bake in a backend / unit / algorithm).
- `self-development/kelos-reviewer.yaml` — defer deep API design review to `/kelos api-review` for diffs touching `api/`, while still flagging the obvious permanence risks (bad names, hard-to-extend shapes, removed/renamed fields, silent semantic changes).
- `self-development/kelos-planner.yaml` — add a new "3a" planning step for issues that involve `api/` changes: propose the exact name, justify it against existing Kelos CRDs and Kubernetes natives, address shape/extensibility, spell out compatibility impact, and surface unresolved naming/shape questions in *Open Questions & Risks*.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Prompt-only change to read-only self-development agents — no controller, schema, or API behavior changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens API design guidance in self-development prompts so CRD fields are treated as permanent, with naming consistency and extensibility checked up front. Prompt-only change: deep API review moves to `/kelos api-review` and a planner step is added for `api/` changes.

- **Refactors**
  - `self-development/kelos-api-reviewer.yaml`: Add permanence callout. Expand naming checks against Kelos CRDs and Kubernetes natives (`template`, `selector`, `replicas`, `conditions`, `phase`, `observedGeneration`). Add extensibility checklist (struct-over-scalar/bool, enum-over-bool, list-of-struct, avoid stringly types and backend/unit-baked names).
  - `self-development/kelos-reviewer.yaml`: Defer deep API design to `/kelos api-review` for `api/` diffs. Keep quick flags for misleading names, hard-to-extend shapes, field removals/renames, and silent semantic changes.
  - `self-development/kelos-planner.yaml`: Add step 3a for `api/` changes. Require exact names, consistency with Kelos/Kubernetes, shape/extensibility and compatibility notes, and list open questions.

<sup>Written for commit 1e7bbc70eba263dcc19bd6d9c0779e5f1356d156. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1063?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

