### PR TITLE
feat(capture): emit agent response text in KELOS_OUTPUTS

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -3,6 +3,7 @@ package capture
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -88,6 +89,15 @@ func captureOutputs(r runner, usageFile string) []string {
 		if v, ok := usage[key]; ok {
 			outputs = append(outputs, key+": "+v)
 		}
+	}
+
+	// Emit the agent's visible response text so reporters (Slack thread
+	// replies, GitHub PR comments) can surface the answer to the user
+	// instead of only the task title and token counts. Base64-encoded
+	// because the text may span multiple lines, which would otherwise
+	// break the line-delimited KELOS_OUTPUTS contract.
+	if response := ParseResponse(agentType, usageFile); response != "" {
+		outputs = append(outputs, "response: "+base64.StdEncoding.EncodeToString([]byte(response)))
 	}
 
 	return outputs

--- a/internal/capture/response.go
+++ b/internal/capture/response.go
@@ -1,0 +1,198 @@
+package capture
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// ParseResponse extracts the agent's final response text from the agent
+// output file. The returned string is the user-visible answer (or
+// concatenation of answers across turns) and is intended for reporters
+// that surface task results back to the originating channel (Slack thread,
+// GitHub PR comment, etc.).
+//
+// Returns an empty string if the file is unreadable, the agent type is
+// unknown, or the agent produced no extractable response text.
+func ParseResponse(agentType, filePath string) string {
+	if agentType == "" {
+		return ""
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	var lines [][]byte
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		lines = append(lines, append([]byte(nil), scanner.Bytes()...))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	switch agentType {
+	case "claude-code":
+		return parseClaudeCodeResponse(lines)
+	case "codex":
+		return parseCodexResponse(lines)
+	case "gemini":
+		return parseGeminiResponse(lines)
+	case "opencode":
+		return parseOpencodeResponse(lines)
+	case "cursor":
+		return parseCursorResponse(lines)
+	default:
+		return ""
+	}
+}
+
+// parseCodexResponse concatenates the text of every
+// {"type":"item.completed","item":{"type":"agent_message","text":"..."}}
+// event, in order. Codex may emit several agent_message items across turns
+// or alongside tool use, so joining them preserves the full visible answer.
+func parseCodexResponse(lines [][]byte) string {
+	var parts []string
+	for _, line := range lines {
+		m := parseLine(line)
+		if m == nil || m["type"] != "item.completed" {
+			continue
+		}
+		item, ok := m["item"].(map[string]any)
+		if !ok || item["type"] != "agent_message" {
+			continue
+		}
+		if text, ok := item["text"].(string); ok && text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// parseClaudeCodeResponse extracts the assistant message text. Claude
+// Code's stream-json format emits text in either:
+//   - {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
+//     (one per turn during the run), or
+//   - {"type":"result","result":"..."} (a final summary line).
+//
+// The final summary is preferred when present; otherwise we fall back to
+// the concatenated text blocks across all assistant turns.
+func parseClaudeCodeResponse(lines [][]byte) string {
+	if last := findLastByType(lines, "result"); last != nil {
+		if result, ok := last["result"].(string); ok && result != "" {
+			return result
+		}
+	}
+	var parts []string
+	for _, line := range lines {
+		m := parseLine(line)
+		if m == nil || m["type"] != "assistant" {
+			continue
+		}
+		msg, ok := m["message"].(map[string]any)
+		if !ok {
+			continue
+		}
+		content, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, block := range content {
+			b, ok := block.(map[string]any)
+			if !ok || b["type"] != "text" {
+				continue
+			}
+			if text, ok := b["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// parseGeminiResponse concatenates the text of every
+// {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
+// event. Gemini follows the same assistant-content shape as claude-code
+// for visible output (the final {"type":"result"} line carries only stats).
+func parseGeminiResponse(lines [][]byte) string {
+	var parts []string
+	for _, line := range lines {
+		m := parseLine(line)
+		if m == nil {
+			continue
+		}
+		// Streamed text events: {"type":"text","text":"..."}
+		if m["type"] == "text" {
+			if text, ok := m["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+			continue
+		}
+		// Structured assistant events with content blocks.
+		if m["type"] != "assistant" {
+			continue
+		}
+		msg, ok := m["message"].(map[string]any)
+		if !ok {
+			continue
+		}
+		content, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, block := range content {
+			b, ok := block.(map[string]any)
+			if !ok || b["type"] != "text" {
+				continue
+			}
+			if text, ok := b["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// parseOpencodeResponse extracts text from {"type":"text","text":"..."}
+// events, falling back to {"type":"step_finish","part":{"text":"..."}}
+// when the streamed text events are absent. Opencode emits raw text
+// fragments without an outer message envelope.
+func parseOpencodeResponse(lines [][]byte) string {
+	var parts []string
+	for _, line := range lines {
+		m := parseLine(line)
+		if m == nil {
+			continue
+		}
+		switch m["type"] {
+		case "text":
+			if text, ok := m["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+				continue
+			}
+			if part, ok := m["part"].(map[string]any); ok {
+				if text, ok := part["text"].(string); ok && text != "" {
+					parts = append(parts, text)
+				}
+			}
+		case "step_finish":
+			if part, ok := m["part"].(map[string]any); ok {
+				if text, ok := part["text"].(string); ok && text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// parseCursorResponse extracts text from cursor's stream-json output. The
+// shape mirrors claude-code: assistant events carry the visible text and
+// the trailing result event carries usage stats.
+func parseCursorResponse(lines [][]byte) string {
+	return parseClaudeCodeResponse(lines)
+}
+

--- a/internal/capture/response_test.go
+++ b/internal/capture/response_test.go
@@ -1,0 +1,158 @@
+package capture
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentType string
+		content   string
+		want      string
+	}{
+		{
+			name:      "codex single agent_message",
+			agentType: "codex",
+			content: `{"type":"thread.started","thread_id":"abc"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2 + 2 = 4"}}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":8}}
+`,
+			want: "2 + 2 = 4",
+		},
+		{
+			name:      "codex multiple agent_messages concatenated",
+			agentType: "codex",
+			content: `{"type":"item.completed","item":{"type":"agent_message","text":"First part."}}
+{"type":"item.completed","item":{"type":"agent_message","text":"Second part."}}
+`,
+			want: "First part.\n\nSecond part.",
+		},
+		{
+			name:      "codex ignores non-agent_message items",
+			agentType: "codex",
+			content: `{"type":"item.completed","item":{"type":"tool_use","text":"ls -la"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"Here are the files."}}
+`,
+			want: "Here are the files.",
+		},
+		{
+			name:      "codex no agent_message returns empty",
+			agentType: "codex",
+			content: `{"type":"turn.started"}
+{"type":"turn.completed","usage":{"input_tokens":50,"output_tokens":0}}
+`,
+			want: "",
+		},
+		{
+			name:      "claude-code result field preferred",
+			agentType: "claude-code",
+			content: `{"type":"assistant","message":{"content":[{"type":"text","text":"Thinking..."}]}}
+{"type":"result","result":"Final answer here.","usage":{"input_tokens":100,"output_tokens":50}}
+`,
+			want: "Final answer here.",
+		},
+		{
+			name:      "claude-code falls back to assistant blocks when result has no text",
+			agentType: "claude-code",
+			content: `{"type":"assistant","message":{"content":[{"type":"text","text":"Hello."}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"World."}]}}
+{"type":"result","usage":{"input_tokens":100,"output_tokens":50}}
+`,
+			want: "Hello.\n\nWorld.",
+		},
+		{
+			name:      "claude-code ignores non-text content blocks",
+			agentType: "claude-code",
+			content: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"},{"type":"text","text":"Done."}]}}
+`,
+			want: "Done.",
+		},
+		{
+			name:      "gemini text events concatenated without separator",
+			agentType: "gemini",
+			content: `{"type":"text","text":"Here are "}
+{"type":"text","text":"the files."}
+{"type":"result","stats":{"inputTokens":100,"outputTokens":50}}
+`,
+			want: "Here are the files.",
+		},
+		{
+			name:      "gemini assistant content blocks",
+			agentType: "gemini",
+			content: `{"type":"assistant","message":{"content":[{"type":"text","text":"Result."}]}}
+`,
+			want: "Result.",
+		},
+		{
+			name:      "opencode text events",
+			agentType: "opencode",
+			content: `{"type":"text","text":"Step 1."}
+{"type":"text","text":" Step 2."}
+{"type":"step_finish","part":{"tokens":{"input":100,"output":50}}}
+`,
+			want: "Step 1. Step 2.",
+		},
+		{
+			name:      "opencode step_finish part.text fallback",
+			agentType: "opencode",
+			content: `{"type":"step_finish","part":{"text":"Final answer.","tokens":{"input":100,"output":50}}}
+`,
+			want: "Final answer.",
+		},
+		{
+			name:      "cursor uses claude-code shape",
+			agentType: "cursor",
+			content: `{"type":"result","result":"Cursor reply."}
+`,
+			want: "Cursor reply.",
+		},
+		{
+			name:      "unknown agent returns empty",
+			agentType: "unknown",
+			content:   `{"type":"item.completed","item":{"type":"agent_message","text":"ignored"}}`,
+			want:      "",
+		},
+		{
+			name:      "empty agent type returns empty",
+			agentType: "",
+			content:   `{"type":"item.completed","item":{"type":"agent_message","text":"ignored"}}`,
+			want:      "",
+		},
+		{
+			name:      "malformed JSON lines skipped",
+			agentType: "codex",
+			content: `not json
+{"type":"item.completed","item":{"type":"agent_message","text":"Recovered."}}
+also not json
+`,
+			want: "Recovered.",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempFile(t, tc.content)
+			got := ParseResponse(tc.agentType, path)
+			if got != tc.want {
+				t.Errorf("ParseResponse(%q) = %q, want %q", tc.agentType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseResponseMissingFile(t *testing.T) {
+	got := ParseResponse("codex", filepath.Join(t.TempDir(), "does-not-exist.jsonl"))
+	if got != "" {
+		t.Errorf("ParseResponse on missing file = %q, want empty string", got)
+	}
+}
+
+func TestParseResponseEmptyFile(t *testing.T) {
+	got := ParseResponse("codex", writeTempFile(t, ""))
+	if got != "" {
+		t.Errorf("ParseResponse on empty file = %q, want empty string", got)
+	}
+}
+


### PR DESCRIPTION
## Problem

`kelos-capture` currently extracts only deterministic metadata (branch, commit, PR links, token usage) from agent runs. The agent's visible answer text never makes it into `Task.status.results`, which means downstream reporters have no body to surface.

The centralized Slack reporter in `internal/reporting/slack.go` does:

```go
resp := results["response"]
decoded := decodeResponse(resp)
if resp != "" {
    responseBlocks = responseToBlocks(decoded)
}
```

Because `results["response"]` is always empty, the success reply in the thread shows only the task title and token usage — the answer text is dropped.


