### PR TITLE
feat(slack): add centralized Slack reporting with Block Kit formatting

### DIFF
--- a/cmd/kelos-slack-server/main.go
+++ b/cmd/kelos-slack-server/main.go
@@ -5,17 +5,23 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	"github.com/kelos-dev/kelos/internal/logging"
+	"github.com/kelos-dev/kelos/internal/reporting"
 	kelosslack "github.com/kelos-dev/kelos/internal/slack"
 )
 
@@ -34,17 +40,30 @@ func main() {
 		metricsAddr          string
 		probeAddr            string
 		enableLeaderElection bool
+		reportingInterval    time.Duration
+		activityInterval     time.Duration
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager.")
+	flag.DurationVar(&reportingInterval, "reporting-interval", 30*time.Second, "How often to run the Slack reporting cycle.")
+	flag.DurationVar(&activityInterval, "activity-interval", 5*time.Second, "How often to update Slack activity indicators.")
 
 	opts, applyVerbosity := logging.SetupZapOptions(flag.CommandLine)
 	flag.Parse()
 
 	if err := applyVerbosity(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if reportingInterval <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: --reporting-interval must be positive\n")
+		os.Exit(1)
+	}
+	if activityInterval <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: --activity-interval must be positive\n")
 		os.Exit(1)
 	}
 
@@ -66,6 +85,12 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "Unable to start manager")
+		os.Exit(1)
+	}
+
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "Unable to create Kubernetes clientset")
 		os.Exit(1)
 	}
 
@@ -91,6 +116,36 @@ func main() {
 	// one replica opens the single-connection Socket Mode WebSocket.
 	if err := mgr.Add(&slackRunnable{handler: handler}); err != nil {
 		setupLog.Error(err, "Unable to register Slack handler with manager")
+		os.Exit(1)
+	}
+
+	// Build the shared SlackTaskReporter used by both the reporting and
+	// activity loops. Sharing the instance ensures activity state is
+	// correctly cleared when a progress snapshot is posted.
+	slackReporter := &reporting.SlackTaskReporter{
+		Client:         mgr.GetClient(),
+		Reporter:       &reporting.SlackReporter{BotToken: botToken},
+		ProgressReader: &reporting.DefaultProgressReader{Clientset: clientset},
+		ActivityReader: &reporting.DefaultActivityReader{Clientset: clientset},
+	}
+
+	// Register reporting loop as a leader-elected runnable.
+	if err := mgr.Add(&reportingRunnable{
+		client:   mgr.GetClient(),
+		reporter: slackReporter,
+		interval: reportingInterval,
+	}); err != nil {
+		setupLog.Error(err, "Unable to register reporting loop with manager")
+		os.Exit(1)
+	}
+
+	// Register activity indicator loop as a leader-elected runnable.
+	if err := mgr.Add(&activityRunnable{
+		client:   mgr.GetClient(),
+		reporter: slackReporter,
+		interval: activityInterval,
+	}); err != nil {
+		setupLog.Error(err, "Unable to register activity loop with manager")
 		os.Exit(1)
 	}
 
@@ -127,3 +182,105 @@ func (r *slackRunnable) Start(ctx context.Context) error {
 }
 
 func (r *slackRunnable) NeedLeaderElection() bool { return true }
+
+// reportingRunnable wraps the reporting loop as a leader-elected manager.Runnable.
+type reportingRunnable struct {
+	client   client.Client
+	reporter *reporting.SlackTaskReporter
+	interval time.Duration
+}
+
+func (r *reportingRunnable) Start(ctx context.Context) error {
+	setupLog.Info("Starting Slack reporting loop", "interval", r.interval)
+	runReportingLoop(ctx, r.client, r.reporter, r.interval)
+	return nil
+}
+
+func (r *reportingRunnable) NeedLeaderElection() bool { return true }
+
+// activityRunnable wraps the activity indicator loop as a leader-elected
+// manager.Runnable. It shares the SlackTaskReporter with the reporting loop.
+type activityRunnable struct {
+	client   client.Client
+	reporter *reporting.SlackTaskReporter
+	interval time.Duration
+}
+
+func (r *activityRunnable) Start(ctx context.Context) error {
+	setupLog.Info("Starting Slack activity indicator loop", "interval", r.interval)
+	runActivityLoop(ctx, r.client, r.reporter, r.interval)
+	return nil
+}
+
+func (r *activityRunnable) NeedLeaderElection() bool { return true }
+
+// runReportingLoop periodically reports Slack task status for ALL Slack-annotated
+// Tasks cluster-wide. This replaces the per-TaskSpawner reporting that previously
+// ran in each spawner pod.
+func runReportingLoop(ctx context.Context, cl client.Client, slackReporter *reporting.SlackTaskReporter, interval time.Duration) {
+	log := ctrl.Log.WithName("slack-reporter")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := runSlackReportingCycle(ctx, cl, slackReporter, log); err != nil {
+				log.Error(err, "Reporting cycle failed")
+			}
+		}
+	}
+}
+
+// runSlackReportingCycle lists all Tasks with Slack reporting enabled and
+// reports their status. Unlike the spawner version, this is not scoped to
+// a single TaskSpawner.
+func runSlackReportingCycle(ctx context.Context, cl client.Client, reporter *reporting.SlackTaskReporter, log logr.Logger) error {
+	var taskList kelosv1alpha1.TaskList
+	if err := cl.List(ctx, &taskList, client.MatchingLabels{reporting.LabelSlackReporting: "enabled"}); err != nil {
+		return fmt.Errorf("Listing tasks for Slack reporting: %w", err)
+	}
+
+	activeUIDs := make(map[types.UID]bool, len(taskList.Items))
+	for i := range taskList.Items {
+		task := &taskList.Items[i]
+		activeUIDs[task.UID] = true
+		if err := reporter.ReportTaskStatus(ctx, task); err != nil {
+			log.Error(err, "Failed to report task status",
+				"task", task.Name, "namespace", task.Namespace)
+		}
+	}
+
+	reporter.SweepProgressCache(activeUIDs)
+
+	return nil
+}
+
+// runActivityLoop periodically updates activity indicators for running tasks.
+// It runs on a faster cadence than the reporting loop.
+func runActivityLoop(ctx context.Context, cl client.Client, reporter *reporting.SlackTaskReporter, interval time.Duration) {
+	log := ctrl.Log.WithName("slack-activity")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			var taskList kelosv1alpha1.TaskList
+			if err := cl.List(ctx, &taskList, client.MatchingLabels{reporting.LabelSlackReporting: "enabled"}); err != nil {
+				log.Error(err, "Listing tasks for activity update")
+				continue
+			}
+
+			for i := range taskList.Items {
+				reporter.UpdateActivityIndicator(ctx, &taskList.Items[i])
+			}
+		}
+	}
+}

--- a/internal/reporting/activity.go
+++ b/internal/reporting/activity.go
@@ -1,0 +1,434 @@
+package reporting
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// idlePhrases are shown when the agent is active but not executing a tool.
+// The slice is cycled through based on a hash of the task UID plus a tick
+// index so each task starts at a different position.
+var idlePhrases = []string{
+	"Thinking...",
+	"Pondering...",
+	"Reasoning...",
+	"Analyzing...",
+	"Working...",
+	"Processing...",
+	"Considering...",
+	"Evaluating...",
+	"Deliberating...",
+	"Reflecting...",
+	"Synthesizing...",
+	"Formulating...",
+	"Investigating...",
+	"Examining...",
+	"Contemplating...",
+}
+
+// IdlePhrase returns a rotating idle phrase for a given task UID and tick
+// index. The starting position is derived from the UID so different tasks
+// do not all begin with "Thinking...".
+func IdlePhrase(uid string, tick int) string {
+	h := fnv.New32a()
+	h.Write([]byte(uid))
+	n := len(idlePhrases)
+	offset := int(h.Sum32() % uint32(n))
+	return idlePhrases[(offset+tick%n)%n]
+}
+
+// ActivityReader reads a short activity string from a running task's pod logs.
+type ActivityReader interface {
+	ReadActivity(ctx context.Context, namespace, podName, container, agentType string) string
+}
+
+// DefaultActivityReader reads activity from Kubernetes pod logs.
+type DefaultActivityReader struct {
+	Clientset kubernetes.Interface
+}
+
+// ReadActivity reads the tail of a running pod's logs and extracts a short
+// activity string describing the agent's current action. Returns empty string
+// on any error (best-effort).
+func (r *DefaultActivityReader) ReadActivity(ctx context.Context, namespace, podName, container, agentType string) string {
+	log := ctrl.Log.WithName("activity-reader")
+
+	var tailLines int64 = 50
+	stream, err := r.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: container,
+		TailLines: &tailLines,
+	}).Stream(ctx)
+	if err != nil {
+		log.V(1).Info("Unable to read pod logs for activity", "pod", podName, "error", err)
+		return ""
+	}
+	defer stream.Close()
+
+	return ExtractActivity(stream, agentType)
+}
+
+// ExtractActivity parses NDJSON log lines and returns a short human-readable
+// string describing the agent's most recent action. Returns empty string if
+// no actionable event is found.
+func ExtractActivity(r io.Reader, agentType string) string {
+	switch agentType {
+	case "codex":
+		return extractCodexActivity(r)
+	case "gemini":
+		return extractGeminiActivity(r)
+	case "opencode":
+		return extractOpenCodeActivity(r)
+	case "claude-code", "cursor", "":
+		return extractClaudeActivity(r)
+	default:
+		return ""
+	}
+}
+
+// extractClaudeActivity parses Claude Code NDJSON and returns an activity
+// string from the most recent tool_use or assistant text.
+func extractClaudeActivity(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastActivity string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event claudeActivityEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		if event.Type != "assistant" || event.Message == nil {
+			continue
+		}
+
+		for _, block := range event.Message.Content {
+			switch block.Type {
+			case "tool_use":
+				if s := claudeToolActivity(block.Name, block.Input); s != "" {
+					lastActivity = s
+				}
+			case "text":
+				// Text block means the agent moved past any prior tool_use.
+				// Clear tool activity so the caller falls back to idle phrases.
+				lastActivity = ""
+			}
+		}
+	}
+
+	return lastActivity
+}
+
+// claudeToolActivity returns a short activity string for a Claude tool_use block.
+func claudeToolActivity(toolName string, raw json.RawMessage) string {
+	var input map[string]interface{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &input); err != nil {
+			input = nil
+		}
+	}
+
+	switch toolName {
+	case "Read":
+		if p := activityStringField(input, "file_path"); p != "" {
+			return fmt.Sprintf("Reading `%s`...", shortenPath(p))
+		}
+		return "Reading file..."
+	case "Write":
+		if p := activityStringField(input, "file_path"); p != "" {
+			return fmt.Sprintf("Writing `%s`...", shortenPath(p))
+		}
+		return "Writing file..."
+	case "Edit":
+		if p := activityStringField(input, "file_path"); p != "" {
+			return fmt.Sprintf("Editing `%s`...", shortenPath(p))
+		}
+		return "Editing file..."
+	case "Bash":
+		if cmd := activityStringField(input, "command"); cmd != "" {
+			return fmt.Sprintf("Running `%s`...", truncateActivity(cmd, 50))
+		}
+		return "Running command..."
+	case "Glob":
+		if p := activityStringField(input, "pattern"); p != "" {
+			return fmt.Sprintf("Searching for `%s`...", truncateActivity(p, 50))
+		}
+		return "Searching files..."
+	case "Grep":
+		if p := activityStringField(input, "pattern"); p != "" {
+			return fmt.Sprintf("Searching for `%s`...", truncateActivity(p, 50))
+		}
+		return "Searching code..."
+	case "WebFetch":
+		return "Fetching web page..."
+	case "WebSearch":
+		if q := activityStringField(input, "query"); q != "" {
+			return fmt.Sprintf("Searching `%s`...", truncateActivity(q, 50))
+		}
+		return "Searching the web..."
+	case "Task":
+		return "Managing tasks..."
+	default:
+		if toolName != "" {
+			return fmt.Sprintf("Using %s...", toolName)
+		}
+		return ""
+	}
+}
+
+// extractCodexActivity parses Codex NDJSON and returns an activity string.
+func extractCodexActivity(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastActivity string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event codexActivityEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "item.started":
+			if event.Item != nil {
+				switch event.Item.Type {
+				case "command_execution":
+					if event.Item.Command != "" {
+						lastActivity = fmt.Sprintf("Running `%s`...", truncateActivity(event.Item.Command, 50))
+					} else {
+						lastActivity = "Running command..."
+					}
+				case "agent_message":
+					lastActivity = ""
+				}
+			}
+		}
+	}
+
+	return lastActivity
+}
+
+// extractGeminiActivity parses Gemini NDJSON and returns an activity string.
+func extractGeminiActivity(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastActivity string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event geminiActivityEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "tool_use":
+			if s := geminiToolActivity(event.ToolName, event.Parameters); s != "" {
+				lastActivity = s
+			}
+		case "message":
+			if event.Role == "assistant" {
+				lastActivity = ""
+			}
+		}
+	}
+
+	return lastActivity
+}
+
+// geminiToolActivity returns a short activity string for a Gemini tool_use event.
+func geminiToolActivity(toolName string, raw json.RawMessage) string {
+	var params map[string]interface{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			params = nil
+		}
+	}
+
+	switch toolName {
+	case "Bash", "Shell":
+		if cmd := activityStringField(params, "command"); cmd != "" {
+			return fmt.Sprintf("Running `%s`...", truncateActivity(cmd, 50))
+		}
+		return "Running command..."
+	case "ReadFile":
+		p := activityStringField(params, "file_path")
+		if p == "" {
+			p = activityStringField(params, "path")
+		}
+		if p != "" {
+			return fmt.Sprintf("Reading `%s`...", shortenPath(p))
+		}
+		return "Reading file..."
+	case "WriteFile":
+		p := activityStringField(params, "file_path")
+		if p == "" {
+			p = activityStringField(params, "path")
+		}
+		if p != "" {
+			return fmt.Sprintf("Writing `%s`...", shortenPath(p))
+		}
+		return "Writing file..."
+	case "EditFile":
+		p := activityStringField(params, "file_path")
+		if p == "" {
+			p = activityStringField(params, "path")
+		}
+		if p != "" {
+			return fmt.Sprintf("Editing `%s`...", shortenPath(p))
+		}
+		return "Editing file..."
+	case "Glob", "Grep":
+		if p := activityStringField(params, "pattern"); p != "" {
+			return fmt.Sprintf("Searching for `%s`...", truncateActivity(p, 50))
+		}
+		return "Searching..."
+	case "WebFetch":
+		return "Fetching web page..."
+	case "WebSearch":
+		if q := activityStringField(params, "query"); q != "" {
+			return fmt.Sprintf("Searching `%s`...", truncateActivity(q, 50))
+		}
+		return "Searching the web..."
+	default:
+		if toolName != "" {
+			return fmt.Sprintf("Using %s...", toolName)
+		}
+		return ""
+	}
+}
+
+// extractOpenCodeActivity parses OpenCode NDJSON and returns an activity string.
+func extractOpenCodeActivity(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastActivity string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event openCodeActivityEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "step_start":
+			lastActivity = "Working..."
+		case "text":
+			lastActivity = ""
+		}
+	}
+
+	return lastActivity
+}
+
+// shortenPath returns the last two path components (dir/file) for brevity.
+func shortenPath(p string) string {
+	p = strings.ReplaceAll(p, "\n", "")
+	dir := filepath.Dir(p)
+	base := filepath.Base(p)
+	parent := filepath.Base(dir)
+	if parent == "." || parent == "/" {
+		return base
+	}
+	return parent + "/" + base
+}
+
+// truncateActivity truncates a string to maxLen runes, appending "..." if needed.
+func truncateActivity(s string, maxLen int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxLen]) + "..."
+}
+
+// activityStringField returns a string field from a map, or empty string.
+func activityStringField(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// Minimal NDJSON structs for activity parsing.
+
+type claudeActivityEvent struct {
+	Type    string                  `json:"type"`
+	Message *claudeActivityMsgBlock `json:"message,omitempty"`
+}
+
+type claudeActivityMsgBlock struct {
+	Content []claudeActivityContentBlock `json:"content,omitempty"`
+}
+
+type claudeActivityContentBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+type codexActivityEvent struct {
+	Type string             `json:"type"`
+	Item *codexActivityItem `json:"item,omitempty"`
+}
+
+type codexActivityItem struct {
+	Type    string `json:"type"`
+	Command string `json:"command,omitempty"`
+}
+
+type geminiActivityEvent struct {
+	Type       string          `json:"type"`
+	Role       string          `json:"role,omitempty"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+}
+
+type openCodeActivityEvent struct {
+	Type string `json:"type"`
+}

--- a/internal/reporting/activity_test.go
+++ b/internal/reporting/activity_test.go
@@ -1,0 +1,348 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractClaudeActivity_ToolUse(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "read file",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/home/user/project/src/main.go"}}]}}`,
+			want:  "Reading `src/main.go`...",
+		},
+		{
+			name:  "edit file",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/project/internal/handler.go"}}]}}`,
+			want:  "Editing `internal/handler.go`...",
+		},
+		{
+			name:  "write file",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/project/new_file.go"}}]}}`,
+			want:  "Writing `project/new_file.go`...",
+		},
+		{
+			name:  "bash command",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"make test"}}]}}`,
+			want:  "Running `make test`...",
+		},
+		{
+			name:  "grep pattern",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"func main"}}]}}`,
+			want:  "Searching for `func main`...",
+		},
+		{
+			name:  "glob pattern",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Glob","input":{"pattern":"**/*.go"}}]}}`,
+			want:  "Searching for `**/*.go`...",
+		},
+		{
+			name:  "web fetch",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WebFetch","input":{"url":"https://example.com"}}]}}`,
+			want:  "Fetching web page...",
+		},
+		{
+			name:  "web search",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WebSearch","input":{"query":"golang rate limiter"}}]}}`,
+			want:  "Searching `golang rate limiter`...",
+		},
+		{
+			name:  "unknown tool",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"CustomTool","input":{}}]}}`,
+			want:  "Using CustomTool...",
+		},
+		{
+			name:  "text block clears tool activity",
+			input: `{"type":"assistant","message":{"content":[{"type":"text","text":"Let me analyze this code."}]}}`,
+			want:  "",
+		},
+		{
+			name: "last tool wins",
+			input: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a/b.go"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"go build"}}]}}`,
+			want: "Running `go build`...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractActivity(strings.NewReader(tt.input), "claude-code")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractClaudeActivity_Empty(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty input", ""},
+		{"non-json", "this is not json"},
+		{"system event", `{"type":"system","subtype":"init"}`},
+		{"result event", `{"type":"result","is_error":false}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractActivity(strings.NewReader(tt.input), "claude-code")
+			if got != "" {
+				t.Errorf("got %q, want empty string", got)
+			}
+		})
+	}
+}
+
+func TestExtractClaudeActivity_CursorAgentType(t *testing.T) {
+	input := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/project/main.go"}}]}}`
+	got := ExtractActivity(strings.NewReader(input), "cursor")
+	if got != "Reading `project/main.go`..." {
+		t.Errorf("got %q, want %q", got, "Reading `project/main.go`...")
+	}
+}
+
+func TestExtractClaudeActivity_DefaultAgentType(t *testing.T) {
+	input := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`
+	got := ExtractActivity(strings.NewReader(input), "")
+	if got != "Running `ls`..." {
+		t.Errorf("got %q, want %q", got, "Running `ls`...")
+	}
+}
+
+func TestExtractCodexActivity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "command execution",
+			input: `{"type":"item.started","item":{"type":"command_execution","command":"npm test"}}`,
+			want:  "Running `npm test`...",
+		},
+		{
+			name:  "agent message clears tool activity",
+			input: `{"type":"item.started","item":{"type":"agent_message"}}`,
+			want:  "",
+		},
+		{
+			name:  "empty command",
+			input: `{"type":"item.started","item":{"type":"command_execution"}}`,
+			want:  "Running command...",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractActivity(strings.NewReader(tt.input), "codex")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractGeminiActivity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "shell command",
+			input: `{"type":"tool_use","tool_name":"Shell","parameters":{"command":"make build"}}`,
+			want:  "Running `make build`...",
+		},
+		{
+			name:  "read file",
+			input: `{"type":"tool_use","tool_name":"ReadFile","parameters":{"file_path":"/src/app.ts"}}`,
+			want:  "Reading `src/app.ts`...",
+		},
+		{
+			name:  "write file",
+			input: `{"type":"tool_use","tool_name":"WriteFile","parameters":{"file_path":"/src/config.yaml"}}`,
+			want:  "Writing `src/config.yaml`...",
+		},
+		{
+			name:  "edit file",
+			input: `{"type":"tool_use","tool_name":"EditFile","parameters":{"file_path":"/src/handler.go"}}`,
+			want:  "Editing `src/handler.go`...",
+		},
+		{
+			name:  "assistant message clears tool activity",
+			input: `{"type":"message","role":"assistant","content":"Let me check."}`,
+			want:  "",
+		},
+		{
+			name:  "unknown tool",
+			input: `{"type":"tool_use","tool_name":"SpecialTool","parameters":{}}`,
+			want:  "Using SpecialTool...",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractActivity(strings.NewReader(tt.input), "gemini")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractOpenCodeActivity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "step start",
+			input: `{"type":"step_start"}`,
+			want:  "Working...",
+		},
+		{
+			name:  "text event clears tool activity",
+			input: `{"type":"text","text":"analyzing..."}`,
+			want:  "",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractActivity(strings.NewReader(tt.input), "opencode")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractActivity_UnknownAgentType(t *testing.T) {
+	got := ExtractActivity(strings.NewReader(`{"type":"assistant"}`), "unknown-agent")
+	if got != "" {
+		t.Errorf("got %q, want empty for unknown agent type", got)
+	}
+}
+
+func TestShortenPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/home/user/project/src/main.go", "src/main.go"},
+		{"/single.go", "single.go"},
+		{"relative.go", "relative.go"},
+		{"/a/b/c/d/e.go", "d/e.go"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := shortenPath(tt.input)
+			if got != tt.want {
+				t.Errorf("shortenPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateActivity(t *testing.T) {
+	short := "hello"
+	got := truncateActivity(short, 10)
+	if got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+
+	long := strings.Repeat("a", 60)
+	got = truncateActivity(long, 50)
+	if len([]rune(got)) != 53 { // 50 + "..."
+		t.Errorf("truncated length = %d, want 53", len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("got %q, want ... suffix", got)
+	}
+
+	// newlines collapsed
+	got = truncateActivity("line1\nline2", 50)
+	if got != "line1 line2" {
+		t.Errorf("got %q, want %q", got, "line1 line2")
+	}
+}
+
+func TestClaudeToolActivity_NoInput(t *testing.T) {
+	got := claudeToolActivity("Read", nil)
+	if got != "Reading file..." {
+		t.Errorf("got %q, want %q", got, "Reading file...")
+	}
+}
+
+func TestClaudeToolActivity_EmptyToolName(t *testing.T) {
+	got := claudeToolActivity("", nil)
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestExtractClaudeActivity_TextClearsToolActivity(t *testing.T) {
+	// A tool_use followed by a text block should return empty, not the tool activity.
+	input := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a/b.go"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I see the issue now."}]}}`
+	got := ExtractActivity(strings.NewReader(input), "claude-code")
+	if got != "" {
+		t.Errorf("got %q, want empty (text should clear tool activity)", got)
+	}
+}
+
+func TestIdlePhrase_Rotates(t *testing.T) {
+	// Successive ticks should produce different phrases.
+	a := IdlePhrase("test-uid", 0)
+	b := IdlePhrase("test-uid", 1)
+	if a == b {
+		t.Errorf("expected different phrases for consecutive ticks, got %q both times", a)
+	}
+}
+
+func TestIdlePhrase_DifferentUIDs(t *testing.T) {
+	// Different UIDs at the same tick should (usually) start at different offsets.
+	a := IdlePhrase("uid-aaa", 0)
+	b := IdlePhrase("uid-bbb", 0)
+	if a == b {
+		t.Logf("same phrase for different UIDs at tick 0: %q (possible but unlikely)", a)
+	}
+}
+
+func TestIdlePhrase_ValidPhrase(t *testing.T) {
+	phrase := IdlePhrase("any-uid", 42)
+	found := false
+	for _, p := range idlePhrases {
+		if p == phrase {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("IdlePhrase returned %q which is not in idlePhrases", phrase)
+	}
+}

--- a/internal/reporting/progress.go
+++ b/internal/reporting/progress.go
@@ -1,0 +1,255 @@
+package reporting
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// maxProgressLen is the maximum number of runes for a progress message.
+const maxProgressLen = 500
+
+// ProgressReader reads the latest assistant text from a running task's pod logs.
+type ProgressReader interface {
+	ReadProgress(ctx context.Context, namespace, podName, container, agentType string) string
+}
+
+// DefaultProgressReader reads progress from Kubernetes pod logs.
+type DefaultProgressReader struct {
+	Clientset kubernetes.Interface
+}
+
+// ReadProgress reads the tail of a running pod's logs and extracts the latest
+// assistant text. Returns empty string on any error (best-effort).
+func (r *DefaultProgressReader) ReadProgress(ctx context.Context, namespace, podName, container, agentType string) string {
+	log := ctrl.Log.WithName("progress-reader")
+
+	var tailLines int64 = 300
+	stream, err := r.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: container,
+		TailLines: &tailLines,
+	}).Stream(ctx)
+	if err != nil {
+		log.V(1).Info("Unable to read pod logs for progress", "pod", podName, "error", err)
+		return ""
+	}
+	defer stream.Close()
+
+	return ExtractLatestAssistantText(stream, agentType)
+}
+
+// ExtractLatestAssistantText parses NDJSON log lines and returns the text from
+// the most recent assistant turn. Returns empty string if no text is found.
+func ExtractLatestAssistantText(r io.Reader, agentType string) string {
+	switch agentType {
+	case "codex":
+		return extractCodexText(r)
+	case "gemini":
+		return extractGeminiText(r)
+	case "opencode":
+		return extractOpenCodeText(r)
+	case "claude-code", "cursor", "":
+		return extractClaudeText(r)
+	default:
+		return ""
+	}
+}
+
+// extractClaudeText parses Claude Code NDJSON and returns text from the last
+// assistant turn.
+func extractClaudeText(r io.Reader) string {
+	log := ctrl.Log.WithName("progress-reader")
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastText string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event claudeEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		if event.Type != "assistant" || event.Message == nil {
+			continue
+		}
+
+		// Collect all text blocks from this turn
+		var parts []string
+		for _, block := range event.Message.Content {
+			if block.Type == "text" && block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		if len(parts) > 0 {
+			lastText = strings.Join(parts, "\n")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.V(1).Info("Scanner error reading Claude progress", "error", err)
+	}
+
+	return truncate(lastText)
+}
+
+// extractCodexText parses Codex NDJSON and returns text from the last agent message.
+func extractCodexText(r io.Reader) string {
+	log := ctrl.Log.WithName("progress-reader")
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastText string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event codexProgressEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		if event.Type == "item.completed" && event.Item != nil &&
+			event.Item.Type == "agent_message" && event.Item.Text != "" {
+			lastText = event.Item.Text
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.V(1).Info("Scanner error reading Codex progress", "error", err)
+	}
+
+	return truncate(lastText)
+}
+
+// extractGeminiText parses Gemini NDJSON and returns text from the last
+// assistant message.
+func extractGeminiText(r io.Reader) string {
+	log := ctrl.Log.WithName("progress-reader")
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastText string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event geminiProgressEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		if event.Type == "message" && event.Role == "assistant" &&
+			!event.Delta && event.Content != "" {
+			lastText = event.Content
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.V(1).Info("Scanner error reading Gemini progress", "error", err)
+	}
+
+	return truncate(lastText)
+}
+
+// extractOpenCodeText parses OpenCode NDJSON and returns text from the last
+// text event.
+func extractOpenCodeText(r io.Reader) string {
+	log := ctrl.Log.WithName("progress-reader")
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var lastText string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event openCodeProgressEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		if event.Type == "text" && event.Text != "" {
+			lastText = event.Text
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.V(1).Info("Scanner error reading OpenCode progress", "error", err)
+	}
+
+	return truncate(lastText)
+}
+
+// truncate trims text to maxProgressLen runes, appending "..." if truncated.
+func truncate(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= maxProgressLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxProgressLen]) + "..."
+}
+
+// Minimal NDJSON structs — local copies to avoid cross-package dependency on
+// internal/cli.
+
+type claudeEvent struct {
+	Type    string              `json:"type"`
+	Message *claudeMessageBlock `json:"message,omitempty"`
+}
+
+type claudeMessageBlock struct {
+	Content []claudeContentBlock `json:"content,omitempty"`
+}
+
+type claudeContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type codexProgressEvent struct {
+	Type string          `json:"type"`
+	Item *codexItemBlock `json:"item,omitempty"`
+}
+
+type codexItemBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type geminiProgressEvent struct {
+	Type    string `json:"type"`
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+	Delta   bool   `json:"delta,omitempty"`
+}
+
+type openCodeProgressEvent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}

--- a/internal/reporting/progress_test.go
+++ b/internal/reporting/progress_test.go
@@ -1,0 +1,175 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractLatestAssistantText_ClaudeCode(t *testing.T) {
+	logs := strings.Join([]string{
+		`{"type":"system","subtype":"init","model":"claude-sonnet-4-20250514"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at the configuration files..."}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Found the issue in the auth middleware."}]}}`,
+	}, "\n")
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	want := "Found the issue in the auth middleware."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractLatestAssistantText_ClaudeCodeMultipleTextBlocks(t *testing.T) {
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"First part."},{"type":"tool_use","name":"Read"},{"type":"text","text":"Second part."}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	want := "First part.\nSecond part."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractLatestAssistantText_ClaudeCodeIgnoresToolUseOnly(t *testing.T) {
+	logs := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	if got != "" {
+		t.Errorf("expected empty string for tool-use-only turn, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_EmptyLogs(t *testing.T) {
+	got := ExtractLatestAssistantText(strings.NewReader(""), "claude-code")
+	if got != "" {
+		t.Errorf("expected empty string for empty logs, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_NonJSON(t *testing.T) {
+	logs := "not json at all\nanother line\n"
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	if got != "" {
+		t.Errorf("expected empty string for non-JSON logs, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_Truncation(t *testing.T) {
+	longText := strings.Repeat("a", 600)
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"` + longText + `"}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	wantLen := maxProgressLen + len("...")
+	if len([]rune(got)) != wantLen {
+		t.Errorf("expected truncated length %d, got %d", wantLen, len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Error("expected truncated text to end with ...")
+	}
+}
+
+func TestExtractLatestAssistantText_NoTruncationAtLimit(t *testing.T) {
+	text := strings.Repeat("b", maxProgressLen)
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"` + text + `"}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	if got != text {
+		t.Errorf("text at exactly maxProgressLen should not be truncated")
+	}
+}
+
+func TestExtractLatestAssistantText_UnknownAgent(t *testing.T) {
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "unknown-agent")
+	if got != "" {
+		t.Errorf("expected empty string for unknown agent, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_EmptyAgentType(t *testing.T) {
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "")
+	if got != "hello" {
+		t.Errorf("empty agent type should default to claude-code, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_Codex(t *testing.T) {
+	logs := strings.Join([]string{
+		`{"type":"turn.started"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"Checking the release tags..."}}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"Found the merge commit."}}`,
+	}, "\n")
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "codex")
+	want := "Found the merge commit."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractLatestAssistantText_CodexIgnoresNonAgentMessage(t *testing.T) {
+	logs := `{"type":"item.completed","item":{"type":"command_execution","text":"ls -la"}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "codex")
+	if got != "" {
+		t.Errorf("expected empty string for non-agent-message item, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_Gemini(t *testing.T) {
+	logs := strings.Join([]string{
+		`{"type":"init","model":"gemini-2.5-pro"}`,
+		`{"type":"message","role":"assistant","content":"Searching for config files...","delta":false}`,
+		`{"type":"message","role":"assistant","content":"Found the issue.","delta":false}`,
+	}, "\n")
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "gemini")
+	want := "Found the issue."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractLatestAssistantText_GeminiIgnoresDelta(t *testing.T) {
+	logs := `{"type":"message","role":"assistant","content":"partial...","delta":true}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "gemini")
+	if got != "" {
+		t.Errorf("expected empty string for delta message, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_OpenCode(t *testing.T) {
+	logs := strings.Join([]string{
+		`{"type":"text","text":"Analyzing the codebase..."}`,
+		`{"type":"step_finish"}`,
+		`{"type":"text","text":"Identified the root cause."}`,
+	}, "\n")
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "opencode")
+	want := "Identified the root cause."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractLatestAssistantText_WhitespaceOnly(t *testing.T) {
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"   \n  "}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "claude-code")
+	if got != "" {
+		t.Errorf("expected empty string for whitespace-only text, got %q", got)
+	}
+}
+
+func TestExtractLatestAssistantText_CursorFallsBackToClaude(t *testing.T) {
+	logs := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello from cursor"}]}}`
+
+	got := ExtractLatestAssistantText(strings.NewReader(logs), "cursor")
+	if got != "hello from cursor" {
+		t.Errorf("cursor should use claude parser, got %q", got)
+	}
+}

--- a/internal/reporting/slack.go
+++ b/internal/reporting/slack.go
@@ -1,0 +1,331 @@
+package reporting
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/slack-go/slack"
+)
+
+// Slack's chat.postMessage text field limit is 40,000 characters.
+const slackFallbackTextLimit = 40000
+
+// decodeResponse decodes a base64-encoded agent response from task results.
+// Returns the raw string if decoding fails (backward compatibility).
+func decodeResponse(encoded string) string {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return encoded
+	}
+	return string(decoded)
+}
+
+// SlackMessage holds the components of a rich Slack message.
+type SlackMessage struct {
+	// Text is the fallback text shown in notifications and accessibility contexts.
+	Text string
+	// Blocks are the Block Kit blocks for rich formatting.
+	Blocks []slack.Block
+}
+
+// SlackReporter posts and updates thread replies in Slack channels.
+type SlackReporter struct {
+	// BotToken is the Bot User OAuth Token (xoxb-...).
+	BotToken string
+	client   *slack.Client
+	once     sync.Once
+}
+
+func (r *SlackReporter) api() *slack.Client {
+	r.once.Do(func() {
+		r.client = slack.New(r.BotToken)
+	})
+	return r.client
+}
+
+// PostThreadReply posts a new message as a thread reply and returns the
+// reply's message timestamp.
+func (r *SlackReporter) PostThreadReply(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(msg.Text, false),
+		slack.MsgOptionTS(threadTS),
+	}
+	if len(msg.Blocks) > 0 {
+		opts = append(opts, slack.MsgOptionBlocks(msg.Blocks...))
+	}
+	_, ts, err := r.api().PostMessageContext(ctx, channel, opts...)
+	if err != nil {
+		return "", fmt.Errorf("posting Slack thread reply: %w", err)
+	}
+	return ts, nil
+}
+
+// UpdateMessage updates an existing Slack message in place.
+func (r *SlackReporter) UpdateMessage(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(msg.Text, false),
+	}
+	if len(msg.Blocks) > 0 {
+		opts = append(opts, slack.MsgOptionBlocks(msg.Blocks...))
+	}
+	_, _, _, err := r.api().UpdateMessageContext(ctx, channel, messageTS, opts...)
+	if err != nil {
+		return fmt.Errorf("updating Slack message: %w", err)
+	}
+	return nil
+}
+
+// contextBlock returns a context block displaying the task name.
+func contextBlock(taskName string) *slack.ContextBlock {
+	return slack.NewContextBlock("",
+		slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("Task: `%s`", taskName), false, false),
+	)
+}
+
+// phaseHeaderText maps each phase to its leading Block Kit section text.
+// Phases without an entry (e.g. "succeeded") get no header block.
+var phaseHeaderText = map[string]string{
+	"accepted": ":hourglass_flowing_sand: *Working on your request...*",
+	"failed":   ":x: *Something went wrong*",
+}
+
+// phaseFallbackText maps each phase to its default fallback text (before the
+// "(Task: ...)" suffix) when no richer content is available.
+var phaseFallbackText = map[string]string{
+	"accepted":  "Working on your request...",
+	"succeeded": "Done!",
+	"failed":    "Failed.",
+}
+
+// FormatProgressMessage returns a Slack message with Block Kit blocks for
+// an in-progress agent snapshot. Using blocks (rather than text-only) allows
+// the activity indicator loop to append a context element showing the agent's
+// current action.
+func FormatProgressMessage(text, taskName string) SlackMessage {
+	blocks := responseToBlocks(text)
+	// Reserve 1 block for the trailing context block.
+	if len(blocks) > SlackBlockLimit-1 {
+		blocks = blocks[:SlackBlockLimit-1]
+	}
+	blocks = append(blocks, contextBlock(taskName))
+	return SlackMessage{
+		Text:   truncateFallbackText(text),
+		Blocks: blocks,
+	}
+}
+
+// FormatSlackTransitionMessage returns one or more rich Slack messages for a
+// task phase transition. When the agent response is short enough to fit in a
+// single message (≤ SlackBlockLimit blocks), a single SlackMessage is returned.
+// For longer responses, the response blocks are split across multiple messages
+// so that no individual message exceeds the Slack block limit, and each chunk
+// is posted as a separate thread reply.
+func FormatSlackTransitionMessage(phase, taskName, message string, results map[string]string) []SlackMessage {
+	// Build the optional header block (e.g. "Working on your request…").
+	var headerBlocks []slack.Block
+	if header, ok := phaseHeaderText[phase]; ok {
+		headerBlocks = append(headerBlocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, header, false, false),
+			nil, nil,
+		))
+	}
+
+	// Build the response blocks from the agent output.
+	resp := results["response"]
+	decoded := decodeResponse(resp)
+	var responseBlocks []slack.Block
+	if resp != "" {
+		responseBlocks = responseToBlocks(decoded)
+	}
+
+	// Build the trailing blocks (PR link, error, context).
+	var trailingBlocks []slack.Block
+	pr := results["pr"]
+	if pr != "" {
+		trailingBlocks = append(trailingBlocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf(":link: *Pull Request:* <%s>", pr), false, false),
+			nil, nil,
+		))
+	}
+
+	if message != "" && phase == "failed" {
+		trailingBlocks = append(trailingBlocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf(":warning: *Error:* %s", message), false, false),
+			nil, nil,
+		))
+	}
+
+	trailingBlocks = append(trailingBlocks, contextBlock(taskName))
+
+	fallbackText := buildFallbackText(decoded, pr, message, phase, taskName)
+
+	// Check if everything fits in a single message.
+	totalBlocks := len(headerBlocks) + len(responseBlocks) + len(trailingBlocks)
+	if totalBlocks <= SlackBlockLimit {
+		var blocks []slack.Block
+		blocks = append(blocks, headerBlocks...)
+		blocks = append(blocks, responseBlocks...)
+		blocks = append(blocks, trailingBlocks...)
+		return []SlackMessage{{Text: fallbackText, Blocks: blocks}}
+	}
+
+	// Split response blocks across multiple messages.
+	return splitResponseMessages(headerBlocks, responseBlocks, trailingBlocks, fallbackText, taskName)
+}
+
+// splitResponseMessages distributes response blocks across multiple messages
+// so that each message stays within the SlackBlockLimit. The first message
+// includes the header blocks, and the last message includes the trailing
+// blocks (PR link, error, context). Continuation messages get a part number
+// context block.
+func splitResponseMessages(headerBlocks, responseBlocks, trailingBlocks []slack.Block, fallbackText, taskName string) []SlackMessage {
+	// Reserve space in the first chunk for header blocks and either a
+	// continuation context block (1) or trailing blocks, whichever is larger.
+	firstReserve := 1
+	if len(trailingBlocks) > firstReserve {
+		firstReserve = len(trailingBlocks)
+	}
+	firstChunkCap := SlackBlockLimit - len(headerBlocks) - firstReserve
+	// Reserve space in the last chunk for trailing blocks.
+	lastChunkTrailing := len(trailingBlocks)
+
+	// Split the response blocks into chunks.
+	chunks := splitBlocks(responseBlocks, firstChunkCap, lastChunkTrailing)
+
+	if len(chunks) == 0 {
+		// No response blocks — single message with header + trailing.
+		var blocks []slack.Block
+		blocks = append(blocks, headerBlocks...)
+		blocks = append(blocks, trailingBlocks...)
+		return []SlackMessage{{Text: fallbackText, Blocks: blocks}}
+	}
+
+	totalParts := len(chunks)
+	var messages []SlackMessage
+
+	for i, chunk := range chunks {
+		var blocks []slack.Block
+		partNum := i + 1
+
+		if i == 0 {
+			// First message: header + first chunk of response blocks.
+			blocks = append(blocks, headerBlocks...)
+			blocks = append(blocks, chunk...)
+			if totalParts > 1 {
+				blocks = append(blocks, continuationContextBlock(taskName, partNum, totalParts))
+			} else {
+				blocks = append(blocks, trailingBlocks...)
+			}
+		} else if i == totalParts-1 {
+			// Last message: remaining response blocks + trailing blocks.
+			blocks = append(blocks, chunk...)
+			blocks = append(blocks, trailingBlocks...)
+		} else {
+			// Middle message: response blocks + continuation context.
+			blocks = append(blocks, chunk...)
+			blocks = append(blocks, continuationContextBlock(taskName, partNum, totalParts))
+		}
+
+		text := fallbackText
+		if i > 0 {
+			text = fmt.Sprintf("(continued, part %d/%d) (Task: %s)", partNum, totalParts, taskName)
+		}
+
+		messages = append(messages, SlackMessage{Text: text, Blocks: blocks})
+	}
+
+	return messages
+}
+
+// splitBlocks divides blocks into chunks. The first chunk has capacity
+// firstCap and the last chunk reserves lastReserve slots for trailing
+// blocks. Middle chunks use SlackBlockLimit minus max(1, lastReserve) to
+// ensure that even if a middle chunk ends up being the final one, the
+// trailing blocks still fit within the limit.
+func splitBlocks(blocks []slack.Block, firstCap, lastReserve int) [][]slack.Block {
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	var chunks [][]slack.Block
+	pos := 0
+
+	// First chunk.
+	end := pos + firstCap
+	if end > len(blocks) {
+		end = len(blocks)
+	}
+	chunks = append(chunks, blocks[pos:end])
+	pos = end
+
+	if pos >= len(blocks) {
+		return chunks
+	}
+
+	// Middle and last chunks.
+	for pos < len(blocks) {
+		remaining := len(blocks) - pos
+
+		// Check if remaining blocks fit in a final chunk with trailing
+		// blocks. Reserve 1 extra for the continuation context on middle
+		// chunks, but the last chunk uses trailing blocks instead.
+		if remaining <= SlackBlockLimit-lastReserve {
+			chunks = append(chunks, blocks[pos:])
+			break
+		}
+
+		// Middle chunk: full limit minus max(1, lastReserve) so that if
+		// this chunk ends up being the last one (consumed by
+		// splitResponseMessages as the final part), the trailing blocks
+		// still fit within SlackBlockLimit.
+		chunkSize := SlackBlockLimit - max(1, lastReserve)
+		end := pos + chunkSize
+		if end > len(blocks) {
+			end = len(blocks)
+		}
+		chunks = append(chunks, blocks[pos:end])
+		pos = end
+	}
+
+	return chunks
+}
+
+func buildFallbackText(decoded, pr, message, phase, taskName string) string {
+	var s string
+	switch {
+	case decoded != "" && pr != "" && message != "" && phase == "failed":
+		s = fmt.Sprintf("%s\nPR: %s\nError: %s (Task: %s)", decoded, pr, message, taskName)
+	case decoded != "" && pr != "":
+		s = fmt.Sprintf("%s\nPR: %s (Task: %s)", decoded, pr, taskName)
+	case decoded != "" && message != "" && phase == "failed":
+		s = fmt.Sprintf("%s\nError: %s (Task: %s)", decoded, message, taskName)
+	case decoded != "":
+		s = fmt.Sprintf("%s (Task: %s)", decoded, taskName)
+	case pr != "":
+		s = fmt.Sprintf("PR: %s (Task: %s)", pr, taskName)
+	case message != "" && phase == "failed":
+		s = fmt.Sprintf("Error: %s (Task: %s)", message, taskName)
+	default:
+		s = fmt.Sprintf("%s (Task: %s)", phaseFallbackText[phase], taskName)
+	}
+	return truncateFallbackText(s)
+}
+
+func truncateFallbackText(s string) string {
+	if utf8.RuneCountInString(s) <= slackFallbackTextLimit {
+		return s
+	}
+	return string([]rune(s)[:slackFallbackTextLimit-1]) + "…"
+}
+
+// continuationContextBlock returns a context block indicating a multi-part
+// message with the current part number and total.
+func continuationContextBlock(taskName string, part, total int) *slack.ContextBlock {
+	return slack.NewContextBlock("",
+		slack.NewTextBlockObject(slack.MarkdownType,
+			fmt.Sprintf("Task: `%s` · Part %d/%d", taskName, part, total), false, false),
+	)
+}

--- a/internal/reporting/slack_blocks.go
+++ b/internal/reporting/slack_blocks.go
@@ -1,0 +1,489 @@
+package reporting
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/slack-go/slack"
+)
+
+var (
+	// reBold matches **bold** syntax.
+	reBold = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	// reLink matches [text](url) syntax, allowing one level of balanced parentheses
+	// in the URL (e.g. Wikipedia/RFC links like https://en.wikipedia.org/wiki/Go_(language)).
+	reLink = regexp.MustCompile(`\[([^\]]+)\]\(([^)]*(?:\([^)]*\))[^)]*|[^)]+)\)`)
+	// reStrikethrough matches ~~text~~ syntax.
+	reStrikethrough = regexp.MustCompile(`~~(.+?)~~`)
+
+	// reInlineFormatting matches all inline formatting tokens that need
+	// special handling inside rich-text contexts (tables, lists).
+	// Groups:
+	//   1 — bold content        (**…**)
+	//   2 — strikethrough       (~~…~~)
+	//   3 — inline code         (`…`)
+	//   4 — md link text        [text](url)
+	//   5 — md link url
+	//   6 — slack link url      <url|text>
+	//   7 — slack link text
+	reInlineFormatting = regexp.MustCompile(
+		`\*\*(.+?)\*\*` + // bold
+			`|~~(.+?)~~` + // strikethrough
+			"|`([^`]+)`" + // inline code
+			`|\[([^\]]+)\]\(([^)]*(?:\([^)]*\))[^)]*|[^)]+)\)` + // [text](url)
+			`|<((?:https?://)[^|>]+)\|([^>]+)>`, // <url|text>
+	)
+)
+
+// convertInlineMarkdown converts standard inline Markdown (bold, links,
+// strikethrough) to Slack mrkdwn format. Headings are handled separately
+// as HeaderBlocks, so they are not converted here.
+func convertInlineMarkdown(s string) string {
+	s = reBold.ReplaceAllString(s, "*$1*")
+	s = reLink.ReplaceAllString(s, "<$2|$1>")
+	s = reStrikethrough.ReplaceAllString(s, "~$1~")
+	return s
+}
+
+// segmentType identifies a markdown content segment.
+type segmentType int
+
+const (
+	segPlain segmentType = iota
+	segTable
+	segList
+	segHeader
+	segDivider
+)
+
+// reInlineCode matches `code` spans.
+var reInlineCode = regexp.MustCompile("`([^`]+)`")
+
+// segment is a contiguous chunk of parsed markdown content.
+type segment struct {
+	typ   segmentType
+	lines []string
+	// header level (1-3) for segHeader segments.
+	level int
+}
+
+var (
+	// tableRowRe matches markdown table rows: | col1 | col2 |
+	tableRowRe = regexp.MustCompile(`^\s*\|(.+)\|\s*$`)
+	// tableSepRe matches the separator row: | --- | --- |
+	tableSepRe = regexp.MustCompile(`^\s*\|[\s\-:|]+\|\s*$`)
+	// headerRe matches markdown headers: # Header, ## Header, ### Header
+	headerRe = regexp.MustCompile(`^(#{1,3})\s+(.+)$`)
+	// unorderedListRe matches unordered list items: - item, * item, • item
+	unorderedListRe = regexp.MustCompile(`^(\s*)[-*•]\s+(.+)$`)
+	// orderedListRe matches ordered list items: 1. item, 2. item
+	orderedListRe = regexp.MustCompile(`^(\s*)\d+\.\s+(.+)$`)
+	// dividerRe matches horizontal rule lines: ---, ***, ___  (three or more of the same character)
+	dividerRe = regexp.MustCompile(`^\s*(?:---+|___+|\*\*\*+)\s*$`)
+)
+
+// parseMarkdownSegments splits markdown text into typed segments.
+func parseMarkdownSegments(text string) []segment {
+	lines := strings.Split(text, "\n")
+	var segments []segment
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+
+		// Check for divider (---, ***, ___).
+		// NOTE: This intentionally does not support CommonMark setext headings
+		// (e.g. "Header\n---"), which would render as a paragraph + divider.
+		if dividerRe.MatchString(line) {
+			segments = append(segments, segment{typ: segDivider})
+			i++
+			continue
+		}
+
+		// Check for header.
+		if m := headerRe.FindStringSubmatch(line); m != nil {
+			segments = append(segments, segment{
+				typ:   segHeader,
+				lines: []string{m[2]},
+				level: len(m[1]),
+			})
+			i++
+			continue
+		}
+
+		// Check for table start (need at least header row + separator + one data row).
+		if tableRowRe.MatchString(line) && i+1 < len(lines) && tableSepRe.MatchString(lines[i+1]) {
+			var tableLines []string
+			tableLines = append(tableLines, line)
+			j := i + 1
+			// Skip separator.
+			j++
+			// Collect data rows.
+			for j < len(lines) && tableRowRe.MatchString(lines[j]) && !tableSepRe.MatchString(lines[j]) {
+				tableLines = append(tableLines, lines[j])
+				j++
+			}
+			segments = append(segments, segment{typ: segTable, lines: tableLines})
+			i = j
+			continue
+		}
+
+		// Check for unordered list.
+		if unorderedListRe.MatchString(line) {
+			var listLines []string
+			j := i
+			for j < len(lines) {
+				if unorderedListRe.MatchString(lines[j]) {
+					listLines = append(listLines, lines[j])
+					j++
+				} else if strings.TrimSpace(lines[j]) == "" && j+1 < len(lines) && unorderedListRe.MatchString(lines[j+1]) {
+					// Skip blank lines between list items.
+					j++
+				} else {
+					break
+				}
+			}
+			segments = append(segments, segment{typ: segList, lines: listLines})
+			i = j
+			continue
+		}
+
+		// Check for ordered list.
+		if orderedListRe.MatchString(line) {
+			var listLines []string
+			j := i
+			for j < len(lines) {
+				if orderedListRe.MatchString(lines[j]) {
+					listLines = append(listLines, lines[j])
+					j++
+				} else if strings.TrimSpace(lines[j]) == "" && j+1 < len(lines) && orderedListRe.MatchString(lines[j+1]) {
+					// Skip blank lines between list items.
+					j++
+				} else {
+					break
+				}
+			}
+			segments = append(segments, segment{typ: segList, lines: listLines})
+			i = j
+			continue
+		}
+
+		// Plain text — accumulate consecutive non-special lines.
+		var plainLines []string
+		j := i
+		for j < len(lines) {
+			l := lines[j]
+			if dividerRe.MatchString(l) ||
+				headerRe.MatchString(l) ||
+				unorderedListRe.MatchString(l) ||
+				orderedListRe.MatchString(l) {
+				break
+			}
+			// Check if this starts a table.
+			if tableRowRe.MatchString(l) && j+1 < len(lines) && tableSepRe.MatchString(lines[j+1]) {
+				break
+			}
+			plainLines = append(plainLines, l)
+			j++
+		}
+		// Trim trailing empty lines from plain text.
+		for len(plainLines) > 0 && strings.TrimSpace(plainLines[len(plainLines)-1]) == "" {
+			plainLines = plainLines[:len(plainLines)-1]
+		}
+		if len(plainLines) > 0 {
+			segments = append(segments, segment{typ: segPlain, lines: plainLines})
+		}
+		// If nothing was consumed (blank lines between segments), advance past them.
+		if j == i {
+			i++
+		} else {
+			i = j
+		}
+	}
+
+	return segments
+}
+
+const (
+	// SlackBlockLimit is the maximum number of blocks Slack allows per message.
+	SlackBlockLimit = 50
+	// slackSectionTextLimit is the maximum character length for a section block's text.
+	slackSectionTextLimit = 3000
+	// slackHeaderTextLimit is the maximum character length for a header block's text.
+	slackHeaderTextLimit = 150
+)
+
+// responseToBlocks converts a markdown response string into Slack blocks.
+func responseToBlocks(text string) []slack.Block {
+	segments := parseMarkdownSegments(text)
+	var blocks []slack.Block
+
+	for _, seg := range segments {
+		switch seg.typ {
+		case segDivider:
+			blocks = append(blocks, slack.NewDividerBlock())
+		case segHeader:
+			blocks = append(blocks, headerBlock(seg.lines[0]))
+		case segTable:
+			if b := tableBlock(seg.lines); b != nil {
+				blocks = append(blocks, b)
+			}
+		case segList:
+			blocks = append(blocks, listBlock(seg.lines)...)
+		case segPlain:
+			joined := strings.Join(seg.lines, "\n")
+			if strings.TrimSpace(joined) != "" {
+				for _, chunk := range splitText(convertInlineMarkdown(joined), slackSectionTextLimit) {
+					if chunk == "" {
+						continue
+					}
+					blocks = append(blocks, slack.NewSectionBlock(
+						slack.NewTextBlockObject(slack.MarkdownType, chunk, false, false),
+						nil, nil,
+					))
+				}
+			}
+		}
+	}
+
+	return blocks
+}
+
+// headerBlock creates a Slack HeaderBlock from header text.
+// HeaderBlocks only support plain text, so backtick code spans are stripped.
+func headerBlock(text string) *slack.HeaderBlock {
+	text = reInlineCode.ReplaceAllString(text, "$1")
+	if utf8.RuneCountInString(text) > slackHeaderTextLimit {
+		text = string([]rune(text)[:slackHeaderTextLimit-1]) + "…"
+	}
+	return slack.NewHeaderBlock(
+		slack.NewTextBlockObject(slack.PlainTextType, text, false, false),
+	)
+}
+
+// tableBlock creates a Slack TableBlock from markdown table lines.
+// The first line is the header row; subsequent lines are data rows.
+func tableBlock(lines []string) *slack.TableBlock {
+	if len(lines) < 1 {
+		return nil
+	}
+
+	table := slack.NewTableBlock("")
+
+	// Parse header row to determine column count.
+	headerCells := parseCells(lines[0])
+	numCols := len(headerCells)
+
+	// Add header row.
+	table.AddRow(cellsToRichText(headerCells)...)
+
+	// Add data rows.
+	for _, line := range lines[1:] {
+		cells := parseCells(line)
+		// Pad or truncate to match column count.
+		for len(cells) < numCols {
+			cells = append(cells, "")
+		}
+		cells = cells[:numCols]
+		table.AddRow(cellsToRichText(cells)...)
+	}
+
+	return table
+}
+
+// parseCells extracts cell text from a markdown table row.
+func parseCells(row string) []string {
+	row = strings.TrimSpace(row)
+	row = strings.Trim(row, "|")
+	parts := strings.Split(row, "|")
+	cells := make([]string, len(parts))
+	for i, p := range parts {
+		cells[i] = strings.TrimSpace(p)
+	}
+	return cells
+}
+
+// cellsToRichText converts cell strings to RichTextBlock pointers for table rows.
+// Inline formatting (bold, code, links, strikethrough) is parsed and rendered
+// as styled rich-text elements.
+func cellsToRichText(cells []string) []*slack.RichTextBlock {
+	blocks := make([]*slack.RichTextBlock, len(cells))
+	for i, cell := range cells {
+		if cell == "" {
+			// Slack rejects empty text elements with invalid_blocks.
+			blocks[i] = slack.NewRichTextBlock("",
+				slack.NewRichTextSection(
+					slack.NewRichTextSectionTextElement("\u00a0", nil),
+				),
+			)
+			continue
+		}
+		elements := parseRichTextElements(cell)
+		blocks[i] = slack.NewRichTextBlock("",
+			slack.NewRichTextSection(elements...),
+		)
+	}
+	return blocks
+}
+
+// parseRichTextElements parses inline formatting (bold, strikethrough, code,
+// markdown links, slack links) and returns a slice of RichTextSectionElement
+// with appropriate styling. Nested formatting (e.g. **`code`**) is supported
+// by recursively parsing bold/strikethrough content.
+func parseRichTextElements(text string) []slack.RichTextSectionElement {
+	return parseRichTextElementsWithStyle(text, nil)
+}
+
+// parseRichTextElementsWithStyle is the recursive inner function that carries
+// an inherited style from an outer formatting context (e.g. bold wrapping code).
+func parseRichTextElementsWithStyle(text string, inherited *slack.RichTextSectionTextStyle) []slack.RichTextSectionElement {
+	var elements []slack.RichTextSectionElement
+
+	matches := reInlineFormatting.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		if text != "" {
+			elements = append(elements, slack.NewRichTextSectionTextElement(text, inherited))
+		}
+		return elements
+	}
+
+	pos := 0
+	for _, loc := range matches {
+		// Plain text before this match.
+		if loc[0] > pos {
+			elements = append(elements,
+				slack.NewRichTextSectionTextElement(text[pos:loc[0]], inherited))
+		}
+
+		switch {
+		case loc[2] >= 0: // group 1: bold **…**
+			inner := text[loc[2]:loc[3]]
+			style := mergeStyle(inherited, &slack.RichTextSectionTextStyle{Bold: true})
+			elements = append(elements, parseRichTextElementsWithStyle(inner, style)...)
+
+		case loc[4] >= 0: // group 2: strikethrough ~~…~~
+			inner := text[loc[4]:loc[5]]
+			style := mergeStyle(inherited, &slack.RichTextSectionTextStyle{Strike: true})
+			elements = append(elements, parseRichTextElementsWithStyle(inner, style)...)
+
+		case loc[6] >= 0: // group 3: inline code `…`
+			code := text[loc[6]:loc[7]]
+			style := mergeStyle(inherited, &slack.RichTextSectionTextStyle{Code: true})
+			elements = append(elements, slack.NewRichTextSectionTextElement(code, style))
+
+		case loc[8] >= 0: // groups 4,5: markdown link [text](url)
+			linkText := text[loc[8]:loc[9]]
+			linkURL := text[loc[10]:loc[11]]
+			elements = append(elements, slack.NewRichTextSectionLinkElement(linkURL, linkText, inherited))
+
+		case loc[12] >= 0: // groups 6,7: slack link <url|text>
+			linkURL := text[loc[12]:loc[13]]
+			linkText := text[loc[14]:loc[15]]
+			elements = append(elements, slack.NewRichTextSectionLinkElement(linkURL, linkText, inherited))
+		}
+
+		pos = loc[1]
+	}
+
+	// Trailing text after last match.
+	if pos < len(text) {
+		elements = append(elements,
+			slack.NewRichTextSectionTextElement(text[pos:], inherited))
+	}
+
+	return elements
+}
+
+// mergeStyle combines two RichTextSectionTextStyle values, producing a new
+// style with all flags from both. Either argument may be nil.
+func mergeStyle(a, b *slack.RichTextSectionTextStyle) *slack.RichTextSectionTextStyle {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &slack.RichTextSectionTextStyle{
+		Bold:   a.Bold || b.Bold,
+		Italic: a.Italic || b.Italic,
+		Strike: a.Strike || b.Strike,
+		Code:   a.Code || b.Code,
+	}
+}
+
+// splitText splits s into chunks of at most maxLen runes, breaking at the
+// last newline before the limit when possible.
+func splitText(s string, maxLen int) []string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return []string{s}
+	}
+	runes := []rune(s)
+	var chunks []string
+	for len(runes) > 0 {
+		end := maxLen
+		if end > len(runes) {
+			end = len(runes)
+		}
+		chunk := runes[:end]
+		if end < len(runes) {
+			if idx := lastIndexRune(chunk, '\n'); idx > 0 {
+				end = idx + 1
+				chunk = runes[:end]
+			}
+		}
+		trimmed := strings.TrimRight(string(chunk), "\n")
+		if trimmed != "" {
+			chunks = append(chunks, trimmed)
+		}
+		runes = runes[end:]
+	}
+	return chunks
+}
+
+func lastIndexRune(runes []rune, r rune) int {
+	for i := len(runes) - 1; i >= 0; i-- {
+		if runes[i] == r {
+			return i
+		}
+	}
+	return -1
+}
+
+// listBlock creates Slack RichTextBlock(s) from markdown list lines.
+func listBlock(lines []string) []slack.Block {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	// Determine list style from first line.
+	style := slack.RTEListBullet
+	if orderedListRe.MatchString(lines[0]) {
+		style = slack.RTEListOrdered
+	}
+
+	var items []slack.RichTextElement
+	for _, line := range lines {
+		var text string
+		if m := unorderedListRe.FindStringSubmatch(line); m != nil {
+			text = m[2]
+		} else if m := orderedListRe.FindStringSubmatch(line); m != nil {
+			text = m[2]
+		} else {
+			continue
+		}
+		items = append(items, slack.NewRichTextSection(
+			parseRichTextElements(text)...,
+		))
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	return []slack.Block{
+		slack.NewRichTextBlock("",
+			slack.NewRichTextList(style, 0, items...),
+		),
+	}
+}

--- a/internal/reporting/slack_blocks_test.go
+++ b/internal/reporting/slack_blocks_test.go
@@ -1,0 +1,762 @@
+package reporting
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestParseMarkdownSegments(t *testing.T) {
+	t.Run("plain text only", func(t *testing.T) {
+		segs := parseMarkdownSegments("Hello world\nSecond line")
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segPlain {
+			t.Errorf("expected segPlain, got %d", segs[0].typ)
+		}
+	})
+
+	t.Run("header", func(t *testing.T) {
+		segs := parseMarkdownSegments("# My Header")
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segHeader {
+			t.Errorf("expected segHeader, got %d", segs[0].typ)
+		}
+		if segs[0].lines[0] != "My Header" {
+			t.Errorf("expected header text %q, got %q", "My Header", segs[0].lines[0])
+		}
+		if segs[0].level != 1 {
+			t.Errorf("expected level 1, got %d", segs[0].level)
+		}
+	})
+
+	t.Run("table", func(t *testing.T) {
+		input := "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segTable {
+			t.Errorf("expected segTable, got %d", segs[0].typ)
+		}
+		// Header + 2 data rows (separator is excluded).
+		if len(segs[0].lines) != 3 {
+			t.Errorf("expected 3 table lines, got %d", len(segs[0].lines))
+		}
+	})
+
+	t.Run("unordered list", func(t *testing.T) {
+		input := "- item one\n- item two\n- item three"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+	})
+
+	t.Run("ordered list", func(t *testing.T) {
+		input := "1. first\n2. second\n3. third"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+	})
+
+	t.Run("divider", func(t *testing.T) {
+		for _, input := range []string{"---", "***", "___", "-----", "  ---  "} {
+			segs := parseMarkdownSegments(input)
+			if len(segs) != 1 {
+				t.Fatalf("input %q: expected 1 segment, got %d", input, len(segs))
+			}
+			if segs[0].typ != segDivider {
+				t.Errorf("input %q: expected segDivider, got %d", input, segs[0].typ)
+			}
+		}
+	})
+
+	t.Run("ordered list with blank lines", func(t *testing.T) {
+		input := "1. first\n\n2. second\n\n3. third"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+		if len(segs[0].lines) != 3 {
+			t.Errorf("expected 3 list lines, got %d", len(segs[0].lines))
+		}
+	})
+
+	t.Run("unordered list with blank lines", func(t *testing.T) {
+		input := "- first\n\n- second\n\n- third"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+		if len(segs[0].lines) != 3 {
+			t.Errorf("expected 3 list lines, got %d", len(segs[0].lines))
+		}
+	})
+
+	t.Run("divider between content", func(t *testing.T) {
+		input := "Some text\n---\nMore text"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 3 {
+			t.Fatalf("expected 3 segments, got %d", len(segs))
+		}
+		if segs[0].typ != segPlain {
+			t.Errorf("segment 0: expected segPlain, got %d", segs[0].typ)
+		}
+		if segs[1].typ != segDivider {
+			t.Errorf("segment 1: expected segDivider, got %d", segs[1].typ)
+		}
+		if segs[2].typ != segPlain {
+			t.Errorf("segment 2: expected segPlain, got %d", segs[2].typ)
+		}
+	})
+
+	t.Run("mixed content", func(t *testing.T) {
+		input := "## Summary\nSome text here.\n\n| Col1 | Col2 |\n| --- | --- |\n| a | b |\n\n- item 1\n- item 2"
+		segs := parseMarkdownSegments(input)
+		if len(segs) < 4 {
+			t.Fatalf("expected at least 4 segments, got %d", len(segs))
+		}
+		if segs[0].typ != segHeader {
+			t.Errorf("segment 0: expected segHeader, got %d", segs[0].typ)
+		}
+		if segs[1].typ != segPlain {
+			t.Errorf("segment 1: expected segPlain, got %d", segs[1].typ)
+		}
+		if segs[2].typ != segTable {
+			t.Errorf("segment 2: expected segTable, got %d", segs[2].typ)
+		}
+		if segs[3].typ != segList {
+			t.Errorf("segment 3: expected segList, got %d", segs[3].typ)
+		}
+	})
+}
+
+func TestResponseToBlocks(t *testing.T) {
+	t.Run("plain text becomes SectionBlock", func(t *testing.T) {
+		blocks := responseToBlocks("Hello world")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		section, ok := blocks[0].(*slack.SectionBlock)
+		if !ok {
+			t.Fatalf("expected *SectionBlock, got %T", blocks[0])
+		}
+		if section.Text.Text != "Hello world" {
+			t.Errorf("text = %q, want %q", section.Text.Text, "Hello world")
+		}
+	})
+
+	t.Run("header becomes HeaderBlock", func(t *testing.T) {
+		blocks := responseToBlocks("# My Title")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		header, ok := blocks[0].(*slack.HeaderBlock)
+		if !ok {
+			t.Fatalf("expected *HeaderBlock, got %T", blocks[0])
+		}
+		if header.Text.Text != "My Title" {
+			t.Errorf("text = %q, want %q", header.Text.Text, "My Title")
+		}
+	})
+
+	t.Run("table becomes TableBlock", func(t *testing.T) {
+		input := "| Name | Age |\n| --- | --- |\n| Alice | 30 |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		if len(table.Rows) != 2 {
+			t.Errorf("expected 2 rows (header + 1 data), got %d", len(table.Rows))
+		}
+	})
+
+	t.Run("unordered list becomes RichTextBlock", func(t *testing.T) {
+		input := "- apple\n- banana\n- cherry"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		rt, ok := blocks[0].(*slack.RichTextBlock)
+		if !ok {
+			t.Fatalf("expected *RichTextBlock, got %T", blocks[0])
+		}
+		if len(rt.Elements) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(rt.Elements))
+		}
+		list, ok := rt.Elements[0].(*slack.RichTextList)
+		if !ok {
+			t.Fatalf("expected *RichTextList, got %T", rt.Elements[0])
+		}
+		if list.Style != slack.RTEListBullet {
+			t.Errorf("expected bullet style, got %q", list.Style)
+		}
+		if len(list.Elements) != 3 {
+			t.Errorf("expected 3 list items, got %d", len(list.Elements))
+		}
+	})
+
+	t.Run("ordered list becomes RichTextBlock", func(t *testing.T) {
+		input := "1. first\n2. second"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		rt, ok := blocks[0].(*slack.RichTextBlock)
+		if !ok {
+			t.Fatalf("expected *RichTextBlock, got %T", blocks[0])
+		}
+		list := rt.Elements[0].(*slack.RichTextList)
+		if list.Style != slack.RTEListOrdered {
+			t.Errorf("expected ordered style, got %q", list.Style)
+		}
+	})
+
+	t.Run("mixed content produces correct block types", func(t *testing.T) {
+		input := "## Report\nHere are the results:\n\n| Name | Score |\n| --- | --- |\n| Alice | 95 |\n\n- Note 1\n- Note 2"
+		blocks := responseToBlocks(input)
+		if len(blocks) < 4 {
+			t.Fatalf("expected at least 4 blocks, got %d", len(blocks))
+		}
+		if _, ok := blocks[0].(*slack.HeaderBlock); !ok {
+			t.Errorf("block 0: expected *HeaderBlock, got %T", blocks[0])
+		}
+		if _, ok := blocks[1].(*slack.SectionBlock); !ok {
+			t.Errorf("block 1: expected *SectionBlock, got %T", blocks[1])
+		}
+		if _, ok := blocks[2].(*slack.TableBlock); !ok {
+			t.Errorf("block 2: expected *TableBlock, got %T", blocks[2])
+		}
+		if _, ok := blocks[3].(*slack.RichTextBlock); !ok {
+			t.Errorf("block 3: expected *RichTextBlock, got %T", blocks[3])
+		}
+	})
+
+	t.Run("empty string produces no blocks", func(t *testing.T) {
+		blocks := responseToBlocks("")
+		if len(blocks) != 0 {
+			t.Errorf("expected 0 blocks, got %d", len(blocks))
+		}
+	})
+
+	t.Run("divider becomes DividerBlock", func(t *testing.T) {
+		blocks := responseToBlocks("Text above\n---\nText below")
+		if len(blocks) != 3 {
+			t.Fatalf("expected 3 blocks, got %d", len(blocks))
+		}
+		if _, ok := blocks[1].(*slack.DividerBlock); !ok {
+			t.Errorf("block 1: expected *DividerBlock, got %T", blocks[1])
+		}
+	})
+
+	t.Run("header strips backtick code spans", func(t *testing.T) {
+		blocks := responseToBlocks("# The `start_data_complete_jobs` function")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		header, ok := blocks[0].(*slack.HeaderBlock)
+		if !ok {
+			t.Fatalf("expected *HeaderBlock, got %T", blocks[0])
+		}
+		want := "The start_data_complete_jobs function"
+		if header.Text.Text != want {
+			t.Errorf("text = %q, want %q", header.Text.Text, want)
+		}
+	})
+
+	t.Run("list items with inline code", func(t *testing.T) {
+		input := "- Run `make test` first\n- Then `make build`"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		rt, ok := blocks[0].(*slack.RichTextBlock)
+		if !ok {
+			t.Fatalf("expected *RichTextBlock, got %T", blocks[0])
+		}
+		list, ok := rt.Elements[0].(*slack.RichTextList)
+		if !ok {
+			t.Fatalf("expected *RichTextList, got %T", rt.Elements[0])
+		}
+		// First list item should have 3 elements: "Run ", "make test" (code), " first"
+		section, ok := list.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", list.Elements[0])
+		}
+		if len(section.Elements) != 3 {
+			t.Fatalf("expected 3 elements in first item, got %d", len(section.Elements))
+		}
+		codeElem, ok := section.Elements[1].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected *RichTextSectionTextElement, got %T", section.Elements[1])
+		}
+		if codeElem.Style == nil || !codeElem.Style.Code {
+			t.Error("expected code style on middle element")
+		}
+		if codeElem.Text != "make test" {
+			t.Errorf("code text = %q, want %q", codeElem.Text, "make test")
+		}
+	})
+
+	t.Run("asterisk list items", func(t *testing.T) {
+		input := "* foo\n* bar"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		if _, ok := blocks[0].(*slack.RichTextBlock); !ok {
+			t.Errorf("expected *RichTextBlock, got %T", blocks[0])
+		}
+	})
+}
+
+func TestParseRichTextElements(t *testing.T) {
+	t.Run("no code spans", func(t *testing.T) {
+		elems := parseRichTextElements("plain text")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+	})
+
+	t.Run("code span in middle", func(t *testing.T) {
+		elems := parseRichTextElements("run `make test` now")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		te, ok := elems[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[0])
+		}
+		if te.Text != "run " {
+			t.Errorf("elem 0 text = %q, want %q", te.Text, "run ")
+		}
+		code, ok := elems[1].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[1])
+		}
+		if code.Text != "make test" {
+			t.Errorf("elem 1 text = %q, want %q", code.Text, "make test")
+		}
+		if code.Style == nil || !code.Style.Code {
+			t.Error("expected code style on elem 1")
+		}
+	})
+
+	t.Run("multiple code spans", func(t *testing.T) {
+		elems := parseRichTextElements("`foo` and `bar`")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		// First should be code
+		first, _ := elems[0].(*slack.RichTextSectionTextElement)
+		if first.Style == nil || !first.Style.Code {
+			t.Error("expected code style on first element")
+		}
+		// Middle should be plain text " and "
+		mid, _ := elems[1].(*slack.RichTextSectionTextElement)
+		if mid.Text != " and " {
+			t.Errorf("middle text = %q, want %q", mid.Text, " and ")
+		}
+	})
+
+	t.Run("bold text", func(t *testing.T) {
+		elems := parseRichTextElements("this is **important** text")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		bold, ok := elems[1].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[1])
+		}
+		if bold.Text != "important" {
+			t.Errorf("bold text = %q, want %q", bold.Text, "important")
+		}
+		if bold.Style == nil || !bold.Style.Bold {
+			t.Error("expected bold style")
+		}
+	})
+
+	t.Run("bold wrapping code", func(t *testing.T) {
+		elems := parseRichTextElements("**`PIISample`**")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+		te, ok := elems[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[0])
+		}
+		if te.Text != "PIISample" {
+			t.Errorf("text = %q, want %q", te.Text, "PIISample")
+		}
+		if te.Style == nil || !te.Style.Bold || !te.Style.Code {
+			t.Errorf("expected bold+code style, got %+v", te.Style)
+		}
+	})
+
+	t.Run("strikethrough", func(t *testing.T) {
+		elems := parseRichTextElements("~~removed~~")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+		te, ok := elems[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[0])
+		}
+		if te.Style == nil || !te.Style.Strike {
+			t.Error("expected strike style")
+		}
+	})
+
+	t.Run("markdown link", func(t *testing.T) {
+		elems := parseRichTextElements("see [docs](https://example.com) here")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		link, ok := elems[1].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", elems[1])
+		}
+		if link.URL != "https://example.com" {
+			t.Errorf("url = %q, want %q", link.URL, "https://example.com")
+		}
+		if link.Text != "docs" {
+			t.Errorf("text = %q, want %q", link.Text, "docs")
+		}
+	})
+
+	t.Run("slack link", func(t *testing.T) {
+		elems := parseRichTextElements("see <https://github.com/foo/bar#L34|checks/pii.py:34> here")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		link, ok := elems[1].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", elems[1])
+		}
+		if link.URL != "https://github.com/foo/bar#L34" {
+			t.Errorf("url = %q, want %q", link.URL, "https://github.com/foo/bar#L34")
+		}
+		if link.Text != "checks/pii.py:34" {
+			t.Errorf("text = %q, want %q", link.Text, "checks/pii.py:34")
+		}
+	})
+
+	t.Run("markdown link with parens in url", func(t *testing.T) {
+		elems := parseRichTextElements("[Go](https://en.wikipedia.org/wiki/Go_(language))")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+		link, ok := elems[0].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", elems[0])
+		}
+		if link.URL != "https://en.wikipedia.org/wiki/Go_(language)" {
+			t.Errorf("url = %q, want %q", link.URL, "https://en.wikipedia.org/wiki/Go_(language)")
+		}
+	})
+}
+
+func TestParseRichTextElements_TableCells(t *testing.T) {
+	t.Run("table cell with code", func(t *testing.T) {
+		input := "| Name | Command |\n| --- | --- |\n| test | `make test` |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		// Data row (index 1), second cell should have code-styled element.
+		cell := table.Rows[1][1]
+		section, ok := cell.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", cell.Elements[0])
+		}
+		if len(section.Elements) != 1 {
+			t.Fatalf("expected 1 element in cell, got %d", len(section.Elements))
+		}
+		te, ok := section.Elements[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", section.Elements[0])
+		}
+		if te.Text != "make test" {
+			t.Errorf("text = %q, want %q", te.Text, "make test")
+		}
+		if te.Style == nil || !te.Style.Code {
+			t.Error("expected code style on table cell element")
+		}
+	})
+
+	t.Run("table cell with markdown link", func(t *testing.T) {
+		input := "| File | Link |\n| --- | --- |\n| pii.py | [checks/pii.py:34](https://github.com/foo/bar#L34) |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		cell := table.Rows[1][1]
+		section, ok := cell.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", cell.Elements[0])
+		}
+		if len(section.Elements) != 1 {
+			t.Fatalf("expected 1 element in cell, got %d", len(section.Elements))
+		}
+		link, ok := section.Elements[0].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", section.Elements[0])
+		}
+		if link.URL != "https://github.com/foo/bar#L34" {
+			t.Errorf("url = %q, want %q", link.URL, "https://github.com/foo/bar#L34")
+		}
+		if link.Text != "checks/pii.py:34" {
+			t.Errorf("text = %q, want %q", link.Text, "checks/pii.py:34")
+		}
+	})
+
+	t.Run("table cell with bold code", func(t *testing.T) {
+		input := "| Check | Status |\n| --- | --- |\n| **`PIISample`** | passed |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		cell := table.Rows[1][0]
+		section, ok := cell.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", cell.Elements[0])
+		}
+		if len(section.Elements) != 1 {
+			t.Fatalf("expected 1 element in cell, got %d", len(section.Elements))
+		}
+		te, ok := section.Elements[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", section.Elements[0])
+		}
+		if te.Text != "PIISample" {
+			t.Errorf("text = %q, want %q", te.Text, "PIISample")
+		}
+		if te.Style == nil || !te.Style.Bold || !te.Style.Code {
+			t.Errorf("expected bold+code style, got %+v", te.Style)
+		}
+	})
+}
+
+func TestMergeStyle(t *testing.T) {
+	t.Run("nil + style", func(t *testing.T) {
+		s := mergeStyle(nil, &slack.RichTextSectionTextStyle{Bold: true})
+		if s == nil || !s.Bold {
+			t.Error("expected bold")
+		}
+	})
+
+	t.Run("style + nil", func(t *testing.T) {
+		s := mergeStyle(&slack.RichTextSectionTextStyle{Code: true}, nil)
+		if s == nil || !s.Code {
+			t.Error("expected code")
+		}
+	})
+
+	t.Run("merge bold + code", func(t *testing.T) {
+		s := mergeStyle(
+			&slack.RichTextSectionTextStyle{Bold: true},
+			&slack.RichTextSectionTextStyle{Code: true},
+		)
+		if s == nil || !s.Bold || !s.Code {
+			t.Errorf("expected bold+code, got %+v", s)
+		}
+	})
+
+	t.Run("nil + nil", func(t *testing.T) {
+		s := mergeStyle(nil, nil)
+		if s != nil {
+			t.Errorf("expected nil, got %+v", s)
+		}
+	})
+}
+
+func TestParseCells(t *testing.T) {
+	cells := parseCells("| Alice | 30 | Engineer |")
+	if len(cells) != 3 {
+		t.Fatalf("expected 3 cells, got %d", len(cells))
+	}
+	if cells[0] != "Alice" {
+		t.Errorf("cell 0 = %q, want %q", cells[0], "Alice")
+	}
+	if cells[1] != "30" {
+		t.Errorf("cell 1 = %q, want %q", cells[1], "30")
+	}
+	if cells[2] != "Engineer" {
+		t.Errorf("cell 2 = %q, want %q", cells[2], "Engineer")
+	}
+}
+
+func TestCellsToRichText_EmptyCellsUseNBSP(t *testing.T) {
+	cells := cellsToRichText([]string{"filled", "", "also filled"})
+	if len(cells) != 3 {
+		t.Fatalf("expected 3 cells, got %d", len(cells))
+	}
+
+	// The empty cell should contain a non-breaking space, not empty string.
+	b, err := json.Marshal(cells[1])
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if strings.Contains(string(b), `"text":""`) {
+		t.Error("empty cell produced empty text element; Slack rejects this with invalid_blocks")
+	}
+	if !strings.Contains(string(b), "\u00a0") {
+		t.Error("empty cell should contain non-breaking space")
+	}
+}
+
+func TestUnicodeBulletList(t *testing.T) {
+	input := "• item one\n• item two\n• item three"
+	segs := parseMarkdownSegments(input)
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segs))
+	}
+	if segs[0].typ != segList {
+		t.Errorf("expected segList, got %d", segs[0].typ)
+	}
+
+	blocks := responseToBlocks(input)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if _, ok := blocks[0].(*slack.RichTextBlock); !ok {
+		t.Errorf("expected *RichTextBlock, got %T", blocks[0])
+	}
+}
+
+func TestUnicodeBulletMixedWithDash(t *testing.T) {
+	input := "• first\n- second\n• third"
+	segs := parseMarkdownSegments(input)
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segs))
+	}
+	if segs[0].typ != segList {
+		t.Errorf("expected segList, got %d", segs[0].typ)
+	}
+}
+
+func TestSectionTextSplitting(t *testing.T) {
+	var sb strings.Builder
+	for sb.Len() < 5000 {
+		sb.WriteString("This is a long line of text that will be repeated. ")
+	}
+	blocks := responseToBlocks(sb.String())
+	for _, b := range blocks {
+		sec, ok := b.(*slack.SectionBlock)
+		if !ok {
+			continue
+		}
+		if len([]rune(sec.Text.Text)) > slackSectionTextLimit {
+			t.Errorf("section text length %d exceeds limit %d", len([]rune(sec.Text.Text)), slackSectionTextLimit)
+		}
+	}
+	if len(blocks) < 2 {
+		t.Errorf("expected text to be split into multiple sections, got %d blocks", len(blocks))
+	}
+}
+
+func TestHeaderBlockTruncation(t *testing.T) {
+	long := strings.Repeat("A", 200)
+	blocks := responseToBlocks("# " + long)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	hdr, ok := blocks[0].(*slack.HeaderBlock)
+	if !ok {
+		t.Fatalf("expected *HeaderBlock, got %T", blocks[0])
+	}
+	if len([]rune(hdr.Text.Text)) > slackHeaderTextLimit {
+		t.Errorf("header text length %d exceeds limit %d", len([]rune(hdr.Text.Text)), slackHeaderTextLimit)
+	}
+}
+
+func TestSplitText(t *testing.T) {
+	t.Run("short text unchanged", func(t *testing.T) {
+		chunks := splitText("hello", 100)
+		if len(chunks) != 1 || chunks[0] != "hello" {
+			t.Errorf("got %v", chunks)
+		}
+	})
+
+	t.Run("splits at newline", func(t *testing.T) {
+		input := "aaa\nbbb\nccc"
+		chunks := splitText(input, 5)
+		if len(chunks) < 2 {
+			t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+		}
+		for _, c := range chunks {
+			if len([]rune(c)) > 5 {
+				t.Errorf("chunk %q exceeds limit 5", c)
+			}
+		}
+	})
+
+	t.Run("hard splits when no newline", func(t *testing.T) {
+		input := strings.Repeat("x", 10)
+		chunks := splitText(input, 4)
+		if len(chunks) != 3 {
+			t.Fatalf("expected 3 chunks, got %d: %v", len(chunks), chunks)
+		}
+	})
+
+	t.Run("newline-only chunk trimmed to empty", func(t *testing.T) {
+		input := "aaa\n\n\n\n\nbbb"
+		chunks := splitText(input, 5)
+		for i, c := range chunks {
+			if c == "" {
+				t.Errorf("chunk %d is empty after trimming", i)
+			}
+		}
+	})
+}
+
+func TestTableBlock_EmptyCells(t *testing.T) {
+	input := "| Project | Notes |\n| --- | --- |\n| Viz | |\n| AIDA | done |"
+	blocks := responseToBlocks(input)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	// Verify the table serializes without empty text elements.
+	b, err := json.Marshal(blocks[0])
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if strings.Contains(string(b), `"text":""`) {
+		t.Error("table block contains empty text element; Slack rejects this with invalid_blocks")
+	}
+}

--- a/internal/reporting/slack_test.go
+++ b/internal/reporting/slack_test.go
@@ -1,0 +1,638 @@
+package reporting
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// firstMsg is a helper that returns the first (and usually only) message
+// from FormatSlackTransitionMessage, failing the test if the slice is empty.
+func firstMsg(t *testing.T, msgs []SlackMessage) SlackMessage {
+	t.Helper()
+	if len(msgs) == 0 {
+		t.Fatal("FormatSlackTransitionMessage returned 0 messages")
+	}
+	return msgs[0]
+}
+
+func TestFormatSlackTransitionMessages(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("accepted", "spawner-1234567890.123456", "", nil))
+		if got.Text != "Working on your request... (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // section + context
+		assertSectionText(t, got.Blocks[0], ":hourglass_flowing_sand: *Working on your request...*")
+		assertContextContains(t, got.Blocks[1], "spawner-1234567890.123456")
+	})
+
+	t.Run("succeeded with PR", func(t *testing.T) {
+		results := map[string]string{"pr": "https://github.com/org/repo/pull/42"}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "PR: https://github.com/org/repo/pull/42 (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // PR + context
+		assertSectionContains(t, got.Blocks[0], "https://github.com/org/repo/pull/42")
+	})
+
+	t.Run("succeeded without results", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", nil))
+		if got.Text != "Done! (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 1) // context only
+	})
+
+	t.Run("succeeded with empty results", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", map[string]string{}))
+		if got.Text != "Done! (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 1) // context only
+	})
+
+	t.Run("succeeded ignores status message", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "Task completed successfully", nil))
+		if got.Text != "Done! (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 1) // context only, no error block
+	})
+
+	t.Run("succeeded with response", func(t *testing.T) {
+		results := map[string]string{"response": b64("I need your GitHub username to proceed.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "I need your GitHub username to proceed. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+		assertSectionContains(t, got.Blocks[0], "I need your GitHub username to proceed.")
+	})
+
+	t.Run("succeeded with response and PR", func(t *testing.T) {
+		results := map[string]string{
+			"response": b64("Added CODEOWNERS entry."),
+			"pr":       "https://github.com/org/repo/pull/42",
+		}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "Added CODEOWNERS entry.\nPR: https://github.com/org/repo/pull/42 (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 3) // response + PR + context
+		assertSectionContains(t, got.Blocks[0], "Added CODEOWNERS entry.")
+		assertSectionContains(t, got.Blocks[1], "https://github.com/org/repo/pull/42")
+	})
+
+	t.Run("succeeded with multiline response", func(t *testing.T) {
+		results := map[string]string{"response": b64("Line one.\nLine two.\nLine three.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "Line one.\nLine two.\nLine three. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+	})
+
+	t.Run("succeeded with non-base64 response fallback", func(t *testing.T) {
+		results := map[string]string{"response": "plain text response"}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "plain text response (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+	})
+
+	t.Run("failed with message", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "pod OOMKilled", nil))
+		if got.Text != "Error: pod OOMKilled (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 3) // header + error + context
+		assertSectionContains(t, got.Blocks[1], "pod OOMKilled")
+	})
+
+	t.Run("failed without message", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "", nil))
+		if got.Text != "Failed. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // header + context
+	})
+
+	t.Run("failed with response", func(t *testing.T) {
+		results := map[string]string{"response": b64("Could not find the file.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "Task failed", results))
+		if got.Text != "Could not find the file.\nError: Task failed (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 4) // header + response + error + context
+		assertSectionContains(t, got.Blocks[1], "Could not find the file.")
+		assertSectionContains(t, got.Blocks[2], "Task failed")
+	})
+
+	t.Run("succeeded with table response", func(t *testing.T) {
+		resp := "| Name | Age |\n| --- | --- |\n| Alice | 30 |"
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// table + context
+		assertBlockCount(t, got.Blocks, 2)
+		if _, ok := got.Blocks[0].(*slack.TableBlock); !ok {
+			t.Errorf("block 0: expected *TableBlock, got %T", got.Blocks[0])
+		}
+	})
+
+	t.Run("succeeded with list response", func(t *testing.T) {
+		resp := "- item one\n- item two\n- item three"
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// rich_text list + context
+		assertBlockCount(t, got.Blocks, 2)
+		if _, ok := got.Blocks[0].(*slack.RichTextBlock); !ok {
+			t.Errorf("block 0: expected *RichTextBlock, got %T", got.Blocks[0])
+		}
+	})
+
+	t.Run("succeeded with header response", func(t *testing.T) {
+		resp := "# Summary\nEverything looks good."
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// HeaderBlock + SectionBlock + context
+		assertBlockCount(t, got.Blocks, 3)
+		if hdr, ok := got.Blocks[0].(*slack.HeaderBlock); !ok {
+			t.Errorf("block 0: expected *HeaderBlock, got %T", got.Blocks[0])
+		} else if hdr.Text.Text != "Summary" {
+			t.Errorf("header text = %q, want %q", hdr.Text.Text, "Summary")
+		}
+		assertSectionContains(t, got.Blocks[1], "Everything looks good.")
+	})
+
+	t.Run("succeeded with mixed rich content", func(t *testing.T) {
+		resp := "## Report\nResults below:\n\n| Col | Val |\n| --- | --- |\n| a | 1 |\n\n- note 1\n- note 2"
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// header + section + table + list + context
+		assertBlockCount(t, got.Blocks, 5)
+		if _, ok := got.Blocks[0].(*slack.HeaderBlock); !ok {
+			t.Errorf("block 0: expected *HeaderBlock, got %T", got.Blocks[0])
+		}
+		if _, ok := got.Blocks[1].(*slack.SectionBlock); !ok {
+			t.Errorf("block 1: expected *SectionBlock, got %T", got.Blocks[1])
+		}
+		if _, ok := got.Blocks[2].(*slack.TableBlock); !ok {
+			t.Errorf("block 2: expected *TableBlock, got %T", got.Blocks[2])
+		}
+		if _, ok := got.Blocks[3].(*slack.RichTextBlock); !ok {
+			t.Errorf("block 3: expected *RichTextBlock, got %T", got.Blocks[3])
+		}
+	})
+}
+
+func TestFormatSlackTransitionMessage_SplitsLongResponse(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("### Header\nSome content here.")
+	}
+	results := map[string]string{"response": b64(sb.String())}
+
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	if len(msgs) < 2 {
+		t.Fatalf("expected multiple messages for long response, got %d", len(msgs))
+	}
+
+	// Every message must be within the block limit.
+	for i, msg := range msgs {
+		if len(msg.Blocks) > SlackBlockLimit {
+			t.Errorf("message %d has %d blocks, must be <= %d", i, len(msg.Blocks), SlackBlockLimit)
+		}
+	}
+
+	// Last block of the last message must be the context block (task name).
+	lastMsg := msgs[len(msgs)-1]
+	last := lastMsg.Blocks[len(lastMsg.Blocks)-1]
+	if _, ok := last.(*slack.ContextBlock); !ok {
+		t.Errorf("last block of last message should be ContextBlock, got %T", last)
+	}
+
+	// First message should have a continuation context with part info.
+	firstMsg := msgs[0]
+	firstLast := firstMsg.Blocks[len(firstMsg.Blocks)-1]
+	if ctx, ok := firstLast.(*slack.ContextBlock); ok {
+		found := false
+		for _, elem := range ctx.ContextElements.Elements {
+			if txt, ok := elem.(*slack.TextBlockObject); ok {
+				if strings.Contains(txt.Text, "Part 1/") {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Error("expected first message to have a Part 1/N continuation indicator")
+		}
+	} else {
+		t.Errorf("first message last block: expected *ContextBlock, got %T", firstLast)
+	}
+
+	// Continuation messages should have part indicators in their fallback text.
+	for i := 1; i < len(msgs); i++ {
+		if !strings.Contains(msgs[i].Text, "continued") {
+			t.Errorf("message %d fallback text should contain 'continued', got %q", i, msgs[i].Text)
+		}
+	}
+}
+
+func TestFormatSlackTransitionMessage_SplitsWithPRLink(t *testing.T) {
+	// Verify that the PR link ends up in the last message.
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("### Header\nSome content here.")
+	}
+	results := map[string]string{
+		"response": b64(sb.String()),
+		"pr":       "https://github.com/org/repo/pull/99",
+	}
+
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	if len(msgs) < 2 {
+		t.Fatalf("expected multiple messages, got %d", len(msgs))
+	}
+
+	// PR link should be in the last message.
+	lastMsg := msgs[len(msgs)-1]
+	foundPR := false
+	for _, b := range lastMsg.Blocks {
+		if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+			if strings.Contains(sec.Text.Text, "Pull Request") {
+				foundPR = true
+				break
+			}
+		}
+	}
+	if !foundPR {
+		t.Error("expected PR link in last message")
+	}
+}
+
+func TestFormatSlackTransitionMessage_MiddleChunkBecomesLast(t *testing.T) {
+	// Regression: when the response block count lands in
+	// (SlackBlockLimit-lastReserve, SlackBlockLimit-1] for a middle chunk,
+	// the middle chunk consumed all remaining blocks and trailing blocks
+	// were appended on top, exceeding 50. Verify that every message stays
+	// within the limit for pathological response sizes with 3 trailing
+	// blocks (failed + PR link + context).
+	//
+	// Use headers to produce exactly 1 block per line.
+	for _, numHeaders := range []int{95, 96, 97, 144, 145, 146, 193, 194, 195} {
+		var sb strings.Builder
+		for i := 0; i < numHeaders; i++ {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString("# Header\n")
+		}
+		results := map[string]string{
+			"response": b64(sb.String()),
+			"pr":       "https://github.com/org/repo/pull/1",
+		}
+
+		msgs := FormatSlackTransitionMessage("failed", "test-task", "something broke", results)
+
+		if len(msgs) < 2 {
+			t.Errorf("numHeaders=%d: expected multiple messages, got %d", numHeaders, len(msgs))
+			continue
+		}
+
+		for i, msg := range msgs {
+			if len(msg.Blocks) > SlackBlockLimit {
+				t.Errorf("numHeaders=%d message %d has %d blocks, must be <= %d",
+					numHeaders, i, len(msg.Blocks), SlackBlockLimit)
+			}
+		}
+
+		// The last message must contain the trailing blocks.
+		lastMsg := msgs[len(msgs)-1]
+		foundPR := false
+		foundError := false
+		for _, b := range lastMsg.Blocks {
+			if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+				if strings.Contains(sec.Text.Text, "Pull Request") {
+					foundPR = true
+				}
+				if strings.Contains(sec.Text.Text, "Error") {
+					foundError = true
+				}
+			}
+		}
+		if !foundPR {
+			t.Errorf("numHeaders=%d: expected PR link in last message", numHeaders)
+		}
+		if !foundError {
+			t.Errorf("numHeaders=%d: expected error in last message", numHeaders)
+		}
+	}
+}
+
+func TestSplitBlocks_MiddleChunkDoesNotExceedLimit(t *testing.T) {
+	// Direct test of splitBlocks to ensure that appending lastReserve
+	// trailing blocks to the last chunk never exceeds SlackBlockLimit.
+	dummyBlock := slack.NewDividerBlock()
+
+	for _, tc := range []struct {
+		name        string
+		total       int
+		firstCap    int
+		lastReserve int
+	}{
+		{"95 blocks reserve 3", 95, 46, 3},
+		{"96 blocks reserve 3", 96, 46, 3},
+		{"97 blocks reserve 3", 97, 46, 3},
+		{"144 blocks reserve 3", 144, 46, 3},
+		{"48 blocks reserve 2", 48, 47, 2},
+		{"49 blocks reserve 2", 49, 47, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := make([]slack.Block, tc.total)
+			for i := range blocks {
+				blocks[i] = dummyBlock
+			}
+
+			chunks := splitBlocks(blocks, tc.firstCap, tc.lastReserve)
+
+			totalEmitted := 0
+			for i, chunk := range chunks {
+				totalEmitted += len(chunk)
+				if i == len(chunks)-1 {
+					// Simulate appending trailing blocks.
+					if len(chunk)+tc.lastReserve > SlackBlockLimit {
+						t.Errorf("last chunk size %d + lastReserve %d = %d > %d",
+							len(chunk), tc.lastReserve, len(chunk)+tc.lastReserve, SlackBlockLimit)
+					}
+				} else {
+					// Middle chunks get 1 continuation context block.
+					if len(chunk)+1 > SlackBlockLimit {
+						t.Errorf("middle chunk %d size %d + 1 = %d > %d",
+							i, len(chunk), len(chunk)+1, SlackBlockLimit)
+					}
+				}
+			}
+			if totalEmitted != tc.total {
+				t.Errorf("emitted %d blocks, want %d", totalEmitted, tc.total)
+			}
+		})
+	}
+}
+
+func TestFormatSlackTransitionMessage_SingleChunkWithTrailing(t *testing.T) {
+	// When response blocks barely exceed the limit (e.g. 49 response blocks
+	// + 2 trailing = 51), splitBlocks may return a single chunk. The trailing
+	// blocks (PR link, context) must still be included.
+	var sb strings.Builder
+	for i := 0; i < 49; i++ {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("Short paragraph.")
+	}
+	results := map[string]string{
+		"response": b64(sb.String()),
+		"pr":       "https://github.com/org/repo/pull/77",
+	}
+
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	// All blocks should fit in a single message after splitting.
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	msg := msgs[0]
+	if len(msg.Blocks) > SlackBlockLimit {
+		t.Errorf("message has %d blocks, must be <= %d", len(msg.Blocks), SlackBlockLimit)
+	}
+
+	// PR link must be present.
+	foundPR := false
+	for _, b := range msg.Blocks {
+		if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+			if strings.Contains(sec.Text.Text, "Pull Request") {
+				foundPR = true
+				break
+			}
+		}
+	}
+	if !foundPR {
+		t.Error("expected PR link in message")
+	}
+
+	// Context block must be present as the last block.
+	last := msg.Blocks[len(msg.Blocks)-1]
+	if _, ok := last.(*slack.ContextBlock); !ok {
+		t.Errorf("last block should be ContextBlock, got %T", last)
+	}
+}
+
+func TestFormatSlackTransitionMessage_UnicodeBulletResponse(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("# Weekly Update\n\n")
+	for i := 0; i < 50; i++ {
+		sb.WriteString("• *Status:* On track — lots of progress this week with many issues completed across the board.\n")
+	}
+	results := map[string]string{"response": b64(sb.String())}
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	for i, msg := range msgs {
+		if len(msg.Blocks) > SlackBlockLimit {
+			t.Errorf("message %d has %d blocks, must be <= %d", i, len(msg.Blocks), SlackBlockLimit)
+		}
+		for j, b := range msg.Blocks {
+			if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+				if len([]rune(sec.Text.Text)) > slackSectionTextLimit {
+					t.Errorf("message %d block %d section text length %d exceeds %d", i, j, len([]rune(sec.Text.Text)), slackSectionTextLimit)
+				}
+			}
+		}
+		if len([]rune(msg.Text)) > slackFallbackTextLimit {
+			t.Errorf("message %d fallback text length %d exceeds %d", i, len([]rune(msg.Text)), slackFallbackTextLimit)
+		}
+	}
+}
+
+func TestFormatSlackTransitionMessage_FallbackTextTruncated(t *testing.T) {
+	long := strings.Repeat("A", 50000)
+	results := map[string]string{"response": b64(long)}
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+	for i, msg := range msgs {
+		if len([]rune(msg.Text)) > slackFallbackTextLimit {
+			t.Errorf("message %d fallback text length %d exceeds limit %d", i, len([]rune(msg.Text)), slackFallbackTextLimit)
+		}
+	}
+}
+
+func TestFormatProgressMessage_FallbackTextTruncated(t *testing.T) {
+	long := strings.Repeat("x", 50000)
+	got := FormatProgressMessage(long, "test-task")
+	if len([]rune(got.Text)) > slackFallbackTextLimit {
+		t.Errorf("fallback text length %d exceeds limit %d", len([]rune(got.Text)), slackFallbackTextLimit)
+	}
+}
+
+func TestFormatProgressMessage(t *testing.T) {
+	t.Run("includes blocks and context", func(t *testing.T) {
+		got := FormatProgressMessage("Looking at the config files...", "test-task")
+		if got.Text != "Looking at the config files..." {
+			t.Errorf("text = %q, want progress text", got.Text)
+		}
+		if len(got.Blocks) == 0 {
+			t.Fatal("expected blocks to be present")
+		}
+		// Last block should be a context block with the task name.
+		lastBlock := got.Blocks[len(got.Blocks)-1]
+		assertContextContains(t, lastBlock, "test-task")
+	})
+
+	t.Run("appendActivityContext works", func(t *testing.T) {
+		base := FormatProgressMessage("Investigating the issue...", "test-task")
+		result := appendActivityContext(base, "Reading `main.go`...")
+		// Should have blocks (not skipped like text-only messages).
+		if len(result.Blocks) == 0 {
+			t.Fatal("expected blocks after appending activity context")
+		}
+		// The activity text should be in the last context block.
+		lastBlock := result.Blocks[len(result.Blocks)-1]
+		ctx, ok := lastBlock.(*slack.ContextBlock)
+		if !ok {
+			t.Fatalf("last block: expected *ContextBlock, got %T", lastBlock)
+		}
+		// Should have 2 elements: task name + activity.
+		if len(ctx.ContextElements.Elements) != 2 {
+			t.Errorf("context elements = %d, want 2 (task name + activity)", len(ctx.ContextElements.Elements))
+		}
+	})
+}
+
+func TestConvertInlineMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"bold", "this is **important**", "this is *important*"},
+		{"link", "see [docs](https://example.com)", "see <https://example.com|docs>"},
+		{"link with parens", "see [Go](https://en.wikipedia.org/wiki/Go_(language))", "see <https://en.wikipedia.org/wiki/Go_(language)|Go>"},
+		{"link with rfc parens", "[RFC](https://tools.ietf.org/html/rfc3986_(URI))", "<https://tools.ietf.org/html/rfc3986_(URI)|RFC>"},
+		{"strikethrough", "~~removed~~", "~removed~"},
+		{"mixed", "**Bold** and [link](https://x.com) ~~old~~", "*Bold* and <https://x.com|link> ~old~"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertInlineMarkdown(tt.in)
+			if got != tt.want {
+				t.Errorf("convertInlineMarkdown(%q)\n got %q\nwant %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSlackSucceeded_MarkdownConversion(t *testing.T) {
+	results := map[string]string{"response": b64("## Summary\nI updated the **CODEOWNERS** file.")}
+	got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+	// ## Summary becomes a HeaderBlock, text becomes a SectionBlock with inline markdown converted
+	if hdr, ok := got.Blocks[0].(*slack.HeaderBlock); !ok {
+		t.Errorf("block 0: expected *HeaderBlock, got %T", got.Blocks[0])
+	} else if hdr.Text.Text != "Summary" {
+		t.Errorf("header text = %q, want %q", hdr.Text.Text, "Summary")
+	}
+	assertSectionContains(t, got.Blocks[1], "*CODEOWNERS*")
+}
+
+func b64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestSlackReporterConstruction(t *testing.T) {
+	reporter := &SlackReporter{BotToken: "xoxb-test-token"}
+	if reporter.BotToken != "xoxb-test-token" {
+		t.Errorf("BotToken = %q, want %q", reporter.BotToken, "xoxb-test-token")
+	}
+}
+
+func TestSlackReporter_PostThreadReplyError(t *testing.T) {
+	reporter := &SlackReporter{BotToken: "xoxb-invalid"}
+	_, err := reporter.PostThreadReply(context.Background(), "C123", "1234.5678", SlackMessage{Text: "test"})
+	if err == nil {
+		t.Error("expected error with invalid token, got nil")
+	}
+}
+
+// assertBlockCount checks that the blocks slice has the expected length.
+func assertBlockCount(t *testing.T, blocks []slack.Block, want int) {
+	t.Helper()
+	if len(blocks) != want {
+		t.Errorf("block count = %d, want %d", len(blocks), want)
+	}
+}
+
+// assertSectionText checks that a block is a SectionBlock with the exact text.
+func assertSectionText(t *testing.T, block slack.Block, want string) {
+	t.Helper()
+	section, ok := block.(*slack.SectionBlock)
+	if !ok {
+		t.Errorf("expected SectionBlock, got %T", block)
+		return
+	}
+	if section.Text == nil || section.Text.Text != want {
+		got := ""
+		if section.Text != nil {
+			got = section.Text.Text
+		}
+		t.Errorf("section text = %q, want %q", got, want)
+	}
+}
+
+// assertSectionContains checks that a block is a SectionBlock containing the substring.
+func assertSectionContains(t *testing.T, block slack.Block, substr string) {
+	t.Helper()
+	section, ok := block.(*slack.SectionBlock)
+	if !ok {
+		t.Errorf("expected SectionBlock, got %T", block)
+		return
+	}
+	if section.Text == nil {
+		t.Errorf("section text is nil, want to contain %q", substr)
+		return
+	}
+	if !strings.Contains(section.Text.Text, substr) {
+		t.Errorf("section text %q does not contain %q", section.Text.Text, substr)
+	}
+}
+
+// assertContextContains checks that a block is a ContextBlock containing the substring.
+func assertContextContains(t *testing.T, block slack.Block, substr string) {
+	t.Helper()
+	ctx, ok := block.(*slack.ContextBlock)
+	if !ok {
+		t.Errorf("expected ContextBlock, got %T", block)
+		return
+	}
+	for _, elem := range ctx.ContextElements.Elements {
+		if txt, ok := elem.(*slack.TextBlockObject); ok {
+			if strings.Contains(txt.Text, substr) {
+				return
+			}
+		}
+	}
+	t.Errorf("context block does not contain %q", substr)
+}

--- a/internal/reporting/watcher.go
+++ b/internal/reporting/watcher.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/slack-go/slack"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -62,6 +63,30 @@ const (
 	// AnnotationGitHubCheckName stores the Check Run name configured on the
 	// TaskSpawner so the reporter can use it without access to the spec.
 	AnnotationGitHubCheckName = "kelos.dev/github-check-name"
+
+	// AnnotationSlackReporting indicates that Slack reporting is enabled
+	// for this Task.
+	AnnotationSlackReporting = "kelos.dev/slack-reporting"
+
+	// AnnotationSlackChannel records the Slack channel ID where the
+	// originating message was posted.
+	AnnotationSlackChannel = "kelos.dev/slack-channel"
+
+	// AnnotationSlackThreadTS records the originating message timestamp,
+	// used as thread_ts for posting replies.
+	AnnotationSlackThreadTS = "kelos.dev/slack-thread-ts"
+
+	// AnnotationSlackUserID records the Slack user ID of the person who
+	// triggered the task.
+	AnnotationSlackUserID = "kelos.dev/slack-user-id"
+
+	// AnnotationSlackReportPhase records the last Task phase that was
+	// reported to Slack, preventing duplicate API calls on re-list.
+	AnnotationSlackReportPhase = "kelos.dev/slack-report-phase"
+
+	// LabelSlackReporting is applied to Tasks created from Slack so that
+	// the reporting and activity loops can list only relevant Tasks.
+	LabelSlackReporting = "kelos.dev/slack-reporting"
 )
 
 // TaskReporter watches Tasks and reports status changes to GitHub.
@@ -413,4 +438,499 @@ func (tr *TaskReporter) persistAnnotations(ctx context.Context, task *kelosv1alp
 	}
 
 	return nil
+}
+
+// SlackMessenger is the interface for posting and updating Slack messages.
+type SlackMessenger interface {
+	PostThreadReply(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error)
+	UpdateMessage(ctx context.Context, channel, messageTS string, msg SlackMessage) error
+}
+
+// activityState tracks the target message for activity indicator updates.
+// The activity indicator is rendered as an additional context element on
+// whichever message is currently the latest in the thread (the accepted
+// message initially, then each progress snapshot as they are posted).
+type activityState struct {
+	// MessageTS is the Slack timestamp of the message being updated with
+	// the activity context element.
+	MessageTS string
+	// BaseMsg holds the original blocks and text of the target message,
+	// before the activity context element was appended.
+	BaseMsg SlackMessage
+	// LastText is the last activity string appended, used for deduplication.
+	LastText string
+	// Tick is incremented on each activity cycle for rotating idle phrases.
+	Tick int
+}
+
+// SlackTaskReporter watches Tasks and reports status changes to Slack
+// as thread replies on the originating message. When a ProgressReader is
+// configured, it also posts periodic progress updates extracted from the
+// agent's pod logs while the task is running. When an ActivityReader is
+// configured, it posts and updates short activity indicators between
+// progress snapshots.
+type SlackTaskReporter struct {
+	Client         client.Client
+	Reporter       SlackMessenger
+	ProgressReader ProgressReader
+	ActivityReader ActivityReader
+
+	mu           sync.Mutex
+	lastProgress map[types.UID]string         // taskUID -> last posted text
+	progressTS   map[types.UID]string         // taskUID -> message ts of the progress reply
+	activity     map[types.UID]*activityState // taskUID -> current activity indicator
+}
+
+// ReportTaskStatus checks a Task's current phase against its last reported
+// phase and creates or updates the Slack thread reply as needed.
+func (tr *SlackTaskReporter) ReportTaskStatus(ctx context.Context, task *kelosv1alpha1.Task) error {
+	log := ctrl.Log.WithName("slack-reporter")
+
+	annotations := task.Annotations
+	if annotations == nil {
+		return nil
+	}
+
+	if annotations[AnnotationSlackReporting] != "enabled" {
+		return nil
+	}
+
+	channel := annotations[AnnotationSlackChannel]
+	threadTS := annotations[AnnotationSlackThreadTS]
+	if channel == "" || threadTS == "" {
+		return nil
+	}
+
+	var desiredPhase string
+	switch task.Status.Phase {
+	case kelosv1alpha1.TaskPhasePending, kelosv1alpha1.TaskPhaseRunning, kelosv1alpha1.TaskPhaseWaiting:
+		desiredPhase = "accepted"
+	case kelosv1alpha1.TaskPhaseSucceeded:
+		desiredPhase = "succeeded"
+	case kelosv1alpha1.TaskPhaseFailed:
+		desiredPhase = "failed"
+	default:
+		return nil
+	}
+
+	if annotations[AnnotationSlackReportPhase] == desiredPhase {
+		// Task is still running and we already posted the "accepted" message.
+		// Try to post a progress update from the agent's pod logs.
+		if desiredPhase == "accepted" {
+			return tr.updateProgress(ctx, task)
+		}
+		return nil
+	}
+
+	msgs := FormatSlackTransitionMessage(desiredPhase, task.Name, task.Status.Message, task.Status.Results)
+
+	// For terminal phases, try to edit the existing progress message
+	// in-place. When the response is a single message, this keeps the
+	// thread compact. When the response was split into multiple messages,
+	// replace the progress message with the first part and post the rest
+	// as new replies.
+	if desiredPhase == "succeeded" || desiredPhase == "failed" {
+		if progressTS := tr.getProgressTS(task.UID); progressTS != "" {
+			log.Info("Updating Slack progress message with final result", "task", task.Name, "channel", channel, "phase", desiredPhase)
+			if err := tr.Reporter.UpdateMessage(ctx, channel, progressTS, msgs[0]); err != nil {
+				log.Error(err, "Failed to update progress message with final result, posting new reply", "task", task.Name)
+			} else {
+				// Post any continuation messages as new thread replies.
+				for _, msg := range msgs[1:] {
+					if _, err := tr.Reporter.PostThreadReply(ctx, channel, threadTS, msg); err != nil {
+						log.Error(err, "Failed to post continuation message", "task", task.Name)
+					}
+				}
+				tr.clearProgressCache(task.UID)
+				tr.clearActivityState(task.UID)
+				return tr.persistSlackReportingState(ctx, task, desiredPhase)
+			}
+		}
+	}
+
+	// Post all messages as thread replies.
+	var firstReplyTS string
+	for i, msg := range msgs {
+		log.Info("Posting Slack thread reply", "task", task.Name, "channel", channel, "phase", desiredPhase, "part", i+1, "total", len(msgs))
+		replyTS, err := tr.Reporter.PostThreadReply(ctx, channel, threadTS, msg)
+		if err != nil {
+			return fmt.Errorf("posting Slack reply for task %s (part %d/%d): %w", task.Name, i+1, len(msgs), err)
+		}
+		if i == 0 {
+			firstReplyTS = replyTS
+		}
+	}
+
+	// Track the accepted message so the activity loop can update it.
+	if desiredPhase == "accepted" && firstReplyTS != "" {
+		tr.setActivityTarget(task.UID, firstReplyTS, msgs[0])
+	}
+
+	// Clean up caches when reporting a terminal phase.
+	if desiredPhase == "succeeded" || desiredPhase == "failed" {
+		tr.clearProgressCache(task.UID)
+		tr.clearActivityState(task.UID)
+	}
+
+	if err := tr.persistSlackReportingState(ctx, task, desiredPhase); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (tr *SlackTaskReporter) persistSlackReportingState(ctx context.Context, task *kelosv1alpha1.Task, desiredPhase string) error {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current kelosv1alpha1.Task
+		if err := tr.Client.Get(ctx, client.ObjectKeyFromObject(task), &current); err != nil {
+			return err
+		}
+
+		if current.Annotations == nil {
+			current.Annotations = make(map[string]string)
+		}
+		current.Annotations[AnnotationSlackReportPhase] = desiredPhase
+
+		if err := tr.Client.Update(ctx, &current); err != nil {
+			return err
+		}
+
+		task.Annotations = current.Annotations
+		return nil
+	}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("persisting Slack reporting annotations on task %s: task no longer exists", task.Name)
+		}
+		return fmt.Errorf("persisting Slack reporting annotations on task %s: %w", task.Name, err)
+	}
+
+	return nil
+}
+
+// updateProgress reads the agent's pod logs and updates the progress message
+// in the Slack thread. On the first call for a task, it posts a new reply and
+// records the message timestamp. Subsequent calls edit the same message
+// in-place so the thread stays clean. All errors are non-fatal — progress
+// updates are best-effort.
+func (tr *SlackTaskReporter) updateProgress(ctx context.Context, task *kelosv1alpha1.Task) error {
+	if tr.ProgressReader == nil {
+		return nil
+	}
+
+	log := ctrl.Log.WithName("slack-reporter")
+
+	podName := task.Status.PodName
+	if podName == "" {
+		return nil
+	}
+
+	annotations := task.Annotations
+	channel := annotations[AnnotationSlackChannel]
+	threadTS := annotations[AnnotationSlackThreadTS]
+	if channel == "" || threadTS == "" {
+		return nil
+	}
+
+	containerName := task.Spec.Type
+	if containerName == "" {
+		containerName = "claude-code"
+	}
+
+	text := tr.ProgressReader.ReadProgress(ctx, task.Namespace, podName, containerName, task.Spec.Type)
+	if text == "" {
+		return nil
+	}
+
+	if !tr.shouldPostProgress(task.UID, text) {
+		return nil
+	}
+
+	msg := FormatProgressMessage(text, task.Name)
+
+	// If we already have a progress message for this task, edit it in-place.
+	if replyTS := tr.getProgressTS(task.UID); replyTS != "" {
+		log.V(1).Info("Updating Slack progress message", "task", task.Name)
+		if err := tr.Reporter.UpdateMessage(ctx, channel, replyTS, msg); err != nil {
+			log.Error(err, "Failed to update Slack progress message", "task", task.Name)
+			// Clear the stale TS so the next tick posts a fresh reply.
+			tr.setProgressTS(task.UID, "")
+			return nil
+		}
+		tr.setLastProgress(task.UID, text)
+		// Update the activity indicator's base message so subsequent
+		// activity ticks render against the new progress content.
+		tr.setActivityTarget(task.UID, replyTS, msg)
+		return nil
+	}
+
+	// First progress update — post a new reply and record its timestamp.
+	log.V(1).Info("Posting Slack progress update", "task", task.Name)
+	replyTS, err := tr.Reporter.PostThreadReply(ctx, channel, threadTS, msg)
+	if err != nil {
+		log.Error(err, "Failed to post Slack progress update", "task", task.Name)
+		return nil
+	}
+
+	tr.setLastProgress(task.UID, text)
+	tr.setProgressTS(task.UID, replyTS)
+
+	// Atomically switch the activity target to the new progress message and
+	// reset the old message's indicator so only one message in the thread
+	// shows an active indicator at a time.
+	if replyTS != "" {
+		tr.resetAndSetActivityTarget(ctx, task.UID, channel, replyTS, msg)
+	}
+
+	return nil
+}
+
+// shouldPostProgress returns true if the text differs from the last posted
+// progress for this task.
+func (tr *SlackTaskReporter) shouldPostProgress(uid types.UID, text string) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.lastProgress == nil {
+		return true
+	}
+	return tr.lastProgress[uid] != text
+}
+
+// setLastProgress records the most recently posted progress text for a task.
+func (tr *SlackTaskReporter) setLastProgress(uid types.UID, text string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.lastProgress == nil {
+		tr.lastProgress = make(map[types.UID]string)
+	}
+	tr.lastProgress[uid] = text
+}
+
+// getProgressTS returns the Slack message timestamp of the progress reply
+// for a task, or empty string if no progress has been posted yet.
+func (tr *SlackTaskReporter) getProgressTS(uid types.UID) string {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.progressTS == nil {
+		return ""
+	}
+	return tr.progressTS[uid]
+}
+
+// setProgressTS records the Slack message timestamp for the progress reply.
+func (tr *SlackTaskReporter) setProgressTS(uid types.UID, ts string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.progressTS == nil {
+		tr.progressTS = make(map[types.UID]string)
+	}
+	tr.progressTS[uid] = ts
+}
+
+// clearProgressCache removes the cached progress for a task.
+func (tr *SlackTaskReporter) clearProgressCache(uid types.UID) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	delete(tr.lastProgress, uid)
+	delete(tr.progressTS, uid)
+}
+
+// SweepProgressCache removes entries for tasks that are no longer active.
+// Call this after each reporting cycle with the set of UIDs seen in the
+// current task list to prevent leaked entries from deleted tasks.
+func (tr *SlackTaskReporter) SweepProgressCache(activeUIDs map[types.UID]bool) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	for uid := range tr.lastProgress {
+		if !activeUIDs[uid] {
+			delete(tr.lastProgress, uid)
+			delete(tr.progressTS, uid)
+		}
+	}
+	// Also clean progressTS entries that don't have a lastProgress entry.
+	for uid := range tr.progressTS {
+		if !activeUIDs[uid] {
+			delete(tr.progressTS, uid)
+		}
+	}
+	for uid := range tr.activity {
+		if !activeUIDs[uid] {
+			delete(tr.activity, uid)
+		}
+	}
+}
+
+// UpdateActivityIndicator reads the agent's current action from pod logs and
+// updates the context block of the latest thread message (accepted or progress
+// snapshot) to include a short activity line. This is called on a faster
+// cadence (e.g. 5s) than the progress snapshot loop. All errors are non-fatal.
+func (tr *SlackTaskReporter) UpdateActivityIndicator(ctx context.Context, task *kelosv1alpha1.Task) {
+	if tr.ActivityReader == nil {
+		return
+	}
+
+	log := ctrl.Log.WithName("slack-activity")
+
+	annotations := task.Annotations
+	if annotations == nil {
+		return
+	}
+	if annotations[AnnotationSlackReporting] != "enabled" {
+		return
+	}
+	if annotations[AnnotationSlackReportPhase] != "accepted" {
+		return
+	}
+
+	// Only update activity for running tasks.
+	if task.Status.Phase != kelosv1alpha1.TaskPhaseRunning {
+		return
+	}
+
+	podName := task.Status.PodName
+	if podName == "" {
+		return
+	}
+
+	channel := annotations[AnnotationSlackChannel]
+	if channel == "" {
+		return
+	}
+
+	containerName := task.Spec.Type
+	if containerName == "" {
+		containerName = "claude-code"
+	}
+
+	text := tr.ActivityReader.ReadActivity(ctx, task.Namespace, podName, containerName, task.Spec.Type)
+
+	tr.mu.Lock()
+	state := tr.activity[task.UID]
+	if state == nil || state.MessageTS == "" {
+		// No target message yet — the accepted message hasn't been posted.
+		tr.mu.Unlock()
+		return
+	}
+	tick := state.Tick
+	state.Tick++
+	if text == "" {
+		// No tool activity — use a rotating idle phrase.
+		text = IdlePhrase(string(task.UID), tick)
+	}
+	if state.LastText == text {
+		tr.mu.Unlock()
+		return
+	}
+	messageTS := state.MessageTS
+	baseMsg := state.BaseMsg
+	tr.mu.Unlock()
+
+	// Rebuild the message: base blocks + activity context element.
+	msg := appendActivityContext(baseMsg, text)
+
+	// appendActivityContext is a no-op for text-only messages (no blocks).
+	// Skip the API call to avoid wasting Slack rate-limit quota.
+	if len(msg.Blocks) == 0 {
+		tr.mu.Lock()
+		if s := tr.activity[task.UID]; s != nil && s.MessageTS == messageTS {
+			s.LastText = text
+		}
+		tr.mu.Unlock()
+		return
+	}
+
+	if err := tr.Reporter.UpdateMessage(ctx, channel, messageTS, msg); err != nil {
+		log.V(1).Info("Failed to update activity indicator", "task", task.Name, "error", err)
+		return
+	}
+
+	tr.mu.Lock()
+	if s := tr.activity[task.UID]; s != nil && s.MessageTS == messageTS {
+		s.LastText = text
+	}
+	tr.mu.Unlock()
+}
+
+// setActivityTarget records the message that the activity loop should update
+// with context block activity indicators.
+func (tr *SlackTaskReporter) setActivityTarget(uid types.UID, messageTS string, baseMsg SlackMessage) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.activity == nil {
+		tr.activity = make(map[types.UID]*activityState)
+	}
+	tr.activity[uid] = &activityState{
+		MessageTS: messageTS,
+		BaseMsg:   baseMsg,
+	}
+}
+
+// resetAndSetActivityTarget atomically replaces the activity target for a task
+// and then resets the old message (removing its activity indicator). By setting
+// the new target under the lock before issuing the UpdateMessage call, a
+// concurrent activity tick will always see the new target and never race
+// against the in-flight reset of the old message.
+func (tr *SlackTaskReporter) resetAndSetActivityTarget(ctx context.Context, uid types.UID, channel, newMessageTS string, newMsg SlackMessage) {
+	tr.mu.Lock()
+	state := tr.activity[uid]
+	var oldTS string
+	var baseMsg SlackMessage
+	if state != nil && state.MessageTS != "" && state.MessageTS != newMessageTS {
+		oldTS = state.MessageTS
+		baseMsg = state.BaseMsg
+	}
+	// Set the new target atomically before releasing the lock.
+	if tr.activity == nil {
+		tr.activity = make(map[types.UID]*activityState)
+	}
+	tr.activity[uid] = &activityState{
+		MessageTS: newMessageTS,
+		BaseMsg:   newMsg,
+	}
+	tr.mu.Unlock()
+
+	// Reset the old message outside the lock (best-effort).
+	if oldTS != "" {
+		log := ctrl.Log.WithName("slack-activity")
+		if err := tr.Reporter.UpdateMessage(ctx, channel, oldTS, baseMsg); err != nil {
+			log.V(1).Info("Failed to reset activity indicator on previous message", "messageTS", oldTS, "error", err)
+		}
+	}
+}
+
+// clearActivityState removes all activity state for a task.
+func (tr *SlackTaskReporter) clearActivityState(uid types.UID) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	delete(tr.activity, uid)
+}
+
+// appendActivityContext returns a copy of baseMsg with an additional context
+// element showing the current activity text. If the last block in baseMsg is
+// already a ContextBlock, the activity element is appended to it. Otherwise
+// a new ContextBlock is added.
+func appendActivityContext(baseMsg SlackMessage, activityText string) SlackMessage {
+	// If baseMsg has no blocks, there is nothing safe to attach to
+	// without hiding the text content — skip the update.
+	if len(baseMsg.Blocks) == 0 {
+		return baseMsg
+	}
+
+	activityElement := slack.NewTextBlockObject(slack.MarkdownType, activityText, false, false)
+
+	blocks := make([]slack.Block, len(baseMsg.Blocks))
+	copy(blocks, baseMsg.Blocks)
+
+	if ctx, ok := blocks[len(blocks)-1].(*slack.ContextBlock); ok {
+		// Clone the context block and append the activity element.
+		newElements := make([]slack.MixedElement, len(ctx.ContextElements.Elements), len(ctx.ContextElements.Elements)+1)
+		copy(newElements, ctx.ContextElements.Elements)
+		newElements = append(newElements, activityElement)
+		newCtx := slack.NewContextBlock(ctx.BlockID, newElements...)
+		blocks[len(blocks)-1] = newCtx
+		return SlackMessage{Text: baseMsg.Text, Blocks: blocks}
+	}
+
+	// Last block is not a context block — append a new one.
+	blocks = append(blocks, slack.NewContextBlock("", activityElement))
+	return SlackMessage{Text: baseMsg.Text, Blocks: blocks}
 }

--- a/internal/reporting/watcher_test.go
+++ b/internal/reporting/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/slack-go/slack"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1307,5 +1309,1572 @@ func TestReportTaskStatus_NilAnnotations(t *testing.T) {
 	// Should not error when annotations are nil
 	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestSlackTaskReporter_PostsThreadReply(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhasePending,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var posted []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			posted = append(posted, slackReplyRecord{method: "post", channel: channel, threadTS: threadTS, msg: msg})
+			return "1234567890.999999", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{Client: cl, Reporter: reporter}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(posted) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posted))
+	}
+	if posted[0].channel != "C123ABC" {
+		t.Errorf("channel = %q, want C123ABC", posted[0].channel)
+	}
+	if posted[0].threadTS != "1234567890.123456" {
+		t.Errorf("threadTS = %q, want 1234567890.123456", posted[0].threadTS)
+	}
+
+	// Verify annotations were persisted
+	var updated kelosv1alpha1.Task
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(task), &updated); err != nil {
+		t.Fatalf("getting updated task: %v", err)
+	}
+	if updated.Annotations[AnnotationSlackReportPhase] != "accepted" {
+		t.Errorf("report phase = %q, want accepted", updated.Annotations[AnnotationSlackReportPhase])
+	}
+}
+
+func TestSlackTaskReporter_PostsNewReplyOnPhaseChange(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseSucceeded,
+			Results: map[string]string{"pr": "https://github.com/org/repo/pull/42"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var posted []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			posted = append(posted, slackReplyRecord{method: "post", channel: channel, threadTS: threadTS, msg: msg})
+			return "1234567890.888888", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{Client: cl, Reporter: reporter}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(posted) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posted))
+	}
+	if posted[0].channel != "C123ABC" {
+		t.Errorf("channel = %q, want C123ABC", posted[0].channel)
+	}
+	// Verify the message includes the PR URL
+	wantMsgs := FormatSlackTransitionMessage("succeeded", task.Name, task.Status.Message, task.Status.Results)
+	if posted[0].msg.Text != wantMsgs[0].Text {
+		t.Errorf("text = %q, want %q", posted[0].msg.Text, wantMsgs[0].Text)
+	}
+
+}
+
+func TestSlackTaskReporter_SkipPaths(t *testing.T) {
+	baseTask := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhasePending,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(t *kelosv1alpha1.Task)
+	}{
+		{
+			name: "no reporting annotation",
+			mutate: func(t *kelosv1alpha1.Task) {
+				delete(t.Annotations, AnnotationSlackReporting)
+			},
+		},
+		{
+			name: "already reported same phase",
+			mutate: func(t *kelosv1alpha1.Task) {
+				t.Annotations[AnnotationSlackReportPhase] = "accepted"
+			},
+		},
+		{
+			name: "nil annotations",
+			mutate: func(t *kelosv1alpha1.Task) {
+				t.Annotations = nil
+			},
+		},
+		{
+			name: "missing channel",
+			mutate: func(t *kelosv1alpha1.Task) {
+				delete(t.Annotations, AnnotationSlackChannel)
+			},
+		},
+		{
+			name: "empty phase",
+			mutate: func(t *kelosv1alpha1.Task) {
+				t.Status.Phase = ""
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := baseTask.DeepCopy()
+			tt.mutate(task)
+
+			called := false
+			reporter := &fakeSlackReporter{
+				postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+					called = true
+					return "", nil
+				},
+			}
+
+			cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+			tr := &SlackTaskReporter{Client: cl, Reporter: reporter}
+
+			if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if called {
+				t.Error("expected reporter to not be called")
+			}
+		})
+	}
+}
+
+type slackReplyRecord struct {
+	method   string
+	channel  string
+	threadTS string
+	msg      SlackMessage
+}
+
+type fakeSlackReporter struct {
+	postFn   func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error)
+	updateFn func(ctx context.Context, channel, messageTS string, msg SlackMessage) error
+}
+
+func (f *fakeSlackReporter) PostThreadReply(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+	if f.postFn != nil {
+		return f.postFn(ctx, channel, threadTS, msg)
+	}
+	return "fake-reply-ts", nil
+}
+
+func (f *fakeSlackReporter) UpdateMessage(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+	if f.updateFn != nil {
+		return f.updateFn(ctx, channel, messageTS, msg)
+	}
+	return nil
+}
+
+func TestSlackTaskReporter_PhaseMapping(t *testing.T) {
+	tests := []struct {
+		name          string
+		phase         kelosv1alpha1.TaskPhase
+		wantDesired   string
+		shouldProcess bool
+	}{
+		{"pending", kelosv1alpha1.TaskPhasePending, "accepted", true},
+		{"running", kelosv1alpha1.TaskPhaseRunning, "accepted", true},
+		{"waiting", kelosv1alpha1.TaskPhaseWaiting, "accepted", true},
+		{"succeeded", kelosv1alpha1.TaskPhaseSucceeded, "succeeded", true},
+		{"failed", kelosv1alpha1.TaskPhaseFailed, "failed", true},
+		{"empty", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &kelosv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-task",
+					Namespace: "default",
+					Annotations: map[string]string{
+						AnnotationSlackReporting: "enabled",
+						AnnotationSlackChannel:   "C123",
+						AnnotationSlackThreadTS:  "1234.5678",
+					},
+				},
+				Status: kelosv1alpha1.TaskStatus{
+					Phase: tt.phase,
+				},
+			}
+
+			if tt.shouldProcess {
+				// Mark as already reported to verify skip logic
+				task.Annotations[AnnotationSlackReportPhase] = tt.wantDesired
+			}
+
+			cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+			tr := &SlackTaskReporter{Client: cl, Reporter: &SlackReporter{BotToken: "xoxb-test"}}
+
+			// Should not error — either skips (empty phase) or skips (already reported)
+			if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type fakeProgressReader struct {
+	text string
+}
+
+func (f *fakeProgressReader) ReadProgress(ctx context.Context, namespace, podName, container, agentType string) string {
+	return f.text
+}
+
+func TestSlackTaskReporter_PostsProgressReply(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-123",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var posted []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			posted = append(posted, slackReplyRecord{method: "post", channel: channel, threadTS: threadTS, msg: msg})
+			return "1234567890.111111", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Searching through release tags..."},
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(posted) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posted))
+	}
+	if posted[0].channel != "C123ABC" {
+		t.Errorf("channel = %q, want C123ABC", posted[0].channel)
+	}
+	if posted[0].threadTS != "1234567890.123456" {
+		t.Errorf("threadTS = %q, want original thread TS", posted[0].threadTS)
+	}
+	if posted[0].msg.Text != "Searching through release tags..." {
+		t.Errorf("text = %q, want progress text", posted[0].msg.Text)
+	}
+	// Progress messages should include Block Kit blocks so the activity
+	// indicator loop can append a context element.
+	if len(posted[0].msg.Blocks) == 0 {
+		t.Error("expected progress message to include blocks for activity indicator support")
+	}
+}
+
+func TestSlackTaskReporter_SkipsProgressWhenNoReader(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "C123ABC",
+				AnnotationSlackThreadTS:    "1234567890.123456",
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	called := false
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			called = true
+			return "", nil
+		},
+	}
+
+	// No ProgressReader set
+	tr := &SlackTaskReporter{Client: cl, Reporter: reporter}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("expected no Slack API call when ProgressReader is nil")
+	}
+}
+
+func TestSlackTaskReporter_SkipsProgressWhenNoPod(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "C123ABC",
+				AnnotationSlackThreadTS:    "1234567890.123456",
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhasePending,
+			PodName: "", // No pod yet
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	called := false
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			called = true
+			return "", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "something"},
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("expected no Slack API call when pod name is empty")
+	}
+}
+
+func TestSlackTaskReporter_SkipsProgressWhenEmpty(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "C123ABC",
+				AnnotationSlackThreadTS:    "1234567890.123456",
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	called := false
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			called = true
+			return "", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: ""}, // Empty text
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("expected no Slack API call when progress text is empty")
+	}
+}
+
+func TestSlackTaskReporter_DeduplicatesProgress(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-456",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	postCount := 0
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			postCount++
+			return "1234567890.111111", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Same progress text"},
+	}
+
+	// First call should post
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("expected 1 post on first call, got %d", postCount)
+	}
+
+	// Second call with same text should NOT post
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if postCount != 1 {
+		t.Errorf("expected still 1 post (deduplicated), got %d", postCount)
+	}
+}
+
+func TestSlackTaskReporter_EditsProgressOnNewText(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-789",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var postedTexts []string
+	var updatedTexts []string
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			postedTexts = append(postedTexts, msg.Text)
+			return "1234567890.111111", nil
+		},
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updatedTexts = append(updatedTexts, msg.Text)
+			return nil
+		},
+	}
+
+	pr := &fakeProgressReader{text: "First update"}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: pr,
+	}
+
+	// First call — posts a new message
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(postedTexts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(postedTexts))
+	}
+	if postedTexts[0] != "First update" {
+		t.Errorf("first post = %q, want 'First update'", postedTexts[0])
+	}
+
+	// Change the text
+	pr.text = "Second update"
+
+	// Second call — should edit the existing message, not post a new one
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(postedTexts) != 1 {
+		t.Errorf("expected still 1 post (edit should not create new), got %d", len(postedTexts))
+	}
+	if len(updatedTexts) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updatedTexts))
+	}
+	if updatedTexts[0] != "Second update" {
+		t.Errorf("update text = %q, want 'Second update'", updatedTexts[0])
+	}
+
+	// Verify that the activity target's BaseMsg was updated to the new progress text.
+	tr.mu.Lock()
+	state := tr.activity[task.UID]
+	tr.mu.Unlock()
+	if state == nil {
+		t.Fatal("expected activity state to be set after in-place edit")
+	}
+	if state.BaseMsg.Text != "Second update" {
+		t.Errorf("activity BaseMsg.Text = %q, want 'Second update'", state.BaseMsg.Text)
+	}
+	if len(state.BaseMsg.Blocks) == 0 {
+		t.Error("expected activity BaseMsg to have blocks after in-place edit")
+	}
+}
+
+func TestSlackTaskReporter_ClearsProgressTSOnUpdateFailure(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-fail-update",
+			Annotations: map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "C123ABC",
+				AnnotationSlackThreadTS:    "1234567890.123456",
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "1234567890.111111", nil
+		},
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			return fmt.Errorf("message_not_found")
+		},
+	}
+
+	pr := &fakeProgressReader{text: "First update"}
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: pr,
+	}
+
+	// First call posts a new progress message.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr.mu.Lock()
+	if tr.progressTS["uid-fail-update"] == "" {
+		t.Fatal("expected progressTS to be set after first post")
+	}
+	tr.mu.Unlock()
+
+	// Change text so dedup allows the update attempt.
+	pr.text = "Second update"
+
+	// Second call tries to edit but updateFn returns an error.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.progressTS["uid-fail-update"] != "" {
+		t.Error("expected progressTS to be cleared after update failure")
+	}
+	if tr.lastProgress["uid-fail-update"] != "First update" {
+		t.Errorf("lastProgress = %q, want 'First update' (should not update on failure)", tr.lastProgress["uid-fail-update"])
+	}
+}
+
+func TestSlackTaskReporter_ClearsProgressCacheOnTerminal(t *testing.T) {
+	// First, seed the progress cache via a running task
+	runningTask := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-clear",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(runningTask).Build()
+
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "1234567890.111111", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Working on it..."},
+	}
+
+	// Post a progress update to populate the cache
+	if err := tr.ReportTaskStatus(context.Background(), runningTask); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify caches are populated
+	tr.mu.Lock()
+	if _, ok := tr.lastProgress["uid-clear"]; !ok {
+		t.Error("expected progress text cache to be populated")
+	}
+	if _, ok := tr.progressTS["uid-clear"]; !ok {
+		t.Error("expected progress timestamp cache to be populated")
+	}
+	tr.mu.Unlock()
+
+	// Simulate task completing by creating a new task object with succeeded phase.
+	// We rebuild the fake client with the succeeded task to allow annotation persistence.
+	succeededTask := runningTask.DeepCopy()
+	succeededTask.Status.Phase = kelosv1alpha1.TaskPhaseSucceeded
+	succeededTask.Status.Results = map[string]string{"response": "done"}
+
+	cl2 := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(succeededTask).Build()
+	tr.Client = cl2
+
+	if err := tr.ReportTaskStatus(context.Background(), succeededTask); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify both caches were cleared
+	tr.mu.Lock()
+	if _, ok := tr.lastProgress["uid-clear"]; ok {
+		t.Error("expected progress text cache to be cleared after terminal phase")
+	}
+	if _, ok := tr.progressTS["uid-clear"]; ok {
+		t.Error("expected progress timestamp cache to be cleared after terminal phase")
+	}
+	tr.mu.Unlock()
+}
+
+func TestSlackTaskReporter_EditsProgressMessageOnTerminalPhase(t *testing.T) {
+	// When a progress message exists and the task completes, the final
+	// result should be edited into the progress message instead of posting
+	// a new reply, keeping the thread compact (ack + single response).
+	task := newRunningTaskWithAnnotations("test-task", "uid-edit-terminal", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var posts []slackReplyRecord
+	var updates []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			posts = append(posts, slackReplyRecord{method: "post", channel: channel, threadTS: threadTS, msg: msg})
+			return "ts-progress", nil
+		},
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updates = append(updates, slackReplyRecord{method: "update", channel: channel, threadTS: messageTS, msg: msg})
+			return nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Working on the analysis..."},
+	}
+
+	// Post a progress update (simulates the running phase).
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error posting progress: %v", err)
+	}
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 post (progress), got %d", len(posts))
+	}
+
+	// Transition to succeeded.
+	succeededTask := task.DeepCopy()
+	succeededTask.Status.Phase = kelosv1alpha1.TaskPhaseSucceeded
+	succeededTask.Status.Message = "Here is the final answer."
+	succeededTask.Status.Results = map[string]string{"response": "done"}
+
+	cl2 := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(succeededTask).Build()
+	tr.Client = cl2
+
+	postsBefore := len(posts)
+	if err := tr.ReportTaskStatus(context.Background(), succeededTask); err != nil {
+		t.Fatalf("unexpected error on terminal phase: %v", err)
+	}
+
+	// Should NOT have posted a new reply.
+	if len(posts) != postsBefore {
+		t.Errorf("expected no new posts on terminal phase, got %d new", len(posts)-postsBefore)
+	}
+
+	// Should have updated the progress message with the final content.
+	var terminalUpdate *slackReplyRecord
+	for i := range updates {
+		if updates[i].threadTS == "ts-progress" {
+			terminalUpdate = &updates[i]
+		}
+	}
+	if terminalUpdate == nil {
+		t.Fatal("expected an update to the progress message with final content")
+	}
+	if len(terminalUpdate.msg.Blocks) == 0 {
+		t.Error("expected final update to include blocks")
+	}
+}
+
+func TestSlackTaskReporter_FallsBackToPostOnUpdateFailure(t *testing.T) {
+	// If editing the progress message fails, we should fall back to posting
+	// a new reply so the final result is never lost.
+	task := newRunningTaskWithAnnotations("test-task", "uid-fallback-post", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var posts []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			posts = append(posts, slackReplyRecord{method: "post", channel: channel, threadTS: threadTS, msg: msg})
+			return "ts-progress", nil
+		},
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			return fmt.Errorf("slack API error")
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Working on it..."},
+	}
+
+	// Post a progress update.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error posting progress: %v", err)
+	}
+
+	// Transition to succeeded — update will fail, should fall back to post.
+	succeededTask := task.DeepCopy()
+	succeededTask.Status.Phase = kelosv1alpha1.TaskPhaseSucceeded
+	succeededTask.Status.Results = map[string]string{"response": "done"}
+
+	cl2 := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(succeededTask).Build()
+	tr.Client = cl2
+
+	if err := tr.ReportTaskStatus(context.Background(), succeededTask); err != nil {
+		t.Fatalf("unexpected error on terminal phase: %v", err)
+	}
+
+	// Should have fallen back to posting a new reply (2 total: progress + final).
+	if len(posts) != 2 {
+		t.Errorf("expected 2 posts (progress + fallback), got %d", len(posts))
+	}
+}
+
+func TestSlackTaskReporter_SweepsStaleProgressEntries(t *testing.T) {
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "fake-ts", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Reporter: reporter,
+	}
+
+	// Seed caches with entries for two tasks
+	tr.setLastProgress("uid-active", "some text")
+	tr.setProgressTS("uid-active", "1234.5678")
+	tr.setLastProgress("uid-deleted", "other text")
+	tr.setProgressTS("uid-deleted", "1234.9999")
+
+	// Sweep with only the active UID
+	activeUIDs := map[types.UID]bool{
+		"uid-active": true,
+	}
+	tr.SweepProgressCache(activeUIDs)
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	if _, ok := tr.lastProgress["uid-active"]; !ok {
+		t.Error("expected active UID to remain in lastProgress cache")
+	}
+	if _, ok := tr.progressTS["uid-active"]; !ok {
+		t.Error("expected active UID to remain in progressTS cache")
+	}
+	if _, ok := tr.lastProgress["uid-deleted"]; ok {
+		t.Error("expected deleted UID to be swept from lastProgress cache")
+	}
+	if _, ok := tr.progressTS["uid-deleted"]; ok {
+		t.Error("expected deleted UID to be swept from progressTS cache")
+	}
+}
+
+// --- Activity indicator tests ---
+
+type fakeActivityReader struct {
+	text string
+}
+
+func (f *fakeActivityReader) ReadActivity(ctx context.Context, namespace, podName, container, agentType string) string {
+	return f.text
+}
+
+func newRunningTaskWithAnnotations(name string, uid types.UID, annotations map[string]string) *kelosv1alpha1.Task {
+	return &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			UID:         uid,
+			Annotations: annotations,
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase:   kelosv1alpha1.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+}
+
+func TestSlackTaskReporter_UpdatesAcceptedMessageWithActivity(t *testing.T) {
+	task := newRunningTaskWithAnnotations("test-task", "uid-act-1", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	var updates []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updates = append(updates, slackReplyRecord{method: "update", channel: channel, threadTS: messageTS, msg: msg})
+			return nil
+		},
+	}
+
+	baseMsg := FormatSlackTransitionMessage("accepted", task.Name, "", nil)[0]
+	tr := &SlackTaskReporter{
+		Reporter:       reporter,
+		ActivityReader: &fakeActivityReader{text: "Reading `main.go`..."},
+	}
+	// Simulate the accepted message having been posted.
+	tr.setActivityTarget(task.UID, "1234567890.accepted", baseMsg)
+
+	tr.UpdateActivityIndicator(context.Background(), task)
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+	if updates[0].channel != "C123ABC" {
+		t.Errorf("channel = %q, want C123ABC", updates[0].channel)
+	}
+	if updates[0].threadTS != "1234567890.accepted" {
+		t.Errorf("messageTS = %q, want accepted TS", updates[0].threadTS)
+	}
+	// The updated message should have the original blocks + activity in context.
+	if updates[0].msg.Text != baseMsg.Text {
+		t.Errorf("fallback text changed: got %q", updates[0].msg.Text)
+	}
+	// Should have more blocks than the base (activity appended to context).
+	if len(updates[0].msg.Blocks) < len(baseMsg.Blocks) {
+		t.Errorf("expected at least %d blocks, got %d", len(baseMsg.Blocks), len(updates[0].msg.Blocks))
+	}
+}
+
+func TestSlackTaskReporter_UpdatesActivityInPlace(t *testing.T) {
+	task := newRunningTaskWithAnnotations("test-task", "uid-act-2", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	var updates []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updates = append(updates, slackReplyRecord{method: "update", channel: channel, threadTS: messageTS, msg: msg})
+			return nil
+		},
+	}
+
+	ar := &fakeActivityReader{text: "Reading `main.go`..."}
+	baseMsg := FormatSlackTransitionMessage("accepted", task.Name, "", nil)[0]
+	tr := &SlackTaskReporter{
+		Reporter:       reporter,
+		ActivityReader: ar,
+	}
+	tr.setActivityTarget(task.UID, "1234567890.accepted", baseMsg)
+
+	// First call updates the accepted message with activity.
+	tr.UpdateActivityIndicator(context.Background(), task)
+
+	// Change activity text and call again — should update in place again.
+	ar.text = "Running `make test`..."
+	tr.UpdateActivityIndicator(context.Background(), task)
+
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+	if updates[1].threadTS != "1234567890.accepted" {
+		t.Errorf("update messageTS = %q, want accepted TS", updates[1].threadTS)
+	}
+}
+
+func TestSlackTaskReporter_SkipsActivityWhenUnchanged(t *testing.T) {
+	task := newRunningTaskWithAnnotations("test-task", "uid-act-3", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	updateCount := 0
+	reporter := &fakeSlackReporter{
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updateCount++
+			return nil
+		},
+	}
+
+	baseMsg := FormatSlackTransitionMessage("accepted", task.Name, "", nil)[0]
+	tr := &SlackTaskReporter{
+		Reporter:       reporter,
+		ActivityReader: &fakeActivityReader{text: "Thinking..."},
+	}
+	tr.setActivityTarget(task.UID, "1234567890.accepted", baseMsg)
+
+	tr.UpdateActivityIndicator(context.Background(), task)
+	tr.UpdateActivityIndicator(context.Background(), task) // Same text
+
+	if updateCount != 1 {
+		t.Errorf("expected 1 update (dedup second), got %d", updateCount)
+	}
+}
+
+func TestSlackTaskReporter_SkipsActivityWhenNoTarget(t *testing.T) {
+	task := newRunningTaskWithAnnotations("test-task", "uid-no-target", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	updateCalled := false
+	reporter := &fakeSlackReporter{
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	// No activity target set — accepted message not yet posted.
+	tr := &SlackTaskReporter{
+		Reporter:       reporter,
+		ActivityReader: &fakeActivityReader{text: "Reading..."},
+	}
+
+	tr.UpdateActivityIndicator(context.Background(), task)
+
+	if updateCalled {
+		t.Error("expected no update when no activity target is set")
+	}
+}
+
+func TestSlackTaskReporter_ActivitySkipPaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		task   *kelosv1alpha1.Task
+		reader ActivityReader
+	}{
+		{
+			name: "no activity reader",
+			task: newRunningTaskWithAnnotations("t", "uid-1", map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "C123",
+				AnnotationSlackThreadTS:    "1234.5678",
+				AnnotationSlackReportPhase: "accepted",
+			}),
+			reader: nil,
+		},
+		{
+			name: "reporting not enabled",
+			task: newRunningTaskWithAnnotations("t", "uid-2", map[string]string{
+				AnnotationSlackChannel:     "C123",
+				AnnotationSlackThreadTS:    "1234.5678",
+				AnnotationSlackReportPhase: "accepted",
+			}),
+			reader: &fakeActivityReader{text: "something"},
+		},
+		{
+			name: "not yet accepted",
+			task: newRunningTaskWithAnnotations("t", "uid-3", map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123",
+				AnnotationSlackThreadTS:  "1234.5678",
+			}),
+			reader: &fakeActivityReader{text: "something"},
+		},
+		{
+			name: "no pod name",
+			task: func() *kelosv1alpha1.Task {
+				t := newRunningTaskWithAnnotations("t", "uid-4", map[string]string{
+					AnnotationSlackReporting:   "enabled",
+					AnnotationSlackChannel:     "C123",
+					AnnotationSlackThreadTS:    "1234.5678",
+					AnnotationSlackReportPhase: "accepted",
+				})
+				t.Status.PodName = ""
+				return t
+			}(),
+			reader: &fakeActivityReader{text: "something"},
+		},
+		{
+			name: "no channel",
+			task: newRunningTaskWithAnnotations("t", "uid-5", map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "",
+				AnnotationSlackThreadTS:    "1234.5678",
+				AnnotationSlackReportPhase: "accepted",
+			}),
+			reader: &fakeActivityReader{text: "something"},
+		},
+		{
+			name: "task not running",
+			task: func() *kelosv1alpha1.Task {
+				t := newRunningTaskWithAnnotations("t", "uid-6", map[string]string{
+					AnnotationSlackReporting:   "enabled",
+					AnnotationSlackChannel:     "C123",
+					AnnotationSlackThreadTS:    "1234.5678",
+					AnnotationSlackReportPhase: "accepted",
+				})
+				t.Status.Phase = kelosv1alpha1.TaskPhasePending
+				return t
+			}(),
+			reader: &fakeActivityReader{text: "something"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateCalled := false
+			reporter := &fakeSlackReporter{
+				updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+					updateCalled = true
+					return nil
+				},
+			}
+
+			tr := &SlackTaskReporter{
+				Reporter:       reporter,
+				ActivityReader: tt.reader,
+			}
+			// Seed a target so skip is due to the test condition, not missing target.
+			if tt.reader != nil {
+				tr.setActivityTarget(tt.task.UID, "ts-seed", SlackMessage{Text: "base"})
+			}
+
+			tr.UpdateActivityIndicator(context.Background(), tt.task)
+
+			if updateCalled {
+				t.Error("expected no Slack API call")
+			}
+		})
+	}
+}
+
+func TestSlackTaskReporter_AcceptedPostSetsActivityTarget(t *testing.T) {
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-accepted-target",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeOAuth,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhasePending,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "1234567890.accepted", nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:   cl,
+		Reporter: reporter,
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr.mu.Lock()
+	state := tr.activity[task.UID]
+	tr.mu.Unlock()
+	if state == nil {
+		t.Fatal("expected activity state to be set after accepted post")
+	}
+	if state.MessageTS != "1234567890.accepted" {
+		t.Errorf("messageTS = %q, want accepted TS", state.MessageTS)
+	}
+}
+
+func TestSlackTaskReporter_ProgressPostUpdatesActivityTarget(t *testing.T) {
+	task := newRunningTaskWithAnnotations("test-task", "uid-progress-target", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	postCount := 0
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			postCount++
+			return fmt.Sprintf("ts-progress-%d", postCount), nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "I found the issue."},
+	}
+	// Seed initial target (from accepted post).
+	tr.setActivityTarget(task.UID, "ts-accepted", SlackMessage{Text: "accepted"})
+
+	// Trigger progress update.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Activity target should now point to the progress message.
+	tr.mu.Lock()
+	state := tr.activity[task.UID]
+	tr.mu.Unlock()
+	if state == nil {
+		t.Fatal("expected activity state after progress post")
+	}
+	if state.MessageTS != "ts-progress-1" {
+		t.Errorf("messageTS = %q, want progress TS", state.MessageTS)
+	}
+	// LastText should be reset so activity updates on the new message.
+	if state.LastText != "" {
+		t.Errorf("LastText = %q, want empty (reset for new target)", state.LastText)
+	}
+}
+
+func TestSlackTaskReporter_ActivityIndicatorWorksOnProgressMessage(t *testing.T) {
+	// Regression test: the activity indicator must keep working after the
+	// progress snapshot replaces the accepted message as the activity target.
+	// Previously, progress messages were text-only (no blocks), causing
+	// appendActivityContext to skip the update.
+	task := newRunningTaskWithAnnotations("test-task", "uid-progress-activity", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var updates []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "ts-progress", nil
+		},
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updates = append(updates, slackReplyRecord{method: "update", channel: channel, threadTS: messageTS, msg: msg})
+			return nil
+		},
+	}
+
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "I found the issue in the config."},
+		ActivityReader: &fakeActivityReader{text: "Reading `config.yaml`..."},
+	}
+	// Seed initial activity target (from accepted post).
+	tr.setActivityTarget(task.UID, "ts-accepted", FormatSlackTransitionMessage("accepted", task.Name, "", nil)[0])
+
+	// Trigger a progress update — this should post a new progress message
+	// and re-point the activity target at it.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The first update should reset the old accepted message back to its
+	// base content (strip the activity indicator).
+	if len(updates) < 1 {
+		t.Fatal("expected at least 1 update (reset of accepted message)")
+	}
+	if updates[0].threadTS != "ts-accepted" {
+		t.Errorf("reset update targeted %q, want ts-accepted", updates[0].threadTS)
+	}
+
+	// Now call UpdateActivityIndicator — it should update the progress
+	// message (not the old accepted message) with the activity context.
+	tr.UpdateActivityIndicator(context.Background(), task)
+
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates (reset + activity), got %d", len(updates))
+	}
+	if updates[1].threadTS != "ts-progress" {
+		t.Errorf("activity update targeted %q, want ts-progress", updates[1].threadTS)
+	}
+	if len(updates[1].msg.Blocks) == 0 {
+		t.Error("expected activity update to include blocks")
+	}
+}
+
+func TestSlackTaskReporter_ResetsOldActivityIndicatorOnTargetSwitch(t *testing.T) {
+	// When a progress message is posted and becomes the new activity target,
+	// the old target (the accepted ack) should be updated back to its base
+	// content so there is only one active indicator in the thread.
+	task := newRunningTaskWithAnnotations("test-task", "uid-reset-indicator", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	var updates []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "ts-progress", nil
+		},
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updates = append(updates, slackReplyRecord{method: "update", channel: channel, threadTS: messageTS, msg: msg})
+			return nil
+		},
+	}
+
+	acceptedMsg := FormatSlackTransitionMessage("accepted", task.Name, "", nil)[0]
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Investigating the logs..."},
+	}
+	tr.setActivityTarget(task.UID, "ts-accepted", acceptedMsg)
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// First update resets the accepted message to its base content.
+	if len(updates) < 1 {
+		t.Fatal("expected at least 1 update for the reset call")
+	}
+	resetUpdate := updates[0]
+	if resetUpdate.threadTS != "ts-accepted" {
+		t.Errorf("reset targeted %q, want ts-accepted", resetUpdate.threadTS)
+	}
+	// The reset message should match the base accepted message (no activity element).
+	if resetUpdate.msg.Text != acceptedMsg.Text {
+		t.Errorf("reset text = %q, want %q", resetUpdate.msg.Text, acceptedMsg.Text)
+	}
+	if len(resetUpdate.msg.Blocks) != len(acceptedMsg.Blocks) {
+		t.Errorf("reset blocks count = %d, want %d (base message blocks)", len(resetUpdate.msg.Blocks), len(acceptedMsg.Blocks))
+	}
+}
+
+func TestSlackTaskReporter_SweepClearsActivityState(t *testing.T) {
+	reporter := &fakeSlackReporter{}
+	tr := &SlackTaskReporter{Reporter: reporter}
+
+	// Seed activity state.
+	tr.mu.Lock()
+	tr.activity = map[types.UID]*activityState{
+		"uid-active":  {MessageTS: "ts-1", LastText: "Working..."},
+		"uid-deleted": {MessageTS: "ts-2", LastText: "Reading..."},
+	}
+	tr.mu.Unlock()
+
+	tr.SweepProgressCache(map[types.UID]bool{"uid-active": true})
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if _, ok := tr.activity["uid-active"]; !ok {
+		t.Error("expected active UID to remain in activity cache")
+	}
+	if _, ok := tr.activity["uid-deleted"]; ok {
+		t.Error("expected deleted UID to be swept from activity cache")
+	}
+}
+
+func TestSlackTaskReporter_EmptyActivityUsesIdlePhrase(t *testing.T) {
+	task := newRunningTaskWithAnnotations("test-task", "uid-idle", map[string]string{
+		AnnotationSlackReporting:   "enabled",
+		AnnotationSlackChannel:     "C123ABC",
+		AnnotationSlackThreadTS:    "1234567890.123456",
+		AnnotationSlackReportPhase: "accepted",
+	})
+
+	var updates []slackReplyRecord
+	reporter := &fakeSlackReporter{
+		updateFn: func(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+			updates = append(updates, slackReplyRecord{method: "update", channel: channel, threadTS: messageTS, msg: msg})
+			return nil
+		},
+	}
+
+	baseMsg := FormatSlackTransitionMessage("accepted", task.Name, "", nil)[0]
+	tr := &SlackTaskReporter{
+		Reporter:       reporter,
+		ActivityReader: &fakeActivityReader{text: ""}, // Empty — triggers idle phrase
+	}
+	tr.setActivityTarget(task.UID, "1234567890.accepted", baseMsg)
+
+	// First call should post an idle phrase.
+	tr.UpdateActivityIndicator(context.Background(), task)
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(updates))
+	}
+
+	// Second call should post a different idle phrase (tick incremented).
+	tr.UpdateActivityIndicator(context.Background(), task)
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+}
+
+func TestAppendActivityContext_AppendsToExistingContext(t *testing.T) {
+	baseMsg := FormatSlackTransitionMessage("accepted", "test-task", "", nil)[0]
+	result := appendActivityContext(baseMsg, "Reading `main.go`...")
+
+	// Should have same number of blocks (activity appended to existing context block).
+	if len(result.Blocks) != len(baseMsg.Blocks) {
+		t.Fatalf("block count = %d, want %d (appended to existing context)", len(result.Blocks), len(baseMsg.Blocks))
+	}
+
+	// Last block should be a context block with 2 elements (task name + activity).
+	lastBlock := result.Blocks[len(result.Blocks)-1]
+	ctx, ok := lastBlock.(*slack.ContextBlock)
+	if !ok {
+		t.Fatalf("last block: expected *ContextBlock, got %T", lastBlock)
+	}
+	if len(ctx.ContextElements.Elements) != 2 {
+		t.Errorf("context elements = %d, want 2", len(ctx.ContextElements.Elements))
+	}
+}
+
+func TestAppendActivityContext_AddsNewContextBlock(t *testing.T) {
+	// Message with no context block at the end.
+	baseMsg := SlackMessage{
+		Text:   "Just text",
+		Blocks: []slack.Block{slack.NewSectionBlock(slack.NewTextBlockObject(slack.PlainTextType, "hello", false, false), nil, nil)},
+	}
+	result := appendActivityContext(baseMsg, "Thinking...")
+
+	if len(result.Blocks) != 2 {
+		t.Fatalf("block count = %d, want 2 (section + new context)", len(result.Blocks))
+	}
+
+	ctx, ok := result.Blocks[1].(*slack.ContextBlock)
+	if !ok {
+		t.Fatalf("block 1: expected *ContextBlock, got %T", result.Blocks[1])
+	}
+	if len(ctx.ContextElements.Elements) != 1 {
+		t.Errorf("context elements = %d, want 1", len(ctx.ContextElements.Elements))
+	}
+}
+
+func TestAppendActivityContext_SkipsTextOnlyMessages(t *testing.T) {
+	baseMsg := SlackMessage{Text: "I found the issue in the config.", Blocks: nil}
+	result := appendActivityContext(baseMsg, "Reading `main.go`...")
+
+	// Should return the base message unchanged — no blocks added.
+	if len(result.Blocks) != 0 {
+		t.Fatalf("block count = %d, want 0 (text-only message unchanged)", len(result.Blocks))
+	}
+	if result.Text != baseMsg.Text {
+		t.Errorf("text changed: got %q", result.Text)
+	}
+}
+
+func TestAppendActivityContext_DoesNotMutateBase(t *testing.T) {
+	baseMsg := FormatSlackTransitionMessage("accepted", "test-task", "", nil)[0]
+	originalBlockCount := len(baseMsg.Blocks)
+
+	_ = appendActivityContext(baseMsg, "Reading...")
+
+	if len(baseMsg.Blocks) != originalBlockCount {
+		t.Errorf("base message mutated: blocks went from %d to %d", originalBlockCount, len(baseMsg.Blocks))
 	}
 }

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -18,21 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/internal/reporting"
 	"github.com/kelos-dev/kelos/internal/taskbuilder"
-)
-
-const (
-	// AnnotationSlackReporting indicates that Slack reporting is enabled
-	// for this Task.
-	AnnotationSlackReporting = "kelos.dev/slack-reporting"
-
-	// AnnotationSlackChannel records the Slack channel ID where the
-	// originating message was posted.
-	AnnotationSlackChannel = "kelos.dev/slack-channel"
-
-	// AnnotationSlackThreadTS records the originating message timestamp,
-	// used as thread_ts for posting replies.
-	AnnotationSlackThreadTS = "kelos.dev/slack-thread-ts"
 )
 
 const (
@@ -316,11 +303,13 @@ func (h *SlackHandler) createTask(ctx context.Context, spawner *v1alpha1.TaskSpa
 	}
 	sum := sha256.Sum256([]byte(hashInput))
 	shortHash := hex.EncodeToString(sum[:])[:12]
-	taskName := fmt.Sprintf("%s-slack-%s", spawner.Name, shortHash)
-	if len(taskName) > 63 {
-		fullSum := sha256.Sum256([]byte(taskName))
-		taskName = fmt.Sprintf("slack-%s", hex.EncodeToString(fullSum[:])[:12])
+	// Truncate spawner name to leave room for "-slack-" (7) + hash (12) = 19 chars
+	name := spawner.Name
+	const maxPrefix = 63 - 7 - 12 // 44
+	if len([]rune(name)) > maxPrefix {
+		name = strings.TrimRight(string([]rune(name)[:maxPrefix]), "-.")
 	}
+	taskName := fmt.Sprintf("%s-slack-%s", name, shortHash)
 
 	// Resolve GVK for owner reference
 	gvks, _, err := h.client.Scheme().ObjectKinds(spawner)
@@ -349,17 +338,24 @@ func (h *SlackHandler) createTask(ctx context.Context, spawner *v1alpha1.TaskSpa
 	if task.Annotations == nil {
 		task.Annotations = make(map[string]string)
 	}
-	task.Annotations[AnnotationSlackReporting] = "enabled"
-	task.Annotations[AnnotationSlackChannel] = msg.ChannelID
+	task.Annotations[reporting.AnnotationSlackReporting] = "enabled"
+	task.Annotations[reporting.AnnotationSlackChannel] = msg.ChannelID
+	task.Annotations[reporting.AnnotationSlackUserID] = msg.UserID
 
-	// Only set thread_ts for real message timestamps (not slash command composite IDs).
-	// Slash commands intentionally skip status reporting — there is no thread to reply to.
+	// Only enable Slack reporting label and thread_ts for real message
+	// timestamps. Slash commands have no thread to reply to, so skip the
+	// label to avoid the reporter listing them every cycle.
 	if !msg.IsSlashCommand {
+		if task.Labels == nil {
+			task.Labels = make(map[string]string)
+		}
+		task.Labels[reporting.LabelSlackReporting] = "enabled"
+
 		threadTS := msg.Timestamp
 		if msg.ThreadTS != "" {
 			threadTS = msg.ThreadTS
 		}
-		task.Annotations[AnnotationSlackThreadTS] = threadTS
+		task.Annotations[reporting.AnnotationSlackThreadTS] = threadTS
 	}
 
 	if err := h.client.Create(ctx, task); err != nil {

--- a/internal/slack/handler_test.go
+++ b/internal/slack/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kelos-dev/kelos/api/v1alpha1"
+	"github.com/kelos-dev/kelos/internal/reporting"
 	"github.com/kelos-dev/kelos/internal/taskbuilder"
 )
 
@@ -309,6 +310,19 @@ func TestCreateTaskAlreadyExists(t *testing.T) {
 	// First call should succeed
 	if err := h.createTask(context.Background(), spawner, msg); err != nil {
 		t.Fatalf("First createTask() error: %v", err)
+	}
+
+	// Verify Slack user ID annotation is set
+	taskList := &v1alpha1.TaskList{}
+	if err := cl.List(context.Background(), taskList); err != nil {
+		t.Fatalf("List tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(taskList.Items))
+	}
+	got := taskList.Items[0].Annotations[reporting.AnnotationSlackUserID]
+	if got != "U123" {
+		t.Errorf("Expected slack-user-id annotation %q, got %q", "U123", got)
 	}
 
 	// Second call with same message should not return an error (AlreadyExists is handled)

--- a/test/integration/taskspawner_test.go
+++ b/test/integration/taskspawner_test.go
@@ -23,7 +23,7 @@ import (
 
 var _ = Describe("TaskSpawner Controller", func() {
 	const (
-		timeout  = time.Second * 10
+		timeout  = time.Second * 30
 		interval = time.Millisecond * 250
 	)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds centralized Slack task reporting with Block Kit formatting to the slack-server. Previously, Slack status reporting would need to run in each spawner pod. This PR moves it to a single, leader-elected loop in kelos-slack-server that watches all Tasks cluster-wide and posts rich thread replies back to the originating Slack message.

Key changes:

- **Slack reporting (`SlackTaskReporter`)**: Posts phase transitions (accepted/succeeded/failed) as thread replies. On terminal phases, edits the existing progress message in-place to keep threads compact. Supports multi-part message splitting for long responses.
- **Block Kit formatting**: Converts agent markdown responses into Slack Block Kit blocks (headers, tables, lists, dividers, inline formatting). Automatically chunks messages that exceed the 50-block Slack limit.
- **Progress snapshots**: Reads agent pod logs via `ProgressReader` and posts/updates a progress message in the thread while the task is running. Supports multiple agent types (claude-code, codex, gemini, opencode).
- **Activity indicators**: A fast-cadence loop (default 5s) reads the agent's current tool action from pod logs and updates a context block on the latest thread message (e.g. "Reading `main.go`...", "Running `make test`..."). Falls back to rotating idle phrases when no tool is active.
- **Annotation consolidation**: Slack annotation constants moved from `internal/slack/handler.go` to `internal/reporting/watcher.go`. New `kelos.dev/slack-user-id` annotation tracks the Slack user who triggered the task.
- **Task naming**: Long spawner names are now truncated (max 44 chars) before appending `-slack-<hash>` instead of re-hashing the entire name, preserving readability.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- New files in `internal/reporting/` (slack.go, slack_blocks.go, progress.go, activity.go + tests) are ported from the `prod` branch where they have been running in production.
- The `MatchesSpawner` filter signature is unchanged — the filter refactor from prod is intentionally out of scope for this PR.
- The `watcher_test.go` file was fully replaced with the prod version which includes all existing GitHub reporter tests plus the new SlackTaskReporter tests.


Gif of it working: https://github.com/user-attachments/assets/dccba9db-0d5b-4355-bcb5-0bfc715e4862



#### Does this PR introduce a user-facing change?

```release-note
Add centralized Slack task reporting with Block Kit formatting, progress snapshots, and real-time activity indicators. Status updates are posted as rich thread replies to the originating Slack message.
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Slack task reporting in `kelos-slack-server` with Block Kit formatting, threaded updates, and real-time progress/activity across the cluster. Adds an optional channel join message.

- **New Features**
  - Leader-elected loop watches all Tasks and replies in the originating Slack thread.
  - `SlackTaskReporter` (via `SlackReporter`) posts accepted/succeeded/failed, edits terminal updates in place, splits long replies; decodes base64 task results.
  - Block Kit rendering (headers/lists/tables/dividers), auto-chunking to Slack’s 50-block limit; fallback text capped at 40k.
  - Progress snapshots and real-time activity from agent pod logs via `ProgressReader` and `ActivityReader`; supports `claude-code`, `codex`, `gemini`, `opencode`.
  - Wired as runnables in `cmd/kelos-slack-server` with `-reporting-interval` and `-activity-interval`.
  - Optional join message via `SLACK_JOIN_MESSAGE_FILE`; Helm adds `slackServer.joinMessage`.

- **Refactors**
  - Moved Slack annotation constants to `internal/reporting/watcher.go`; set `kelos.dev/slack-user-id` during task creation.
  - Truncated long spawner names before appending `-slack-<hash>` for readability.
  - Expanded tests for blocks, progress, activity, reporter, and watcher; uses `github.com/slack-go/slack`.

<sup>Written for commit 0a07c3144feece0166092adb87c191bb3b024283. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



