### PR TITLE
self-development: Enable reporting on webhook-based TaskSpawners

### DIFF
--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -54,6 +54,8 @@ spec:
           bodyContains: /kelos api-review
           state: open
           author: kelos-bot[bot]
+      reporting:
+        enabled: true
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -41,6 +41,8 @@ spec:
           bodyContains: /kelos plan
           state: open
           author: kelos-bot[bot]
+      reporting:
+        enabled: true
   maxConcurrency: 2
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -31,6 +31,8 @@ spec:
             - generated-by-kelos
           state: open
           draft: false
+      reporting:
+        enabled: true
   maxConcurrency: 2
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -53,6 +53,8 @@ spec:
           bodyContains: /kelos review
           state: open
           author: kelos-bot[bot]
+      reporting:
+        enabled: true
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -14,6 +14,8 @@ spec:
           bodyContains: /kelos squash-commits
           state: open
           author: gjkim42
+      reporting:
+        enabled: true
   maxConcurrency: 1
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -21,6 +21,8 @@ spec:
           excludeLabels:
             - triage-accepted
           state: open
+      reporting:
+        enabled: true
   maxConcurrency: 8
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -51,6 +51,8 @@ spec:
           bodyContains: /kelos pick-up
           state: open
           author: kelos-bot[bot]
+      reporting:
+        enabled: true
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enables `reporting.enabled: true` under `githubWebhook` on every webhook-driven TaskSpawner in `self-development/`, taking advantage of the new GitHubWebhook reporting support added in #966.

With this change, the webhook server posts and updates a standard status comment on the originating issue or PR as each spawned Task transitions phases — giving immediate, visible feedback when an agent picks up a `/kelos` command, runs, and finishes.

Updated spawners:
- `kelos-workers`
- `kelos-planner`
- `kelos-reviewer`
- `kelos-api-reviewer`
- `kelos-pr-responder`
- `kelos-triage`
- `kelos-squash-commits`

The five cron-based spawners (`kelos-fake-user`, `kelos-fake-strategist`, `kelos-config-update`, `kelos-self-update`, `kelos-image-update`) are intentionally untouched — they have no originating issue or PR to report to.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Each change is a two-line YAML addition under `spec.when.githubWebhook`. No prompt or behavior changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable status reporting for all webhook-driven TaskSpawners in `self-development` by setting `reporting.enabled: true` under `githubWebhook`. The webhook server now posts and updates a status comment on the originating issue or PR as tasks pick up, run, and finish; cron-based spawners are unchanged.

<sup>Written for commit d3b5034206e4bbfcd6cd3a24ccecf16e9711d34d. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1064?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

