### PR TITLE
Migrate development agents to Codex

### DIFF
--- a/kanon-development/README.md
+++ b/kanon-development/README.md
@@ -28,18 +28,18 @@ maintain (`kanon-development/*`) live in *this* repository, so they use the
 
 ## TaskSpawners
 
-| TaskSpawner | Trigger | Model | Description |
+| TaskSpawner | Trigger | Agent | Description |
 |---|---|---|---|
-| **kanon-workers** | Webhook: issue comment `/kelos pick-up` | Opus | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
-| **kanon-planner** | Webhook: issue comment `/kelos plan` | Opus | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
-| **kanon-reviewer** | Webhook: PR comment `/kelos review` | Opus | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
-| **kanon-pr-responder** | Webhook: PR review/comment with `/kelos pick-up` | Opus | Re-engages on PR review feedback and updates the existing branch incrementally |
-| **kanon-triage** | Webhook: issue opened/reopened (untriaged) | Opus | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
-| **kanon-fake-user** | Cron (daily 09:00 UTC) | Sonnet | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
-| **kanon-fake-strategist** | Cron (every 12 hours) | Opus | Explores new use cases, integrations, and managed-settings types |
-| **kanon-config-update** | Cron (daily 18:00 UTC) | Opus | Reviews recent Kanon PR feedback and updates the `kanon-development/` config accordingly |
-| **kanon-self-update** | Cron (daily 06:00 UTC) | Opus | Reviews and tunes the `kanon-development/` prompts, configs, and README — the pipeline improves itself |
-| **kanon-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Sonnet | Rebases and squashes PR branch commits into a single clean commit |
+| **kanon-workers** | Webhook: issue comment `/kelos pick-up` | Codex | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
+| **kanon-planner** | Webhook: issue comment `/kelos plan` | Codex | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
+| **kanon-reviewer** | Webhook: PR comment `/kelos review` | Codex | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
+| **kanon-pr-responder** | Webhook: PR review/comment with `/kelos pick-up` | Codex | Re-engages on PR review feedback and updates the existing branch incrementally |
+| **kanon-triage** | Webhook: issue opened/reopened (untriaged) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
+| **kanon-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
+| **kanon-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integrations, and managed-settings types |
+| **kanon-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent Kanon PR feedback and updates the `kanon-development/` config accordingly |
+| **kanon-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes the `kanon-development/` prompts, configs, and README — the pipeline improves itself |
+| **kanon-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Codex | Rebases and squashes PR branch commits into a single clean commit |
 
 > **Not ported from `self-development/`:** `kelos-api-reviewer` (Kanon has no
 > Kubernetes CRDs/API surface to review) and `kelos-image-update` (Kanon has no
@@ -63,7 +63,7 @@ Picks up open GitHub issues when a maintainer posts `/kelos pick-up` and creates
 | | |
 |---|---|
 | **Trigger** | GitHub `issue_comment` webhook with `/kelos pick-up` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 8 |
 
 **Key features:**
@@ -85,7 +85,7 @@ Reacts to `/kelos plan` comments on open issues. Investigates the issue, inspect
 | | |
 |---|---|
 | **Trigger** | GitHub `issue_comment` webhook with `/kelos plan` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 2 |
 
 **Handoff flow:**
@@ -104,7 +104,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review`.
 | | |
 |---|---|
 | **Trigger** | GitHub PR comment webhook with `/kelos review` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 3 |
 
 **Key features:**
@@ -131,7 +131,7 @@ Picks up open GitHub pull requests when a reviewer requests changes with `/kelos
 | | |
 |---|---|
 | **Trigger** | GitHub PR comment with `/kelos pick-up`, or a PR review whose body contains `/kelos pick-up` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 8 |
 
 **Key features:**
@@ -151,7 +151,7 @@ Triages newly opened (and certain reopened) GitHub issues.
 | | |
 |---|---|
 | **Trigger** | GitHub issue opened (no `triage-accepted`), or reopened with `needs-actor` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 8 |
 
 **For each issue, the agent:**
@@ -176,7 +176,7 @@ Runs daily to test the developer experience as if you were a new user.
 | | |
 |---|---|
 | **Trigger** | Cron `0 9 * * *` (daily at 09:00 UTC) |
-| **Model** | Sonnet |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
@@ -198,7 +198,7 @@ Runs every 12 hours to strategically explore new ways to use and improve Kanon.
 | | |
 |---|---|
 | **Trigger** | Cron `0 */12 * * *` (every 12 hours) |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
@@ -220,7 +220,7 @@ Runs daily to update the Kanon agent configuration based on patterns found in Ka
 | | |
 |---|---|
 | **Trigger** | Cron `0 18 * * *` (daily at 18:00 UTC) |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Workspace** | `kelos-agent` (edits `kanon-development/` in this repo) |
 | **Concurrency** | 1 |
 
@@ -238,7 +238,7 @@ Runs daily to review and improve the `kanon-development/` workflow files themsel
 | | |
 |---|---|
 | **Trigger** | Cron `0 6 * * *` (daily at 06:00 UTC) |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Workspace** | `kelos-agent` (reasons about `kanon-development/` in this repo) |
 | **Concurrency** | 1 |
 
@@ -256,7 +256,7 @@ Rebases and squashes PR branch commits into a single clean commit when a maintai
 | | |
 |---|---|
 | **Trigger** | GitHub PR comment webhook with `/kelos squash-commits` |
-| **Model** | Sonnet |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 **Key features:**
@@ -359,14 +359,15 @@ matching state.
 ### 5. Agent Credentials Secret
 
 The spawners reuse the `kelos-credentials` secret (the AI agent credentials are
-the same regardless of repository):
+the same regardless of repository). The checked-in spawners use Codex OAuth:
 
 ```bash
 kubectl create secret generic kelos-credentials \
-  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-claude-oauth-token>
+  --from-file=CODEX_AUTH_JSON=$HOME/.codex/auth.json
 ```
 
-(Or `--from-literal=ANTHROPIC_API_KEY=<your-api-key>` for API-key auth.)
+For API-key auth, change the task template credential type to `api-key` and use
+`--from-literal=CODEX_API_KEY=<your-openai-api-key>`.
 
 ## Customizing
 

--- a/kanon-development/kanon-config-update.yaml
+++ b/kanon-development/kanon-config-update.yaml
@@ -13,8 +13,8 @@ spec:
     # learning from the kelos-dev/kanon repository's recent activity.
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-fake-strategist.yaml
+++ b/kanon-development/kanon-fake-strategist.yaml
@@ -38,8 +38,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-fake-user.yaml
+++ b/kanon-development/kanon-fake-user.yaml
@@ -38,8 +38,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: sonnet
-    type: claude-code
+    model: gpt-5.4-mini
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-planner.yaml
+++ b/kanon-development/kanon-planner.yaml
@@ -44,8 +44,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-pr-responder.yaml
+++ b/kanon-development/kanon-pr-responder.yaml
@@ -31,8 +31,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-reviewer.yaml
+++ b/kanon-development/kanon-reviewer.yaml
@@ -61,8 +61,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-self-update.yaml
+++ b/kanon-development/kanon-self-update.yaml
@@ -13,8 +13,8 @@ spec:
     # config files, while learning from the kelos-dev/kanon repository's activity.
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-squash-commits.yaml
+++ b/kanon-development/kanon-squash-commits.yaml
@@ -28,8 +28,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: sonnet
-    type: claude-code
+    model: gpt-5.4-mini
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-triage.yaml
+++ b/kanon-development/kanon-triage.yaml
@@ -27,8 +27,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/kanon-development/kanon-workers.yaml
+++ b/kanon-development/kanon-workers.yaml
@@ -55,8 +55,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kanon-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -10,20 +10,20 @@ Each TaskSpawner references an `AgentConfig` that defines git identity, comment 
 
 ## TaskSpawners
 
-| TaskSpawner | Trigger | Model | Description |
+| TaskSpawner | Trigger | Agent | Description |
 |---|---|---|---|
-| **kelos-workers** | Webhook: issue comment `/kelos pick-up` | Opus | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
-| **kelos-planner** | Webhook: issue comment `/kelos plan` | Opus | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
-| **kelos-reviewer** | Webhook: PR comment `/kelos review` | Opus | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
-| **kelos-api-reviewer** | Webhook: issue/PR comment `/kelos api-review` | Opus | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
-| **kelos-pr-responder** | Webhook: PR review/comment on `generated-by-kelos` PRs | Opus | Re-engages on PR review feedback and updates the existing branch incrementally |
-| **kelos-triage** | Webhook: issue opened/labeled/reopened (`needs-actor`) | Opus | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
-| **kelos-fake-user** | Cron (daily 09:00 UTC) | Sonnet | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
-| **kelos-fake-strategist** | Cron (every 12 hours) | Opus | Explores new use cases, integration opportunities, and CRD/API extensions |
-| **kelos-config-update** | Cron (daily 18:00 UTC) | Opus | Reviews recent PR feedback and updates agent configuration (conventions, prompts, configs) accordingly |
-| **kelos-self-update** | Cron (daily 06:00 UTC) | Opus | Reviews and tunes prompts, configs, and workflow files — the pipeline improves itself |
-| **kelos-image-update** | Cron (daily 03:00 UTC) | Sonnet | Checks for newer agent image versions (Claude Code, Codex, Gemini, etc.) and creates PRs to update them |
-| **kelos-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Sonnet | Rebases and squashes PR branch commits into a single clean commit |
+| **kelos-workers** | Webhook: issue comment `/kelos pick-up` | Codex | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
+| **kelos-planner** | Webhook: issue comment `/kelos plan` | Codex | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
+| **kelos-reviewer** | Webhook: PR comment `/kelos review` | Codex | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
+| **kelos-api-reviewer** | Webhook: issue/PR comment `/kelos api-review` | Codex | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
+| **kelos-pr-responder** | Webhook: PR review/comment on `generated-by-kelos` PRs | Codex | Re-engages on PR review feedback and updates the existing branch incrementally |
+| **kelos-triage** | Webhook: issue opened/labeled/reopened (`needs-actor`) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
+| **kelos-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
+| **kelos-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integration opportunities, and CRD/API extensions |
+| **kelos-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent PR feedback and updates agent configuration (conventions, prompts, configs) accordingly |
+| **kelos-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes prompts, configs, and workflow files — the pipeline improves itself |
+| **kelos-image-update** | Cron (daily 03:00 UTC) | Codex | Checks for newer agent image versions (Claude Code, Codex, Gemini, etc.) and creates PRs to update them |
+| **kelos-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Codex | Rebases and squashes PR branch commits into a single clean commit |
 
 ### kelos-workers.yaml
 
@@ -32,7 +32,7 @@ Picks up open GitHub issues when a maintainer posts `/kelos pick-up` and creates
 | | |
 |---|---|
 | **Trigger** | GitHub `issue_comment` webhook with `/kelos pick-up` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 8 |
 
 **Key features:**
@@ -54,7 +54,7 @@ Reacts to `/kelos plan` comments on open issues. Investigates the issue, inspect
 | | |
 |---|---|
 | **Trigger** | GitHub `issue_comment` webhook with `/kelos plan` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 2 |
 
 **Key features:**
@@ -79,7 +79,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review`.
 | | |
 |---|---|
 | **Trigger** | GitHub PR comment webhook with `/kelos review` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 3 |
 
 **Key features:**
@@ -106,7 +106,7 @@ Reviews issues and pull requests for Kubernetes API design conventions, compatib
 | | |
 |---|---|
 | **Trigger** | GitHub issue/PR comment webhook with `/kelos api-review` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 3 |
 
 **Key features:**
@@ -135,7 +135,7 @@ Picks up open GitHub pull requests labeled `generated-by-kelos` when a reviewer 
 | | |
 |---|---|
 | **Trigger** | GitHub PR review/comment webhooks on `generated-by-kelos` pull requests |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 8 |
 
 **Key features:**
@@ -156,7 +156,7 @@ Picks up open GitHub issues labeled `needs-actor` and performs automated triage.
 | | |
 |---|---|
 | **Trigger** | GitHub issue opened/labeled/reopened webhooks with `needs-actor` |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 8 |
 
 **For each issue, the agent:**
@@ -181,7 +181,7 @@ Runs daily to test the developer experience as if you were a new user.
 | | |
 |---|---|
 | **Trigger** | Cron `0 9 * * *` (daily at 09:00 UTC) |
-| **Model** | Sonnet |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
@@ -203,7 +203,7 @@ Runs every 12 hours to strategically explore new ways to use and improve Kelos.
 | | |
 |---|---|
 | **Trigger** | Cron `0 */12 * * *` (every 12 hours) |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
@@ -225,11 +225,11 @@ Runs daily to update agent configuration based on patterns found in PR reviews.
 | | |
 |---|---|
 | **Trigger** | Cron `0 18 * * *` (daily at 18:00 UTC) |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Reviews recent PRs and their review comments to identify recurring feedback patterns, then updates agent configuration accordingly:
-- **Project-level changes** — updates `AGENTS.md`, `CLAUDE.md`, or `self-development/agentconfig.yaml` for conventions that apply to all agents
+- **Project-level changes** — updates `AGENTS.md` or `self-development/agentconfig.yaml` for conventions that apply to all agents
 - **Task-specific changes** — updates TaskSpawner prompts in `self-development/*.yaml` or creates/updates AgentConfig for specific agents
 
 Creates PRs with changes for maintainer review. Skips uncertain or contradictory feedback.
@@ -246,7 +246,7 @@ Runs daily to review and update the self-development workflow files themselves.
 | | |
 |---|---|
 | **Trigger** | Cron `0 6 * * *` (daily at 06:00 UTC) |
-| **Model** | Opus |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
@@ -269,7 +269,7 @@ Runs daily to check for newer versions of coding agent images and creates PRs to
 | | |
 |---|---|
 | **Trigger** | Cron `0 3 * * *` (daily at 03:00 UTC) |
-| **Model** | Sonnet |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 Checks the following coding agents for updates:
@@ -293,7 +293,7 @@ Rebases and squashes PR branch commits into a single clean commit when a maintai
 | | |
 |---|---|
 | **Trigger** | GitHub PR comment webhook with `/kelos squash-commits` |
-| **Model** | Sonnet |
+| **Agent** | Codex |
 | **Concurrency** | 1 |
 
 **Key features:**
@@ -372,18 +372,19 @@ retrigger it with a fresh comment or relabel after deployment.
 
 ### 4. Agent Credentials Secret
 
-Create a secret with your AI agent credentials:
+Create a secret with your Codex credentials. The checked-in spawners use OAuth:
 
-**For OAuth (Claude Code):**
 ```bash
 kubectl create secret generic kelos-credentials \
-  --from-literal=CLAUDE_CODE_OAUTH_TOKEN=<your-claude-oauth-token>
+  --from-file=CODEX_AUTH_JSON=$HOME/.codex/auth.json
 ```
 
-**For API Key:**
+For API-key auth, change the task template credential type to `api-key` and
+create the secret with:
+
 ```bash
 kubectl create secret generic kelos-credentials \
-  --from-literal=ANTHROPIC_API_KEY=<your-api-key>
+  --from-literal=CODEX_API_KEY=<your-openai-api-key>
 ```
 
 ## Customizing for Your Repository
@@ -455,12 +456,17 @@ To adapt these examples for your own repository:
    - Retrigger an existing issue or PR with a fresh comment or relabel after deployment
    - Duplicate a filter if you need to allow multiple specific GitHub usernames
 
-5. **Choose the right model:**
+5. **Adjust the Codex model:**
    ```yaml
    spec:
      taskTemplate:
-       model: sonnet  # or opus for more complex tasks
+       model: gpt-5.5
    ```
+
+   The checked-in spawners use `gpt-5.5` for the tasks that previously used
+   Opus, and `gpt-5.4-mini` for the tasks that previously used Sonnet.
+   Codex reasoning effort is configured through Codex `config.toml`; Kelos does
+   not currently expose it as a Task or TaskSpawner field.
 
 ## Feedback Loop Pattern
 

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -69,8 +69,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -10,8 +10,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
@@ -42,7 +42,7 @@ spec:
       Your goal is to review recent PRs and their review comments, then update agent configuration to reflect lessons learned.
 
       Agent configuration includes:
-      - `AGENTS.md` / `CLAUDE.md` — project-level conventions and instructions for all agents
+      - `AGENTS.md` — project-level conventions and instructions for all agents
       - `self-development/agentconfig.yaml` — shared AgentConfig (agentsMD, plugins, skills, subagents, commands)
       - `self-development/*.yaml` — TaskSpawner prompt templates that guide each agent's behavior
 
@@ -68,7 +68,7 @@ spec:
          For each actionable pattern, determine the right place to update:
 
          **Project-level changes** (affect all agents):
-         - Update `AGENTS.md` and `CLAUDE.md` if the feedback is about general project conventions
+         - Update `AGENTS.md` if the feedback is about general project conventions
          - Update `self-development/agentconfig.yaml` if the feedback is about shared agent behavior
 
          **Task-specific changes** (affect a specific agent):

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -42,8 +42,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -42,8 +42,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: sonnet
-    type: claude-code
+    model: gpt-5.4-mini
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -31,8 +31,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: sonnet
-    type: claude-code
+    model: gpt-5.4-mini
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -44,8 +44,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -31,8 +31,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -70,8 +70,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -42,8 +42,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth
@@ -80,7 +80,7 @@ spec:
       2. **Configuration Alignment**
          - Check that resource requests/limits, models, TTLs, and other settings are appropriate
          - Verify that webhook repositories, events, labels, excludeLabels, and filters are correct and consistent
-         - Ensure AgentConfig instructions in `agentconfig.yaml` match the project's current conventions in `CLAUDE.md`
+         - Ensure AgentConfig instructions in `agentconfig.yaml` match the project's current conventions in `AGENTS.md`
          - Look for inconsistencies between TaskSpawners that should share the same configuration
 
       3. **Workflow Completeness**

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -28,8 +28,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: sonnet
-    type: claude-code
+    model: gpt-5.4-mini
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -27,8 +27,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -74,8 +74,8 @@ spec:
   taskTemplate:
     workspaceRef:
       name: kelos-agent
-    model: opus
-    type: claude-code
+    model: gpt-5.5
+    type: codex
     ttlSecondsAfterFinished: 864000
     credentials:
       type: oauth

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   workspaceRef:
     name: kelos-agent
-  model: opus
-  type: claude-code
+  model: gpt-5.5
+  type: codex
   ttlSecondsAfterFinished: 864000
   credentials:
     type: oauth


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates the self-development and kanon-development Task/TaskSpawner specs from Claude Code to Codex so non-interactive automation uses the shared Codex budget.

This also replaces Claude-specific model aliases with Codex model IDs: former Opus tasks use `gpt-5.5`, and former Sonnet tasks use `gpt-5.4-mini`. The development READMEs and self-maintenance prompts now describe Codex credentials and AGENTS.md-based instructions.

Codex reasoning effort is not set in these manifests because Kelos does not currently expose `model_reasoning_effort` as a Task or TaskSpawner field.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation: make verify

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
