### PR TITLE
docs: fix github webhook example fields

### DIFF
--- a/examples/10-taskspawner-github-webhook/taskspawner.yaml
+++ b/examples/10-taskspawner-github-webhook/taskspawner.yaml
@@ -43,7 +43,7 @@ spec:
           labels: ["bug"]
           excludeLabels: ["wontfix", "duplicate"]
 
-        # Respond to issue comments containing "/kelos"
+        # Respond to issue comments matching "/kelos"
         - event: "issue_comment"
           action: "created"
           bodyPattern: "/kelos"


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Fixes the GitHub webhook TaskSpawner example so new users do not copy invalid or deprecated fields:
- changes the example Workspace `spec.repo` from object form to the string schema used by the API
- replaces deprecated `bodyContains` usage with `bodyPattern` in example 10 and the integration docs filtering list

#### Which issue(s) this PR is related to:

Fixes #1118

#### Special notes for your reviewer:

Orbit assessment: simple -> hunter. This is a docs/example-only fix.

Validation run:
- `git diff --check`
- Python YAML sanity check for `examples/10-taskspawner-github-webhook/taskspawner.yaml`
- grep check that `bodyContains` no longer appears in the issue target files

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GitHub webhook TaskSpawner docs/example to the current schema. Replace `bodyContains` with `bodyPattern`, use string `spec.repo`, and update comment to say “matching”.

<sup>Written for commit 574e2a0d7bdbd9d189fbaa3339738b7e8f7e6a68. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1119?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

