### PR TITLE
Warn agents not to poll with self-matching pgrep -f

### DIFF
--- a/self-development/agentconfig.yaml
+++ b/self-development/agentconfig.yaml
@@ -26,6 +26,7 @@ spec:
       - `make test` — run all unit tests
       - `make test-integration` — run integration tests
       - `make build` — build binary
+    - When polling for a process to finish in shell, do not use `pgrep -f 'CMD_NAME'`: the caller's own argv contains the pattern, so pgrep matches itself and the loop never exits (deadlocks the pod). Either capture the PID at launch (`cmd & PID=$!`) and poll with `kill -0 "$PID"` / `wait "$PID"`, or exclude self from the match (`pgrep -f 'CMD_NAME' | grep -vw $$`).
     - Always try to add or improve tests when modifying code
     - Logging conventions: start log messages with capital letters and do not end with punctuation
     - Commit messages: do not include PR links in commit messages

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -26,6 +26,7 @@ spec:
       - `make test` — run all unit tests
       - `make test-integration` — run integration tests
       - `make build` — build binary
+    - When polling for a process to finish in shell, do not use `pgrep -f 'CMD_NAME'`: the caller's own argv contains the pattern, so pgrep matches itself and the loop never exits (deadlocks the pod). Either capture the PID at launch (`cmd & PID=$!`) and poll with `kill -0 "$PID"` / `wait "$PID"`, or exclude self from the match (`pgrep -f 'CMD_NAME' | grep -vw $$`).
     - Always try to add or improve tests when modifying code
     - Logging conventions: start log messages with capital letters and do not end with punctuation
     - Commit messages: do not include PR links in commit messages


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds a single bullet to the `kelos-dev-agent` (shared) and `kelos-workers-agent` agentsMD warning the agent away from `pgrep -f 'CMD_NAME'` as a process-completion poll, and pointing at two safe alternatives.

##### Background

A live `kelos-workers-issue-comment-*` pod was found wedged with two orphaned polling shells the agent had written:

```
bash -c "until [ -z \"\$(pgrep -f 'make verify')\" ]; do sleep 5; done; tail -60 OUT"
bash -c "until [ ! -e /proc/\$(pgrep -f 'go test ./internal/cli/') ]; do sleep 2; done; cat OUT | tail -30"
```

`pgrep -f PAT` matches any process whose `/proc/*/cmdline` contains `PAT`. The shell running `pgrep -f 'make verify'` has `pgrep -f 'make verify'` in its own argv, so `pgrep` finds the caller itself. The `until` condition is never empty, the loop runs forever, and the `tail` after the `&&` never executes — so the BashOutput tool call the agent is awaiting never returns. Claude sits in `do_epoll_wait` holding pidfds for the wedged shells, the entrypoint waits on claude, and the pod cannot terminate.

The real `make verify` finished long before (`OUT` ends with `Verification passed`). Only the polling shell hangs.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a targeted prompt fix, not a ban on `run_in_background: true`. Backgrounding is fine; only the self-matching polling form is forbidden. Two safe alternatives are suggested:

- **PID capture**: `cmd & PID=$!; while kill -0 "$PID" 2>/dev/null; do sleep N; done`
- **Self-exclusion in pgrep**: `pgrep -f 'CMD_NAME' | grep -vw $$`

The same bullet is added to `kelos-workers-agent` (only used by the workers spawner) and `kelos-dev-agent` (shared by `kelos-pr-responder`, `kelos-config-update`, `kelos-triage`, and `kelos-squash-commits`), so all coding agents pick it up.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```