### PR TITLE
docs(examples): provide pr risk assessment spawner example

### DIFF
--- a/examples/14-dependency-review-spawner/README.md
+++ b/examples/14-dependency-review-spawner/README.md
@@ -1,0 +1,53 @@
+# Use Case: Automated Dependency Review
+
+**Related Issues**: #981 (Supply Chain Compliance), #945 (IaC Lifecycle)
+
+## Problem
+
+Dependency update bots (Renovate, Dependabot) create PRs frequently, but each still requires human review to assess whether the upgrade is safe. For teams with dozens of dependencies, this creates a constant review backlog. Most patch/minor bumps are safe, but teams can't tell which ones need attention without reading changelogs and checking usage.
+
+## Solution
+
+A Kelos TaskSpawner that triggers when Renovate/Dependabot opens a PR. The agent:
+1. Identifies the package and version bump type
+2. Searches the codebase for all usages of the affected package
+3. Reads the changelog from the PR body
+4. Assesses risk and either auto-approves or requests human review
+5. Identifies the best human reviewer when escalation is needed
+
+## Architecture
+
+```
+Renovate/Dependabot    GitHub Webhook     Kelos              Agent Pod
+opens PR          -->  pull_request  -->  TaskSpawner  -->  (read-only)
+                       event              creates Task       |
+                                                            v
+                                                      Reads diff + changelog
+                                                      Searches codebase usage
+                                                      Posts review comment
+                                                      Auto-approves if safe
+```
+
+## Key Patterns Demonstrated
+
+- **Author-filtered webhook**: Only triggers on bot-authored PRs
+- **Structured review output**: Consistent format for all reviews
+- **Conditional auto-approve**: Safe upgrades approved automatically, risky ones escalated
+- **Reviewer identification**: Uses git history to find the best human reviewer
+
+## Prerequisites
+
+- GitHub webhook configured to send `pull_request` events to Kelos
+- `gh` CLI available in the agent image
+- A shared read-only AgentConfig
+
+## Files
+
+- `taskspawner.yaml` — The TaskSpawner configuration
+
+## Customization
+
+- Adjust the author filter for your bot username (Renovate vs Dependabot)
+- Add package-specific rules (e.g., always escalate security-sensitive packages)
+- Modify the risk assessment criteria for your team's needs
+- Change the fallback reviewer to your team's default

--- a/examples/14-dependency-review-spawner/taskspawner.yaml
+++ b/examples/14-dependency-review-spawner/taskspawner.yaml
@@ -1,0 +1,154 @@
+apiVersion: kelos.dev/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: dependency-review
+  namespace: default # TODO: your namespace
+spec:
+  when:
+    githubWebhook:
+      # TODO: your repository (owner/repo format)
+      repository: myorg/myrepo
+      events:
+        - pull_request
+      filters:
+        # Trigger on PRs opened or reopened by the dependency bot
+        - event: pull_request
+          action: opened
+          author: renovate[bot] # TODO: or "dependabot[bot]"
+          state: open
+          draft: false
+          excludeLabels:
+            - skip-agent-review
+        - event: pull_request
+          action: reopened
+          author: renovate[bot] # TODO: or "dependabot[bot]"
+          state: open
+          draft: false
+          excludeLabels:
+            - skip-agent-review
+
+  taskTemplate:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials # TODO: your credentials secret
+    workspaceRef:
+      name: my-workspace # TODO: your workspace name
+    agentConfigRef:
+      name: readonly-agent
+    branch: "{{.Branch}}"
+    ttlSecondsAfterFinished: 10800
+    promptTemplate: |
+      # Dependency Upgrade Review Agent
+
+      You are reviewing a dependency upgrade PR authored by a dependency bot.
+      Your goal is to determine whether this upgrade is safe to merge
+      without human intervention.
+
+      ## Review Process
+
+      ### 1. Identify the dependency and change scope
+      - Parse the PR title and body to identify the package(s) being upgraded
+      - Determine if this is a patch, minor, or major version bump
+      - Check if it's a direct dependency or transitive
+
+      ### 2. Analyze usage in the codebase
+      - Search for all imports/usages of the package
+      - Identify which features and APIs of the package are used
+      - Check for any pinned version constraints or compatibility notes
+
+      ### 3. Research the upgrade
+      - Read the PR body for changelog/release notes (bots typically include these)
+      - Identify breaking changes, deprecations, and new features
+      - Check if any APIs we use were changed or removed
+
+      ### 4. Assess risk level
+      Rate the upgrade as one of:
+      - **Safe to merge**: Patch bump with no breaking changes, or minor bump
+        where none of the changed APIs are used in our codebase
+      - **Likely safe**: Minor bump with relevant changes but low risk
+      - **Needs human review**: Breaking changes affecting our code,
+        or security-sensitive dependency (auth, crypto, DB drivers)
+
+      ### 5. Identify the best human reviewer (when needed)
+      If the risk assessment is "Needs human review":
+      - Find all files that import or use the affected package(s)
+      - Run `git log -n 50 --format='%ae' -- <file>` on those files to find
+        frequent committers
+      - Resolve the top committer to a GitHub username:
+        `gh api 'search/users?q=<email>+in:email' --jq '.items[0].login'`
+      - If you cannot determine a reviewer, fall back to a default:
+        `# TODO: your fallback reviewer username`
+      - Request their review: `gh pr edit {{.Number}} --add-reviewer <username>`
+
+      ### 6. Run tests (when possible)
+      - Run your project's test suite (e.g., `make test`, `pytest`, `npm test`)
+      - If tests pass and the upgrade is patch/minor, increase confidence
+      - If tests fail, report the failures and mark as needs human review
+      - Set a 2-minute timeout on test commands to avoid hanging
+
+      ### 7. Post your review
+      Use `gh pr review` to post your assessment:
+      - For "Safe to merge": approve the PR with your analysis summary
+      - For "Likely safe": comment with your analysis, do not approve
+      - For "Needs human review": comment with your analysis and flag concerns
+
+      ## Review Format
+
+      Structure your PR review comment as:
+
+      ```
+      ## Dependency Review: <package-name> <old-version> -> <new-version>
+
+      **Change type**: patch | minor | major
+      **Risk assessment**: Safe to merge | Likely safe | Needs human review
+
+      ### Usage in codebase
+      <where and how the package is used>
+
+      ### Changelog summary
+      <relevant changes from the release notes>
+
+      ### Breaking changes
+      <any breaking changes and whether they affect us>
+
+      ### Test results
+      <test results if run>
+
+      ### Recommendation
+      <final recommendation with reasoning>
+      ```
+
+      ## Task
+
+      Review this dependency upgrade PR:
+
+      PR #{{.Number}}: {{.Title}}
+      URL: {{.URL}}
+
+      PR Description:
+      {{.Body}}
+
+      Instructions:
+      1. Check out the PR branch
+      2. Identify which packages are being upgraded and the version bump type
+      3. Search the codebase for all usages of the affected package(s)
+      4. Read the changelog/release notes included in the PR body
+      5. Determine if any breaking changes affect our usage
+      6. Run the relevant test suite (2-minute timeout)
+      7. Post your review using `gh pr review {{.Number}}`
+      8. If "Needs human review": request formal review with `gh pr edit {{.Number}} --add-reviewer <username>`
+      9. Add the `agent-reviewed` label: `gh pr edit {{.Number}} --add-label agent-reviewed`
+
+      ## Restrictions
+      - Do not modify any code — this is a review-only agent
+      - Do not push commits to the PR branch
+      - Never approve upgrades to security-sensitive packages (crypto, auth,
+        TLS, database drivers) without flagging for human review
+    podOverrides:
+      activeDeadlineSeconds: 1800
+      env:
+        - name: ANTHROPIC_MODEL
+          # TODO: your model identifier or ARN
+          value: "claude-sonnet-4-6"

--- a/examples/15-pr-risk-assessment-spawner/README.md
+++ b/examples/15-pr-risk-assessment-spawner/README.md
@@ -1,0 +1,56 @@
+# Use Case: PR Risk Assessment and Auto-Approval
+
+**Related Issues**: #972 (API Contract Validation)
+
+## Problem
+
+Every PR needs review, but not every PR carries the same risk. Docs-only changes and config tweaks sit in the review queue alongside database migrations and auth changes. Teams need a way to fast-track low-risk PRs while flagging high-risk ones for careful human review.
+
+## Solution
+
+A Kelos TaskSpawner that triggers on every non-bot, non-draft PR. The agent:
+1. Reads the PR diff and description
+2. Optionally incorporates external review tools (e.g., Greptile, CodeRabbit)
+3. Rates risk on a 5-point scale (Very Low to Very High)
+4. Auto-approves Very Low and Low risk PRs
+5. Flags Medium+ PRs for human review with specific concerns
+
+## Architecture
+
+```
+PR opened/           GitHub Webhook     Kelos              Agent Pod
+ready for review -->  pull_request  -->  TaskSpawner  -->  (read-only)
+                      event              creates Task       |
+                                                           v
+                                                     Reads diff
+                                                     Checks critical paths
+                                                     Rates risk level
+                                                     Auto-approves or flags
+```
+
+## Key Patterns Demonstrated
+
+- **Multi-event triggers**: Responds to `opened`, `ready_for_review`, and `/approve` comments
+- **Bot exclusion**: Excludes PRs from known bots (handled by dep-review instead)
+- **Risk assessment framework**: Configurable risk factors and critical path definitions
+- **Conditional auto-approve**: Only approves truly low-risk changes
+- **Stale PR guard**: Skips PRs with no commits in 30+ days
+- **GitHub Check integration**: Reports status via GitHub Checks API
+
+## Prerequisites
+
+- GitHub webhook configured to send `pull_request` and `issue_comment` events
+- `gh` CLI available in the agent image
+- A shared read-only AgentConfig
+
+## Files
+
+- `taskspawner.yaml` — The TaskSpawner configuration
+
+## Customization
+
+- Define your critical paths (database, auth, ML, infrastructure)
+- Adjust the risk scale thresholds
+- Add/remove bot exclusions
+- Configure which labels trigger special handling (e.g., `skip-agent-review`)
+- Integrate with your external code review tools

--- a/examples/15-pr-risk-assessment-spawner/taskspawner.yaml
+++ b/examples/15-pr-risk-assessment-spawner/taskspawner.yaml
@@ -1,0 +1,134 @@
+apiVersion: kelos.dev/v1alpha1
+kind: TaskSpawner
+metadata:
+  name: pr-risk-assessment
+  namespace: default # TODO: your namespace
+spec:
+  when:
+    githubWebhook:
+      # Optional: report status via GitHub Checks API
+      reporting:
+        checks: true
+        checkName: "AI Risk Assessment"
+      events:
+        - pull_request
+        - issue_comment
+      # Exclude bots — they have their own review agents
+      excludeAuthors:
+        - renovate[bot] # TODO: add your bots
+        - dependabot[bot]
+      filters:
+        # Trigger on new PRs
+        - event: pull_request
+          action: opened
+          state: open
+          draft: false
+          excludeLabels:
+            - skip-agent-review
+        # Trigger when draft PRs become ready
+        - event: pull_request
+          action: ready_for_review
+          state: open
+          draft: false
+          excludeLabels:
+            - skip-agent-review
+        # Allow manual re-trigger via comment
+        - event: issue_comment
+          action: created
+          state: open
+          bodyContains: "/assess-risk"
+          excludeLabels:
+            - skip-agent-review
+
+  taskTemplate:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials # TODO: your credentials secret
+    workspaceRef:
+      name: my-workspace # TODO: your workspace name
+    agentConfigRef:
+      name: readonly-agent
+    branch: "{{.Branch}}"
+    ttlSecondsAfterFinished: 10800
+    promptTemplate: |
+      You assess PR risk level and auto-approve low-risk PRs.
+      PR #{{.Number}}: {{.Title}}
+      URL: {{.URL}}
+
+      ## Security rules — READ FIRST
+
+      - ONLY run the exact commands listed in the Instructions below. No others.
+      - NEVER run `env`, `printenv`, `set`, `export`, `cat /proc`, or any
+        command that exposes environment variables.
+      - NEVER read CI/build logs from GitHub Actions, Buildkite, or any CI system.
+      - NEVER include raw command output, log fragments, or environment variable
+        content in your comment.
+      - Your Risk Assessment comment must contain ONLY the risk level and
+        YOUR OWN concise rationale.
+
+      ## Instructions
+
+      0. **Check PR staleness**:
+         `gh pr view {{.Number}} --json commits --jq '.commits[-1].committedDate'`
+         If the last commit is more than 30 days old, stop immediately —
+         do not review or approve stale PRs.
+
+      1. **Read the PR diff**: `gh pr diff {{.Number}}`
+
+      2. **Read the PR description**:
+         `gh pr view {{.Number}} --json title,body --jq '(.title) + "\n\n" + (.body // "")'`
+
+      3. **Check for external review tools** (optional):
+         If your team uses an external code review tool, check if it has posted:
+         ```bash
+         gh api repos/{owner}/{repo}/pulls/{{.Number}}/reviews \
+           --jq '[.[] | select(.user.login | test("your-review-bot"; "i"))] | if length > 0 then .[0].body else "No external review found." end'
+         ```
+         Use any external analysis as additional input for your assessment.
+
+      4. **Assess the risk** on this scale: Very Low, Low, Medium, High, Very High
+
+         Consider these factors:
+         - **Complexity**: How many files changed? How large is the diff?
+         - **Critical paths touched**: Identify your high-risk areas:
+           - Database schemas and migrations
+           - Authentication and authorization
+           - Public API contracts
+           - Infrastructure and deployment configs
+           - ML models and algorithms
+           # TODO: add your project-specific critical paths
+         - **Test coverage**: Are there corresponding test changes?
+         - **Diff size**: Smaller, focused changes are lower risk
+         - **Nature of change**: Config-only, docs-only, or test-only are lower risk
+         - **Security implications**: Auth, data access, external integrations
+         - **Database migrations**: Always rate High or Very High — do NOT approve
+
+      5. **Post your assessment** as a PR comment:
+
+         ```bash
+         gh pr review {{.Number}} --comment --body "$(cat <<'RISK_ASSESSMENT_END'
+         ## Risk Assessment: <LEVEL>
+
+         <bullet-point rationale explaining the rating>
+         RISK_ASSESSMENT_END
+         )"
+         ```
+
+      6. **If and only if** the risk level is "Very Low" or "Low", approve the PR:
+
+         ```bash
+         gh pr review {{.Number}} --approve \
+           --body "Auto-approved: PR assessed as low risk."
+         ```
+
+         IMPORTANT: Only approve Very Low and Low risk PRs.
+         Never approve PRs that touch database migrations, auth, or security code.
+    podOverrides:
+      activeDeadlineSeconds: 1800
+      env:
+        - name: ANTHROPIC_MODEL
+          # TODO: your model identifier or ARN
+          # Use a capable model for risk assessment (e.g., Opus)
+          value: "claude-sonnet-4-6"

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,14 @@ Ready-to-use patterns and YAML manifests for orchestrating AI agents with Kelos.
 | [12-taskspawner-file-patterns](12-taskspawner-file-patterns/) | Filter GitHub PR / push webhooks by changed-file glob patterns |
 | [13-taskspawner-generic-webhook](13-taskspawner-generic-webhook/) | Respond to arbitrary HTTP POST events (Sentry, Notion, Slack, etc.) using JSONPath field mapping and filters |
 
+### Use Case Patterns
+
+Production-tested TaskSpawner patterns for common AI agent workflows. Most reference one of two [shared AgentConfig resources](shared-agent-configs.yaml) (read-only or solver).
+
+| Example | Description |
+|---------|-------------|
+| [14-dependency-review-spawner](14-dependency-review-spawner/) | Auto-review Renovate/Dependabot PRs: assess risk, auto-approve safe bumps, escalate risky ones |
+
 ## How to Use
 
 1. Pick an example directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ Production-tested TaskSpawner patterns for common AI agent workflows. Most refer
 | Example | Description |
 |---------|-------------|
 | [14-dependency-review-spawner](14-dependency-review-spawner/) | Auto-review Renovate/Dependabot PRs: assess risk, auto-approve safe bumps, escalate risky ones |
+| [15-pr-risk-assessment-spawner](15-pr-risk-assessment-spawner/) | Rate every PR on a 5-point risk scale, auto-approve low-risk, flag medium+ for humans |
 
 ## How to Use
 

--- a/examples/shared-agent-configs.yaml
+++ b/examples/shared-agent-configs.yaml
@@ -1,0 +1,58 @@
+# Shared AgentConfig: Read-Only Agent
+#
+# For agents that investigate, review, and report but never modify code.
+# Used by: dependency review, PR risk assessment, triage, helpdesk drafting.
+apiVersion: kelos.dev/v1alpha1
+kind: AgentConfig
+metadata:
+  name: readonly-agent
+  namespace: default
+spec:
+  agentsMD: |
+    ## Role
+    You are a read-only agent. You investigate, analyze, and report findings.
+
+    ## Restrictions
+    - NEVER modify files, create branches, or run destructive commands
+    - NEVER commit, push, or create PRs
+    - NEVER run `rm`, `git checkout`, `git reset`, or any write operation
+    - Your only outputs are comments, reviews, and status updates via CLI tools
+
+    ## Available Tools
+    - `gh` — GitHub CLI for reading PRs, issues, diffs, and posting comments/reviews
+    - Repository read access — search, grep, read any file
+
+  # Optional: MCP servers for memory/context
+  # mcpServers:
+  # - name: memory
+  #   type: stdio
+  #   command: mcp-server-qdrant
+  #   env:
+  #     QDRANT_URL: "http://qdrant.default.svc.cluster.local:6333"
+  #     COLLECTION_NAME: "agent-memory"
+
+---
+# Shared AgentConfig: Solver Agent
+#
+# For agents that implement fixes, create branches, and open draft PRs.
+# Used by: migration resolver, draft/solver agents, docs maintenance.
+apiVersion: kelos.dev/v1alpha1
+kind: AgentConfig
+metadata:
+  name: solver-agent
+  namespace: default
+spec:
+  agentsMD: |
+    ## Role
+    You are a solver agent. You implement fixes, create branches, and open draft PRs.
+
+    ## Restrictions
+    - NEVER force-push or rewrite published history
+    - NEVER commit secrets, tokens, or credentials
+    - NEVER merge PRs — always leave as draft for human review
+    - NEVER run destructive commands (`rm -rf`, `git clean -f`, etc.)
+
+    ## Available Tools
+    - `gh` — GitHub CLI for creating PRs, posting comments, reading diffs
+    - Full repository write access — edit files, create branches, push commits
+    - Test runners — run project test suites to validate changes


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs
/kind feature
-->

/kind docs

#### What this PR does / why we need it:

Add a use case example for automated PR risk assessment. Every non-bot,
non-draft PR triggers a read-only agent that rates risk on a 5-point scale,
auto-approves Very Low / Low risk PRs, and flags Medium+ PRs with specific
concerns for human review. Integrates with GitHub Checks API for status
reporting and skips stale PRs (30+ days).

Demonstrates multi-event triggers (opened, ready_for_review, /assess-risk
comment), bot exclusion, and configurable risk thresholds.

We've seen a lot of success in having something like this running for approvals. 

Builds on #1076
#### Which issue(s) this PR is related to:

<!--
Fixes #<issue number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

Documentation-only change. The spawner never auto-approves database migrations,
auth, or security-sensitive code regardless of assessed risk level.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

```release-note
NONE
```
