### PR TITLE
docs(examples):  provide dependency review spawner

### DIFF
--- a/examples/14-dependency-review-spawner/README.md
+++ b/examples/14-dependency-review-spawner/README.md
@@ -1,0 +1,53 @@
+# Use Case: Automated Dependency Review
+
+**Related Issues**: #981 (Supply Chain Compliance), #945 (IaC Lifecycle)
+
+## Problem
+
+Dependency update bots (Renovate, Dependabot) create PRs frequently, but each still requires human review to assess whether the upgrade is safe. For teams with dozens of dependencies, this creates a constant review backlog. Most patch/minor bumps are safe, but teams can't tell which ones need attention without reading changelogs and checking usage.
+
+## Solution
+
+A Kelos TaskSpawner that triggers when Renovate/Dependabot opens a PR. The agent:
+1. Identifies the package and version bump type
+2. Searches the codebase for all usages of the affected package
+3. Reads the changelog from the PR body
+4. Assesses risk and either auto-approves or requests human review
+5. Identifies the best human reviewer when escalation is needed
+
+## Architecture
+
+```
+Renovate/Dependabot    GitHub Webhook     Kelos              Agent Pod
+opens PR          -->  pull_request  -->  TaskSpawner  -->  (read-only)
+                       event              creates Task       |
+                                                            v
+                                                      Reads diff + changelog
+                                                      Searches codebase usage
+                                                      Posts review comment
+                                                      Auto-approves if safe
+```
+
+## Key Patterns Demonstrated
+
+- **Author-filtered webhook**: Only triggers on bot-authored PRs
+- **Structured review output**: Consistent format for all reviews
+- **Conditional auto-approve**: Safe upgrades approved automatically, risky ones escalated
+- **Reviewer identification**: Uses git history to find the best human reviewer
+
+## Prerequisites
+
+- GitHub webhook configured to send `pull_request` events to Kelos
+- `gh` CLI available in the agent image
+- A shared read-only AgentConfig
+
+## Files
+
+- `taskspawner.yaml` — The TaskSpawner configuration
+
+## Customization
+
+- Adjust the author filter for your bot username (Renovate vs Dependabot)
+- Add package-specific rules (e.g., always escalate security-sensitive packages)
+- Modify the risk assessment criteria for your team's needs
+- Change the fallback reviewer to your team's default

--- a/examples/14-dependency-review-spawner/taskspawner.yaml
+++ b/examples/14-dependency-review-spawner/taskspawner.yaml
@@ -1,0 +1,154 @@
+apiVersion: kelos.dev/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: dependency-review
+  namespace: default # TODO: your namespace
+spec:
+  when:
+    githubWebhook:
+      # TODO: your repository (owner/repo format)
+      repository: myorg/myrepo
+      events:
+        - pull_request
+      filters:
+        # Trigger on PRs opened or reopened by the dependency bot
+        - event: pull_request
+          action: opened
+          author: renovate[bot] # TODO: or "dependabot[bot]"
+          state: open
+          draft: false
+          excludeLabels:
+            - skip-agent-review
+        - event: pull_request
+          action: reopened
+          author: renovate[bot] # TODO: or "dependabot[bot]"
+          state: open
+          draft: false
+          excludeLabels:
+            - skip-agent-review
+
+  taskTemplate:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials # TODO: your credentials secret
+    workspaceRef:
+      name: my-workspace # TODO: your workspace name
+    agentConfigRef:
+      name: readonly-agent
+    branch: "{{.Branch}}"
+    ttlSecondsAfterFinished: 10800
+    promptTemplate: |
+      # Dependency Upgrade Review Agent
+
+      You are reviewing a dependency upgrade PR authored by a dependency bot.
+      Your goal is to determine whether this upgrade is safe to merge
+      without human intervention.
+
+      ## Review Process
+
+      ### 1. Identify the dependency and change scope
+      - Parse the PR title and body to identify the package(s) being upgraded
+      - Determine if this is a patch, minor, or major version bump
+      - Check if it's a direct dependency or transitive
+
+      ### 2. Analyze usage in the codebase
+      - Search for all imports/usages of the package
+      - Identify which features and APIs of the package are used
+      - Check for any pinned version constraints or compatibility notes
+
+      ### 3. Research the upgrade
+      - Read the PR body for changelog/release notes (bots typically include these)
+      - Identify breaking changes, deprecations, and new features
+      - Check if any APIs we use were changed or removed
+
+      ### 4. Assess risk level
+      Rate the upgrade as one of:
+      - **Safe to merge**: Patch bump with no breaking changes, or minor bump
+        where none of the changed APIs are used in our codebase
+      - **Likely safe**: Minor bump with relevant changes but low risk
+      - **Needs human review**: Breaking changes affecting our code,
+        or security-sensitive dependency (auth, crypto, DB drivers)
+
+      ### 5. Identify the best human reviewer (when needed)
+      If the risk assessment is "Needs human review":
+      - Find all files that import or use the affected package(s)
+      - Run `git log -n 50 --format='%ae' -- <file>` on those files to find
+        frequent committers
+      - Resolve the top committer to a GitHub username:
+        `gh api 'search/users?q=<email>+in:email' --jq '.items[0].login'`
+      - If you cannot determine a reviewer, fall back to a default:
+        `# TODO: your fallback reviewer username`
+      - Request their review: `gh pr edit {{.Number}} --add-reviewer <username>`
+
+      ### 6. Run tests (when possible)
+      - Run your project's test suite (e.g., `make test`, `pytest`, `npm test`)
+      - If tests pass and the upgrade is patch/minor, increase confidence
+      - If tests fail, report the failures and mark as needs human review
+      - Set a 2-minute timeout on test commands to avoid hanging
+
+      ### 7. Post your review
+      Use `gh pr review` to post your assessment:
+      - For "Safe to merge": approve the PR with your analysis summary
+      - For "Likely safe": comment with your analysis, do not approve
+      - For "Needs human review": comment with your analysis and flag concerns
+
+      ## Review Format
+
+      Structure your PR review comment as:
+
+      ```
+      ## Dependency Review: <package-name> <old-version> -> <new-version>
+
+      **Change type**: patch | minor | major
+      **Risk assessment**: Safe to merge | Likely safe | Needs human review
+
+      ### Usage in codebase
+      <where and how the package is used>
+
+      ### Changelog summary
+      <relevant changes from the release notes>
+
+      ### Breaking changes
+      <any breaking changes and whether they affect us>
+
+      ### Test results
+      <test results if run>
+
+      ### Recommendation
+      <final recommendation with reasoning>
+      ```
+
+      ## Task
+
+      Review this dependency upgrade PR:
+
+      PR #{{.Number}}: {{.Title}}
+      URL: {{.URL}}
+
+      PR Description:
+      {{.Body}}
+
+      Instructions:
+      1. Check out the PR branch
+      2. Identify which packages are being upgraded and the version bump type
+      3. Search the codebase for all usages of the affected package(s)
+      4. Read the changelog/release notes included in the PR body
+      5. Determine if any breaking changes affect our usage
+      6. Run the relevant test suite (2-minute timeout)
+      7. Post your review using `gh pr review {{.Number}}`
+      8. If "Needs human review": request formal review with `gh pr edit {{.Number}} --add-reviewer <username>`
+      9. Add the `agent-reviewed` label: `gh pr edit {{.Number}} --add-label agent-reviewed`
+
+      ## Restrictions
+      - Do not modify any code — this is a review-only agent
+      - Do not push commits to the PR branch
+      - Never approve upgrades to security-sensitive packages (crypto, auth,
+        TLS, database drivers) without flagging for human review
+    podOverrides:
+      activeDeadlineSeconds: 1800
+      env:
+        - name: ANTHROPIC_MODEL
+          # TODO: your model identifier or ARN
+          value: "claude-sonnet-4-6"

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,14 @@ Ready-to-use patterns and YAML manifests for orchestrating AI agents with Kelos.
 | [12-taskspawner-file-patterns](12-taskspawner-file-patterns/) | Filter GitHub PR / push webhooks by changed-file glob patterns |
 | [13-taskspawner-generic-webhook](13-taskspawner-generic-webhook/) | Respond to arbitrary HTTP POST events (Sentry, Notion, Slack, etc.) using JSONPath field mapping and filters |
 
+### Use Case Patterns
+
+Production-tested TaskSpawner patterns for common AI agent workflows. Most reference one of two [shared AgentConfig resources](shared-agent-configs.yaml) (read-only or solver).
+
+| Example | Description |
+|---------|-------------|
+| [14-dependency-review-spawner](14-dependency-review-spawner/) | Auto-review Renovate/Dependabot PRs: assess risk, auto-approve safe bumps, escalate risky ones |
+
 ## How to Use
 
 1. Pick an example directory.

--- a/examples/shared-agent-configs.yaml
+++ b/examples/shared-agent-configs.yaml
@@ -1,0 +1,58 @@
+# Shared AgentConfig: Read-Only Agent
+#
+# For agents that investigate, review, and report but never modify code.
+# Used by: dependency review, PR risk assessment, triage, helpdesk drafting.
+apiVersion: kelos.dev/v1alpha1
+kind: AgentConfig
+metadata:
+  name: readonly-agent
+  namespace: default
+spec:
+  agentsMD: |
+    ## Role
+    You are a read-only agent. You investigate, analyze, and report findings.
+
+    ## Restrictions
+    - NEVER modify files, create branches, or run destructive commands
+    - NEVER commit, push, or create PRs
+    - NEVER run `rm`, `git checkout`, `git reset`, or any write operation
+    - Your only outputs are comments, reviews, and status updates via CLI tools
+
+    ## Available Tools
+    - `gh` — GitHub CLI for reading PRs, issues, diffs, and posting comments/reviews
+    - Repository read access — search, grep, read any file
+
+  # Optional: MCP servers for memory/context
+  # mcpServers:
+  # - name: memory
+  #   type: stdio
+  #   command: mcp-server-qdrant
+  #   env:
+  #     QDRANT_URL: "http://qdrant.default.svc.cluster.local:6333"
+  #     COLLECTION_NAME: "agent-memory"
+
+---
+# Shared AgentConfig: Solver Agent
+#
+# For agents that implement fixes, create branches, and open draft PRs.
+# Used by: migration resolver, draft/solver agents, docs maintenance.
+apiVersion: kelos.dev/v1alpha1
+kind: AgentConfig
+metadata:
+  name: solver-agent
+  namespace: default
+spec:
+  agentsMD: |
+    ## Role
+    You are a solver agent. You implement fixes, create branches, and open draft PRs.
+
+    ## Restrictions
+    - NEVER force-push or rewrite published history
+    - NEVER commit secrets, tokens, or credentials
+    - NEVER merge PRs — always leave as draft for human review
+    - NEVER run destructive commands (`rm -rf`, `git clean -f`, etc.)
+
+    ## Available Tools
+    - `gh` — GitHub CLI for creating PRs, posting comments, reading diffs
+    - Full repository write access — edit files, create branches, push commits
+    - Test runners — run project test suites to validate changes


### PR DESCRIPTION
#### What type of PR is this?
/kind docs

#### What this PR does / why we need it:
Add a use case example for automated dependency review via TaskSpawner. When
Renovate or Dependabot opens a PR, a read-only agent investigates the package
change, assesses risk, and either auto-approves safe bumps or escalates to the
best human reviewer (identified via git blame history).

Includes a TaskSpawner manifest with author-filtered webhooks, structured review
output, conditional auto-approval, and reviewer identification patterns.

#### Which issue(s) this PR is related to:
Refs #981
Refs #945

#981 proposes supply chain compliance (SBOM, license auditing, provenance).
Dependency review is the first step toward that goal — understanding each
dependency change as it arrives.

#945 proposes IaC lifecycle automation for Terraform providers. This use case
demonstrates the same "external tool opens a PR → agent reviews it" pattern that
IaC provider upgrades would follow.

#### Special notes for your reviewer:
This is a documentation-only change adding example manifests under a use case
directory. No API or controller changes.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```