### PR TITLE
Add generic source condition to serviceaccount and ClusterRole/ClusterRoleBinding

### DIFF
--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -235,7 +235,7 @@ subjects:
   - kind: ServiceAccount
     name: kelos-controller
     namespace: kelos-system
-{{- if or .Values.webhookServer.sources.github.enabled .Values.webhookServer.sources.linear.enabled }}
+{{- if or .Values.webhookServer.sources.github.enabled .Values.webhookServer.sources.linear.enabled .Values.webhookServer.sources.generic.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/manifests/charts/kelos/templates/serviceaccount.yaml
+++ b/internal/manifests/charts/kelos/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: kelos-controller
   namespace: kelos-system
-{{- if or .Values.webhookServer.sources.github.enabled .Values.webhookServer.sources.linear.enabled }}
+{{- if or .Values.webhookServer.sources.github.enabled .Values.webhookServer.sources.linear.enabled .Values.webhookServer.sources.generic.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
#### What type of PR is this?

/kind bug



#### What this PR does / why we need it:

Fixes #1268

#### Which issue(s) this PR is related to:

Fixes #1268

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

```release-note
Fix ServiceAccount and RBAC creation for generic webhooks
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.Values.webhookServer.sources.generic.enabled` to the Helm conditionals in `serviceaccount.yaml` and `rbac.yaml` so generic-only installs create the ServiceAccount and ClusterRole/ClusterRoleBinding without errors.

<sup>Written for commit 5daced46b2d24be5950aaa851c890db448ec76fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



