### PR TITLE
self-development: enable GitHub Checks on PR-related TaskSpawners

### DIFF
--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -67,6 +67,7 @@ spec:
           author: kelos-bot[bot]
       reporting:
         enabled: true
+        checks: {}
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -33,6 +33,7 @@ spec:
           draft: false
       reporting:
         enabled: true
+        checks: {}
   maxConcurrency: 2
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -66,6 +66,7 @@ spec:
           author: kelos-bot[bot]
       reporting:
         enabled: true
+        checks: {}
   maxConcurrency: 3
   taskTemplate:
     workspaceRef:

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -22,6 +22,7 @@ spec:
           author: gjkim42
       reporting:
         enabled: true
+        checks: {}
   maxConcurrency: 1
   taskTemplate:
     workspaceRef:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds `reporting.checks: {}` to the four webhook-driven TaskSpawners that operate on pull requests:

- `kelos-reviewer`
- `kelos-api-reviewer`
- `kelos-pr-responder`
- `kelos-squash-commits`

Each spawner now creates a GitHub Check Run on the PR head SHA (in addition to the existing status comment), so Kelos task outcomes appear in the PR Checks tab and can be required by branch protection rules.

The other webhook spawners (`kelos-workers`, `kelos-planner`, `kelos-triage`) trigger on issues, not PR commits, so they remain comment-only — and the CEL validation on `GitHubWebhook` would reject `checks` for them anyway since they lack a pull-request event type.

Default Check Run names (`Kelos: <spawner-name>`) are used; no overrides.

Requires the GitHub token used by the webhook server to have `checks:write` permission.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables GitHub Checks for PR-related TaskSpawners so Kelos results appear in the PR Checks tab and can be enforced by branch protection.

- **New Features**
  - Added `reporting.checks: {}` to: `kelos-reviewer`, `kelos-api-reviewer`, `kelos-pr-responder`, `kelos-squash-commits`.
  - Each spawner now creates a Check Run on the PR head SHA, alongside the status comment.
  - Issue-triggered spawners remain comment-only.

- **Migration**
  - The GitHub token used by the webhook server must have `checks:write` permission.

<sup>Written for commit 429288d27d34b481cffd9d11f61d82877eb246e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

