### PR TITLE
Apply kanon-development resources in deploy-dev workflow

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -199,3 +199,6 @@ jobs:
 
       - name: Apply self-development resources
         run: kubectl apply -f self-development/ -n "${KELOS_NAMESPACE}"
+
+      - name: Apply kanon-development resources
+        run: kubectl apply -f kanon-development/ -n "${KELOS_NAMESPACE}"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds an `Apply kanon-development resources` step to the Deploy to Dev workflow,
mirroring the existing `Apply self-development resources` step. The
`kanon-development/` directory (added previously) holds the TaskSpawners and
AgentConfigs that drive autonomous development of `kelos-dev/kanon`, but nothing
applied them to the cluster on merge — they had to be `kubectl apply`-ed by hand.

With this step, both orchestration directories are reconciled into
`${KELOS_NAMESPACE}` on every merge to `main` (Release → Deploy to Dev). The new
step runs after the self-development step, so the `kelos-dev-agent` AgentConfig
and `kelos-agent` Workspace that the `kanon-config-update` / `kanon-self-update`
spawners reference already exist by the time the kanon resources are applied.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The kanon spawners also reference a `kanon-agent` Workspace, which (like
`kelos-agent` for self-development) is a prerequisite created out of band and is
not part of `kanon-development/`. This PR does not change that; it only automates
applying the spawner/config manifests that already live in the repo.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically applies `kanon-development/` resources in the Deploy to Dev workflow, mirroring the existing self-development step. This reconciles kanon TaskSpawners and AgentConfigs into `${KELOS_NAMESPACE}` on every merge to `main`, removing the need for manual `kubectl apply`.

<sup>Written for commit d669a22ce6432d9daf4c012b1cd98ff309cec6b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

