### PR TITLE
Raise kelos-workers and kelos-pr-responder maxConcurrency to 8

### DIFF
--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -26,7 +26,7 @@ spec:
       reporting:
         enabled: true
         checks: {}
-  maxConcurrency: 2
+  maxConcurrency: 8
   taskTemplate:
     workspaceRef:
       name: kelos-agent

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -51,7 +51,7 @@ spec:
           author: gjkim42
       reporting:
         enabled: true
-  maxConcurrency: 3
+  maxConcurrency: 8
   taskTemplate:
     workspaceRef:
       name: kelos-agent


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bumps `maxConcurrency` on `kelos-workers` (3 → 8) and `kelos-pr-responder` (2 → 8) so more incoming events can run in parallel.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Related to #1163, which bumps the per-task `requests.memory` for these same two spawners from 512Mi to 1Gi. With 8 concurrent tasks per spawner and 1 GiB requests each, peak memory commitment is ~16 GiB across the two spawners — comfortably within node capacity.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `maxConcurrency` to 8 for `kelos-workers` (3→8) and `kelos-pr-responder` (2→8) so more incoming events run in parallel. This reduces queueing and event latency, and pairs with #1163’s memory bump to remain within node capacity.

<sup>Written for commit 01e06f9ea52c34ee916e9c0b58431a67e5b5742b. Summary will update on new commits. <a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1167?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

