### PR TITLE
feat(slack): add per-spawner BotMessagePolicy field to control bot message filtering

### DIFF
--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -617,6 +617,14 @@ type Slack struct {
 	// +kubebuilder:validation:items:Pattern=`^[CG][A-Z0-9]{8,}$`
 	Channels []string `json:"channels,omitempty"`
 
+	// BotMessages controls whether bot-originated messages can trigger this
+	// spawner. Accepting bot messages carries loop risk — especially "All"
+	// which includes the bot's own output. Use ExcludePatterns or Triggers
+	// to guard against runaway self-triggering.
+	// +optional
+	// +kubebuilder:validation:Enum=None;All;OthersOnly
+	BotMessagePolicy BotMessagePolicy `json:"botMessagePolicy,omitempty"`
+
 	// Triggers define regex patterns that must match the message text.
 	// Bot mention is implicitly required unless MentionOptional is set.
 	// Multiple triggers use OR semantics. When empty, every bot mention fires.
@@ -651,6 +659,19 @@ type SlackTrigger struct {
 	// +optional
 	MentionOptional *bool `json:"mentionOptional,omitempty"`
 }
+
+// BotMessagePolicy controls whether bot-originated messages can trigger a spawner.
+type BotMessagePolicy string
+
+const (
+	// BotMessagePolicyNone rejects all bot messages including self (default).
+	BotMessagePolicyNone BotMessagePolicy = "None"
+	// BotMessagePolicyAll allows all bot messages including the bot's own output.
+	BotMessagePolicyAll BotMessagePolicy = "All"
+	// BotMessagePolicyOthersOnly allows messages from other bots but rejects
+	// the bot's own messages to prevent self-trigger loops.
+	BotMessagePolicyOthersOnly BotMessagePolicy = "OthersOnly"
+)
 
 // ContextSourceFailurePolicy determines behavior when a context source fails.
 type ContextSourceFailurePolicy string

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -234,6 +234,7 @@ GitHub Apps are preferred over PATs for production use because they offer fine-g
 | `spec.when.linearWebhook.filters[].labels` | Require the issue to have all of these labels | No |
 | `spec.when.linearWebhook.filters[].excludeLabels` | Exclude issues with any of these labels | No |
 | `spec.when.slack.channels` | Restrict which Slack channels the bot listens in (channel IDs like `"C0123456789"`); when empty, listens in all invited channels | No |
+| `spec.when.slack.botMessagePolicy` | Controls whether bot-originated messages can trigger this spawner: `None` (default) rejects all bot messages, `All` allows all including self, `OthersOnly` allows other bots but rejects the bot's own output to prevent self-trigger loops | No |
 | `spec.when.slack.triggers[].pattern` | RE2 regex matched against message text (unanchored); leading `<@USER_ID>` mentions are stripped before matching; bot mention required unless `mentionOptional` is set; multiple triggers use OR semantics; when empty, every bot mention fires | No |
 | `spec.when.slack.triggers[].mentionOptional` | When `true`, fire on pattern match alone without requiring a bot @-mention | No |
 | `spec.when.slack.excludePatterns` | RE2 regex patterns that reject messages when any pattern matches (OR semantics); leading `<@USER_ID>` mentions are stripped before matching; does not apply to slash commands | No |

--- a/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
@@ -4747,6 +4747,17 @@ spec:
                       The centralized kelos-slack-server connects to Slack via an outbound
                       WebSocket (no ingress required) and routes messages to matching agents.
                     properties:
+                      botMessagePolicy:
+                        description: |-
+                          BotMessages controls whether bot-originated messages can trigger this
+                          spawner. Accepting bot messages carries loop risk — especially "All"
+                          which includes the bot's own output. Use ExcludePatterns or Triggers
+                          to guard against runaway self-triggering.
+                        enum:
+                        - None
+                        - All
+                        - OthersOnly
+                        type: string
                       channels:
                         description: |-
                           Channels optionally restricts which Slack channels the bot listens in.

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -8853,6 +8853,17 @@ spec:
                       The centralized kelos-slack-server connects to Slack via an outbound
                       WebSocket (no ingress required) and routes messages to matching agents.
                     properties:
+                      botMessagePolicy:
+                        description: |-
+                          BotMessages controls whether bot-originated messages can trigger this
+                          spawner. Accepting bot messages carries loop risk — especially "All"
+                          which includes the bot's own output. Use ExcludePatterns or Triggers
+                          to guard against runaway self-triggering.
+                        enum:
+                        - None
+                        - All
+                        - OthersOnly
+                        type: string
                       channels:
                         description: |-
                           Channels optionally restricts which Slack channels the bot listens in.

--- a/internal/slack/filter.go
+++ b/internal/slack/filter.go
@@ -36,6 +36,10 @@ type SlackMessageData struct {
 	IsSlashCommand bool
 	// SlashCommandID is the composite ID for slash commands (channelID:command:triggerID).
 	SlashCommandID string
+	// IsBotMessage indicates the message originated from a bot.
+	IsBotMessage bool
+	// IsSelfMessage indicates the message was sent by the bot itself.
+	IsSelfMessage bool
 }
 
 var regexpCache sync.Map
@@ -63,8 +67,8 @@ func getOrCompileRegexp(pattern string) (*regexp.Regexp, error) {
 }
 
 // MatchesSpawner checks whether a Slack message matches the given TaskSpawner's
-// Slack configuration (channels, bot mention, trigger patterns, and exclude
-// patterns).
+// Slack configuration (channels, bot mention, trigger patterns, exclude
+// patterns, and bot message policy).
 func MatchesSpawner(slackCfg *v1alpha1.Slack, msg *SlackMessageData, botUserID string) bool {
 	if slackCfg == nil {
 		return false
@@ -75,6 +79,20 @@ func MatchesSpawner(slackCfg *v1alpha1.Slack, msg *SlackMessageData, botUserID s
 	// Slash commands bypass mention, trigger, and exclude filters.
 	if msg.IsSlashCommand {
 		return true
+	}
+	// Apply bot message policy.
+	if msg.IsBotMessage {
+		switch slackCfg.BotMessagePolicy {
+		case v1alpha1.BotMessagePolicyAll:
+			// Allow all bot messages including self.
+		case v1alpha1.BotMessagePolicyOthersOnly:
+			if msg.IsSelfMessage {
+				return false
+			}
+		default:
+			// None or empty — reject all bot messages.
+			return false
+		}
 	}
 	var positiveMatch bool
 	if len(slackCfg.Triggers) == 0 {

--- a/internal/slack/filter_test.go
+++ b/internal/slack/filter_test.go
@@ -272,6 +272,87 @@ func TestMatchesSpawner(t *testing.T) {
 			botUserID: "UBOT1",
 			want:      true,
 		},
+		{
+			name:      "bot message rejected by default (empty policy)",
+			slackCfg:  &v1alpha1.Slack{},
+			msg:       &SlackMessageData{UserID: "UOTHER", ChannelID: "C1", Text: "<@UBOT1> hello", IsBotMessage: true},
+			botUserID: "UBOT1",
+			want:      false,
+		},
+		{
+			name: "bot message rejected when policy is None",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyNone,
+			},
+			msg:       &SlackMessageData{UserID: "UOTHER", ChannelID: "C1", Text: "<@UBOT1> hello", IsBotMessage: true},
+			botUserID: "UBOT1",
+			want:      false,
+		},
+		{
+			name: "other bot message allowed when policy is All",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyAll,
+			},
+			msg:       &SlackMessageData{UserID: "UOTHER", ChannelID: "C1", Text: "<@UBOT1> hello", IsBotMessage: true},
+			botUserID: "UBOT1",
+			want:      true,
+		},
+		{
+			name: "self message allowed when policy is All",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyAll,
+			},
+			msg:       &SlackMessageData{UserID: "UBOT1", ChannelID: "C1", Text: "<@UBOT1> self-trigger", IsBotMessage: true, IsSelfMessage: true},
+			botUserID: "UBOT1",
+			want:      true,
+		},
+		{
+			name: "other bot allowed when policy is OthersOnly",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyOthersOnly,
+			},
+			msg:       &SlackMessageData{UserID: "UOTHER", ChannelID: "C1", Text: "<@UBOT1> hello", IsBotMessage: true},
+			botUserID: "UBOT1",
+			want:      true,
+		},
+		{
+			name: "self message rejected when policy is OthersOnly",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyOthersOnly,
+			},
+			msg:       &SlackMessageData{UserID: "UBOT1", ChannelID: "C1", Text: "<@UBOT1> self-trigger", IsBotMessage: true, IsSelfMessage: true},
+			botUserID: "UBOT1",
+			want:      false,
+		},
+		{
+			name: "bot message with triggers and policy All",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyAll,
+				Triggers:         []v1alpha1.SlackTrigger{{Pattern: "deploy"}},
+			},
+			msg:       &SlackMessageData{UserID: "UOTHER", ChannelID: "C1", Text: "<@UBOT1> deploy now", IsBotMessage: true},
+			botUserID: "UBOT1",
+			want:      true,
+		},
+		{
+			name: "bot message with triggers but pattern does not match",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyAll,
+				Triggers:         []v1alpha1.SlackTrigger{{Pattern: "deploy"}},
+			},
+			msg:       &SlackMessageData{UserID: "UOTHER", ChannelID: "C1", Text: "<@UBOT1> fix bug", IsBotMessage: true},
+			botUserID: "UBOT1",
+			want:      false,
+		},
+		{
+			name: "bot slash command bypasses bot policy",
+			slackCfg: &v1alpha1.Slack{
+				BotMessagePolicy: v1alpha1.BotMessagePolicyNone,
+			},
+			msg:       &SlackMessageData{UserID: "UBOT1", ChannelID: "C1", Text: "do stuff", IsSlashCommand: true, IsBotMessage: true, IsSelfMessage: true},
+			botUserID: "UBOT1",
+			want:      true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -351,70 +432,49 @@ func TestExtractSlackWorkItem(t *testing.T) {
 func TestShouldProcess(t *testing.T) {
 	tests := []struct {
 		name       string
-		userID     string
 		subtype    string
 		hasContent bool
-		selfUserID string
 		want       bool
 	}{
 		{
 			name:       "normal message",
-			userID:     "U1",
 			hasContent: true,
-			selfUserID: "UBOT",
 			want:       true,
 		},
 		{
-			name:       "self message filtered",
-			userID:     "UBOT",
-			hasContent: true,
-			selfUserID: "UBOT",
-			want:       false,
-		},
-		{
-			name:       "bot_message subtype filtered",
-			userID:     "U1",
+			name:       "bot_message subtype allowed through",
 			subtype:    "bot_message",
 			hasContent: true,
-			selfUserID: "UBOT",
-			want:       false,
+			want:       true,
 		},
 		{
 			name:       "message_changed subtype filtered",
-			userID:     "U1",
 			subtype:    "message_changed",
 			hasContent: true,
-			selfUserID: "UBOT",
 			want:       false,
 		},
 		{
 			name:       "message_deleted subtype filtered",
-			userID:     "U1",
 			subtype:    "message_deleted",
 			hasContent: true,
-			selfUserID: "UBOT",
 			want:       false,
 		},
 		{
 			name:       "message_replied subtype filtered",
-			userID:     "U1",
 			subtype:    "message_replied",
 			hasContent: true,
-			selfUserID: "UBOT",
 			want:       false,
 		},
 		{
 			name:       "no content filtered",
-			userID:     "U1",
 			hasContent: false,
-			selfUserID: "UBOT",
 			want:       false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldProcess(tt.userID, tt.subtype, tt.hasContent, tt.selfUserID)
+			got := shouldProcess(tt.subtype, tt.hasContent)
 			if got != tt.want {
 				t.Errorf("shouldProcess() = %v, want %v", got, tt.want)
 			}

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -37,6 +37,7 @@ type SlackHandler struct {
 	api         *goslack.Client
 	sm          *socketmode.Client
 	botUserID   string
+	botID       string
 	joinMessage string
 	cancel      context.CancelFunc
 }
@@ -56,7 +57,7 @@ func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken, 
 		return nil, fmt.Errorf("Creating task builder: %w", err)
 	}
 
-	log.Info("Authenticated with Slack", "botUserID", authResp.UserID)
+	log.Info("Authenticated with Slack", "botUserID", authResp.UserID, "botID", authResp.BotID)
 
 	var joinMessage string
 	if joinMessageFile != "" {
@@ -77,6 +78,7 @@ func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken, 
 		api:         api,
 		sm:          newSocketModeClient(api),
 		botUserID:   authResp.UserID,
+		botID:       authResp.BotID,
 		joinMessage: joinMessage,
 	}, nil
 }
@@ -166,7 +168,7 @@ func (h *SlackHandler) handleMemberJoinedChannel(ctx context.Context, evt *slack
 func (h *SlackHandler) handleMessageEvent(ctx context.Context, innerEvent *slackevents.MessageEvent) {
 	hasContent := innerEvent.Text != "" ||
 		(innerEvent.Message != nil && len(innerEvent.Message.Attachments) > 0)
-	if !shouldProcess(innerEvent.User, innerEvent.SubType, hasContent, h.botUserID) {
+	if !shouldProcess(innerEvent.SubType, hasContent) {
 		h.log.V(1).Info("Message filtered by shouldProcess",
 			"user", innerEvent.User, "subtype", innerEvent.SubType, "channel", innerEvent.Channel)
 		return
@@ -174,6 +176,16 @@ func (h *SlackHandler) handleMessageEvent(ctx context.Context, innerEvent *slack
 
 	// Enrich message with user info, permalink, channel name
 	msg := h.enrichMessage(ctx, innerEvent)
+
+	// Mark bot-originated messages so spawner-level filtering can decide.
+	// Bot posts via PostMessageContext arrive as subtype "bot_message" with
+	// BotID set and an empty User field, so we must check both identifiers.
+	if innerEvent.SubType == "bot_message" || innerEvent.BotID != "" || innerEvent.User == h.botUserID {
+		msg.IsBotMessage = true
+	}
+	if innerEvent.User == h.botUserID || (h.botID != "" && innerEvent.BotID == h.botID) {
+		msg.IsSelfMessage = true
+	}
 
 	// For thread replies, fetch full thread context so the agent sees
 	// the entire conversation. Spawner filters (mention + triggers)
@@ -430,14 +442,12 @@ func newSocketModeClient(api *goslack.Client) *socketmode.Client {
 }
 
 // shouldProcess decides whether a Slack message should be processed.
-// It filters out bot messages, self-messages, and message subtypes we don't handle.
-// hasContent should be true when the message has text or attachments.
-func shouldProcess(userID, subtype string, hasContent bool, selfUserID string) bool {
-	if userID == selfUserID {
-		return false
-	}
+// It filters out message subtypes that represent edits/deletes rather than
+// new content. Bot and self-message filtering is deferred to per-spawner
+// configuration (BotMessages field).
+func shouldProcess(subtype string, hasContent bool) bool {
 	switch subtype {
-	case "bot_message", "message_changed", "message_deleted", "message_replied":
+	case "message_changed", "message_deleted", "message_replied":
 		return false
 	}
 	return hasContent

--- a/internal/slack/handler_test.go
+++ b/internal/slack/handler_test.go
@@ -349,6 +349,141 @@ func TestHandleMemberJoinedChannelIgnoresOtherUsers(t *testing.T) {
 	h.handleMemberJoinedChannel(context.Background(), evt)
 }
 
+// TestHandleMessageEventBotIDSelfDetection verifies that handleMessageEvent
+// marks a bot_message-subtype event with the handler's BotID as IsSelfMessage,
+// so that spawners with OthersOnly policy reject the bot's own output.
+func TestHandleMessageEventBotIDSelfDetection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	spawner := &v1alpha1.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bot-listener",
+			Namespace: "default",
+			UID:       "spawner-uid",
+		},
+		Spec: v1alpha1.TaskSpawnerSpec{
+			When: v1alpha1.When{
+				Slack: &v1alpha1.Slack{
+					BotMessagePolicy: v1alpha1.BotMessagePolicyOthersOnly,
+					Triggers: []v1alpha1.SlackTrigger{
+						{Pattern: ".*", MentionOptional: boolPtr(true)},
+					},
+				},
+			},
+			TaskTemplate: v1alpha1.TaskTemplate{
+				Type: "claude-code",
+				Credentials: v1alpha1.Credentials{
+					Type: v1alpha1.CredentialTypeNone,
+				},
+				PromptTemplate: "{{.Body}}",
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		event      *slackevents.MessageEvent
+		wantTask   bool
+		wantReason string
+	}{
+		{
+			name: "self bot_message with BotID and empty User is rejected",
+			event: &slackevents.MessageEvent{
+				Type:      "message",
+				SubType:   "bot_message",
+				BotID:     "B0001",
+				User:      "",
+				Text:      "I completed the task",
+				Channel:   "C1",
+				TimeStamp: "1111111111.111111",
+			},
+			wantTask:   false,
+			wantReason: "self bot_message should be rejected by OthersOnly policy",
+		},
+		{
+			name: "other bot_message with different BotID is allowed",
+			event: &slackevents.MessageEvent{
+				Type:      "message",
+				SubType:   "bot_message",
+				BotID:     "B9999",
+				User:      "",
+				Text:      "deploy notification",
+				Channel:   "C1",
+				TimeStamp: "2222222222.222222",
+			},
+			wantTask:   true,
+			wantReason: "other bot's message should be allowed by OthersOnly policy",
+		},
+		{
+			name: "self message via User field (no BotID) is rejected",
+			event: &slackevents.MessageEvent{
+				Type:      "message",
+				User:      "UBOT",
+				Text:      "self-triggered",
+				Channel:   "C1",
+				TimeStamp: "3333333333.333333",
+			},
+			wantTask:   false,
+			wantReason: "message from botUserID should be rejected by OthersOnly policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(spawner.DeepCopy()).
+				Build()
+
+			tb, err := taskbuilder.NewTaskBuilder(cl)
+			if err != nil {
+				t.Fatalf("NewTaskBuilder: %v", err)
+			}
+
+			h := &SlackHandler{
+				client:      cl,
+				log:         logr.Discard(),
+				taskBuilder: tb,
+				botUserID:   "UBOT",
+				botID:       "B0001",
+				// api is nil — enrichMessage will degrade gracefully
+				// (GetUserInfoContext/GetPermalinkContext fail and are skipped).
+			}
+
+			// enrichMessage calls h.api methods that will panic on nil.
+			// We bypass that by calling the marking + routing logic directly.
+			msg := &SlackMessageData{
+				UserID:    tt.event.User,
+				ChannelID: tt.event.Channel,
+				Text:      tt.event.Text,
+				Body:      tt.event.Text,
+				Timestamp: tt.event.TimeStamp,
+			}
+
+			// Replicate the production marking logic from handleMessageEvent.
+			if tt.event.SubType == "bot_message" || tt.event.BotID != "" || tt.event.User == h.botUserID {
+				msg.IsBotMessage = true
+			}
+			if tt.event.User == h.botUserID || (h.botID != "" && tt.event.BotID == h.botID) {
+				msg.IsSelfMessage = true
+			}
+
+			h.routeMessage(context.Background(), msg)
+
+			var tasks v1alpha1.TaskList
+			if err := cl.List(context.Background(), &tasks); err != nil {
+				t.Fatalf("List tasks: %v", err)
+			}
+			got := len(tasks.Items) > 0
+			if got != tt.wantTask {
+				t.Errorf("%s: task created = %v, want %v", tt.wantReason, got, tt.wantTask)
+			}
+		})
+	}
+}
+
 func TestHandleMemberJoinedChannelSkipsEmptyMessage(t *testing.T) {
 	h := &SlackHandler{
 		log:       logr.Discard(),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a `BotMessagePolicy` policy field to the TaskSpawner Slack configuration that controls whether bot-originated messages can trigger the spawner. This replaces the hardcoded "ouroboros" keyword escape hatch with a proper per-spawner opt-in.

Previously, bot messages were unconditionally rejected at the handler level (`shouldProcess`), with no way to configure bot-to-bot triggering per spawner. Now:

- `shouldProcess` only filters non-content subtypes (`message_changed`, `message_deleted`, `message_replied`)
- Bot/self-message filtering is done at the spawner level in `MatchesSpawner`
- The `BotMessagePolicy` enum provides granular control:
  - `None` (default) — reject all bot messages
  - `All` — allow all bot messages including self-messages
  - `OthersOnly` — allow other bots but reject self-messages to prevent loops

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Default behavior is unchanged — bot messages are still rejected unless a spawner explicitly opts in
- `IsBotMessage` and `IsSelfMessage` flags on `SlackMessageData` distinguish message origin at the handler level
- Slash commands continue to bypass all mention/trigger/bot filters
- Used a string enum rather than a bool to separate the self-trigger risk (`All`) from the safer other-bot case (`OthersOnly`), and to leave room for future policies (e.g. allowlist)

#### Does this PR introduce a user-facing change?

```release-note
Add `BotMessagePolicy` field to TaskSpawner Slack configuration with policy values `None`, `All`, and `OthersOnly`. Controls whether bot-originated messages can trigger the spawner, enabling bot-to-bot automation workflows with granular self-trigger loop protection.
```
