### PR TITLE
fix: prevent duplicate webhook tasks for same PR branch

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -416,6 +416,20 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 
 		spawnerLog.Info("Webhook matches spawner filters - creating task")
 
+		// Check if an active task already exists for this spawner + source item.
+		// This prevents duplicate tasks when multiple webhook events fire for the
+		// same PR/issue (e.g., label added while a babysitter task is running).
+		sourceBranch := webhookBranch(parsed)
+		if sourceBranch != "" {
+			active, err := h.hasActiveTaskForBranch(ctx, spawner, sourceBranch)
+			if err != nil {
+				spawnerLog.Error(err, "Failed to check for active tasks, proceeding with creation")
+			} else if active {
+				spawnerLog.Info("Active task already exists for this branch, skipping", "branch", sourceBranch)
+				continue
+			}
+		}
+
 		// Create task for this spawner
 		err = h.createTask(ctx, spawner, eventType, parsed, deliveryID)
 		if err != nil {
@@ -528,13 +542,9 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *v1alpha1.TaskS
 
 	log.Info("Extracted template variables", "ID", templateVars["ID"], "Title", templateVars["Title"], "Action", templateVars["Action"])
 
-	// Build unique task name using a hash of the delivery ID to avoid collisions.
-	// Hashing gives uniform 12-hex-char suffix regardless of input length,
-	// avoiding the collision risk of simple prefix truncation.
-	sanitizedEventType := strings.ReplaceAll(eventType, "_", "-")
-	sum := sha256.Sum256([]byte(deliveryID))
-	shortHash := hex.EncodeToString(sum[:])[:12]
-	taskName := fmt.Sprintf("%s-%s-%s", spawner.Name, sanitizedEventType, shortHash)
+	// Build a human-readable task name including repo and PR/issue number when
+	// available, with a short delivery hash suffix for uniqueness across retriggers.
+	taskName := buildWebhookTaskName(spawner.Name, eventType, parsed, deliveryID)
 	if len(taskName) > 63 {
 		taskName = strings.TrimRight(taskName[:63], "-.")
 	}
@@ -596,6 +606,40 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *v1alpha1.TaskS
 	return nil
 }
 
+// hasActiveTaskForBranch checks whether an active (non-terminal) task already
+// exists for the given spawner and branch. This prevents duplicate task creation
+// when multiple webhook events fire for the same PR/issue while a task is
+// already Pending, Running, or Waiting.
+func (h *WebhookHandler) hasActiveTaskForBranch(ctx context.Context, spawner *v1alpha1.TaskSpawner, branch string) (bool, error) {
+	var taskList v1alpha1.TaskList
+	if err := h.client.List(ctx, &taskList,
+		client.InNamespace(spawner.Namespace),
+		client.MatchingLabels{"kelos.dev/taskspawner": spawner.Name},
+	); err != nil {
+		return false, fmt.Errorf("listing tasks for spawner %s: %w", spawner.Name, err)
+	}
+
+	for i := range taskList.Items {
+		task := &taskList.Items[i]
+		if task.Status.Phase == v1alpha1.TaskPhaseSucceeded || task.Status.Phase == v1alpha1.TaskPhaseFailed {
+			continue
+		}
+		if task.Spec.Branch == branch {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// webhookBranch extracts the branch from a parsed webhook event.
+func webhookBranch(parsed *ParsedWebhook) string {
+	if parsed.GitHub != nil {
+		return parsed.GitHub.Branch
+	}
+	return ""
+}
+
 // spawnerNeedsChangedFiles returns true if any webhook filter uses filePatterns,
 // meaning changed file data must be fetched for PR events.
 func spawnerNeedsChangedFiles(spawner *v1alpha1.TaskSpawner) bool {
@@ -635,6 +679,60 @@ func (h *WebhookHandler) getGenericSpawners(ctx context.Context) []*v1alpha1.Tas
 		}
 	}
 	return spawners
+}
+
+// buildWebhookTaskName constructs a human-readable task name that includes the
+// repo name and PR/issue number when available. Format:
+//
+//	<spawner>-<repo>-<kind><number>-<hash>  (e.g., "babysitter-dquality-pr-30170-a1b2c3d4")
+//
+// Falls back to the legacy format when no number is available:
+//
+//	<spawner>-<eventType>-<hash>
+func buildWebhookTaskName(spawnerName, eventType string, parsed *ParsedWebhook, deliveryID string) string {
+	sum := sha256.Sum256([]byte(deliveryID))
+	shortHash := hex.EncodeToString(sum[:])[:8]
+
+	if parsed.GitHub != nil && parsed.GitHub.Number > 0 && parsed.GitHub.RepositoryName != "" {
+		kind := "pr"
+		if eventType == "issues" || (eventType == "issue_comment" && parsed.GitHub.PullRequestAPIURL == "") {
+			kind = "issue"
+		}
+		safeRepo := sanitizeK8sNameSegment(parsed.GitHub.RepositoryName)
+		return fmt.Sprintf("%s-%s-%s-%d-%s", spawnerName, safeRepo, kind, parsed.GitHub.Number, shortHash)
+	}
+
+	if parsed.Linear != nil && parsed.ID != "" {
+		linearType := strings.ToLower(parsed.Linear.Type)
+		if linearType == "" {
+			linearType = "linear"
+		}
+		safeID := sanitizeK8sNameSegment(parsed.ID)
+		return fmt.Sprintf("%s-%s-%s-%s", spawnerName, linearType, safeID, shortHash)
+	}
+
+	if parsed.Generic != nil && parsed.ID != "" {
+		sanitizedID := sanitizeK8sNameSegment(parsed.ID)
+		sanitizedSource := sanitizeK8sNameSegment(eventType)
+		return fmt.Sprintf("%s-%s-%s-%s", spawnerName, sanitizedSource, sanitizedID, shortHash)
+	}
+
+	sanitizedEventType := sanitizeK8sNameSegment(eventType)
+	return fmt.Sprintf("%s-%s-%s", spawnerName, sanitizedEventType, shortHash)
+}
+
+// sanitizeK8sNameSegment lowercases a string and strips characters that are
+// invalid in Kubernetes resource names (must match [a-z0-9-]).
+func sanitizeK8sNameSegment(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "_", "-")
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // webhookSourceKind determines the reporting source kind from a GitHub webhook event.

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -225,6 +225,170 @@ func TestServeHTTP_DuplicateDeliveryIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_SkipsDuplicateTaskForSameBranch(t *testing.T) {
+	spawner := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-dedup-spawner",
+			Namespace: "default",
+			UID:       "branch-dedup-uid",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubWebhook: &kelosv1alpha1.GitHubWebhook{
+					Events: []string{"pull_request"},
+				},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type: "claude-code",
+				Credentials: kelosv1alpha1.Credentials{
+					Type: "api-key",
+				},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					Name: "test-workspace",
+				},
+				PromptTemplate: "{{.Title}}",
+				Branch:         "{{.Branch}}",
+			},
+		},
+	}
+
+	// Pre-existing active task for the same branch
+	existingTask := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-dedup-spawner-repo-pr-99-aabbccdd",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kelos.dev/taskspawner": "branch-dedup-spawner",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Branch: "feature-branch",
+			Type:   "claude-code",
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhaseRunning,
+		},
+	}
+
+	handler := newTestHandler(t, spawner, existingTask)
+
+	payload := []byte(`{
+		"action": "labeled",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"pull_request": {
+			"number": 99,
+			"title": "Test PR",
+			"body": "PR body",
+			"html_url": "https://github.com/org/repo/pull/99",
+			"state": "open",
+			"head": {"ref": "feature-branch"}
+		}
+	}`)
+	sig := signPayload(payload, []byte(testSecret))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set(GitHubEventHeader, "pull_request")
+	req.Header.Set(GitHubSignatureHeader, sig)
+	req.Header.Set(GitHubDeliveryHeader, "new-delivery-for-same-pr")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var taskList kelosv1alpha1.TaskList
+	if err := handler.client.List(context.Background(), &taskList); err != nil {
+		t.Fatal(err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Errorf("Expected still 1 task (deduplication), got %d", len(taskList.Items))
+	}
+}
+
+func TestServeHTTP_AllowsTaskForSameBranchAfterCompletion(t *testing.T) {
+	spawner := &kelosv1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-retrigger-spawner",
+			Namespace: "default",
+			UID:       "branch-retrigger-uid",
+		},
+		Spec: kelosv1alpha1.TaskSpawnerSpec{
+			When: kelosv1alpha1.When{
+				GitHubWebhook: &kelosv1alpha1.GitHubWebhook{
+					Events: []string{"pull_request"},
+				},
+			},
+			TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Type: "claude-code",
+				Credentials: kelosv1alpha1.Credentials{
+					Type: "api-key",
+				},
+				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					Name: "test-workspace",
+				},
+				PromptTemplate: "{{.Title}}",
+				Branch:         "{{.Branch}}",
+			},
+		},
+	}
+
+	// Pre-existing completed task for the same branch — should NOT block new task
+	completedTask := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "branch-retrigger-spawner-repo-pr-99-oldold01",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kelos.dev/taskspawner": "branch-retrigger-spawner",
+			},
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Branch: "feature-branch",
+			Type:   "claude-code",
+		},
+		Status: kelosv1alpha1.TaskStatus{
+			Phase: kelosv1alpha1.TaskPhaseSucceeded,
+		},
+	}
+
+	handler := newTestHandler(t, spawner, completedTask)
+
+	payload := []byte(`{
+		"action": "labeled",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"pull_request": {
+			"number": 99,
+			"title": "Test PR",
+			"body": "PR body",
+			"html_url": "https://github.com/org/repo/pull/99",
+			"state": "open",
+			"head": {"ref": "feature-branch"}
+		}
+	}`)
+	sig := signPayload(payload, []byte(testSecret))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set(GitHubEventHeader, "pull_request")
+	req.Header.Set(GitHubSignatureHeader, sig)
+	req.Header.Set(GitHubDeliveryHeader, "retrigger-delivery")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var taskList kelosv1alpha1.TaskList
+	if err := handler.client.List(context.Background(), &taskList); err != nil {
+		t.Fatal(err)
+	}
+	if len(taskList.Items) != 2 {
+		t.Errorf("Expected 2 tasks (completed + new), got %d", len(taskList.Items))
+	}
+}
+
 func TestServeHTTP_CreatesTaskForMatchingSpawner(t *testing.T) {
 	spawner := &kelosv1alpha1.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1859,5 +2023,110 @@ func TestServeHTTP_ChecksOnlyWithoutCommentReporting(t *testing.T) {
 	}
 	if task.Annotations[reporting.AnnotationSourceSHA] != "aaa111bbb222" {
 		t.Errorf("Expected source-sha 'aaa111bbb222', got %q", task.Annotations[reporting.AnnotationSourceSHA])
+	}
+}
+
+func TestBuildWebhookTaskName(t *testing.T) {
+	tests := []struct {
+		name       string
+		spawner    string
+		eventType  string
+		parsed     *ParsedWebhook
+		deliveryID string
+		wantPrefix string
+	}{
+		{
+			name:      "GitHub PR includes repo and number",
+			spawner:   "babysitter",
+			eventType: "pull_request",
+			parsed: &ParsedWebhook{
+				ID: "30170",
+				GitHub: &GitHubEventData{
+					Number:         30170,
+					RepositoryName: "dquality",
+				},
+			},
+			deliveryID: "delivery-1",
+			wantPrefix: "babysitter-dquality-pr-30170-",
+		},
+		{
+			name:      "GitHub issue includes repo and number",
+			spawner:   "triage",
+			eventType: "issues",
+			parsed: &ParsedWebhook{
+				ID: "42",
+				GitHub: &GitHubEventData{
+					Number:         42,
+					RepositoryName: "myrepo",
+				},
+			},
+			deliveryID: "delivery-2",
+			wantPrefix: "triage-myrepo-issue-42-",
+		},
+		{
+			name:      "GitHub repo name is lowercased and sanitized",
+			spawner:   "worker",
+			eventType: "pull_request",
+			parsed: &ParsedWebhook{
+				ID: "5",
+				GitHub: &GitHubEventData{
+					Number:         5,
+					RepositoryName: "DataQuality_App",
+				},
+			},
+			deliveryID: "delivery-uppercase",
+			wantPrefix: "worker-dataquality-app-pr-5-",
+		},
+		{
+			name:      "GitHub issue_comment on PR uses pr kind",
+			spawner:   "responder",
+			eventType: "issue_comment",
+			parsed: &ParsedWebhook{
+				ID: "100",
+				GitHub: &GitHubEventData{
+					Number:            100,
+					RepositoryName:    "myrepo",
+					PullRequestAPIURL: "https://api.github.com/repos/org/myrepo/pulls/100",
+				},
+			},
+			deliveryID: "delivery-3",
+			wantPrefix: "responder-myrepo-pr-100-",
+		},
+		{
+			name:      "Linear includes type and ID",
+			spawner:   "linear-worker",
+			eventType: "issue",
+			parsed: &ParsedWebhook{
+				ID:     "LIN-99",
+				Linear: &LinearEventData{Type: "Issue", ID: "LIN-99"},
+			},
+			deliveryID: "delivery-4",
+			wantPrefix: "linear-worker-issue-lin-99-",
+		},
+		{
+			name:      "fallback uses event type",
+			spawner:   "generic",
+			eventType: "push",
+			parsed: &ParsedWebhook{
+				GitHub: &GitHubEventData{
+					Number:         0,
+					RepositoryName: "",
+				},
+			},
+			deliveryID: "delivery-5",
+			wantPrefix: "generic-push-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildWebhookTaskName(tt.spawner, tt.eventType, tt.parsed, tt.deliveryID)
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("buildWebhookTaskName() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+			if len(got) > 63 {
+				t.Errorf("buildWebhookTaskName() length %d exceeds 63", len(got))
+			}
+		})
 	}
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

The webhook handler generated task names using `sha256(deliveryID)`, so multiple GitHub events for the same PR (labeled, ready_for_review, etc.) each created a separate task. This adds branch-based deduplication that skips task creation when an active task already exists for the same spawner and branch. Also makes task names human-readable by including the repo name and PR/issue number (e.g., `babysitter-dquality-pr-30170-a1b2c3d4`).

#### Which issue(s) this PR is related to:

Fixes #1155

#### Special notes for your reviewer:

- `buildWebhookTaskName` constructs human-readable names with repo/PR number and a short delivery hash for uniqueness
- `sanitizeK8sNameSegment` ensures all name segments comply with DNS label requirements
- Dedup logic lists active tasks by spawner+branch label and skips creation if one exists
- On dedup check failure, logs error but proceeds with task creation rather than dropping the event

#### Does this PR introduce a user-facing change?

```release-note
Fix duplicate task creation when multiple webhook events fire for the same PR by adding branch-based deduplication and human-readable task naming.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate webhook tasks for the same PR branch by adding branch-based deduplication in the `internal/webhook` handler. Also switches to human-readable, DNS-safe task names that include repo and PR/issue number. Fixes #1155.

- **Bug Fixes**
  - Skip creating a task when an active task already exists for the same spawner + branch; allow a new task after the previous one is Succeeded/Failed.
  - Build readable names in the form `<spawner>-<repo>-<pr|issue>-<number>-<hash>` (fallback: `<spawner>-<event>-<hash>`), with all segments sanitized for Kubernetes DNS rules.
  - On dedup check errors, log and proceed with task creation to avoid dropping events.

<sup>Written for commit ce77926a563f9aa27ce71d46103b7587fc9731da. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

