### PR TITLE
test(e2e): poll Task phase via WaitForTaskPhase to fix flake

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -317,6 +317,19 @@ func (f *Framework) GetTaskPhase(name string) string {
 	return string(task.Status.Phase)
 }
 
+// WaitForTaskPhase waits for a Task's status.phase to reach the expected value.
+// The Task controller updates phase asynchronously after the underlying Job
+// transitions, so callers must poll rather than read once.
+func (f *Framework) WaitForTaskPhase(name, phase string) {
+	Eventually(func() string {
+		task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return ""
+		}
+		return string(task.Status.Phase)
+	}, 2*time.Minute, time.Second).Should(Equal(phase), "Task %s did not reach phase %s", name, phase)
+}
+
 // GetTaskOutputs returns the outputs of a Task as a joined string.
 func (f *Framework) GetTaskOutputs(name string) string {
 	task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})

--- a/test/e2e/opencode_test.go
+++ b/test/e2e/opencode_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
@@ -43,7 +42,7 @@ var _ = Describe("OpenCode Task", func() {
 		f.WaitForJobCompletion("opencode-task")
 
 		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("opencode-task")).To(Equal("Succeeded"))
+		f.WaitForTaskPhase("opencode-task", "Succeeded")
 
 		By("getting Job logs")
 		logs := f.GetJobLogs("opencode-task")

--- a/test/e2e/setup_command_test.go
+++ b/test/e2e/setup_command_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Workspace setupCommand", func() {
 		f.WaitForJobCompletion("setup-task")
 
 		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("setup-task")).To(Equal("Succeeded"))
+		f.WaitForTaskPhase("setup-task", "Succeeded")
 
 		By("verifying setup banners appear in Pod logs")
 		logs := f.GetJobLogs("setup-task")

--- a/test/e2e/skills_test.go
+++ b/test/e2e/skills_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Task with skills.sh AgentConfig", func() {
 		f.WaitForJobCompletion("skills-task")
 
 		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("skills-task")).To(Equal("Succeeded"))
+		f.WaitForTaskPhase("skills-task", "Succeeded")
 
 		By("getting Job logs")
 		logs := f.GetJobLogs("skills-task")

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -49,7 +49,7 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.WaitForJobCompletion("basic-task")
 
 			By("verifying Task status is Succeeded")
-			Expect(f.GetTaskPhase("basic-task")).To(Equal("Succeeded"))
+			f.WaitForTaskPhase("basic-task", "Succeeded")
 
 			By("getting Job logs")
 			logs := f.GetJobLogs("basic-task")
@@ -105,7 +105,7 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.WaitForJobCompletion("ws-task")
 
 			By("verifying Task status is Succeeded")
-			Expect(f.GetTaskPhase("ws-task")).To(Equal("Succeeded"))
+			f.WaitForTaskPhase("ws-task", "Succeeded")
 
 			By("getting Job logs")
 			logs := f.GetJobLogs("ws-task")
@@ -166,7 +166,7 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.WaitForJobCompletion("outputs-task")
 
 			By("verifying Task status is Succeeded")
-			Expect(f.GetTaskPhase("outputs-task")).To(Equal("Succeeded"))
+			f.WaitForTaskPhase("outputs-task", "Succeeded")
 
 			By("verifying output markers appear in Pod logs")
 			logs := f.GetJobLogs("outputs-task")
@@ -248,19 +248,17 @@ func describeAgentTests(cfg agentTestConfig) {
 			})
 
 			By("verifying Task B enters Waiting phase while Task A runs")
-			Eventually(func() string {
-				return f.GetTaskPhase("dep-chain-b")
-			}, 30*time.Second, time.Second).Should(Equal("Waiting"))
+			f.WaitForTaskPhase("dep-chain-b", "Waiting")
 
 			By("waiting for Task A to complete")
 			f.WaitForJobCreation("dep-chain-a")
 			f.WaitForJobCompletion("dep-chain-a")
-			Expect(f.GetTaskPhase("dep-chain-a")).To(Equal("Succeeded"))
+			f.WaitForTaskPhase("dep-chain-a", "Succeeded")
 
 			By("waiting for Task B to start and complete after Task A succeeds")
 			f.WaitForJobCreation("dep-chain-b")
 			f.WaitForJobCompletion("dep-chain-b")
-			Expect(f.GetTaskPhase("dep-chain-b")).To(Equal("Succeeded"))
+			f.WaitForTaskPhase("dep-chain-b", "Succeeded")
 		})
 	})
 
@@ -348,7 +346,7 @@ var _ = Describe("Task with make available", func() {
 		f.WaitForJobCompletion("make-task")
 
 		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("make-task")).To(Equal("Succeeded"))
+		f.WaitForTaskPhase("make-task", "Succeeded")
 
 		By("getting Job logs")
 		logs := f.GetJobLogs("make-task")
@@ -413,7 +411,7 @@ var _ = Describe("Task with workspace and secretRef", func() {
 		f.WaitForJobCompletion("github-task")
 
 		By("verifying Task status is Succeeded")
-		Expect(f.GetTaskPhase("github-task")).To(Equal("Succeeded"))
+		f.WaitForTaskPhase("github-task", "Succeeded")
 
 		By("getting Job logs")
 		logs := f.GetJobLogs("github-task")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a flake in the e2e suite where `Task with workspace [codex] should run a Task with workspace to completion` (and several sibling tests) intermittently fail with:

```
Expected
    <string>: Running
to equal
    <string>: Succeeded
```

even though the agent finished cleanly:

- `Pod ws-task-...: phase=Succeeded`
- `Job ws-task: active=0 succeeded=1 failed=0`
- `Task ws-task: phase=Running`

The tests called `WaitForJobCompletion`, which only polls the Job's `Complete` condition, then immediately read `Task.status.phase` once. The Task controller is a separate reconciler that observes the Job and *then* patches `Task.status.phase`, so there is a small async window where the Job is `Complete` but the Task has not yet been updated. The single-shot `Expect(...).To(Equal("Succeeded"))` lost that race.

This PR adds a `WaitForTaskPhase(name, phase)` framework helper that polls until the expected phase is reached (2 min, 1 s interval), and replaces the racy single-shot phase assertions across `task_test.go`, `opencode_test.go`, `setup_command_test.go`, and `skills_test.go`. The helper inlines the Tasks Get call and returns an empty string on transient API errors so `Eventually` keeps polling instead of failing on the first blip — `GetTaskPhase`, by contrast, calls `Expect(err).NotTo(HaveOccurred())`, which would short-circuit the polling loop. This matches the pattern used by other `WaitFor*` helpers in the framework.

The existing 5-minute `Eventually(... == "Failed")` in `setup_command_test.go` is left alone — it waits for the full Job-failure lifecycle (backoff retries before the controller marks the Task `Failed`), which is a different scenario from the post-completion reconciliation gap this helper targets.

Reference flaky run: https://github.com/kelos-dev/kelos/actions/runs/25226338354/job/73970696826

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
