### PR TITLE
feat(slack): post welcome message when bot is added to a channel

### DIFF
--- a/cmd/kelos-slack-server/main.go
+++ b/cmd/kelos-slack-server/main.go
@@ -71,12 +71,15 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	joinMessageFile := os.Getenv("SLACK_JOIN_MESSAGE_FILE")
+
 	// Create the Slack handler
 	handler, err := kelosslack.NewSlackHandler(
 		ctx,
 		mgr.GetClient(),
 		botToken,
 		appToken,
+		joinMessageFile,
 		ctrl.Log.WithName("slack"),
 	)
 	if err != nil {

--- a/internal/manifests/charts/kelos/templates/slack-server-configmap.yaml
+++ b/internal/manifests/charts/kelos/templates/slack-server-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.slackServer.joinMessage }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kelos-slack-server-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kelos
+    app.kubernetes.io/component: slack-server
+data:
+  join-message.txt: |
+    {{- .Values.slackServer.joinMessage | nindent 4 }}
+{{- end }}

--- a/internal/manifests/charts/kelos/templates/slack-server.yaml
+++ b/internal/manifests/charts/kelos/templates/slack-server.yaml
@@ -44,6 +44,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.slackServer.secretName }}
                   key: SLACK_APP_TOKEN
+            {{- if .Values.slackServer.joinMessage }}
+            - name: SLACK_JOIN_MESSAGE_FILE
+              value: /etc/kelos/join-message.txt
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 8080
@@ -67,6 +71,12 @@ spec:
           resources:
             {{- toYaml .Values.slackServer.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.slackServer.joinMessage }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kelos
+              readOnly: true
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -75,4 +85,10 @@ spec:
             capabilities:
               drop:
                 - "ALL"
+      {{- if .Values.slackServer.joinMessage }}
+      volumes:
+        - name: config
+          configMap:
+            name: kelos-slack-server-config
+      {{- end }}
 {{- end }}

--- a/internal/manifests/charts/kelos/values.yaml
+++ b/internal/manifests/charts/kelos/values.yaml
@@ -107,6 +107,8 @@ slackServer:
   image: ghcr.io/kelos-dev/kelos-slack-server
   replicas: 1
   secretName: ""
+  # Message posted when the bot joins a channel. Leave empty to disable.
+  joinMessage: ""
   resources:
     limits:
       cpu: 500m

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -35,7 +35,10 @@ const (
 	AnnotationSlackThreadTS = "kelos.dev/slack-thread-ts"
 )
 
-const enrichCallTimeout = 5 * time.Second
+const (
+	enrichCallTimeout  = 5 * time.Second
+	postMessageTimeout = 5 * time.Second
+)
 
 // SlackHandler handles Slack messages via Socket Mode and routes them to
 // matching TaskSpawners. It is the centralized equivalent of the per-TaskSpawner
@@ -47,11 +50,13 @@ type SlackHandler struct {
 	api         *goslack.Client
 	sm          *socketmode.Client
 	botUserID   string
+	joinMessage string
 	cancel      context.CancelFunc
 }
 
 // NewSlackHandler creates a new handler. Call Start to begin listening.
-func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken string, log logr.Logger) (*SlackHandler, error) {
+// If joinMessageFile is non-empty, the bot posts its contents when added to a channel.
+func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken, joinMessageFile string, log logr.Logger) (*SlackHandler, error) {
 	api := goslack.New(botToken, goslack.OptionAppLevelToken(appToken))
 
 	authResp, err := api.AuthTestContext(ctx)
@@ -66,6 +71,18 @@ func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken s
 
 	log.Info("Authenticated with Slack", "botUserID", authResp.UserID)
 
+	var joinMessage string
+	if joinMessageFile != "" {
+		data, err := os.ReadFile(joinMessageFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading join message file %s: %w", joinMessageFile, err)
+		}
+		joinMessage = strings.TrimSpace(string(data))
+		if joinMessage != "" {
+			log.Info("Join channel message enabled", "file", joinMessageFile)
+		}
+	}
+
 	return &SlackHandler{
 		client:      cl,
 		log:         log,
@@ -73,6 +90,7 @@ func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken s
 		api:         api,
 		sm:          newSocketModeClient(api),
 		botUserID:   authResp.UserID,
+		joinMessage: joinMessage,
 	}, nil
 }
 
@@ -126,13 +144,39 @@ func (h *SlackHandler) handleEventsAPI(ctx context.Context, evt socketmode.Event
 	}
 	h.sm.Ack(*evt.Request)
 
-	innerEvent, ok := eventsAPIEvent.InnerEvent.Data.(*slackevents.MessageEvent)
-	if !ok {
+	switch inner := eventsAPIEvent.InnerEvent.Data.(type) {
+	case *slackevents.MemberJoinedChannelEvent:
+		h.handleMemberJoinedChannel(ctx, inner)
+	case *slackevents.MessageEvent:
+		h.handleMessageEvent(ctx, inner)
+	default:
+		return
+	}
+}
+
+// handleMemberJoinedChannel posts a welcome message when the bot itself is
+// added to a channel. The message text is read from the file pointed to by
+// joinMessageFile. If the file is not configured or cannot be read, the
+// event is silently ignored.
+func (h *SlackHandler) handleMemberJoinedChannel(ctx context.Context, evt *slackevents.MemberJoinedChannelEvent) {
+	if evt.User != h.botUserID {
 		return
 	}
 
-	// MessageEvent.UnmarshalJSON always populates Message, even for regular
-	// (non-subtype) messages, by re-unmarshaling top-level JSON into Message.
+	if h.joinMessage == "" {
+		return
+	}
+
+	h.log.Info("Bot added to channel, posting join message", "channel", evt.Channel)
+
+	postCtx, cancel := context.WithTimeout(ctx, postMessageTimeout)
+	defer cancel()
+	if _, _, err := h.api.PostMessageContext(postCtx, evt.Channel, goslack.MsgOptionText(h.joinMessage, false)); err != nil {
+		h.log.Error(err, "Failed to post join message", "channel", evt.Channel)
+	}
+}
+
+func (h *SlackHandler) handleMessageEvent(ctx context.Context, innerEvent *slackevents.MessageEvent) {
 	hasContent := innerEvent.Text != "" ||
 		(innerEvent.Message != nil && len(innerEvent.Message.Attachments) > 0)
 	if !shouldProcess(innerEvent.User, innerEvent.SubType, hasContent, h.botUserID) {

--- a/internal/slack/handler_test.go
+++ b/internal/slack/handler_test.go
@@ -316,3 +316,37 @@ func TestCreateTaskAlreadyExists(t *testing.T) {
 		t.Fatalf("Second createTask() should not error on AlreadyExists, got: %v", err)
 	}
 }
+
+func TestHandleMemberJoinedChannelIgnoresOtherUsers(t *testing.T) {
+	h := &SlackHandler{
+		log:         logr.Discard(),
+		botUserID:   "UBOT",
+		joinMessage: "Welcome!",
+		// api is nil — if handleMemberJoinedChannel tries to post for a
+		// non-bot user it will panic, which is the desired failure mode here.
+	}
+
+	evt := &slackevents.MemberJoinedChannelEvent{
+		User:    "UOTHER",
+		Channel: "C123",
+	}
+
+	// Should return without attempting to post (no panic = pass).
+	h.handleMemberJoinedChannel(context.Background(), evt)
+}
+
+func TestHandleMemberJoinedChannelSkipsEmptyMessage(t *testing.T) {
+	h := &SlackHandler{
+		log:       logr.Discard(),
+		botUserID: "UBOT",
+		// joinMessage is empty — should not attempt to post.
+		// api is nil — would panic if it tried.
+	}
+
+	evt := &slackevents.MemberJoinedChannelEvent{
+		User:    "UBOT",
+		Channel: "C123",
+	}
+
+	h.handleMemberJoinedChannel(context.Background(), evt)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When the Kelos bot is added to a Slack channel, it now posts a configurable welcome message so users know the bot is available and how to interact with it. The message text is managed via the Helm chart and mounted as a read-only ConfigMap.

Changes:
- Refactor `handleEventsAPI` into a type-switch dispatching to `handleMessageEvent` (existing logic, extracted) and `handleMemberJoinedChannel` (new)
- `handleMemberJoinedChannel` fires only when the bot itself is added (ignores other users joining), reads the message from a file, and posts it to the channel
- The file path comes from the `SLACK_JOIN_MESSAGE_FILE` environment variable, set automatically by the Helm chart when `slackServer.joinMessage` is non-empty
- New `slack-server-configmap.yaml` template creates the ConfigMap; the deployment template conditionally mounts it at `/etc/kelos/join-message.txt`
- Leave `slackServer.joinMessage` empty (the default) to disable the feature entirely — no ConfigMap, no volume, no env var

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The `NewSlackHandler` signature gains a `joinMessageFile string` parameter (between `appToken` and `log`). This is a breaking change for any out-of-tree callers, but there are none.
- The type-switch refactor in `handleEventsAPI` is a no-op for existing behavior — `handleMessageEvent` is a direct extraction of the previous inline code.
- The ConfigMap volume is mounted read-only, compatible with the existing `readOnlyRootFilesystem: true` security context.

#### Does this PR introduce a user-facing change?

```release-note
Add configurable welcome message when the Kelos bot is added to a Slack channel, controlled by the `slackServer.joinMessage` Helm value.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts a welcome message when the Kelos Slack bot is added to a channel. Configurable via the Helm chart and disabled by default.

- **New Features**
  - Posts a message only when the bot joins; reads from `SLACK_JOIN_MESSAGE_FILE` if set.
  - Helm conditionally creates a ConfigMap and mounts it read-only at `/etc/kelos/join-message.txt`; sets `SLACK_JOIN_MESSAGE_FILE` when `slackServer.joinMessage` is set.
  - `handleEventsAPI` now dispatches via type switch to `handleMessageEvent` and `handleMemberJoinedChannel`; existing message handling is unchanged.

- **Migration**
  - To enable, set `slackServer.joinMessage`; leaving it empty creates no ConfigMap, volume, or env var.
  - `NewSlackHandler` now accepts a `joinMessageFile` parameter; internal callers updated.

<sup>Written for commit 8e3617682536ba82f3ab6c7ffe7205c17dfadd9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

