### PR TITLE
feat(codex): bake kubectl + GitHub App credential helper into agent image

### DIFF
--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -49,11 +49,11 @@ RUN chmod +x /kelos_entrypoint.sh
 # Helper scripts for tasks that need git push + cluster read access. Each
 # is a no-op when the corresponding env vars are unset, so adding them
 # costs nothing for Q&A-style tasks that don't mount the github-app
-# Secret or the ServiceAccount token. See codex/bin/README for the
+# Secret or the ServiceAccount token. See codex/scripts/README for the
 # env contract.
-COPY codex/bin/github-app-credential-helper /usr/local/bin/github-app-credential-helper
-COPY codex/bin/github-app-token /usr/local/bin/github-app-token
-COPY codex/bin/kelos-agent-setup /usr/local/bin/kelos-agent-setup
+COPY codex/scripts/github-app-credential-helper /usr/local/bin/github-app-credential-helper
+COPY codex/scripts/github-app-token /usr/local/bin/github-app-token
+COPY codex/scripts/kelos-agent-setup /usr/local/bin/kelos-agent-setup
 RUN chmod +x /usr/local/bin/github-app-credential-helper \
     /usr/local/bin/github-app-token \
     /usr/local/bin/kelos-agent-setup

--- a/codex/Dockerfile
+++ b/codex/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     ca-certificates \
     git \
+    jq \
+    openssl \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -16,6 +18,17 @@ RUN apt-get update && apt-get install -y \
     && apt-get update \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
+
+# kubectl — pinned to a stable minor matching what the cluster runs.
+# Tasks that need cluster introspection use this against the in-cluster
+# API server via the mounted ServiceAccount token.
+ARG KUBECTL_VERSION=v1.31.0
+RUN ARCH=$(dpkg --print-architecture) \
+    && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+    && curl -fsSL -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" \
+    && echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum -c - \
+    && chmod +x /usr/local/bin/kubectl \
+    && rm /tmp/kubectl.sha256
 
 RUN ARCH=$(dpkg --print-architecture) \
     && TARBALL="go${GO_VERSION}.linux-${ARCH}.tar.gz" \
@@ -32,6 +45,18 @@ RUN npm install -g @openai/codex@${CODEX_VERSION}
 
 COPY codex/kelos_entrypoint.sh /kelos_entrypoint.sh
 RUN chmod +x /kelos_entrypoint.sh
+
+# Helper scripts for tasks that need git push + cluster read access. Each
+# is a no-op when the corresponding env vars are unset, so adding them
+# costs nothing for Q&A-style tasks that don't mount the github-app
+# Secret or the ServiceAccount token. See codex/bin/README for the
+# env contract.
+COPY codex/bin/github-app-credential-helper /usr/local/bin/github-app-credential-helper
+COPY codex/bin/github-app-token /usr/local/bin/github-app-token
+COPY codex/bin/kelos-agent-setup /usr/local/bin/kelos-agent-setup
+RUN chmod +x /usr/local/bin/github-app-credential-helper \
+    /usr/local/bin/github-app-token \
+    /usr/local/bin/kelos-agent-setup
 
 ARG TARGETARCH
 COPY bin/kelos-capture-linux-${TARGETARCH} /kelos/kelos-capture

--- a/codex/kelos_entrypoint.sh
+++ b/codex/kelos_entrypoint.sh
@@ -12,6 +12,13 @@ set -uo pipefail
 
 PROMPT="${1:?Prompt argument is required}"
 
+# Optional pre-agent setup. No-op unless the matching env vars are
+# present: GITHUB_APP_CLIENT_ID for git push via App installation tokens
+# and a mounted ServiceAccount token for kubectl. Tasks that don't need
+# either pay no cost; tasks that do get a configured git credential
+# helper and ~/.kube/config before the agent runs.
+/usr/local/bin/kelos-agent-setup
+
 # Write auth.json from env var for OAuth/ChatGPT credential flow.
 # Strip control characters so serde_json's strict parser accepts
 # the file (the env var value may contain raw newlines).

--- a/codex/scripts/README.md
+++ b/codex/scripts/README.md
@@ -1,0 +1,35 @@
+# Codex agent — helper binaries
+
+These scripts are baked into the codex agent image and live on `$PATH`
+inside the running container. They are invoked from
+`codex/kelos_entrypoint.sh` (via `kelos-agent-setup`) or from the agent
+itself once it is running.
+
+## Env-var contract
+
+| Variable | Provided by | Used by | Purpose |
+| --- | --- | --- | --- |
+| `GITHUB_APP_CLIENT_ID` | Task `podOverrides.envFrom` (Secret) | `github-app-token` | JWT `iss` claim — GitHub now accepts Client ID alongside numeric App ID for App authentication. |
+| `GITHUB_APP_INSTALLATION_ID` | Task `podOverrides.envFrom` (Secret) | `github-app-token` | Installation to mint the token for. |
+| `GITHUB_APP_PRIVATE_KEY` | Task `podOverrides.envFrom` (Secret) | `kelos-agent-setup` | Written to `/etc/kelos-agent/github-app.pem` once at startup; the helper reads from the file, not the env var, on each call. |
+| `KUBERNETES_CLUSTER_NAME` | Task `podOverrides.env` (literal) | `kelos-agent-setup` | Optional human-readable cluster name baked into `~/.kube/config`. Defaults to `in-cluster`. |
+
+All three GitHub App variables are mutually required — `kelos-agent-setup`
+aborts the task if `CLIENT_ID` is set but `PRIVATE_KEY` is missing rather
+than silently producing a broken git config. When none of them are set,
+setup is skipped entirely and the container runs as before.
+
+## Binaries
+
+- **`kelos-agent-setup`** — Pre-agent setup invoked from `kelos_entrypoint.sh`. Materialises the GitHub App private key to disk, wires `git config credential.helper`, and synthesises `~/.kube/config` from the projected ServiceAccount token. Each step is a no-op when its inputs are missing, so this script is safe to run unconditionally.
+- **`github-app-credential-helper`** — Git credential helper. Reads the credential request on stdin and, for `github.com` / `api.github.com` over HTTPS, returns a fresh installation token as the password. Returns nothing for other hosts so git falls through to its other helpers.
+- **`github-app-token`** — Signs a short-lived JWT with the App private key and exchanges it at `/app/installations/{id}/access_tokens` for a ~1 h installation token. Three attempts with exponential backoff before failing, so a transient network hiccup doesn't hang `git push`.
+
+## Why credential.helper instead of a static `GITHUB_TOKEN`
+
+Installation tokens expire after one hour. Caching a token at pod start
+would either limit the agent to short tasks or require a rotation
+sidecar. The credential helper mints a new token on each git call, so
+the pod can run for hours without thinking about expiry, and the only
+long-lived secret on disk is the App's RSA private key (read-only,
+0600, under `/etc/kelos-agent/`).

--- a/codex/scripts/github-app-credential-helper
+++ b/codex/scripts/github-app-credential-helper
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Git credential helper: mint a fresh GitHub App installation token on
+# every git operation that needs credentials. Wired in via
+#   git config --global credential.helper github-app-credential-helper
+# from the agent setup step.
+#
+# Invoked by git as `<helper> get` with the credential request on stdin.
+# Only `get` is implemented — `store` and `erase` are no-ops because the
+# token is regenerated each call, so caching it would defeat the purpose.
+set -euo pipefail
+
+if [[ "${1:-}" != "get" ]]; then
+  exit 0
+fi
+
+protocol=""
+host=""
+while IFS= read -r line; do
+  [[ -z "$line" ]] && break
+  case "$line" in
+  protocol=*) protocol="${line#protocol=}" ;;
+  host=*) host="${line#host=}" ;;
+  esac
+done
+
+# Only mint GitHub App tokens for the GitHub host over HTTPS. Any other
+# request gets no credentials, and git falls back to its other helpers.
+if [[ "$protocol" != "https" ]]; then
+  exit 0
+fi
+if [[ "$host" != "github.com" && "$host" != "api.github.com" ]]; then
+  exit 0
+fi
+
+token=$(/usr/local/bin/github-app-token)
+printf 'username=x-access-token\npassword=%s\n\n' "$token"

--- a/codex/scripts/github-app-token
+++ b/codex/scripts/github-app-token
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Print a fresh GitHub App installation token to stdout. Used by the git
+# credential helper and the `gh` wrapper.
+#
+# Reads the GitHub App identity from env (CLIENT_ID is accepted by GitHub
+# as the JWT iss claim — no separate numeric App ID is required for this
+# flow). The signing key is read from a fixed on-disk path written by the
+# agent setup step.
+set -euo pipefail
+
+: "${GITHUB_APP_CLIENT_ID:?GITHUB_APP_CLIENT_ID is required}"
+: "${GITHUB_APP_INSTALLATION_ID:?GITHUB_APP_INSTALLATION_ID is required}"
+
+PEM_FILE="${GITHUB_APP_PRIVATE_KEY_FILE:-/etc/kelos-agent/github-app.pem}"
+if [[ ! -r "$PEM_FILE" ]]; then
+  echo "github-app-token: private key not readable at $PEM_FILE" >&2
+  exit 1
+fi
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+now=$(date +%s)
+iat=$((now - 60))
+exp=$((now + 540))
+
+header=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+payload=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$iat" "$exp" "$GITHUB_APP_CLIENT_ID" | b64url)
+signature=$(printf '%s.%s' "$header" "$payload" |
+  openssl dgst -sha256 -sign "$PEM_FILE" -binary |
+  b64url)
+jwt="${header}.${payload}.${signature}"
+
+# Bounded retry with exponential backoff. Worst-case total wait is ~33s
+# across 3 attempts (10 + 1 + 10 + 2 + 10). Non-zero exit on exhaustion
+# stops git / gh from hanging waiting for credentials that won't arrive.
+attempts=3
+response=""
+for ((i = 1; i <= attempts; i++)); do
+  if response=$(curl -fsSL \
+    --connect-timeout 5 \
+    --max-time 10 \
+    -X POST \
+    -H "Authorization: Bearer $jwt" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens"); then
+    break
+  fi
+  if ((i == attempts)); then
+    echo "github-app-token: failed to mint installation token after ${attempts} attempts" >&2
+    exit 1
+  fi
+  sleep $((2 ** (i - 1)))
+done
+
+printf '%s' "$response" | jq -er '.token'

--- a/codex/scripts/kelos-agent-setup
+++ b/codex/scripts/kelos-agent-setup
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Pre-agent setup for tasks that need git push + cluster read access:
+#
+#   1. Materialise the GitHub App private key from $GITHUB_APP_PRIVATE_KEY
+#      onto disk so the credential helper can sign JWTs with it.
+#   2. Wire git's credential.helper at the global config level so every
+#      `git push` / `gh` call mints a fresh installation token. No static
+#      GITHUB_TOKEN is ever written; tokens are short-lived and per-call.
+#   3. Synthesise a ~/.kube/config from the projected ServiceAccount
+#      token so kubectl, helm, etc. resolve a named cluster — Kelos's
+#      job spec already mounts the token, but downstream tooling that
+#      reads $KUBECONFIG needs an explicit file to work cleanly.
+#
+# This script is a no-op when GITHUB_APP_CLIENT_ID is unset, so it can be
+# called unconditionally from kelos_entrypoint.sh; only tasks whose
+# podOverrides include the github-app secret pay the cost.
+set -euo pipefail
+
+setup_github_app_credentials() {
+  if [[ -z "${GITHUB_APP_CLIENT_ID:-}" ]]; then
+    return 0
+  fi
+  if [[ -z "${GITHUB_APP_PRIVATE_KEY:-}" ]]; then
+    echo "kelos-agent-setup: GITHUB_APP_CLIENT_ID set but GITHUB_APP_PRIVATE_KEY missing" >&2
+    exit 1
+  fi
+
+  local pem_dir pem_file
+  pem_dir="/etc/kelos-agent"
+  pem_file="${pem_dir}/github-app.pem"
+  # umask 077 ensures the dir + file are owner-only without an extra chmod.
+  (umask 077 && mkdir -p "$pem_dir" && printf '%s' "$GITHUB_APP_PRIVATE_KEY" >"$pem_file")
+
+  git config --global credential.helper /usr/local/bin/github-app-credential-helper
+  git config --global credential.useHttpPath true
+}
+
+setup_kubeconfig() {
+  local sa_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+  if [[ ! -r "${sa_dir}/token" ]]; then
+    echo "kelos-agent-setup: no service-account token at ${sa_dir} — skipping kubeconfig" >&2
+    return 0
+  fi
+
+  local cluster_name namespace kube_dir
+  cluster_name="${KUBERNETES_CLUSTER_NAME:-in-cluster}"
+  namespace="$(cat "${sa_dir}/namespace")"
+  kube_dir="${HOME:-/root}/.kube"
+  install -d -m 700 "${kube_dir}"
+
+  cat >"${kube_dir}/config" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: ${cluster_name}
+    cluster:
+      server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
+      certificate-authority: ${sa_dir}/ca.crt
+users:
+  - name: ${cluster_name}
+    user:
+      tokenFile: ${sa_dir}/token
+contexts:
+  - name: ${cluster_name}
+    context:
+      cluster: ${cluster_name}
+      user: ${cluster_name}
+      namespace: ${namespace}
+current-context: ${cluster_name}
+EOF
+  chmod 600 "${kube_dir}/config"
+}
+
+setup_github_app_credentials
+setup_kubeconfig


### PR DESCRIPTION
## Problem

The codex agent image ships neither \`kubectl\` nor a credential path for \`git push\` / \`gh pr create\`. Tasks that need to investigate live cluster state and open a PR back to the service repo (e.g. a debug-and-fix loop triggered from Slack) currently can't.

Existing tasks (Q&A-style, no cluster access, no push) work fine. The bar here is: extend the image **without changing default behaviour** for those.

## Change

- **\`kubectl\`** v1.31.0 pinned via the official k8s download mirror, SHA-verified. Paired with a synthesised \`~/.kube/config\` at startup pointing at the in-cluster API server via the projected ServiceAccount token.
- **GitHub App authentication for git** (three small bash scripts under \`codex/scripts/\`):
  - \`github-app-token\` — signs a JWT with the App private key (\`CLIENT_ID\` as \`iss\`, which GitHub now accepts alongside the numeric App ID) and exchanges it at \`/app/installations/{id}/access_tokens\` for a ~1 h installation token. Bounded retry with exponential backoff so a transient network blip doesn't hang \`git push\`.
  - \`github-app-credential-helper\` — git credential helper. Returns the installation token as the password for \`github.com\` / \`api.github.com\` over HTTPS; no-ops for other hosts so git falls through to its other helpers.
  - \`kelos-agent-setup\` — per-task pre-step invoked from \`kelos_entrypoint.sh\`. Writes the private key to \`/etc/kelos-agent/github-app.pem\` (0600), wires \`git config credential.helper\`, and writes the kubeconfig. **Each step is independent and gated on its own env vars**, so this script is safe to run unconditionally.

Scripts live under \`codex/scripts/\` rather than \`codex/bin/\` because the repo's top-level \`.gitignore\` strips \`bin/\` directories unconditionally for Go build output.

## No static \`GITHUB_TOKEN\`

Installation tokens are minted per git call and expire in ~1 h, so a long-running task doesn't need a rotation sidecar. The only long-lived secret on disk is the App's RSA private key (0600, under \`/etc/kelos-agent/\`). Same posture cursor's worker had.

## Env-var contract

| Variable | Provided by | Required? | Effect |
| --- | --- | --- | --- |
| \`GITHUB_APP_CLIENT_ID\` | Task \`podOverrides.envFrom\` (Secret) | If pushing | Triggers GitHub App credential setup |
| \`GITHUB_APP_INSTALLATION_ID\` | Same | If pushing | Installation to mint tokens for |
| \`GITHUB_APP_PRIVATE_KEY\` | Same | If pushing | Written to disk once at startup |
| \`KUBERNETES_CLUSTER_NAME\` | Task \`podOverrides.env\` | Optional | Human-readable cluster name in kubeconfig (default \`in-cluster\`) |

\`kelos-agent-setup\` aborts if \`CLIENT_ID\` is set but \`PRIVATE_KEY\` is missing rather than silently producing a broken git config.

## Backward compatibility

- Tasks without those env vars run exactly as before — no \`~/.kube/config\` written (no SA token typically anyway), no git credential helper wired, no PEM materialised. Net difference vs current behaviour is one shell invocation of \`kelos-agent-setup\` per task (< 10ms).
- All existing tests pass (\`go test ./internal/... ./cmd/...\`).

## Test plan
- [ ] Image builds (\`make image WHAT=codex IMAGE_PLATFORMS=linux/amd64\`)
- [ ] In a pod without the GitHub App secret: \`kubectl version\` works, \`git config credential.helper\` is unset
- [ ] In a pod with the secret mounted via \`podOverrides.envFrom\`: \`gh auth status\` shows a valid installation token, \`git clone https://github.com/<allowed-repo>\` works, \`gh pr create\` works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `kubectl` v1.31.0 and a GitHub App-backed `git`/`gh` credential path to the codex agent image so tasks can inspect clusters and open PRs. Q&A-only tasks behave the same.

- New Features
  - `kubectl` v1.31.0 installed (SHA-verified). `~/.kube/config` is synthesized from the pod ServiceAccount at startup.
  - GitHub App auth for `git`/`gh` via `github-app-token`, `github-app-credential-helper`, and `kelos-agent-setup`; wired as a `git` credential.helper.
  - Tokens are minted per call (~1h). No static `GITHUB_TOKEN` is stored. `kelos-agent-setup` is safe to run unconditionally.

- Migration
  - No changes required for existing tasks.
  - To enable pushes: set `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` via `podOverrides.envFrom`.
  - Optional: set `KUBERNETES_CLUSTER_NAME` for the kubeconfig name.

<sup>Written for commit 4aae0705b1aafd5263197a80c99c05edf3581f53. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1145?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

