### PR TITLE
feat(ci): swap to multi-stage build so we can matrix the build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+bin/
+.git/
+*.test
+*.out
+coverage.*
+*.coverprofile
+.env
+.claude/
+CLAUDE.local.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,18 +27,26 @@ jobs:
   build-images:
     needs: determine-version
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, arm64]
+        image:
+          - cmd/kelos-controller
+          - cmd/kelos-spawner
+          - cmd/ghproxy
+          - cmd/kelos-webhook-server
+          - cmd/kelos-slack-server
+          - claude-code
+          - codex
+          - gemini
+          - opencode
+          - cursor
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -50,10 +58,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine image name
+        id: meta
+        run: echo "name=$(basename ${{ matrix.image }})" >> "$GITHUB_OUTPUT"
+
       - name: Build and push image
-        env:
-          VERSION: ${{ needs.determine-version.outputs.version }}
-        run: make image IMAGE_PLATFORMS=linux/${{ matrix.arch }} PUSH=true VERSION="$VERSION-${{ matrix.arch }}"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image }}/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          tags: ghcr.io/kelos-dev/${{ steps.meta.outputs.name }}:${{ needs.determine-version.outputs.version }}-${{ matrix.arch }}
+          build-args: |
+            LDFLAGS=-X github.com/kelos-dev/kelos/internal/version.Version=${{ needs.determine-version.outputs.version }}
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
 
   merge-manifests:
     needs: [determine-version, build-images]

--- a/Makefile
+++ b/Makefile
@@ -86,19 +86,9 @@ PUSH ?= false
 
 .PHONY: image
 image: ## Build docker images (use WHAT, IMAGE_PLATFORMS, PUSH=true to customize).
-	@for dir in $(filter cmd/%,$(or $(WHAT),$(IMAGE_DIRS))); do \
-		name=$$(basename $$dir); \
-		for arch in $(IMAGE_ARCHES); do \
-			GOOS=linux GOARCH=$$arch $(MAKE) build WHAT=$$dir; \
-			mv bin/$$name bin/$${name}-linux-$$arch; \
-		done; \
-	done
-	@for arch in $(IMAGE_ARCHES); do \
-		GOOS=linux GOARCH=$$arch $(MAKE) build WHAT=cmd/kelos-capture; \
-		mv bin/kelos-capture bin/kelos-capture-linux-$$arch; \
-	done
 	@for dir in $(or $(WHAT),$(IMAGE_DIRS)); do \
 		docker buildx build --platform $(IMAGE_PLATFORMS) \
+			--build-arg LDFLAGS="$(LDFLAGS)" \
 			$(if $(filter true,$(PUSH)),--push,--load) \
 			-t $(REGISTRY)/$$(basename $$dir):$(VERSION) \
 			-f $$dir/Dockerfile .; \

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.25 AS build-capture
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -o /out/kelos-capture ./cmd/kelos-capture
+
 FROM ubuntu:24.04
 
 ARG GO_VERSION=1.25.0
@@ -33,8 +42,7 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 COPY claude-code/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-ARG TARGETARCH
-COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
+COPY --from=build-capture /out/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash claude
 RUN mkdir -p /home/claude/.claude && chown -R claude:claude /home/claude

--- a/cmd/ghproxy/Dockerfile
+++ b/cmd/ghproxy/Dockerfile
@@ -1,6 +1,14 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH LDFLAGS=""
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags "${LDFLAGS}" -o /out/ghproxy ./cmd/ghproxy
+
 FROM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
 WORKDIR /
-COPY bin/ghproxy-linux-${TARGETARCH} ghproxy
+COPY --from=build /out/ghproxy ghproxy
 USER 65532:65532
 ENTRYPOINT ["/ghproxy"]

--- a/cmd/kelos-controller/Dockerfile
+++ b/cmd/kelos-controller/Dockerfile
@@ -1,6 +1,14 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH LDFLAGS=""
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags "${LDFLAGS}" -o /out/kelos-controller ./cmd/kelos-controller
+
 FROM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-controller-linux-${TARGETARCH} kelos-controller
+COPY --from=build /out/kelos-controller kelos-controller
 USER 65532:65532
 ENTRYPOINT ["/kelos-controller"]

--- a/cmd/kelos-slack-server/Dockerfile
+++ b/cmd/kelos-slack-server/Dockerfile
@@ -1,6 +1,14 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH LDFLAGS=""
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags "${LDFLAGS}" -o /out/kelos-slack-server ./cmd/kelos-slack-server
+
 FROM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-slack-server-linux-${TARGETARCH} kelos-slack-server
+COPY --from=build /out/kelos-slack-server kelos-slack-server
 USER 65532:65532
 ENTRYPOINT ["/kelos-slack-server"]

--- a/cmd/kelos-spawner/Dockerfile
+++ b/cmd/kelos-spawner/Dockerfile
@@ -1,6 +1,14 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH LDFLAGS=""
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags "${LDFLAGS}" -o /out/kelos-spawner ./cmd/kelos-spawner
+
 FROM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-spawner-linux-${TARGETARCH} kelos-spawner
+COPY --from=build /out/kelos-spawner kelos-spawner
 USER 65532:65532
 ENTRYPOINT ["/kelos-spawner"]

--- a/cmd/kelos-webhook-server/Dockerfile
+++ b/cmd/kelos-webhook-server/Dockerfile
@@ -1,6 +1,14 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH LDFLAGS=""
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags "${LDFLAGS}" -o /out/kelos-webhook-server ./cmd/kelos-webhook-server
+
 FROM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
 WORKDIR /
-COPY bin/kelos-webhook-server-linux-${TARGETARCH} kelos-webhook-server
+COPY --from=build /out/kelos-webhook-server kelos-webhook-server
 USER 65532:65532
 ENTRYPOINT ["/kelos-webhook-server"]

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.25 AS build-capture
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -o /out/kelos-capture ./cmd/kelos-capture
+
 FROM ubuntu:24.04
 
 ARG GO_VERSION=1.25.0
@@ -33,8 +42,7 @@ RUN npm install -g @openai/codex@${CODEX_VERSION}
 COPY codex/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-ARG TARGETARCH
-COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
+COPY --from=build-capture /out/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.codex && chown -R agent:agent /home/agent

--- a/cursor/Dockerfile
+++ b/cursor/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.25 AS build-capture
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -o /out/kelos-capture ./cmd/kelos-capture
+
 FROM ubuntu:24.04
 
 ARG GO_VERSION=1.25.0
@@ -30,8 +39,7 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 COPY cursor/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-ARG TARGETARCH
-COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
+COPY --from=build-capture /out/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.cursor && chown -R agent:agent /home/agent

--- a/gemini/Dockerfile
+++ b/gemini/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.25 AS build-capture
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -o /out/kelos-capture ./cmd/kelos-capture
+
 FROM ubuntu:24.04
 
 ARG GO_VERSION=1.25.0
@@ -33,8 +42,7 @@ RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION}
 COPY gemini/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-ARG TARGETARCH
-COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
+COPY --from=build-capture /out/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.gemini && chown -R agent:agent /home/agent

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.25 AS build-capture
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -o /out/kelos-capture ./cmd/kelos-capture
+
 FROM ubuntu:24.04
 
 ARG GO_VERSION=1.25.0
@@ -33,8 +42,7 @@ RUN npm install -g opencode-ai@${OPENCODE_VERSION}
 COPY opencode/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
 
-ARG TARGETARCH
-COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture
+COPY --from=build-capture /out/kelos-capture /kelos/kelos-capture
 
 RUN useradd -u 61100 -m -s /bin/bash agent
 RUN mkdir -p /home/agent/.opencode && chown -R agent:agent /home/agent


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Moves all 10 Docker images to multi-stage builds and expands the release matrix from `arch` (2 jobs) to `image × arch` (20 jobs) so each image builds independently and in parallel.

**Before:** The Makefile `image` target cross-compiled every binary on the host, renamed them with arch suffixes into `bin/`, then each Dockerfile just `COPY`'d the pre-built binary. The release workflow ran 2 matrix jobs (one per arch), each sequentially building all 10 images. A failure in any one image failed the entire arch job.

**After:** Each Dockerfile compiles its own binary in a `golang:1.25` build stage (`build` for server images, `build-capture` for agent images that need `kelos-capture`). The release workflow uses `docker/build-push-action@v6` with an `image × arch` matrix and GHA layer caching, producing 20 parallel jobs with `fail-fast: false`.

**Key changes:**
- **Server Dockerfiles** (`kelos-controller`, `kelos-spawner`, `ghproxy`, `kelos-webhook-server`, `kelos-slack-server`): added `golang:1.25` build stage, version injected via `LDFLAGS` build-arg, binary copied into `distroless/static` runtime stage
- **Agent Dockerfiles** (`claude-code`, `codex`, `gemini`, `opencode`, `cursor`): added `build-capture` stage that compiles `kelos-capture`, replacing `COPY bin/kelos-capture-linux-${TARGETARCH}` with `COPY --from=build-capture`
- **Makefile**: removed pre-compilation loops from `image` target, now just runs `docker buildx build` with `--build-arg LDFLAGS`
- **release.yaml**: `build-images` job uses `image × arch` matrix, `docker/build-push-action@v6`, GHA cache scoped per image+arch, dropped `setup-go` (Go toolchain now lives in Docker)
- **`.dockerignore`**: added to keep build context small (`bin/`, `.git/`, test artifacts, `.env`)

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The `merge-manifests` job is unchanged — it still loops over `IMAGE_DIRS` and stitches per-arch tags into multi-arch manifests
- `release-artifacts` (CLI cross-compile) and `publish-helm-chart` are untouched
- `deploy-dev.yaml` only calls `make build WHAT=cmd/kelos` (host build for CLI), so it's unaffected
- `local-run.sh` still works — `make image` defaults to single-platform `linux/$(LOCAL_ARCH)` with `--load`
- GHA cache uses 20 scoped entries (one per image+arch combo); watch cache quota if it becomes a concern

#### Does this PR introduce a user-facing change?

```release-note
NONE
```