### PR TITLE
Support PR review triggers for self-development commands

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -24,9 +24,10 @@ func TestSelfDevelopmentGitHubSpawnersUseWebhooks(t *testing.T) {
 	}{
 		{file: "kelos-workers.yaml", events: []string{"issue_comment"}},
 		{file: "kelos-planner.yaml", events: []string{"issue_comment"}},
-		{file: "kelos-reviewer.yaml", events: []string{"issue_comment"}},
+		{file: "kelos-reviewer.yaml", events: []string{"issue_comment", "pull_request_review"}},
+		{file: "kelos-api-reviewer.yaml", events: []string{"issue_comment", "pull_request_review"}},
 		{file: "kelos-pr-responder.yaml", events: []string{"issue_comment", "pull_request_review"}},
-		{file: "kelos-squash-commits.yaml", events: []string{"issue_comment"}},
+		{file: "kelos-squash-commits.yaml", events: []string{"issue_comment", "pull_request_review"}},
 		{file: "kelos-triage.yaml", events: []string{"issues"}},
 	}
 

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -43,6 +43,7 @@ spec:
       repository: kelos-dev/kelos
       events:
         - issue_comment
+        - pull_request_review
       filters:
         - event: issue_comment
           action: created
@@ -51,6 +52,16 @@ spec:
           author: gjkim42
         - event: issue_comment
           action: created
+          bodyContains: /kelos api-review
+          state: open
+          author: kelos-bot[bot]
+        - event: pull_request_review
+          action: submitted
+          bodyContains: /kelos api-review
+          state: open
+          author: gjkim42
+        - event: pull_request_review
+          action: submitted
           bodyContains: /kelos api-review
           state: open
           author: kelos-bot[bot]

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -42,6 +42,7 @@ spec:
       repository: kelos-dev/kelos
       events:
         - issue_comment
+        - pull_request_review
       filters:
         - event: issue_comment
           action: created
@@ -50,6 +51,16 @@ spec:
           author: gjkim42
         - event: issue_comment
           action: created
+          bodyContains: /kelos review
+          state: open
+          author: kelos-bot[bot]
+        - event: pull_request_review
+          action: submitted
+          bodyContains: /kelos review
+          state: open
+          author: gjkim42
+        - event: pull_request_review
+          action: submitted
           bodyContains: /kelos review
           state: open
           author: kelos-bot[bot]

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -8,9 +8,15 @@ spec:
       repository: kelos-dev/kelos
       events:
         - issue_comment
+        - pull_request_review
       filters:
         - event: issue_comment
           action: created
+          bodyContains: /kelos squash-commits
+          state: open
+          author: gjkim42
+        - event: pull_request_review
+          action: submitted
           bodyContains: /kelos squash-commits
           state: open
           author: gjkim42


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Allows selected self-development slash commands to trigger from GitHub pull request review submissions as well as normal issue comments. This makes /kelos review, /kelos api-review, and /kelos squash-commits work when they are submitted in a PR review body.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`make test` passed locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
