### PR TITLE
Add documentation completeness check to reviewer

### DIFF
--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -204,6 +204,18 @@ spec:
         page should be able to locate any cited field without already
         knowing the layout of the others. P2.
 
+      **Documentation completeness**:
+      - When a PR introduces or changes user-facing surface — a new or
+        renamed CRD/API field, a CRD schema change, a new CLI command or
+        flag, or a new user-facing feature/behavior — require the matching
+        docs update in the same PR and request it from the author when it
+        is missing. The canonical reference is `docs/reference.md` (the CRD
+        field tables and the `CLI Reference` section); a new feature or
+        workflow may also need `README.md` and an `examples/` entry. Flag a
+        user-facing change that ships with no doc update as P2. Internal-only
+        changes (refactors, tests, files under `self-development/`, or code
+        that does not alter observable behavior) do not need docs.
+
       **Code quality**:
       - No unnecessary code, comments, or dead variables
       - Changes are minimal and focused — no unrelated refactoring


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `kelos-reviewer` TaskSpawner already verified documentation *accuracy* (docs describing what the code actually does) but never asked authors to *add* docs when a PR ships user-facing changes. Many PRs land code without the matching docs update, and the reviewer had no instruction to request it.

This adds a **Documentation completeness** check to the general reviewer's checklist, right after the existing **Documentation accuracy** section. When a PR introduces or changes user-facing surface — a new or renamed CRD/API field, a CRD schema change, a new CLI command or flag, or a new user-facing feature/behavior — the reviewer now requires the matching docs update in the same PR and requests it from the author when missing.

- Points authors to the canonical reference `docs/reference.md` (CRD field tables and the `CLI Reference` section), plus `README.md` and `examples/` for new features or workflows.
- Scoped to user-facing changes; internal-only changes (refactors, tests, files under `self-development/`, or code that does not alter observable behavior) are explicitly excluded.
- Flagged at P2, consistent with how the reviewer already treats documentation as non-blocking for the overall correctness verdict.

Only the general reviewer is changed. `kelos-api-reviewer` already requires godoc on new fields and defers general concerns to the regular reviewer, so the user-facing docs check lives in one place to avoid duplicate findings.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is an internal agent-improvement change confined to `self-development/`.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a documentation completeness check to the general reviewer so PRs with user-facing changes include matching docs (P2). Covers CRD/API field or schema changes, new/renamed CLI commands or flags, and new features; points to docs/reference.md, README.md, and examples; internal-only changes are excluded.

<sup>Written for commit 1c0fd9e58dfd47522f568c53041f2367716775d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

