### PR TITLE
feat(reporting): add Slack message types and Block Kit formatting

### DIFF
--- a/internal/reporting/slack.go
+++ b/internal/reporting/slack.go
@@ -1,0 +1,356 @@
+package reporting
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/slack-go/slack"
+)
+
+// Slack's chat.postMessage text field limit is 40,000 characters.
+const slackFallbackTextLimit = 40000
+
+// decodeResponse decodes a base64-encoded agent response from task results.
+// Returns the raw string if decoding fails (backward compatibility).
+func decodeResponse(encoded string) string {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return encoded
+	}
+	return string(decoded)
+}
+
+// SlackMessage holds the components of a rich Slack message.
+type SlackMessage struct {
+	// Text is the fallback text shown in notifications and accessibility contexts.
+	Text string
+	// Blocks are the Block Kit blocks for rich formatting.
+	Blocks []slack.Block
+}
+
+// SlackReporter posts and updates thread replies in Slack channels.
+type SlackReporter struct {
+	// BotToken is the Bot User OAuth Token (xoxb-...).
+	BotToken string
+	once     sync.Once
+	client   *slack.Client
+}
+
+func (r *SlackReporter) api() *slack.Client {
+	r.once.Do(func() {
+		if r.client == nil {
+			r.client = slack.New(r.BotToken)
+		}
+	})
+	return r.client
+}
+
+// PostThreadReply posts a new message as a thread reply and returns the
+// reply's message timestamp.
+func (r *SlackReporter) PostThreadReply(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(msg.Text, false),
+		slack.MsgOptionTS(threadTS),
+	}
+	if len(msg.Blocks) > 0 {
+		opts = append(opts, slack.MsgOptionBlocks(msg.Blocks...))
+	}
+	_, ts, err := r.api().PostMessageContext(ctx, channel, opts...)
+	if err != nil {
+		return "", fmt.Errorf("posting Slack thread reply: %w", err)
+	}
+	return ts, nil
+}
+
+// UpdateMessage updates an existing Slack message in place.
+func (r *SlackReporter) UpdateMessage(ctx context.Context, channel, messageTS string, msg SlackMessage) error {
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(msg.Text, false),
+	}
+	if len(msg.Blocks) > 0 {
+		opts = append(opts, slack.MsgOptionBlocks(msg.Blocks...))
+	}
+	_, _, _, err := r.api().UpdateMessageContext(ctx, channel, messageTS, opts...)
+	if err != nil {
+		return fmt.Errorf("updating Slack message: %w", err)
+	}
+	return nil
+}
+
+// contextBlock returns a context block displaying the task name.
+func contextBlock(taskName string) *slack.ContextBlock {
+	return slack.NewContextBlock("",
+		slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("Task: `%s`", taskName), false, false),
+	)
+}
+
+// phaseHeaderText maps each phase to its leading Block Kit section text.
+// Phases without an entry (e.g. "succeeded") get no header block.
+var phaseHeaderText = map[string]string{
+	"accepted": ":hourglass_flowing_sand: *Working on your request...*",
+	"failed":   ":x: *Something went wrong*",
+}
+
+// phaseFallbackText maps each phase to its default fallback text (before the
+// "(Task: ...)" suffix) when no richer content is available.
+var phaseFallbackText = map[string]string{
+	"accepted":  "Working on your request...",
+	"succeeded": "Done!",
+	"failed":    "Failed.",
+}
+
+// FormatProgressMessage returns a Slack message with Block Kit blocks for
+// an in-progress agent snapshot. Using blocks (rather than text-only) allows
+// the activity indicator loop to append a context element showing the agent's
+// current action.
+func FormatProgressMessage(text, taskName string) SlackMessage {
+	blocks := responseToBlocks(text)
+	blocks = append(blocks, contextBlock(taskName))
+	return SlackMessage{
+		Text:   truncateFallbackText(text),
+		Blocks: blocks,
+	}
+}
+
+// FormatSlackTransitionMessage returns one or more rich Slack messages for a
+// task phase transition. When the agent response is short enough to fit in a
+// single message (≤ SlackBlockLimit blocks), a single SlackMessage is returned.
+// For longer responses, the response blocks are split across multiple messages
+// so that no individual message exceeds the Slack block limit, and each chunk
+// is posted as a separate thread reply.
+func FormatSlackTransitionMessage(phase, taskName, message string, results map[string]string) []SlackMessage {
+	// Build the optional header block (e.g. "Working on your request…").
+	var headerBlocks []slack.Block
+	if header, ok := phaseHeaderText[phase]; ok {
+		headerBlocks = append(headerBlocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, header, false, false),
+			nil, nil,
+		))
+	}
+
+	// Build the response blocks from the agent output.
+	resp := results["response"]
+	decoded := decodeResponse(resp)
+	var responseBlocks []slack.Block
+	if resp != "" {
+		responseBlocks = responseToBlocks(decoded)
+	}
+
+	// Build the trailing blocks (PR link, error, context).
+	var trailingBlocks []slack.Block
+	pr := results["pr"]
+	if pr != "" {
+		trailingBlocks = append(trailingBlocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf(":link: *Pull Request:* <%s>", pr), false, false),
+			nil, nil,
+		))
+	}
+
+	if message != "" && phase == "failed" {
+		trailingBlocks = append(trailingBlocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf(":warning: *Error:* %s", message), false, false),
+			nil, nil,
+		))
+	}
+
+	trailingBlocks = append(trailingBlocks, contextBlock(taskName))
+
+	fallbackText := buildFallbackText(decoded, pr, message, phase, taskName)
+
+	// Check if everything fits in a single message.
+	totalBlocks := len(headerBlocks) + len(responseBlocks) + len(trailingBlocks)
+	if totalBlocks <= SlackBlockLimit {
+		var blocks []slack.Block
+		blocks = append(blocks, headerBlocks...)
+		blocks = append(blocks, responseBlocks...)
+		blocks = append(blocks, trailingBlocks...)
+		return []SlackMessage{{Text: fallbackText, Blocks: blocks}}
+	}
+
+	// Split response blocks across multiple messages.
+	return splitResponseMessages(headerBlocks, responseBlocks, trailingBlocks, fallbackText, taskName)
+}
+
+// splitResponseMessages distributes response blocks across multiple messages
+// so that each message stays within the SlackBlockLimit. The first message
+// includes the header blocks, and the last message includes the trailing
+// blocks (PR link, error, context). Continuation messages get a part number
+// context block.
+func splitResponseMessages(headerBlocks, responseBlocks, trailingBlocks []slack.Block, fallbackText, taskName string) []SlackMessage {
+	// Reserve space in the first chunk for header blocks and the
+	// continuation context block that will be appended.
+	firstChunkCap := SlackBlockLimit - len(headerBlocks) - 1
+	// Reserve space in the last chunk for trailing blocks.
+	lastChunkTrailing := len(trailingBlocks)
+
+	// Split the response blocks into chunks.
+	chunks := splitBlocks(responseBlocks, firstChunkCap, lastChunkTrailing)
+
+	if len(chunks) == 0 {
+		// No response blocks — single message with header + trailing.
+		var blocks []slack.Block
+		blocks = append(blocks, headerBlocks...)
+		blocks = append(blocks, trailingBlocks...)
+		return []SlackMessage{{Text: fallbackText, Blocks: blocks}}
+	}
+
+	totalParts := len(chunks)
+	var messages []SlackMessage
+
+	for i, chunk := range chunks {
+		var blocks []slack.Block
+		partNum := i + 1
+
+		if i == 0 {
+			// First message: header + first chunk of response blocks.
+			blocks = append(blocks, headerBlocks...)
+			blocks = append(blocks, chunk...)
+			if totalParts > 1 {
+				blocks = append(blocks, continuationContextBlock(taskName, partNum, totalParts))
+			} else {
+				blocks = append(blocks, trailingBlocks...)
+			}
+		} else if i == totalParts-1 {
+			// Last message: remaining response blocks + trailing blocks.
+			blocks = append(blocks, chunk...)
+			blocks = append(blocks, trailingBlocks...)
+		} else {
+			// Middle message: response blocks + continuation context.
+			blocks = append(blocks, chunk...)
+			blocks = append(blocks, continuationContextBlock(taskName, partNum, totalParts))
+		}
+
+		text := fallbackText
+		if i > 0 {
+			text = fmt.Sprintf("(continued, part %d/%d) (Task: %s)", partNum, totalParts, taskName)
+		}
+
+		messages = append(messages, SlackMessage{Text: text, Blocks: blocks})
+	}
+
+	return messages
+}
+
+// splitBlocks divides blocks into chunks. The first chunk has capacity
+// firstCap and the last chunk reserves lastReserve slots for trailing
+// blocks. Middle chunks use the full SlackBlockLimit minus one slot for
+// a continuation context block.
+func splitBlocks(blocks []slack.Block, firstCap, lastReserve int) [][]slack.Block {
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	var chunks [][]slack.Block
+	pos := 0
+
+	// First chunk.
+	end := pos + firstCap
+	if end > len(blocks) {
+		end = len(blocks)
+	}
+	chunks = append(chunks, blocks[pos:end])
+	pos = end
+
+	if pos >= len(blocks) {
+		return chunks
+	}
+
+	// Middle and last chunks.
+	for pos < len(blocks) {
+		remaining := len(blocks) - pos
+
+		// Check if remaining blocks fit in a final chunk with trailing
+		// blocks. Reserve 1 extra for the continuation context on middle
+		// chunks, but the last chunk uses trailing blocks instead.
+		if remaining <= SlackBlockLimit-lastReserve {
+			chunks = append(chunks, blocks[pos:])
+			break
+		}
+
+		// Middle chunk: full limit minus 1 for the continuation context block.
+		chunkSize := SlackBlockLimit - 1
+		end := pos + chunkSize
+		if end > len(blocks) {
+			end = len(blocks)
+		}
+		chunks = append(chunks, blocks[pos:end])
+		pos = end
+	}
+
+	return chunks
+}
+
+func buildFallbackText(decoded, pr, message, phase, taskName string) string {
+	var s string
+	switch {
+	case decoded != "" && pr != "" && message != "" && phase == "failed":
+		s = fmt.Sprintf("%s\nPR: %s\nError: %s (Task: %s)", decoded, pr, message, taskName)
+	case decoded != "" && pr != "":
+		s = fmt.Sprintf("%s\nPR: %s (Task: %s)", decoded, pr, taskName)
+	case decoded != "" && message != "" && phase == "failed":
+		s = fmt.Sprintf("%s\nError: %s (Task: %s)", decoded, message, taskName)
+	case decoded != "":
+		s = fmt.Sprintf("%s (Task: %s)", decoded, taskName)
+	case pr != "":
+		s = fmt.Sprintf("PR: %s (Task: %s)", pr, taskName)
+	case message != "" && phase == "failed":
+		s = fmt.Sprintf("Error: %s (Task: %s)", message, taskName)
+	default:
+		fallback := phaseFallbackText[phase]
+		if fallback == "" {
+			fallback = phase
+		}
+		s = fmt.Sprintf("%s (Task: %s)", fallback, taskName)
+	}
+	return truncateFallbackText(s)
+}
+
+func truncateFallbackText(s string) string {
+	if utf8.RuneCountInString(s) <= slackFallbackTextLimit {
+		return s
+	}
+	return string([]rune(s)[:slackFallbackTextLimit-1]) + "…"
+}
+
+// continuationContextBlock returns a context block indicating a multi-part
+// message with the current part number and total.
+func continuationContextBlock(taskName string, part, total int) *slack.ContextBlock {
+	return slack.NewContextBlock("",
+		slack.NewTextBlockObject(slack.MarkdownType,
+			fmt.Sprintf("Task: `%s` · Part %d/%d", taskName, part, total), false, false),
+	)
+}
+
+// appendActivityContext returns a copy of baseMsg with an additional context
+// element showing the current activity text. If the last block in baseMsg is
+// already a ContextBlock, the activity element is appended to it. Otherwise
+// a new ContextBlock is added.
+func appendActivityContext(baseMsg SlackMessage, activityText string) SlackMessage {
+	// If baseMsg has no blocks, there is nothing safe to attach to
+	// without hiding the text content — skip the update.
+	if len(baseMsg.Blocks) == 0 {
+		return baseMsg
+	}
+
+	activityElement := slack.NewTextBlockObject(slack.MarkdownType, activityText, false, false)
+
+	blocks := make([]slack.Block, len(baseMsg.Blocks))
+	copy(blocks, baseMsg.Blocks)
+
+	if ctx, ok := blocks[len(blocks)-1].(*slack.ContextBlock); ok {
+		// Clone the context block and append the activity element.
+		newElements := make([]slack.MixedElement, len(ctx.ContextElements.Elements), len(ctx.ContextElements.Elements)+1)
+		copy(newElements, ctx.ContextElements.Elements)
+		newElements = append(newElements, activityElement)
+		newCtx := slack.NewContextBlock(ctx.BlockID, newElements...)
+		blocks[len(blocks)-1] = newCtx
+		return SlackMessage{Text: baseMsg.Text, Blocks: blocks}
+	}
+
+	// Last block is not a context block — append a new one.
+	blocks = append(blocks, slack.NewContextBlock("", activityElement))
+	return SlackMessage{Text: baseMsg.Text, Blocks: blocks}
+}

--- a/internal/reporting/slack_blocks.go
+++ b/internal/reporting/slack_blocks.go
@@ -1,0 +1,487 @@
+package reporting
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/slack-go/slack"
+)
+
+var (
+	// reBold matches **bold** syntax.
+	reBold = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	// reLink matches [text](url) syntax, allowing one level of balanced parentheses
+	// in the URL (e.g. Wikipedia/RFC links like https://en.wikipedia.org/wiki/Go_(language)).
+	reLink = regexp.MustCompile(`\[([^\]]+)\]\(([^)]*(?:\([^)]*\))[^)]*|[^)]+)\)`)
+	// reStrikethrough matches ~~text~~ syntax.
+	reStrikethrough = regexp.MustCompile(`~~(.+?)~~`)
+
+	// reInlineFormatting matches all inline formatting tokens that need
+	// special handling inside rich-text contexts (tables, lists).
+	// Groups:
+	//   1 — bold content        (**…**)
+	//   2 — strikethrough       (~~…~~)
+	//   3 — inline code         (`…`)
+	//   4 — md link text        [text](url)
+	//   5 — md link url
+	//   6 — slack link url      <url|text>
+	//   7 — slack link text
+	reInlineFormatting = regexp.MustCompile(
+		`\*\*(.+?)\*\*` + // bold
+			`|~~(.+?)~~` + // strikethrough
+			"|`([^`]+)`" + // inline code
+			`|\[([^\]]+)\]\(([^)]*(?:\([^)]*\))[^)]*|[^)]+)\)` + // [text](url)
+			`|<((?:https?://)[^|>]+)\|([^>]+)>`, // <url|text>
+	)
+)
+
+// convertInlineMarkdown converts standard inline Markdown (bold, links,
+// strikethrough) to Slack mrkdwn format. Headings are handled separately
+// as HeaderBlocks, so they are not converted here.
+func convertInlineMarkdown(s string) string {
+	s = reBold.ReplaceAllString(s, "*$1*")
+	s = reLink.ReplaceAllString(s, "<$2|$1>")
+	s = reStrikethrough.ReplaceAllString(s, "~$1~")
+	return s
+}
+
+// segmentType identifies a markdown content segment.
+type segmentType int
+
+const (
+	segPlain segmentType = iota
+	segTable
+	segList
+	segHeader
+	segDivider
+)
+
+// reInlineCode matches `code` spans.
+var reInlineCode = regexp.MustCompile("`([^`]+)`")
+
+// segment is a contiguous chunk of parsed markdown content.
+type segment struct {
+	typ   segmentType
+	lines []string
+	// header level (1-3) for segHeader segments.
+	level int
+}
+
+var (
+	// tableRowRe matches markdown table rows: | col1 | col2 |
+	tableRowRe = regexp.MustCompile(`^\s*\|(.+)\|\s*$`)
+	// tableSepRe matches the separator row: | --- | --- |
+	tableSepRe = regexp.MustCompile(`^\s*\|[\s\-:|]+\|\s*$`)
+	// headerRe matches markdown headers: # Header, ## Header, ### Header
+	headerRe = regexp.MustCompile(`^(#{1,3})\s+(.+)$`)
+	// unorderedListRe matches unordered list items: - item, * item, • item
+	unorderedListRe = regexp.MustCompile(`^(\s*)[-*•]\s+(.+)$`)
+	// orderedListRe matches ordered list items: 1. item, 2. item
+	orderedListRe = regexp.MustCompile(`^(\s*)\d+\.\s+(.+)$`)
+	// dividerRe matches horizontal rule lines: ---, ***, ___  (three or more of the same character)
+	dividerRe = regexp.MustCompile(`^\s*(?:---+|___+|\*\*\*+)\s*$`)
+)
+
+// parseMarkdownSegments splits markdown text into typed segments.
+func parseMarkdownSegments(text string) []segment {
+	lines := strings.Split(text, "\n")
+	var segments []segment
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+
+		// Check for divider (---, ***, ___).
+		if dividerRe.MatchString(line) {
+			segments = append(segments, segment{typ: segDivider})
+			i++
+			continue
+		}
+
+		// Check for header.
+		if m := headerRe.FindStringSubmatch(line); m != nil {
+			segments = append(segments, segment{
+				typ:   segHeader,
+				lines: []string{m[2]},
+				level: len(m[1]),
+			})
+			i++
+			continue
+		}
+
+		// Check for table start (need at least header row + separator + one data row).
+		if tableRowRe.MatchString(line) && i+1 < len(lines) && tableSepRe.MatchString(lines[i+1]) {
+			var tableLines []string
+			tableLines = append(tableLines, line)
+			j := i + 1
+			// Skip separator.
+			j++
+			// Collect data rows.
+			for j < len(lines) && tableRowRe.MatchString(lines[j]) && !tableSepRe.MatchString(lines[j]) {
+				tableLines = append(tableLines, lines[j])
+				j++
+			}
+			segments = append(segments, segment{typ: segTable, lines: tableLines})
+			i = j
+			continue
+		}
+
+		// Check for unordered list.
+		if unorderedListRe.MatchString(line) {
+			var listLines []string
+			j := i
+			for j < len(lines) {
+				if unorderedListRe.MatchString(lines[j]) {
+					listLines = append(listLines, lines[j])
+					j++
+				} else if strings.TrimSpace(lines[j]) == "" && j+1 < len(lines) && unorderedListRe.MatchString(lines[j+1]) {
+					// Skip blank lines between list items.
+					j++
+				} else {
+					break
+				}
+			}
+			segments = append(segments, segment{typ: segList, lines: listLines})
+			i = j
+			continue
+		}
+
+		// Check for ordered list.
+		if orderedListRe.MatchString(line) {
+			var listLines []string
+			j := i
+			for j < len(lines) {
+				if orderedListRe.MatchString(lines[j]) {
+					listLines = append(listLines, lines[j])
+					j++
+				} else if strings.TrimSpace(lines[j]) == "" && j+1 < len(lines) && orderedListRe.MatchString(lines[j+1]) {
+					// Skip blank lines between list items.
+					j++
+				} else {
+					break
+				}
+			}
+			segments = append(segments, segment{typ: segList, lines: listLines})
+			i = j
+			continue
+		}
+
+		// Plain text — accumulate consecutive non-special lines.
+		var plainLines []string
+		j := i
+		for j < len(lines) {
+			l := lines[j]
+			if dividerRe.MatchString(l) ||
+				headerRe.MatchString(l) ||
+				unorderedListRe.MatchString(l) ||
+				orderedListRe.MatchString(l) {
+				break
+			}
+			// Check if this starts a table.
+			if tableRowRe.MatchString(l) && j+1 < len(lines) && tableSepRe.MatchString(lines[j+1]) {
+				break
+			}
+			plainLines = append(plainLines, l)
+			j++
+		}
+		// Trim trailing empty lines from plain text.
+		for len(plainLines) > 0 && strings.TrimSpace(plainLines[len(plainLines)-1]) == "" {
+			plainLines = plainLines[:len(plainLines)-1]
+		}
+		if len(plainLines) > 0 {
+			segments = append(segments, segment{typ: segPlain, lines: plainLines})
+		}
+		// If nothing was consumed (blank lines between segments), advance past them.
+		if j == i {
+			i++
+		} else {
+			i = j
+		}
+	}
+
+	return segments
+}
+
+const (
+	// SlackBlockLimit is the maximum number of blocks Slack allows per message.
+	SlackBlockLimit = 50
+	// slackSectionTextLimit is the maximum character length for a section block's text.
+	slackSectionTextLimit = 3000
+	// slackHeaderTextLimit is the maximum character length for a header block's text.
+	slackHeaderTextLimit = 150
+)
+
+// responseToBlocks converts a markdown response string into Slack blocks.
+func responseToBlocks(text string) []slack.Block {
+	segments := parseMarkdownSegments(text)
+	var blocks []slack.Block
+
+	for _, seg := range segments {
+		switch seg.typ {
+		case segDivider:
+			blocks = append(blocks, slack.NewDividerBlock())
+		case segHeader:
+			blocks = append(blocks, headerBlock(seg.lines[0]))
+		case segTable:
+			if b := tableBlock(seg.lines); b != nil {
+				blocks = append(blocks, b)
+			}
+		case segList:
+			blocks = append(blocks, listBlock(seg.lines)...)
+		case segPlain:
+			joined := strings.Join(seg.lines, "\n")
+			if strings.TrimSpace(joined) != "" {
+				for _, chunk := range splitText(convertInlineMarkdown(joined), slackSectionTextLimit) {
+					if chunk == "" {
+						continue
+					}
+					blocks = append(blocks, slack.NewSectionBlock(
+						slack.NewTextBlockObject(slack.MarkdownType, chunk, false, false),
+						nil, nil,
+					))
+				}
+			}
+		}
+	}
+
+	return blocks
+}
+
+// headerBlock creates a Slack HeaderBlock from header text.
+// HeaderBlocks only support plain text, so backtick code spans are stripped.
+func headerBlock(text string) *slack.HeaderBlock {
+	text = reInlineCode.ReplaceAllString(text, "$1")
+	if utf8.RuneCountInString(text) > slackHeaderTextLimit {
+		text = string([]rune(text)[:slackHeaderTextLimit-1]) + "…"
+	}
+	return slack.NewHeaderBlock(
+		slack.NewTextBlockObject(slack.PlainTextType, text, false, false),
+	)
+}
+
+// tableBlock creates a Slack TableBlock from markdown table lines.
+// The first line is the header row; subsequent lines are data rows.
+func tableBlock(lines []string) *slack.TableBlock {
+	if len(lines) < 1 {
+		return nil
+	}
+
+	table := slack.NewTableBlock("")
+
+	// Parse header row to determine column count.
+	headerCells := parseCells(lines[0])
+	numCols := len(headerCells)
+
+	// Add header row.
+	table.AddRow(cellsToRichText(headerCells)...)
+
+	// Add data rows.
+	for _, line := range lines[1:] {
+		cells := parseCells(line)
+		// Pad or truncate to match column count.
+		for len(cells) < numCols {
+			cells = append(cells, "")
+		}
+		cells = cells[:numCols]
+		table.AddRow(cellsToRichText(cells)...)
+	}
+
+	return table
+}
+
+// parseCells extracts cell text from a markdown table row.
+func parseCells(row string) []string {
+	row = strings.TrimSpace(row)
+	row = strings.Trim(row, "|")
+	parts := strings.Split(row, "|")
+	cells := make([]string, len(parts))
+	for i, p := range parts {
+		cells[i] = strings.TrimSpace(p)
+	}
+	return cells
+}
+
+// cellsToRichText converts cell strings to RichTextBlock pointers for table rows.
+// Inline formatting (bold, code, links, strikethrough) is parsed and rendered
+// as styled rich-text elements.
+func cellsToRichText(cells []string) []*slack.RichTextBlock {
+	blocks := make([]*slack.RichTextBlock, len(cells))
+	for i, cell := range cells {
+		if cell == "" {
+			// Slack rejects empty text elements with invalid_blocks.
+			blocks[i] = slack.NewRichTextBlock("",
+				slack.NewRichTextSection(
+					slack.NewRichTextSectionTextElement("\u00a0", nil),
+				),
+			)
+			continue
+		}
+		elements := parseRichTextElements(cell)
+		blocks[i] = slack.NewRichTextBlock("",
+			slack.NewRichTextSection(elements...),
+		)
+	}
+	return blocks
+}
+
+// parseRichTextElements parses inline formatting (bold, strikethrough, code,
+// markdown links, slack links) and returns a slice of RichTextSectionElement
+// with appropriate styling. Nested formatting (e.g. **`code`**) is supported
+// by recursively parsing bold/strikethrough content.
+func parseRichTextElements(text string) []slack.RichTextSectionElement {
+	return parseRichTextElementsWithStyle(text, nil)
+}
+
+// parseRichTextElementsWithStyle is the recursive inner function that carries
+// an inherited style from an outer formatting context (e.g. bold wrapping code).
+func parseRichTextElementsWithStyle(text string, inherited *slack.RichTextSectionTextStyle) []slack.RichTextSectionElement {
+	var elements []slack.RichTextSectionElement
+
+	matches := reInlineFormatting.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		if text != "" {
+			elements = append(elements, slack.NewRichTextSectionTextElement(text, inherited))
+		}
+		return elements
+	}
+
+	pos := 0
+	for _, loc := range matches {
+		// Plain text before this match.
+		if loc[0] > pos {
+			elements = append(elements,
+				slack.NewRichTextSectionTextElement(text[pos:loc[0]], inherited))
+		}
+
+		switch {
+		case loc[2] >= 0: // group 1: bold **…**
+			inner := text[loc[2]:loc[3]]
+			style := mergeStyle(inherited, &slack.RichTextSectionTextStyle{Bold: true})
+			elements = append(elements, parseRichTextElementsWithStyle(inner, style)...)
+
+		case loc[4] >= 0: // group 2: strikethrough ~~…~~
+			inner := text[loc[4]:loc[5]]
+			style := mergeStyle(inherited, &slack.RichTextSectionTextStyle{Strike: true})
+			elements = append(elements, parseRichTextElementsWithStyle(inner, style)...)
+
+		case loc[6] >= 0: // group 3: inline code `…`
+			code := text[loc[6]:loc[7]]
+			style := mergeStyle(inherited, &slack.RichTextSectionTextStyle{Code: true})
+			elements = append(elements, slack.NewRichTextSectionTextElement(code, style))
+
+		case loc[8] >= 0: // groups 4,5: markdown link [text](url)
+			linkText := text[loc[8]:loc[9]]
+			linkURL := text[loc[10]:loc[11]]
+			elements = append(elements, slack.NewRichTextSectionLinkElement(linkURL, linkText, inherited))
+
+		case loc[12] >= 0: // groups 6,7: slack link <url|text>
+			linkURL := text[loc[12]:loc[13]]
+			linkText := text[loc[14]:loc[15]]
+			elements = append(elements, slack.NewRichTextSectionLinkElement(linkURL, linkText, inherited))
+		}
+
+		pos = loc[1]
+	}
+
+	// Trailing text after last match.
+	if pos < len(text) {
+		elements = append(elements,
+			slack.NewRichTextSectionTextElement(text[pos:], inherited))
+	}
+
+	return elements
+}
+
+// mergeStyle combines two RichTextSectionTextStyle values, producing a new
+// style with all flags from both. Either argument may be nil.
+func mergeStyle(a, b *slack.RichTextSectionTextStyle) *slack.RichTextSectionTextStyle {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &slack.RichTextSectionTextStyle{
+		Bold:   a.Bold || b.Bold,
+		Italic: a.Italic || b.Italic,
+		Strike: a.Strike || b.Strike,
+		Code:   a.Code || b.Code,
+	}
+}
+
+// splitText splits s into chunks of at most maxLen runes, breaking at the
+// last newline before the limit when possible.
+func splitText(s string, maxLen int) []string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return []string{s}
+	}
+	runes := []rune(s)
+	var chunks []string
+	for len(runes) > 0 {
+		end := maxLen
+		if end > len(runes) {
+			end = len(runes)
+		}
+		chunk := runes[:end]
+		if end < len(runes) {
+			if idx := lastIndexRune(chunk, '\n'); idx > 0 {
+				end = idx + 1
+				chunk = runes[:end]
+			}
+		}
+		trimmed := strings.TrimRight(string(chunk), "\n")
+		if trimmed != "" {
+			chunks = append(chunks, trimmed)
+		}
+		runes = runes[end:]
+	}
+	return chunks
+}
+
+func lastIndexRune(runes []rune, r rune) int {
+	for i := len(runes) - 1; i >= 0; i-- {
+		if runes[i] == r {
+			return i
+		}
+	}
+	return -1
+}
+
+// listBlock creates Slack RichTextBlock(s) from markdown list lines.
+func listBlock(lines []string) []slack.Block {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	// Determine list style from first line.
+	style := slack.RTEListBullet
+	if orderedListRe.MatchString(lines[0]) {
+		style = slack.RTEListOrdered
+	}
+
+	var items []slack.RichTextElement
+	for _, line := range lines {
+		var text string
+		if m := unorderedListRe.FindStringSubmatch(line); m != nil {
+			text = m[2]
+		} else if m := orderedListRe.FindStringSubmatch(line); m != nil {
+			text = m[2]
+		} else {
+			continue
+		}
+		items = append(items, slack.NewRichTextSection(
+			parseRichTextElements(text)...,
+		))
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	return []slack.Block{
+		slack.NewRichTextBlock("",
+			slack.NewRichTextList(style, 0, items...),
+		),
+	}
+}

--- a/internal/reporting/slack_blocks_test.go
+++ b/internal/reporting/slack_blocks_test.go
@@ -1,0 +1,762 @@
+package reporting
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestParseMarkdownSegments(t *testing.T) {
+	t.Run("plain text only", func(t *testing.T) {
+		segs := parseMarkdownSegments("Hello world\nSecond line")
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segPlain {
+			t.Errorf("expected segPlain, got %d", segs[0].typ)
+		}
+	})
+
+	t.Run("header", func(t *testing.T) {
+		segs := parseMarkdownSegments("# My Header")
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segHeader {
+			t.Errorf("expected segHeader, got %d", segs[0].typ)
+		}
+		if segs[0].lines[0] != "My Header" {
+			t.Errorf("expected header text %q, got %q", "My Header", segs[0].lines[0])
+		}
+		if segs[0].level != 1 {
+			t.Errorf("expected level 1, got %d", segs[0].level)
+		}
+	})
+
+	t.Run("table", func(t *testing.T) {
+		input := "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segTable {
+			t.Errorf("expected segTable, got %d", segs[0].typ)
+		}
+		// Header + 2 data rows (separator is excluded).
+		if len(segs[0].lines) != 3 {
+			t.Errorf("expected 3 table lines, got %d", len(segs[0].lines))
+		}
+	})
+
+	t.Run("unordered list", func(t *testing.T) {
+		input := "- item one\n- item two\n- item three"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+	})
+
+	t.Run("ordered list", func(t *testing.T) {
+		input := "1. first\n2. second\n3. third"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+	})
+
+	t.Run("divider", func(t *testing.T) {
+		for _, input := range []string{"---", "***", "___", "-----", "  ---  "} {
+			segs := parseMarkdownSegments(input)
+			if len(segs) != 1 {
+				t.Fatalf("input %q: expected 1 segment, got %d", input, len(segs))
+			}
+			if segs[0].typ != segDivider {
+				t.Errorf("input %q: expected segDivider, got %d", input, segs[0].typ)
+			}
+		}
+	})
+
+	t.Run("ordered list with blank lines", func(t *testing.T) {
+		input := "1. first\n\n2. second\n\n3. third"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+		if len(segs[0].lines) != 3 {
+			t.Errorf("expected 3 list lines, got %d", len(segs[0].lines))
+		}
+	})
+
+	t.Run("unordered list with blank lines", func(t *testing.T) {
+		input := "- first\n\n- second\n\n- third"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segs))
+		}
+		if segs[0].typ != segList {
+			t.Errorf("expected segList, got %d", segs[0].typ)
+		}
+		if len(segs[0].lines) != 3 {
+			t.Errorf("expected 3 list lines, got %d", len(segs[0].lines))
+		}
+	})
+
+	t.Run("divider between content", func(t *testing.T) {
+		input := "Some text\n---\nMore text"
+		segs := parseMarkdownSegments(input)
+		if len(segs) != 3 {
+			t.Fatalf("expected 3 segments, got %d", len(segs))
+		}
+		if segs[0].typ != segPlain {
+			t.Errorf("segment 0: expected segPlain, got %d", segs[0].typ)
+		}
+		if segs[1].typ != segDivider {
+			t.Errorf("segment 1: expected segDivider, got %d", segs[1].typ)
+		}
+		if segs[2].typ != segPlain {
+			t.Errorf("segment 2: expected segPlain, got %d", segs[2].typ)
+		}
+	})
+
+	t.Run("mixed content", func(t *testing.T) {
+		input := "## Summary\nSome text here.\n\n| Col1 | Col2 |\n| --- | --- |\n| a | b |\n\n- item 1\n- item 2"
+		segs := parseMarkdownSegments(input)
+		if len(segs) < 4 {
+			t.Fatalf("expected at least 4 segments, got %d", len(segs))
+		}
+		if segs[0].typ != segHeader {
+			t.Errorf("segment 0: expected segHeader, got %d", segs[0].typ)
+		}
+		if segs[1].typ != segPlain {
+			t.Errorf("segment 1: expected segPlain, got %d", segs[1].typ)
+		}
+		if segs[2].typ != segTable {
+			t.Errorf("segment 2: expected segTable, got %d", segs[2].typ)
+		}
+		if segs[3].typ != segList {
+			t.Errorf("segment 3: expected segList, got %d", segs[3].typ)
+		}
+	})
+}
+
+func TestResponseToBlocks(t *testing.T) {
+	t.Run("plain text becomes SectionBlock", func(t *testing.T) {
+		blocks := responseToBlocks("Hello world")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		section, ok := blocks[0].(*slack.SectionBlock)
+		if !ok {
+			t.Fatalf("expected *SectionBlock, got %T", blocks[0])
+		}
+		if section.Text.Text != "Hello world" {
+			t.Errorf("text = %q, want %q", section.Text.Text, "Hello world")
+		}
+	})
+
+	t.Run("header becomes HeaderBlock", func(t *testing.T) {
+		blocks := responseToBlocks("# My Title")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		header, ok := blocks[0].(*slack.HeaderBlock)
+		if !ok {
+			t.Fatalf("expected *HeaderBlock, got %T", blocks[0])
+		}
+		if header.Text.Text != "My Title" {
+			t.Errorf("text = %q, want %q", header.Text.Text, "My Title")
+		}
+	})
+
+	t.Run("table becomes TableBlock", func(t *testing.T) {
+		input := "| Name | Age |\n| --- | --- |\n| Alice | 30 |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		if len(table.Rows) != 2 {
+			t.Errorf("expected 2 rows (header + 1 data), got %d", len(table.Rows))
+		}
+	})
+
+	t.Run("unordered list becomes RichTextBlock", func(t *testing.T) {
+		input := "- apple\n- banana\n- cherry"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		rt, ok := blocks[0].(*slack.RichTextBlock)
+		if !ok {
+			t.Fatalf("expected *RichTextBlock, got %T", blocks[0])
+		}
+		if len(rt.Elements) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(rt.Elements))
+		}
+		list, ok := rt.Elements[0].(*slack.RichTextList)
+		if !ok {
+			t.Fatalf("expected *RichTextList, got %T", rt.Elements[0])
+		}
+		if list.Style != slack.RTEListBullet {
+			t.Errorf("expected bullet style, got %q", list.Style)
+		}
+		if len(list.Elements) != 3 {
+			t.Errorf("expected 3 list items, got %d", len(list.Elements))
+		}
+	})
+
+	t.Run("ordered list becomes RichTextBlock", func(t *testing.T) {
+		input := "1. first\n2. second"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		rt, ok := blocks[0].(*slack.RichTextBlock)
+		if !ok {
+			t.Fatalf("expected *RichTextBlock, got %T", blocks[0])
+		}
+		list := rt.Elements[0].(*slack.RichTextList)
+		if list.Style != slack.RTEListOrdered {
+			t.Errorf("expected ordered style, got %q", list.Style)
+		}
+	})
+
+	t.Run("mixed content produces correct block types", func(t *testing.T) {
+		input := "## Report\nHere are the results:\n\n| Name | Score |\n| --- | --- |\n| Alice | 95 |\n\n- Note 1\n- Note 2"
+		blocks := responseToBlocks(input)
+		if len(blocks) < 4 {
+			t.Fatalf("expected at least 4 blocks, got %d", len(blocks))
+		}
+		if _, ok := blocks[0].(*slack.HeaderBlock); !ok {
+			t.Errorf("block 0: expected *HeaderBlock, got %T", blocks[0])
+		}
+		if _, ok := blocks[1].(*slack.SectionBlock); !ok {
+			t.Errorf("block 1: expected *SectionBlock, got %T", blocks[1])
+		}
+		if _, ok := blocks[2].(*slack.TableBlock); !ok {
+			t.Errorf("block 2: expected *TableBlock, got %T", blocks[2])
+		}
+		if _, ok := blocks[3].(*slack.RichTextBlock); !ok {
+			t.Errorf("block 3: expected *RichTextBlock, got %T", blocks[3])
+		}
+	})
+
+	t.Run("empty string produces no blocks", func(t *testing.T) {
+		blocks := responseToBlocks("")
+		if len(blocks) != 0 {
+			t.Errorf("expected 0 blocks, got %d", len(blocks))
+		}
+	})
+
+	t.Run("divider becomes DividerBlock", func(t *testing.T) {
+		blocks := responseToBlocks("Text above\n---\nText below")
+		if len(blocks) != 3 {
+			t.Fatalf("expected 3 blocks, got %d", len(blocks))
+		}
+		if _, ok := blocks[1].(*slack.DividerBlock); !ok {
+			t.Errorf("block 1: expected *DividerBlock, got %T", blocks[1])
+		}
+	})
+
+	t.Run("header strips backtick code spans", func(t *testing.T) {
+		blocks := responseToBlocks("# The `start_data_complete_jobs` function")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		header, ok := blocks[0].(*slack.HeaderBlock)
+		if !ok {
+			t.Fatalf("expected *HeaderBlock, got %T", blocks[0])
+		}
+		want := "The start_data_complete_jobs function"
+		if header.Text.Text != want {
+			t.Errorf("text = %q, want %q", header.Text.Text, want)
+		}
+	})
+
+	t.Run("list items with inline code", func(t *testing.T) {
+		input := "- Run `make test` first\n- Then `make build`"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		rt, ok := blocks[0].(*slack.RichTextBlock)
+		if !ok {
+			t.Fatalf("expected *RichTextBlock, got %T", blocks[0])
+		}
+		list, ok := rt.Elements[0].(*slack.RichTextList)
+		if !ok {
+			t.Fatalf("expected *RichTextList, got %T", rt.Elements[0])
+		}
+		// First list item should have 3 elements: "Run ", "make test" (code), " first"
+		section, ok := list.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", list.Elements[0])
+		}
+		if len(section.Elements) != 3 {
+			t.Fatalf("expected 3 elements in first item, got %d", len(section.Elements))
+		}
+		codeElem, ok := section.Elements[1].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected *RichTextSectionTextElement, got %T", section.Elements[1])
+		}
+		if codeElem.Style == nil || !codeElem.Style.Code {
+			t.Error("expected code style on middle element")
+		}
+		if codeElem.Text != "make test" {
+			t.Errorf("code text = %q, want %q", codeElem.Text, "make test")
+		}
+	})
+
+	t.Run("asterisk list items", func(t *testing.T) {
+		input := "* foo\n* bar"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		if _, ok := blocks[0].(*slack.RichTextBlock); !ok {
+			t.Errorf("expected *RichTextBlock, got %T", blocks[0])
+		}
+	})
+}
+
+func TestParseRichTextElements(t *testing.T) {
+	t.Run("no code spans", func(t *testing.T) {
+		elems := parseRichTextElements("plain text")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+	})
+
+	t.Run("code span in middle", func(t *testing.T) {
+		elems := parseRichTextElements("run `make test` now")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		te, ok := elems[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[0])
+		}
+		if te.Text != "run " {
+			t.Errorf("elem 0 text = %q, want %q", te.Text, "run ")
+		}
+		code, ok := elems[1].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[1])
+		}
+		if code.Text != "make test" {
+			t.Errorf("elem 1 text = %q, want %q", code.Text, "make test")
+		}
+		if code.Style == nil || !code.Style.Code {
+			t.Error("expected code style on elem 1")
+		}
+	})
+
+	t.Run("multiple code spans", func(t *testing.T) {
+		elems := parseRichTextElements("`foo` and `bar`")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		// First should be code
+		first, _ := elems[0].(*slack.RichTextSectionTextElement)
+		if first.Style == nil || !first.Style.Code {
+			t.Error("expected code style on first element")
+		}
+		// Middle should be plain text " and "
+		mid, _ := elems[1].(*slack.RichTextSectionTextElement)
+		if mid.Text != " and " {
+			t.Errorf("middle text = %q, want %q", mid.Text, " and ")
+		}
+	})
+
+	t.Run("bold text", func(t *testing.T) {
+		elems := parseRichTextElements("this is **important** text")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		bold, ok := elems[1].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[1])
+		}
+		if bold.Text != "important" {
+			t.Errorf("bold text = %q, want %q", bold.Text, "important")
+		}
+		if bold.Style == nil || !bold.Style.Bold {
+			t.Error("expected bold style")
+		}
+	})
+
+	t.Run("bold wrapping code", func(t *testing.T) {
+		elems := parseRichTextElements("**`PIISample`**")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+		te, ok := elems[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[0])
+		}
+		if te.Text != "PIISample" {
+			t.Errorf("text = %q, want %q", te.Text, "PIISample")
+		}
+		if te.Style == nil || !te.Style.Bold || !te.Style.Code {
+			t.Errorf("expected bold+code style, got %+v", te.Style)
+		}
+	})
+
+	t.Run("strikethrough", func(t *testing.T) {
+		elems := parseRichTextElements("~~removed~~")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+		te, ok := elems[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", elems[0])
+		}
+		if te.Style == nil || !te.Style.Strike {
+			t.Error("expected strike style")
+		}
+	})
+
+	t.Run("markdown link", func(t *testing.T) {
+		elems := parseRichTextElements("see [docs](https://example.com) here")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		link, ok := elems[1].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", elems[1])
+		}
+		if link.URL != "https://example.com" {
+			t.Errorf("url = %q, want %q", link.URL, "https://example.com")
+		}
+		if link.Text != "docs" {
+			t.Errorf("text = %q, want %q", link.Text, "docs")
+		}
+	})
+
+	t.Run("slack link", func(t *testing.T) {
+		elems := parseRichTextElements("see <https://github.com/foo/bar#L34|checks/pii.py:34> here")
+		if len(elems) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(elems))
+		}
+		link, ok := elems[1].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", elems[1])
+		}
+		if link.URL != "https://github.com/foo/bar#L34" {
+			t.Errorf("url = %q, want %q", link.URL, "https://github.com/foo/bar#L34")
+		}
+		if link.Text != "checks/pii.py:34" {
+			t.Errorf("text = %q, want %q", link.Text, "checks/pii.py:34")
+		}
+	})
+
+	t.Run("markdown link with parens in url", func(t *testing.T) {
+		elems := parseRichTextElements("[Go](https://en.wikipedia.org/wiki/Go_(language))")
+		if len(elems) != 1 {
+			t.Fatalf("expected 1 element, got %d", len(elems))
+		}
+		link, ok := elems[0].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", elems[0])
+		}
+		if link.URL != "https://en.wikipedia.org/wiki/Go_(language)" {
+			t.Errorf("url = %q, want %q", link.URL, "https://en.wikipedia.org/wiki/Go_(language)")
+		}
+	})
+}
+
+func TestParseRichTextElements_TableCells(t *testing.T) {
+	t.Run("table cell with code", func(t *testing.T) {
+		input := "| Name | Command |\n| --- | --- |\n| test | `make test` |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		// Data row (index 1), second cell should have code-styled element.
+		cell := table.Rows[1][1]
+		section, ok := cell.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", cell.Elements[0])
+		}
+		if len(section.Elements) != 1 {
+			t.Fatalf("expected 1 element in cell, got %d", len(section.Elements))
+		}
+		te, ok := section.Elements[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", section.Elements[0])
+		}
+		if te.Text != "make test" {
+			t.Errorf("text = %q, want %q", te.Text, "make test")
+		}
+		if te.Style == nil || !te.Style.Code {
+			t.Error("expected code style on table cell element")
+		}
+	})
+
+	t.Run("table cell with markdown link", func(t *testing.T) {
+		input := "| File | Link |\n| --- | --- |\n| pii.py | [checks/pii.py:34](https://github.com/foo/bar#L34) |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		cell := table.Rows[1][1]
+		section, ok := cell.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", cell.Elements[0])
+		}
+		if len(section.Elements) != 1 {
+			t.Fatalf("expected 1 element in cell, got %d", len(section.Elements))
+		}
+		link, ok := section.Elements[0].(*slack.RichTextSectionLinkElement)
+		if !ok {
+			t.Fatalf("expected link element, got %T", section.Elements[0])
+		}
+		if link.URL != "https://github.com/foo/bar#L34" {
+			t.Errorf("url = %q, want %q", link.URL, "https://github.com/foo/bar#L34")
+		}
+		if link.Text != "checks/pii.py:34" {
+			t.Errorf("text = %q, want %q", link.Text, "checks/pii.py:34")
+		}
+	})
+
+	t.Run("table cell with bold code", func(t *testing.T) {
+		input := "| Check | Status |\n| --- | --- |\n| **`PIISample`** | passed |"
+		blocks := responseToBlocks(input)
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 block, got %d", len(blocks))
+		}
+		table, ok := blocks[0].(*slack.TableBlock)
+		if !ok {
+			t.Fatalf("expected *TableBlock, got %T", blocks[0])
+		}
+		cell := table.Rows[1][0]
+		section, ok := cell.Elements[0].(*slack.RichTextSection)
+		if !ok {
+			t.Fatalf("expected *RichTextSection, got %T", cell.Elements[0])
+		}
+		if len(section.Elements) != 1 {
+			t.Fatalf("expected 1 element in cell, got %d", len(section.Elements))
+		}
+		te, ok := section.Elements[0].(*slack.RichTextSectionTextElement)
+		if !ok {
+			t.Fatalf("expected text element, got %T", section.Elements[0])
+		}
+		if te.Text != "PIISample" {
+			t.Errorf("text = %q, want %q", te.Text, "PIISample")
+		}
+		if te.Style == nil || !te.Style.Bold || !te.Style.Code {
+			t.Errorf("expected bold+code style, got %+v", te.Style)
+		}
+	})
+}
+
+func TestMergeStyle(t *testing.T) {
+	t.Run("nil + style", func(t *testing.T) {
+		s := mergeStyle(nil, &slack.RichTextSectionTextStyle{Bold: true})
+		if s == nil || !s.Bold {
+			t.Error("expected bold")
+		}
+	})
+
+	t.Run("style + nil", func(t *testing.T) {
+		s := mergeStyle(&slack.RichTextSectionTextStyle{Code: true}, nil)
+		if s == nil || !s.Code {
+			t.Error("expected code")
+		}
+	})
+
+	t.Run("merge bold + code", func(t *testing.T) {
+		s := mergeStyle(
+			&slack.RichTextSectionTextStyle{Bold: true},
+			&slack.RichTextSectionTextStyle{Code: true},
+		)
+		if s == nil || !s.Bold || !s.Code {
+			t.Errorf("expected bold+code, got %+v", s)
+		}
+	})
+
+	t.Run("nil + nil", func(t *testing.T) {
+		s := mergeStyle(nil, nil)
+		if s != nil {
+			t.Errorf("expected nil, got %+v", s)
+		}
+	})
+}
+
+func TestParseCells(t *testing.T) {
+	cells := parseCells("| Alice | 30 | Engineer |")
+	if len(cells) != 3 {
+		t.Fatalf("expected 3 cells, got %d", len(cells))
+	}
+	if cells[0] != "Alice" {
+		t.Errorf("cell 0 = %q, want %q", cells[0], "Alice")
+	}
+	if cells[1] != "30" {
+		t.Errorf("cell 1 = %q, want %q", cells[1], "30")
+	}
+	if cells[2] != "Engineer" {
+		t.Errorf("cell 2 = %q, want %q", cells[2], "Engineer")
+	}
+}
+
+func TestCellsToRichText_EmptyCellsUseNBSP(t *testing.T) {
+	cells := cellsToRichText([]string{"filled", "", "also filled"})
+	if len(cells) != 3 {
+		t.Fatalf("expected 3 cells, got %d", len(cells))
+	}
+
+	// The empty cell should contain a non-breaking space, not empty string.
+	b, err := json.Marshal(cells[1])
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if strings.Contains(string(b), `"text":""`) {
+		t.Error("empty cell produced empty text element; Slack rejects this with invalid_blocks")
+	}
+	if !strings.Contains(string(b), "\u00a0") {
+		t.Error("empty cell should contain non-breaking space")
+	}
+}
+
+func TestUnicodeBulletList(t *testing.T) {
+	input := "• item one\n• item two\n• item three"
+	segs := parseMarkdownSegments(input)
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segs))
+	}
+	if segs[0].typ != segList {
+		t.Errorf("expected segList, got %d", segs[0].typ)
+	}
+
+	blocks := responseToBlocks(input)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if _, ok := blocks[0].(*slack.RichTextBlock); !ok {
+		t.Errorf("expected *RichTextBlock, got %T", blocks[0])
+	}
+}
+
+func TestUnicodeBulletMixedWithDash(t *testing.T) {
+	input := "• first\n- second\n• third"
+	segs := parseMarkdownSegments(input)
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segs))
+	}
+	if segs[0].typ != segList {
+		t.Errorf("expected segList, got %d", segs[0].typ)
+	}
+}
+
+func TestSectionTextSplitting(t *testing.T) {
+	var sb strings.Builder
+	for sb.Len() < 5000 {
+		sb.WriteString("This is a long line of text that will be repeated. ")
+	}
+	blocks := responseToBlocks(sb.String())
+	for _, b := range blocks {
+		sec, ok := b.(*slack.SectionBlock)
+		if !ok {
+			continue
+		}
+		if len([]rune(sec.Text.Text)) > slackSectionTextLimit {
+			t.Errorf("section text length %d exceeds limit %d", len([]rune(sec.Text.Text)), slackSectionTextLimit)
+		}
+	}
+	if len(blocks) < 2 {
+		t.Errorf("expected text to be split into multiple sections, got %d blocks", len(blocks))
+	}
+}
+
+func TestHeaderBlockTruncation(t *testing.T) {
+	long := strings.Repeat("A", 200)
+	blocks := responseToBlocks("# " + long)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	hdr, ok := blocks[0].(*slack.HeaderBlock)
+	if !ok {
+		t.Fatalf("expected *HeaderBlock, got %T", blocks[0])
+	}
+	if len([]rune(hdr.Text.Text)) > slackHeaderTextLimit {
+		t.Errorf("header text length %d exceeds limit %d", len([]rune(hdr.Text.Text)), slackHeaderTextLimit)
+	}
+}
+
+func TestSplitText(t *testing.T) {
+	t.Run("short text unchanged", func(t *testing.T) {
+		chunks := splitText("hello", 100)
+		if len(chunks) != 1 || chunks[0] != "hello" {
+			t.Errorf("got %v", chunks)
+		}
+	})
+
+	t.Run("splits at newline", func(t *testing.T) {
+		input := "aaa\nbbb\nccc"
+		chunks := splitText(input, 5)
+		if len(chunks) < 2 {
+			t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+		}
+		for _, c := range chunks {
+			if len([]rune(c)) > 5 {
+				t.Errorf("chunk %q exceeds limit 5", c)
+			}
+		}
+	})
+
+	t.Run("hard splits when no newline", func(t *testing.T) {
+		input := strings.Repeat("x", 10)
+		chunks := splitText(input, 4)
+		if len(chunks) != 3 {
+			t.Fatalf("expected 3 chunks, got %d: %v", len(chunks), chunks)
+		}
+	})
+
+	t.Run("newline-only chunk trimmed to empty", func(t *testing.T) {
+		input := "aaa\n\n\n\n\nbbb"
+		chunks := splitText(input, 5)
+		for i, c := range chunks {
+			if c == "" {
+				t.Errorf("chunk %d is empty after trimming", i)
+			}
+		}
+	})
+}
+
+func TestTableBlock_EmptyCells(t *testing.T) {
+	input := "| Project | Notes |\n| --- | --- |\n| Viz | |\n| AIDA | done |"
+	blocks := responseToBlocks(input)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	// Verify the table serializes without empty text elements.
+	b, err := json.Marshal(blocks[0])
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if strings.Contains(string(b), `"text":""`) {
+		t.Error("table block contains empty text element; Slack rejects this with invalid_blocks")
+	}
+}

--- a/internal/reporting/slack_test.go
+++ b/internal/reporting/slack_test.go
@@ -1,0 +1,542 @@
+package reporting
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// firstMsg is a helper that returns the first (and usually only) message
+// from FormatSlackTransitionMessage, failing the test if the slice is empty.
+func firstMsg(t *testing.T, msgs []SlackMessage) SlackMessage {
+	t.Helper()
+	if len(msgs) == 0 {
+		t.Fatal("FormatSlackTransitionMessage returned 0 messages")
+	}
+	return msgs[0]
+}
+
+func TestFormatSlackTransitionMessages(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("accepted", "spawner-1234567890.123456", "", nil))
+		if got.Text != "Working on your request... (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // section + context
+		assertSectionText(t, got.Blocks[0], ":hourglass_flowing_sand: *Working on your request...*")
+		assertContextContains(t, got.Blocks[1], "spawner-1234567890.123456")
+	})
+
+	t.Run("succeeded with PR", func(t *testing.T) {
+		results := map[string]string{"pr": "https://github.com/org/repo/pull/42"}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "PR: https://github.com/org/repo/pull/42 (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // PR + context
+		assertSectionContains(t, got.Blocks[0], "https://github.com/org/repo/pull/42")
+	})
+
+	t.Run("succeeded without results", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", nil))
+		if got.Text != "Done! (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 1) // context only
+	})
+
+	t.Run("succeeded with empty results", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", map[string]string{}))
+		if got.Text != "Done! (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 1) // context only
+	})
+
+	t.Run("succeeded ignores status message", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "Task completed successfully", nil))
+		if got.Text != "Done! (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 1) // context only, no error block
+	})
+
+	t.Run("succeeded with response", func(t *testing.T) {
+		results := map[string]string{"response": b64("I need your GitHub username to proceed.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "I need your GitHub username to proceed. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+		assertSectionContains(t, got.Blocks[0], "I need your GitHub username to proceed.")
+	})
+
+	t.Run("succeeded with response and PR", func(t *testing.T) {
+		results := map[string]string{
+			"response": b64("Added CODEOWNERS entry."),
+			"pr":       "https://github.com/org/repo/pull/42",
+		}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "Added CODEOWNERS entry.\nPR: https://github.com/org/repo/pull/42 (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 3) // response + PR + context
+		assertSectionContains(t, got.Blocks[0], "Added CODEOWNERS entry.")
+		assertSectionContains(t, got.Blocks[1], "https://github.com/org/repo/pull/42")
+	})
+
+	t.Run("succeeded with multiline response", func(t *testing.T) {
+		results := map[string]string{"response": b64("Line one.\nLine two.\nLine three.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "Line one.\nLine two.\nLine three. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+	})
+
+	t.Run("succeeded with non-base64 response fallback", func(t *testing.T) {
+		results := map[string]string{"response": "plain text response"}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "plain text response (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+	})
+
+	t.Run("failed with message", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "pod OOMKilled", nil))
+		if got.Text != "Error: pod OOMKilled (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 3) // header + error + context
+		assertSectionContains(t, got.Blocks[1], "pod OOMKilled")
+	})
+
+	t.Run("failed without message", func(t *testing.T) {
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "", nil))
+		if got.Text != "Failed. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // header + context
+	})
+
+	t.Run("failed with response", func(t *testing.T) {
+		results := map[string]string{"response": b64("Could not find the file.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "Task failed", results))
+		if got.Text != "Could not find the file.\nError: Task failed (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 4) // header + response + error + context
+		assertSectionContains(t, got.Blocks[1], "Could not find the file.")
+		assertSectionContains(t, got.Blocks[2], "Task failed")
+	})
+
+	t.Run("succeeded with table response", func(t *testing.T) {
+		resp := "| Name | Age |\n| --- | --- |\n| Alice | 30 |"
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// table + context
+		assertBlockCount(t, got.Blocks, 2)
+		if _, ok := got.Blocks[0].(*slack.TableBlock); !ok {
+			t.Errorf("block 0: expected *TableBlock, got %T", got.Blocks[0])
+		}
+	})
+
+	t.Run("succeeded with list response", func(t *testing.T) {
+		resp := "- item one\n- item two\n- item three"
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// rich_text list + context
+		assertBlockCount(t, got.Blocks, 2)
+		if _, ok := got.Blocks[0].(*slack.RichTextBlock); !ok {
+			t.Errorf("block 0: expected *RichTextBlock, got %T", got.Blocks[0])
+		}
+	})
+
+	t.Run("succeeded with header response", func(t *testing.T) {
+		resp := "# Summary\nEverything looks good."
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// HeaderBlock + SectionBlock + context
+		assertBlockCount(t, got.Blocks, 3)
+		if hdr, ok := got.Blocks[0].(*slack.HeaderBlock); !ok {
+			t.Errorf("block 0: expected *HeaderBlock, got %T", got.Blocks[0])
+		} else if hdr.Text.Text != "Summary" {
+			t.Errorf("header text = %q, want %q", hdr.Text.Text, "Summary")
+		}
+		assertSectionContains(t, got.Blocks[1], "Everything looks good.")
+	})
+
+	t.Run("succeeded with mixed rich content", func(t *testing.T) {
+		resp := "## Report\nResults below:\n\n| Col | Val |\n| --- | --- |\n| a | 1 |\n\n- note 1\n- note 2"
+		results := map[string]string{"response": b64(resp)}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		// header + section + table + list + context
+		assertBlockCount(t, got.Blocks, 5)
+		if _, ok := got.Blocks[0].(*slack.HeaderBlock); !ok {
+			t.Errorf("block 0: expected *HeaderBlock, got %T", got.Blocks[0])
+		}
+		if _, ok := got.Blocks[1].(*slack.SectionBlock); !ok {
+			t.Errorf("block 1: expected *SectionBlock, got %T", got.Blocks[1])
+		}
+		if _, ok := got.Blocks[2].(*slack.TableBlock); !ok {
+			t.Errorf("block 2: expected *TableBlock, got %T", got.Blocks[2])
+		}
+		if _, ok := got.Blocks[3].(*slack.RichTextBlock); !ok {
+			t.Errorf("block 3: expected *RichTextBlock, got %T", got.Blocks[3])
+		}
+	})
+}
+
+func TestFormatSlackTransitionMessage_SplitsLongResponse(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("### Header\nSome content here.")
+	}
+	results := map[string]string{"response": b64(sb.String())}
+
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	if len(msgs) < 2 {
+		t.Fatalf("expected multiple messages for long response, got %d", len(msgs))
+	}
+
+	// Every message must be within the block limit.
+	for i, msg := range msgs {
+		if len(msg.Blocks) > SlackBlockLimit {
+			t.Errorf("message %d has %d blocks, must be <= %d", i, len(msg.Blocks), SlackBlockLimit)
+		}
+	}
+
+	// Last block of the last message must be the context block (task name).
+	lastMsg := msgs[len(msgs)-1]
+	last := lastMsg.Blocks[len(lastMsg.Blocks)-1]
+	if _, ok := last.(*slack.ContextBlock); !ok {
+		t.Errorf("last block of last message should be ContextBlock, got %T", last)
+	}
+
+	// First message should have a continuation context with part info.
+	firstMsg := msgs[0]
+	firstLast := firstMsg.Blocks[len(firstMsg.Blocks)-1]
+	if ctx, ok := firstLast.(*slack.ContextBlock); ok {
+		found := false
+		for _, elem := range ctx.ContextElements.Elements {
+			if txt, ok := elem.(*slack.TextBlockObject); ok {
+				if strings.Contains(txt.Text, "Part 1/") {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Error("expected first message to have a Part 1/N continuation indicator")
+		}
+	} else {
+		t.Errorf("first message last block: expected *ContextBlock, got %T", firstLast)
+	}
+
+	// Continuation messages should have part indicators in their fallback text.
+	for i := 1; i < len(msgs); i++ {
+		if !strings.Contains(msgs[i].Text, "continued") {
+			t.Errorf("message %d fallback text should contain 'continued', got %q", i, msgs[i].Text)
+		}
+	}
+}
+
+func TestFormatSlackTransitionMessage_SplitsWithPRLink(t *testing.T) {
+	// Verify that the PR link ends up in the last message.
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("### Header\nSome content here.")
+	}
+	results := map[string]string{
+		"response": b64(sb.String()),
+		"pr":       "https://github.com/org/repo/pull/99",
+	}
+
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	if len(msgs) < 2 {
+		t.Fatalf("expected multiple messages, got %d", len(msgs))
+	}
+
+	// PR link should be in the last message.
+	lastMsg := msgs[len(msgs)-1]
+	foundPR := false
+	for _, b := range lastMsg.Blocks {
+		if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+			if strings.Contains(sec.Text.Text, "Pull Request") {
+				foundPR = true
+				break
+			}
+		}
+	}
+	if !foundPR {
+		t.Error("expected PR link in last message")
+	}
+}
+
+func TestFormatSlackTransitionMessage_SingleChunkWithTrailing(t *testing.T) {
+	// When response blocks barely exceed the limit (e.g. 49 response blocks
+	// + 2 trailing = 51), splitBlocks may return a single chunk. The trailing
+	// blocks (PR link, context) must still be included.
+	var sb strings.Builder
+	for i := 0; i < 49; i++ {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("Short paragraph.")
+	}
+	results := map[string]string{
+		"response": b64(sb.String()),
+		"pr":       "https://github.com/org/repo/pull/77",
+	}
+
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	// All blocks should fit in a single message after splitting.
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	msg := msgs[0]
+	if len(msg.Blocks) > SlackBlockLimit {
+		t.Errorf("message has %d blocks, must be <= %d", len(msg.Blocks), SlackBlockLimit)
+	}
+
+	// PR link must be present.
+	foundPR := false
+	for _, b := range msg.Blocks {
+		if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+			if strings.Contains(sec.Text.Text, "Pull Request") {
+				foundPR = true
+				break
+			}
+		}
+	}
+	if !foundPR {
+		t.Error("expected PR link in message")
+	}
+
+	// Context block must be present as the last block.
+	last := msg.Blocks[len(msg.Blocks)-1]
+	if _, ok := last.(*slack.ContextBlock); !ok {
+		t.Errorf("last block should be ContextBlock, got %T", last)
+	}
+}
+
+func TestFormatSlackTransitionMessage_UnicodeBulletResponse(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("# Weekly Update\n\n")
+	for i := 0; i < 50; i++ {
+		sb.WriteString("• *Status:* On track — lots of progress this week with many issues completed across the board.\n")
+	}
+	results := map[string]string{"response": b64(sb.String())}
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+
+	for i, msg := range msgs {
+		if len(msg.Blocks) > SlackBlockLimit {
+			t.Errorf("message %d has %d blocks, must be <= %d", i, len(msg.Blocks), SlackBlockLimit)
+		}
+		for j, b := range msg.Blocks {
+			if sec, ok := b.(*slack.SectionBlock); ok && sec.Text != nil {
+				if len([]rune(sec.Text.Text)) > slackSectionTextLimit {
+					t.Errorf("message %d block %d section text length %d exceeds %d", i, j, len([]rune(sec.Text.Text)), slackSectionTextLimit)
+				}
+			}
+		}
+		if len([]rune(msg.Text)) > slackFallbackTextLimit {
+			t.Errorf("message %d fallback text length %d exceeds %d", i, len([]rune(msg.Text)), slackFallbackTextLimit)
+		}
+	}
+}
+
+func TestFormatSlackTransitionMessage_FallbackTextTruncated(t *testing.T) {
+	long := strings.Repeat("A", 50000)
+	results := map[string]string{"response": b64(long)}
+	msgs := FormatSlackTransitionMessage("succeeded", "test-task", "", results)
+	for i, msg := range msgs {
+		if len([]rune(msg.Text)) > slackFallbackTextLimit {
+			t.Errorf("message %d fallback text length %d exceeds limit %d", i, len([]rune(msg.Text)), slackFallbackTextLimit)
+		}
+	}
+}
+
+func TestFormatProgressMessage_FallbackTextTruncated(t *testing.T) {
+	long := strings.Repeat("x", 50000)
+	got := FormatProgressMessage(long, "test-task")
+	if len([]rune(got.Text)) > slackFallbackTextLimit {
+		t.Errorf("fallback text length %d exceeds limit %d", len([]rune(got.Text)), slackFallbackTextLimit)
+	}
+}
+
+func TestFormatProgressMessage(t *testing.T) {
+	t.Run("includes blocks and context", func(t *testing.T) {
+		got := FormatProgressMessage("Looking at the config files...", "test-task")
+		if got.Text != "Looking at the config files..." {
+			t.Errorf("text = %q, want progress text", got.Text)
+		}
+		if len(got.Blocks) == 0 {
+			t.Fatal("expected blocks to be present")
+		}
+		// Last block should be a context block with the task name.
+		lastBlock := got.Blocks[len(got.Blocks)-1]
+		assertContextContains(t, lastBlock, "test-task")
+	})
+
+	t.Run("appendActivityContext works", func(t *testing.T) {
+		base := FormatProgressMessage("Investigating the issue...", "test-task")
+		result := appendActivityContext(base, "Reading `main.go`...")
+		// Should have blocks (not skipped like text-only messages).
+		if len(result.Blocks) == 0 {
+			t.Fatal("expected blocks after appending activity context")
+		}
+		// The activity text should be in the last context block.
+		lastBlock := result.Blocks[len(result.Blocks)-1]
+		ctx, ok := lastBlock.(*slack.ContextBlock)
+		if !ok {
+			t.Fatalf("last block: expected *ContextBlock, got %T", lastBlock)
+		}
+		// Should have 2 elements: task name + activity.
+		if len(ctx.ContextElements.Elements) != 2 {
+			t.Errorf("context elements = %d, want 2 (task name + activity)", len(ctx.ContextElements.Elements))
+		}
+	})
+}
+
+func TestConvertInlineMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"bold", "this is **important**", "this is *important*"},
+		{"link", "see [docs](https://example.com)", "see <https://example.com|docs>"},
+		{"link with parens", "see [Go](https://en.wikipedia.org/wiki/Go_(language))", "see <https://en.wikipedia.org/wiki/Go_(language)|Go>"},
+		{"link with rfc parens", "[RFC](https://tools.ietf.org/html/rfc3986_(URI))", "<https://tools.ietf.org/html/rfc3986_(URI)|RFC>"},
+		{"strikethrough", "~~removed~~", "~removed~"},
+		{"mixed", "**Bold** and [link](https://x.com) ~~old~~", "*Bold* and <https://x.com|link> ~old~"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertInlineMarkdown(tt.in)
+			if got != tt.want {
+				t.Errorf("convertInlineMarkdown(%q)\n got %q\nwant %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSlackSucceeded_MarkdownConversion(t *testing.T) {
+	results := map[string]string{"response": b64("## Summary\nI updated the **CODEOWNERS** file.")}
+	got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+	// ## Summary becomes a HeaderBlock, text becomes a SectionBlock with inline markdown converted
+	if hdr, ok := got.Blocks[0].(*slack.HeaderBlock); !ok {
+		t.Errorf("block 0: expected *HeaderBlock, got %T", got.Blocks[0])
+	} else if hdr.Text.Text != "Summary" {
+		t.Errorf("header text = %q, want %q", hdr.Text.Text, "Summary")
+	}
+	assertSectionContains(t, got.Blocks[1], "*CODEOWNERS*")
+}
+
+func b64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestSlackReporterConstruction(t *testing.T) {
+	reporter := &SlackReporter{BotToken: "xoxb-test-token"}
+	if reporter.BotToken != "xoxb-test-token" {
+		t.Errorf("BotToken = %q, want %q", reporter.BotToken, "xoxb-test-token")
+	}
+}
+
+func TestSlackReporter_PostThreadReplyError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": "invalid_auth"})
+	}))
+	defer srv.Close()
+
+	client := slack.New("xoxb-fake", slack.OptionAPIURL(srv.URL+"/"))
+	reporter := &SlackReporter{BotToken: "xoxb-fake", client: client}
+	_, err := reporter.PostThreadReply(context.Background(), "C123", "1234.5678", SlackMessage{Text: "test"})
+	if err == nil {
+		t.Error("expected error with invalid token, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_auth") {
+		t.Errorf("expected invalid_auth error, got: %v", err)
+	}
+}
+
+// assertBlockCount checks that the blocks slice has the expected length.
+func assertBlockCount(t *testing.T, blocks []slack.Block, want int) {
+	t.Helper()
+	if len(blocks) != want {
+		t.Errorf("block count = %d, want %d", len(blocks), want)
+	}
+}
+
+// assertSectionText checks that a block is a SectionBlock with the exact text.
+func assertSectionText(t *testing.T, block slack.Block, want string) {
+	t.Helper()
+	section, ok := block.(*slack.SectionBlock)
+	if !ok {
+		t.Errorf("expected SectionBlock, got %T", block)
+		return
+	}
+	if section.Text == nil || section.Text.Text != want {
+		got := ""
+		if section.Text != nil {
+			got = section.Text.Text
+		}
+		t.Errorf("section text = %q, want %q", got, want)
+	}
+}
+
+// assertSectionContains checks that a block is a SectionBlock containing the substring.
+func assertSectionContains(t *testing.T, block slack.Block, substr string) {
+	t.Helper()
+	section, ok := block.(*slack.SectionBlock)
+	if !ok {
+		t.Errorf("expected SectionBlock, got %T", block)
+		return
+	}
+	if section.Text == nil {
+		t.Errorf("section text is nil, want to contain %q", substr)
+		return
+	}
+	if !strings.Contains(section.Text.Text, substr) {
+		t.Errorf("section text %q does not contain %q", section.Text.Text, substr)
+	}
+}
+
+// assertContextContains checks that a block is a ContextBlock containing the substring.
+func assertContextContains(t *testing.T, block slack.Block, substr string) {
+	t.Helper()
+	ctx, ok := block.(*slack.ContextBlock)
+	if !ok {
+		t.Errorf("expected ContextBlock, got %T", block)
+		return
+	}
+	for _, elem := range ctx.ContextElements.Elements {
+		if txt, ok := elem.(*slack.TextBlockObject); ok {
+			if strings.Contains(txt.Text, substr) {
+				return
+			}
+		}
+	}
+	t.Errorf("context block does not contain %q", substr)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds the foundational Slack message types and Block Kit formatting layer to the reporting package. This is a prerequisite for centralized Slack task reporting — the types and formatters introduced here will be consumed by a `SlackTaskReporter` in a follow-up PR.

**`slack.go`** — Core message types and reporter:
- `SlackMessage` struct holding fallback text and Block Kit blocks
- `SlackReporter` implementing `PostThreadReply` and `UpdateMessage` via the Slack API (thread-safe lazy client init with `sync.Once`)
- `FormatSlackTransitionMessage` — builds one or more rich messages for phase transitions (accepted/succeeded/failed), with automatic multi-message splitting when the response exceeds the 50-block Slack limit
- `FormatProgressMessage` — builds a Block Kit message for in-progress agent snapshots
- Fallback text builder with 40,000-char truncation for Slack's `chat.postMessage` limit

**`slack_blocks.go`** — Markdown to Block Kit conversion:
- `responseToBlocks` converts markdown text into typed Slack blocks
- Supported elements: headers (`#`/`##`/`###`), tables, ordered/unordered lists (including `*` and `•` bullets), horizontal dividers (`---`/`***`/`___`), and plain text sections
- Inline formatting: bold, strikethrough, inline code, markdown links `[text](url)`, Slack links `<url|text>`, with recursive nested style support (e.g. `**\`code\`**` renders as bold+code)
- Rich text elements for tables and lists with proper `RichTextSectionTextStyle` propagation
- Section text splitting at 3,000 chars and header truncation at 150 chars per Slack limits
- Empty table cells use non-breaking space to avoid Slack's `invalid_blocks` error

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- These files are ported from the `datagravity-ai/kelos:prod` branch where they have been running in production.
- No callers exist yet in `main` — this PR is pure additions. The `SlackTaskReporter` that consumes these types will land in a follow-up PR.
- The `SlackReporter.PostThreadReply` error-path test (`TestSlackReporter_PostThreadReplyError`) intentionally uses an invalid token to exercise the error wrapping without needing a mock server.
- This is the first of 3 PRs breaking down: https://github.com/kelos-dev/kelos/pull/1093 into composable parts
- Gif of it working: https://github.com/user-attachments/assets/dccba9db-0d5b-4355-bcb5-0bfc715e4862

#### Does this PR introduce a user-facing change?

```release-note
NONE
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds foundational Slack reporting to `internal/reporting` with a Block Kit formatting layer for rich task updates in Slack threads. Long responses split across replies with continuation indicators; no callers in `main` yet.

- **New Features**
  - `SlackMessage` with fallback text (40k cap) and Block Kit blocks; `SlackReporter` supports `PostThreadReply` and `UpdateMessage` with a thread-safe lazy `slack-go` client.
  - `FormatSlackTransitionMessage` builds phase updates, adds PR/error and task context, decodes base64 `results["response"]` (falls back to raw), and splits to stay ≤50 blocks with "Part x/y" and continued fallback text.
  - `FormatProgressMessage` builds in-progress updates; `appendActivityContext` appends the current action to the context.
  - Markdown → Block Kit: headers, tables, ordered/unordered lists (`-`, `*`, `•`), dividers, links (`[text](url)`, `<url|text>`), and inline styles (bold, strikethrough, code) with nested support; section text split at 3k and headers at 150; empty table cells use NBSP to avoid `invalid_blocks`.

<sup>Written for commit b39a2739838b12fc07543fb08d8f22a95a13b89b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





