### PR TITLE
self-development: Trigger kelos-pr-responder on pull_request_review only

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -26,7 +26,7 @@ func TestSelfDevelopmentGitHubSpawnersUseWebhooks(t *testing.T) {
 		{file: "kelos-planner.yaml", events: []string{"issue_comment"}},
 		{file: "kelos-reviewer.yaml", events: []string{"issue_comment", "pull_request_review"}},
 		{file: "kelos-api-reviewer.yaml", events: []string{"issue_comment", "pull_request_review"}},
-		{file: "kelos-pr-responder.yaml", events: []string{"issue_comment", "pull_request_review"}},
+		{file: "kelos-pr-responder.yaml", events: []string{"pull_request_review"}},
 		{file: "kelos-squash-commits.yaml", events: []string{"issue_comment", "pull_request_review"}},
 		{file: "kelos-triage.yaml", events: []string{"issues"}},
 	}

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -7,23 +7,8 @@ spec:
     githubWebhook:
       repository: kelos-dev/kelos
       events:
-        - issue_comment
         - pull_request_review
       filters:
-        - event: issue_comment
-          action: created
-          bodyContains: /kelos pick-up
-          labels:
-            - generated-by-kelos
-          state: open
-          author: gjkim42
-        - event: issue_comment
-          action: created
-          bodyContains: /kelos pick-up
-          labels:
-            - generated-by-kelos
-          state: open
-          author: kelos-bot[bot]
         - event: pull_request_review
           action: submitted
           bodyContains: /kelos pick-up


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`kelos-pr-responder` previously listened to both `issue_comment` and `pull_request_review`. GitHub's `issue_comment` event fires on PR top-level comments as well as issue comments, so a `/kelos pick-up` posted on a PR was double-handled — both `kelos-workers` and `kelos-pr-responder` would spawn tasks for the same comment.

This drops the `issue_comment` trigger from `kelos-pr-responder` so the two TaskSpawners are differentiated by event for now: `kelos-workers` keeps `issue_comment` for issues, and `kelos-pr-responder` only reacts to PR review submissions. Maintainers should re-trigger `kelos-pr-responder` by submitting `/kelos pick-up` in a PR review rather than as a top-level PR comment.

A follow-up will add a proper webhook filter (e.g. `isPullRequest`) so `kelos-workers` can reject PR-comment events at the webhook layer instead of relying on the prompt's step 0 check.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```