### PR TITLE
self-development: Use commentOn filter to split issue and PR triggers

### DIFF
--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -13,6 +13,7 @@ spec:
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
+          commentOn: PullRequest
           labels:
             - generated-by-kelos
           state: open
@@ -20,6 +21,7 @@ spec:
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
+          commentOn: PullRequest
           labels:
             - generated-by-kelos
           state: open

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -14,23 +14,17 @@ spec:
           action: created
           bodyContains: /kelos pick-up
           commentOn: PullRequest
-          labels:
-            - generated-by-kelos
           state: open
           author: gjkim42
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
           commentOn: PullRequest
-          labels:
-            - generated-by-kelos
           state: open
           author: kelos-bot[bot]
         - event: pull_request_review
           action: submitted
           bodyContains: /kelos pick-up
-          labels:
-            - generated-by-kelos
           state: open
           draft: false
       reporting:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -44,11 +44,13 @@ spec:
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
+          commentOn: Issue
           state: open
           author: gjkim42
         - event: issue_comment
           action: created
           bodyContains: /kelos pick-up
+          commentOn: Issue
           state: open
           author: kelos-bot[bot]
       reporting:
@@ -99,7 +101,6 @@ spec:
       Task:
       - 0. Refresh the latest issue state:
         - Re-read the issue and all comments: `gh issue view {{.Number}} --comments`
-        - If `gh pr view {{.Number}}` succeeds, this webhook came from a pull request comment. Exit without doing any work.
       - 1. Set up your working branch. Run this exactly:
         ```
         git fetch --unshallow || true; git fetch origin main; git rebase origin/main


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`kelos-workers` and `kelos-pr-responder` both subscribed to `issue_comment` events for both subjects (issues and PRs, since GitHub fires the same event for both). They worked around it by:

- `kelos-workers`: a prompt-side guard ("if `gh pr view` succeeds, exit without doing any work")
- `kelos-pr-responder`: relying on the `generated-by-kelos` label being present only on PRs

Now that `commentOn` is a first-class filter (added in ff47b1c), this PR sets:

- `commentOn: Issue` on `kelos-workers` so it only fires on plain issues
- `commentOn: PullRequest` on `kelos-pr-responder` so it only fires on PR comments

The redundant prompt-side guard in `kelos-workers` is removed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`kelos-pr-responder` also has a `pull_request_review` filter, which is PR-only by definition and doesn't need `commentOn`. Only the `issue_comment` filters were updated.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the new `commentOn` filter to split issue vs PR comment triggers so `kelos-workers` and `kelos-pr-responder` only run on the right subject. Remove the redundant PR guard and drop the `generated-by-kelos` label requirement.

- **Refactors**
  - `self-development/kelos-workers.yaml`: add `commentOn: Issue` to both `issue_comment` triggers; remove the “exit if this is a PR” step.
  - `self-development/kelos-pr-responder.yaml`: add `commentOn: PullRequest` to `issue_comment` triggers; remove `labels: [generated-by-kelos]` from both `issue_comment` and `pull_request_review` triggers.

<sup>Written for commit 61edfc9e37573e427775f113d9b7ee31e6c5dd03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

