### PR TITLE
Avoid duplicate status comments on fast Task phase transitions

### DIFF
--- a/cmd/kelos-webhook-server/reporting.go
+++ b/cmd/kelos-webhook-server/reporting.go
@@ -30,6 +30,10 @@ type reportingConfig struct {
 type reportingReconciler struct {
 	client.Client
 	config reportingConfig
+	// cache survives across reconciles to backstop the AnnotationGitHubCommentID
+	// annotation on fast Pending→Succeeded transitions where the annotation
+	// Update has not yet propagated to the controller-runtime cache.
+	cache *reporting.ReportStateCache
 }
 
 func (r *reportingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -66,6 +70,7 @@ func (r *reportingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			},
 			BaseURL: r.config.GitHubAPIBaseURL,
 		},
+		Cache: r.cache,
 	}
 
 	if err := reporter.ReportTaskStatus(ctx, &task); err != nil {
@@ -77,6 +82,9 @@ func (r *reportingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 func (r *reportingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.cache == nil {
+		r.cache = reporting.NewReportStateCache()
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("webhook-reporting").
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).

--- a/internal/reporting/watcher.go
+++ b/internal/reporting/watcher.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +49,53 @@ const (
 type TaskReporter struct {
 	Client   client.Client
 	Reporter *GitHubReporter
+	// Cache backstops AnnotationGitHubCommentID and AnnotationGitHubReportPhase
+	// when the persisted Update has not yet propagated to the controller-runtime
+	// cache the caller reads from. Optional; when nil, the reporter relies on
+	// annotations alone (which is sufficient for poll-driven callers).
+	Cache *ReportStateCache
+}
+
+// ReportStateCache tracks the most recent comment ID and reported phase per
+// Task UID so an event-driven reporter does not duplicate-create comments
+// when two reconciles fire faster than the annotation Update propagates to
+// the informer cache.
+//
+// NOTE: entries are not garbage-collected; for the expected workload (a few
+// hundred Tasks per day) the footprint stays small. Add eviction if that
+// changes.
+type ReportStateCache struct {
+	mu      sync.Mutex
+	entries map[types.UID]reportStateEntry
+}
+
+type reportStateEntry struct {
+	commentID int64
+	phase     string
+}
+
+// NewReportStateCache returns an empty cache safe for concurrent use.
+func NewReportStateCache() *ReportStateCache {
+	return &ReportStateCache{entries: make(map[types.UID]reportStateEntry)}
+}
+
+func (c *ReportStateCache) load(uid types.UID) (reportStateEntry, bool) {
+	if c == nil || uid == "" {
+		return reportStateEntry{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[uid]
+	return e, ok
+}
+
+func (c *ReportStateCache) store(uid types.UID, commentID int64, phase string) {
+	if c == nil || uid == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[uid] = reportStateEntry{commentID: commentID, phase: phase}
 }
 
 // ReportTaskStatus checks a Task's current phase against its last reported
@@ -87,21 +136,45 @@ func (tr *TaskReporter) ReportTaskStatus(ctx context.Context, task *kelosv1alpha
 		return nil
 	}
 
-	// Skip if we already reported this phase
-	if annotations[AnnotationGitHubReportPhase] == desiredPhase {
-		return nil
-	}
-
-	commentID := int64(0)
-	if idStr, ok := annotations[AnnotationGitHubCommentID]; ok {
-		var err error
-		commentID, err = strconv.ParseInt(idStr, 10, 64)
-		if err != nil {
-			return fmt.Errorf("parsing %s annotation %q: %w", AnnotationGitHubCommentID, idStr, err)
+	// The in-memory cache is the source of truth when an entry exists — the
+	// reporter writes it before persisting the annotation, so it is always at
+	// least as fresh as the informer-backed read. The annotation is consulted
+	// only when the cache has no entry (e.g., right after a controller
+	// restart, before the cache has been repopulated).
+	var (
+		lastReportedPhase string
+		commentID         int64
+	)
+	cached, hasCached := tr.Cache.load(task.UID)
+	if hasCached {
+		lastReportedPhase = cached.phase
+		commentID = cached.commentID
+	} else {
+		lastReportedPhase = annotations[AnnotationGitHubReportPhase]
+		if idStr, ok := annotations[AnnotationGitHubCommentID]; ok {
+			parsed, err := strconv.ParseInt(idStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("parsing %s annotation %q: %w", AnnotationGitHubCommentID, idStr, err)
+			}
+			commentID = parsed
 		}
 	}
 
-	// Build the comment body
+	if lastReportedPhase == desiredPhase {
+		// Annotation alone records this phase — nothing to do.
+		if !hasCached {
+			return nil
+		}
+		// Cache says we already reported. If the annotation also matches,
+		// nothing to do; otherwise it lags (e.g., previous persist failed)
+		// and we re-attempt persistence so the comment side stays untouched.
+		if annotations[AnnotationGitHubReportPhase] == desiredPhase &&
+			annotations[AnnotationGitHubCommentID] == strconv.FormatInt(commentID, 10) {
+			return nil
+		}
+		return tr.persistReportingState(ctx, task, commentID, desiredPhase)
+	}
+
 	var body string
 	switch desiredPhase {
 	case "accepted":
@@ -113,7 +186,6 @@ func (tr *TaskReporter) ReportTaskStatus(ctx context.Context, task *kelosv1alpha
 	}
 
 	if commentID == 0 {
-		// Create a new comment
 		log.Info("Creating GitHub status comment", "task", task.Name, "number", number, "phase", desiredPhase)
 		newID, err := tr.Reporter.CreateComment(ctx, number, body)
 		if err != nil {
@@ -121,18 +193,18 @@ func (tr *TaskReporter) ReportTaskStatus(ctx context.Context, task *kelosv1alpha
 		}
 		commentID = newID
 	} else {
-		// Update the existing comment
 		log.Info("Updating GitHub status comment", "task", task.Name, "number", number, "phase", desiredPhase, "commentID", commentID)
 		if err := tr.Reporter.UpdateComment(ctx, commentID, body); err != nil {
 			return fmt.Errorf("updating GitHub comment %d for task %s: %w", commentID, task.Name, err)
 		}
 	}
 
-	if err := tr.persistReportingState(ctx, task, commentID, desiredPhase); err != nil {
-		return err
-	}
+	// Record the latest state before persisting the annotation so a concurrent
+	// reconcile that races the annotation Update still sees the correct comment
+	// ID via the in-memory cache and skips re-creation.
+	tr.Cache.store(task.UID, commentID, desiredPhase)
 
-	return nil
+	return tr.persistReportingState(ctx, task, commentID, desiredPhase)
 }
 
 func (tr *TaskReporter) persistReportingState(ctx context.Context, task *kelosv1alpha1.Task, commentID int64, desiredPhase string) error {

--- a/internal/reporting/watcher_test.go
+++ b/internal/reporting/watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strconv"
 	"sync"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +36,25 @@ type commentRecord struct {
 	number int
 	id     int64
 	body   string
+}
+
+type updateCountingClient struct {
+	client.Client
+	mu      sync.Mutex
+	updates int
+}
+
+func (c *updateCountingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.mu.Lock()
+	c.updates++
+	c.mu.Unlock()
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *updateCountingClient) updateCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.updates
 }
 
 type conflictOnceClient struct {
@@ -78,13 +99,16 @@ func newTestServer(t *testing.T) (*httptest.Server, *[]commentRecord) {
 			nextID++
 			records = append(records, commentRecord{
 				method: "create",
+				id:     nextID,
 				body:   body.Body,
 			})
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(commentResponse{ID: nextID})
 		case http.MethodPatch:
+			id, _ := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
 			records = append(records, commentRecord{
 				method: "update",
+				id:     id,
 				body:   body.Body,
 			})
 			w.WriteHeader(http.StatusOK)
@@ -541,6 +565,207 @@ func TestReportTaskStatus_CorruptedCommentIDReturnsError(t *testing.T) {
 	err := tr.ReportTaskStatus(context.Background(), task)
 	if err == nil {
 		t.Fatal("Expected error for corrupted comment ID, got nil")
+	}
+}
+
+func TestReportTaskStatus_CachePopulatedAfterCreate(t *testing.T) {
+	server, _ := newTestServer(t)
+	defer server.Close()
+
+	task := newTaskWithAnnotations("test-task", "default", kelosv1alpha1.TaskPhasePending, map[string]string{
+		AnnotationGitHubReporting: "enabled",
+		AnnotationSourceNumber:    "42",
+		AnnotationSourceKind:      "issue",
+	})
+	task.UID = types.UID("uid-create")
+
+	cache := NewReportStateCache()
+	tr := &TaskReporter{
+		Client: fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build(),
+		Reporter: &GitHubReporter{
+			Owner: "owner", Repo: "repo", Token: "token", BaseURL: server.URL,
+		},
+		Cache: cache,
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	got, ok := cache.load(task.UID)
+	if !ok {
+		t.Fatal("Expected cache entry after successful report")
+	}
+	if got.phase != "accepted" {
+		t.Errorf("Expected cached phase 'accepted', got %q", got.phase)
+	}
+	if got.commentID == 0 {
+		t.Error("Expected non-zero cached comment ID")
+	}
+}
+
+// TestReportTaskStatus_CacheFallbackUpdatesExistingComment exercises the
+// cache-stale read race: the in-memory Task lacks the comment-ID annotation
+// (because the previous reconcile's annotation Update has not propagated to
+// the cached read yet) but the in-memory cache still has it, so the reporter
+// must update the existing comment instead of creating a new one.
+func TestReportTaskStatus_CacheFallbackUpdatesExistingComment(t *testing.T) {
+	server, records := newTestServer(t)
+	defer server.Close()
+
+	task := newTaskWithAnnotations("test-task", "default", kelosv1alpha1.TaskPhaseSucceeded, map[string]string{
+		AnnotationGitHubReporting: "enabled",
+		AnnotationSourceNumber:    "42",
+		AnnotationSourceKind:      "issue",
+	})
+	task.UID = types.UID("uid-fallback")
+
+	cache := NewReportStateCache()
+	cache.store(task.UID, 7777, "accepted")
+
+	tr := &TaskReporter{
+		Client: fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build(),
+		Reporter: &GitHubReporter{
+			Owner: "owner", Repo: "repo", Token: "token", BaseURL: server.URL,
+		},
+		Cache: cache,
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(*records) != 1 {
+		t.Fatalf("Expected 1 API call, got %d", len(*records))
+	}
+	if (*records)[0].method != "update" {
+		t.Errorf("Expected update via cached comment ID, got %s", (*records)[0].method)
+	}
+	if (*records)[0].id != 7777 {
+		t.Errorf("Expected cached comment ID 7777 to be patched, got %d", (*records)[0].id)
+	}
+}
+
+// TestReportTaskStatus_CacheShortCircuitsDuplicateReport simulates two
+// reconciles firing for the same phase before the annotation Update has
+// propagated to the cached read. The first call posts the comment; the second
+// must not post a duplicate even though the Task object it sees still has no
+// AnnotationGitHubReportPhase.
+func TestReportTaskStatus_CacheShortCircuitsDuplicateReport(t *testing.T) {
+	server, records := newTestServer(t)
+	defer server.Close()
+
+	annotations := map[string]string{
+		AnnotationGitHubReporting: "enabled",
+		AnnotationSourceNumber:    "42",
+		AnnotationSourceKind:      "issue",
+	}
+
+	first := newTaskWithAnnotations("test-task", "default", kelosv1alpha1.TaskPhasePending, annotations)
+	first.UID = types.UID("uid-shortcircuit")
+	first.ResourceVersion = ""
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(first).Build()
+	cache := NewReportStateCache()
+	tr := &TaskReporter{
+		Client: cl,
+		Reporter: &GitHubReporter{
+			Owner: "owner", Repo: "repo", Token: "token", BaseURL: server.URL,
+		},
+		Cache: cache,
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), first); err != nil {
+		t.Fatalf("First report failed: %v", err)
+	}
+
+	// Simulate a stale cached read: a second copy of the Task that has not yet
+	// observed the annotation Update from the first reconcile.
+	stale := newTaskWithAnnotations("test-task", "default", kelosv1alpha1.TaskPhasePending, map[string]string{
+		AnnotationGitHubReporting: "enabled",
+		AnnotationSourceNumber:    "42",
+		AnnotationSourceKind:      "issue",
+	})
+	stale.UID = types.UID("uid-shortcircuit")
+
+	if err := tr.ReportTaskStatus(context.Background(), stale); err != nil {
+		t.Fatalf("Second report failed: %v", err)
+	}
+
+	if len(*records) != 1 {
+		t.Fatalf("Expected exactly 1 GitHub API call, got %d (%+v)", len(*records), *records)
+	}
+	if (*records)[0].method != "create" {
+		t.Errorf("Expected the single call to be a create, got %s", (*records)[0].method)
+	}
+}
+
+// TestReportTaskStatus_SkipsRepeatedNoOpPersist verifies that when both the
+// cache and the annotation already record the desired phase + comment ID, no
+// GitHub API call and no Task Update is issued — guarding against reconcile
+// churn on informer resync where the same phase is observed repeatedly.
+func TestReportTaskStatus_SkipsRepeatedNoOpPersist(t *testing.T) {
+	server, records := newTestServer(t)
+	defer server.Close()
+
+	task := newTaskWithAnnotations("test-task", "default", kelosv1alpha1.TaskPhasePending, map[string]string{
+		AnnotationGitHubReporting:   "enabled",
+		AnnotationSourceNumber:      "42",
+		AnnotationSourceKind:        "issue",
+		AnnotationGitHubCommentID:   "9999",
+		AnnotationGitHubReportPhase: "accepted",
+	})
+	task.UID = types.UID("uid-noop")
+
+	cache := NewReportStateCache()
+	cache.store(task.UID, 9999, "accepted")
+
+	counted := &updateCountingClient{
+		Client: fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build(),
+	}
+	tr := &TaskReporter{
+		Client: counted,
+		Reporter: &GitHubReporter{
+			Owner: "owner", Repo: "repo", Token: "token", BaseURL: server.URL,
+		},
+		Cache: cache,
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(*records) != 0 {
+		t.Errorf("Expected no GitHub API calls, got %d", len(*records))
+	}
+	if counted.updateCount() != 0 {
+		t.Errorf("Expected no Task Updates, got %d", counted.updateCount())
+	}
+}
+
+func TestReportTaskStatus_NilCache(t *testing.T) {
+	server, records := newTestServer(t)
+	defer server.Close()
+
+	task := newTaskWithAnnotations("test-task", "default", kelosv1alpha1.TaskPhasePending, map[string]string{
+		AnnotationGitHubReporting: "enabled",
+		AnnotationSourceNumber:    "42",
+		AnnotationSourceKind:      "issue",
+	})
+
+	tr := &TaskReporter{
+		Client: fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build(),
+		Reporter: &GitHubReporter{
+			Owner: "owner", Repo: "repo", Token: "token", BaseURL: server.URL,
+		},
+		// Cache intentionally nil — callers without race exposure (poll-driven
+		// spawner) should keep working.
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(*records) != 1 || (*records)[0].method != "create" {
+		t.Errorf("Expected one create call with nil cache, got %+v", *records)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a duplicate-comment bug seen on fast `Pending → Succeeded` Task transitions
(e.g. https://github.com/kelos-dev/kelos/pull/1064#issuecomment-4352257614 — two
"accepted" and "succeeded" status comments instead of one updated comment).

After creating the GitHub status comment, the webhook reporter persists the
comment ID and reported phase as Task annotations so the next reconcile knows to
PATCH the existing comment instead of POSTing a new one. When the Task moves
phases faster than the informer cache picks up that annotation Update (~1s
window in the wild), the next reconcile reads a stale Task with no comment-ID
annotation and creates a second comment.

This PR adds an in-memory `ReportStateCache` keyed by Task UID and wires it onto
the `TaskReporter`. The cache is the source of truth when an entry is present,
with the annotation acting as the fallback when the cache has no entry (e.g.
right after a controller restart, before the cache repopulates). The reporter
updates the cache synchronously after each successful comment create/update —
before persisting the annotation — so concurrent reconciles see the correct
comment ID even while the annotation Update is still in flight.

The poll-driven `kelos-spawner` does not see this race because its reporting
cycle runs once per `pollInterval` (≥30s), giving the informer plenty of time
to catch up. It keeps working unchanged: `TaskReporter.Cache` is optional, and
the spawner constructs its `TaskReporter` without one.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Cache entries are not garbage-collected. For the expected workload (a few
  hundred Tasks per day) the footprint stays small; a NOTE in the source flags
  that eviction can be added later if needed.
- New unit tests cover: cache populated after successful create, cache fallback
  patches the cached comment when the annotation has not propagated, cache
  short-circuits a duplicate report when phase already cached, and the
  `nil`-cache path keeps working for callers that opt out.

#### Does this PR introduce a user-facing change?

```release-note
Fix the GitHubWebhook-driven TaskSpawner reporter posting duplicate status comments when a Task transitions phases faster than the informer cache propagates the persisted comment-ID annotation.
```