### PR TITLE
Add agent effort level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Kelos is built on four resources, grouped by the two concerns above:
 
 **Defining the agent and its environment**
 
-- **Tasks** — A single agent run: prompt, model, credentials, and Pod-level overrides.
+- **Tasks** — A single agent run: prompt, model, effort, credentials, and Pod-level overrides.
 - **Workspaces** — The git repository (URL, ref, auth) the agent operates in.
 - **AgentConfigs** — Reusable bundles of agent instructions (`AGENTS.md`, `CLAUDE.md`), plugins (skills and agents), and MCP servers.
 
@@ -542,7 +542,7 @@ Kelos uses standard Kubernetes RBAC — use namespace isolation to separate team
 
 Running AI agents costs real money. Here's how to stay in control:
 
-**Model costs vary significantly.** Opus is the most capable but most expensive model. Use `spec.model` (or `model` in config) to choose cheaper models like Sonnet for routine tasks and reserve Opus for complex work. Check the [API pricing](https://docs.anthropic.com/en/docs/about-claude/pricing) page for current rates.
+**Model and effort costs vary significantly.** Use `spec.model` (or `model` in config) to choose the model for each workflow, and use `spec.effort` (or `effort` in config) to lower reasoning effort for routine work or raise it for complex reviews and planning. Check your provider's pricing page for current rates.
 
 **Use `maxConcurrency` to cap spend.** Without it, a TaskSpawner can create unlimited concurrent tasks. If 100 issues match your filter on first poll, that's 100 simultaneous agent runs. Always set a limit:
 

--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -205,6 +205,11 @@ type TaskSpec struct {
 	// +optional
 	Model string `json:"model,omitempty"`
 
+	// Effort optionally controls how much reasoning effort the agent should use.
+	// Values are agent-specific and passed through without validation.
+	// +optional
+	Effort string `json:"effort,omitempty"`
+
 	// Image optionally overrides the default agent container image.
 	// Custom images must implement the agent image interface
 	// (see docs/agent-image-interface.md).

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -825,6 +825,11 @@ type TaskTemplate struct {
 	// +optional
 	Model string `json:"model,omitempty"`
 
+	// Effort optionally controls how much reasoning effort spawned agents should use.
+	// Values are agent-specific and passed through without validation.
+	// +optional
+	Effort string `json:"effort,omitempty"`
+
 	// Image optionally overrides the default agent container image.
 	// Custom images must implement the agent image interface
 	// (see docs/agent-image-interface.md).

--- a/claude-code/kelos_entrypoint.sh
+++ b/claude-code/kelos_entrypoint.sh
@@ -23,6 +23,10 @@ if [ -n "${KELOS_MODEL:-}" ]; then
   ARGS+=("--model" "$KELOS_MODEL")
 fi
 
+if [ -n "${KELOS_EFFORT:-}" ]; then
+  ARGS+=("--effort" "$KELOS_EFFORT")
+fi
+
 # Write user-level instructions (additive, no conflict with repo)
 if [ -n "${KELOS_AGENTS_MD:-}" ]; then
   mkdir -p ~/.claude

--- a/codex/kelos_entrypoint.sh
+++ b/codex/kelos_entrypoint.sh
@@ -31,6 +31,11 @@ if [ -n "${KELOS_MODEL:-}" ]; then
   ARGS+=("--model" "$KELOS_MODEL")
 fi
 
+if [ -n "${KELOS_EFFORT:-}" ]; then
+  SAFE_EFFORT=$(printf '%s' "$KELOS_EFFORT" | tr -d '"\\\n\r')
+  ARGS+=("--config" "model_reasoning_effort=\"$SAFE_EFFORT\"")
+fi
+
 # Write user-level instructions (global scope read by Codex CLI)
 if [ -n "${KELOS_AGENTS_MD:-}" ]; then
   mkdir -p ~/.codex

--- a/cursor/kelos_entrypoint.sh
+++ b/cursor/kelos_entrypoint.sh
@@ -29,9 +29,16 @@ if [ -n "${KELOS_MODEL:-}" ]; then
 fi
 
 # Write user-level instructions (global scope read by Cursor CLI)
-if [ -n "${KELOS_AGENTS_MD:-}" ]; then
+if [ -n "${KELOS_AGENTS_MD:-}" ] || [ -n "${KELOS_EFFORT:-}" ]; then
   mkdir -p ~/.cursor
-  printf '%s' "$KELOS_AGENTS_MD" >~/.cursor/AGENTS.md
+  {
+    if [ -n "${KELOS_AGENTS_MD:-}" ]; then
+      printf '%s\n' "$KELOS_AGENTS_MD"
+    fi
+    if [ -n "${KELOS_EFFORT:-}" ]; then
+      printf '\n# Kelos Effort\nUse %s reasoning effort for this task.\n' "$KELOS_EFFORT"
+    fi
+  } >~/.cursor/AGENTS.md
 fi
 
 # Install each plugin's skills and agents into Cursor's config directories.

--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -29,6 +29,7 @@ Kelos sets the following reserved environment variables on agent containers:
 | Variable | Description | Always set? |
 |---|---|---|
 | `KELOS_MODEL` | The model name to use | Only when `model` is specified in the Task |
+| `KELOS_EFFORT` | Agent reasoning effort to use | Only when `effort` is specified in the Task |
 | `ANTHROPIC_API_KEY` | API key for Anthropic (`claude-code` agent, api-key credential type) | When credential type is `api-key` and agent type is `claude-code` |
 | `CODEX_API_KEY` | API key for OpenAI Codex (`codex` agent, `api-key` credential type) | When credential type is `api-key` and agent type is `codex` |
 | `CODEX_AUTH_JSON` | Contents of `~/.codex/auth.json` (`codex` agent, `oauth` credential type) | When credential type is `oauth` and agent type is `codex` |
@@ -46,11 +47,20 @@ Kelos sets the following reserved environment variables on agent containers:
 | `KELOS_PLUGIN_DIR` | Path to plugin directory containing skills and agents | When `agentConfigRef` is set and `plugins` is non-empty |
 | `KELOS_SETUP_COMMAND` | JSON-encoded exec-form array from `Workspace.spec.setupCommand`, executed by the entrypoint before the agent starts | When the workspace defines `setupCommand` |
 
-> The names listed in this table are reserved. `PodOverrides.Env` entries that
-> reuse a reserved name are dropped so the built-in value always wins; do not
-> set them manually. `KELOS_SETUP_COMMAND` is additionally dropped from
-> `PodOverrides.Env` even when the workspace does not define `setupCommand`,
-> because it drives entrypoint command execution.
+> The names listed in this table are reserved for Kelos behavior. When Kelos
+> sets one on a Task, `PodOverrides.Env` entries that reuse the same name are
+> dropped so the built-in value wins; do not set them manually.
+> `KELOS_SETUP_COMMAND` is additionally dropped from `PodOverrides.Env` even
+> when the workspace does not define `setupCommand`, because it drives
+> entrypoint command execution.
+
+The bundled agent images handle `KELOS_EFFORT` as follows:
+
+- `codex`: sets Codex `model_reasoning_effort`.
+- `claude-code`: passes `--effort`.
+- `gemini`: writes a temporary model alias with `thinkingConfig` when the model family supports it, otherwise adds effort guidance to user-level instructions.
+- `opencode`: writes agent model options including `reasoningEffort` and provider variants where available.
+- `cursor`: adds effort guidance to user-level instructions because Cursor CLI does not expose a documented effort flag.
 
 ### 4. User ID
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,6 +9,7 @@
 | `spec.credentials.type` | `api-key`, `oauth`, or `none`. Use `none` to skip built-in credential injection (e.g., for Bedrock, Vertex AI, or Azure OpenAI credentials provided via `podOverrides.env`) | Yes |
 | `spec.credentials.secretRef.name` | Secret name with credentials (see [secret format](#task-credential-secret-format) below; not required when `type` is `none`) | Conditional |
 | `spec.model` | Model override. The value is passed through to the agent container as `KELOS_MODEL` without validation, so either an agent-native shorthand accepted by the CLI (e.g., `sonnet`, `opus` for Claude Code) or a versioned ID (e.g., `claude-sonnet-4-6`) is valid | No |
+| `spec.effort` | Agent reasoning effort. The value is passed through as `KELOS_EFFORT` without validation. Bundled agents translate common values (`minimal`, `low`, `medium`, `high`, `xhigh`, `max`) to their native controls where supported | No |
 | `spec.image` | Custom agent image override (see [Agent Image Interface](agent-image-interface.md)) | No |
 | `spec.workspaceRef.name` | Name of a Workspace resource to use | No |
 | `spec.agentConfigRef.name` | Name of an AgentConfig resource to use | No |
@@ -285,6 +286,7 @@ GitHub Apps are preferred over PATs for production use because they offer fine-g
 | `spec.taskTemplate.type` | Agent type (`claude-code`, `codex`, `gemini`, `opencode`, or `cursor`) | Yes |
 | `spec.taskTemplate.credentials` | Credentials for the agent (same as Task) | Yes |
 | `spec.taskTemplate.model` | Model override for spawned Tasks. Same pass-through behavior as `Task.spec.model`: either an agent-native shorthand (e.g., `sonnet`, `opus` for Claude Code) or a versioned ID (e.g., `claude-sonnet-4-6`) is valid | No |
+| `spec.taskTemplate.effort` | Reasoning effort for spawned Tasks. Same pass-through behavior as `Task.spec.effort` | No |
 | `spec.taskTemplate.image` | Custom agent image override (see [Agent Image Interface](agent-image-interface.md)) | No |
 | `spec.taskTemplate.agentConfigRef.name` | Name of an AgentConfig resource for spawned Tasks | No |
 | `spec.taskTemplate.promptTemplate` | Go text/template for prompt (see [template variables](#prompttemplate-variables) below) | No |
@@ -440,6 +442,7 @@ Kelos reads defaults from `~/.kelos/config.yaml` (override with `--config`). CLI
 oauthToken: <your-oauth-token>
 # or: apiKey: <your-api-key>
 model: sonnet  # or a versioned ID like 'claude-sonnet-4-6' — see spec.model under Task
+effort: high
 namespace: my-namespace
 ```
 
@@ -504,6 +507,7 @@ The `token` and `githubApp` fields are mutually exclusive. If both `name` and `r
 |-------|-------------|
 | `type` | Default agent type (`claude-code`, `codex`, `gemini`, `opencode`, or `cursor`) |
 | `model` | Default model override |
+| `effort` | Default agent reasoning effort |
 | `namespace` | Default Kubernetes namespace |
 | `agentConfig` | Default AgentConfig resource name |
 
@@ -561,6 +565,7 @@ When the same key is set multiple ways, precedence is: chart defaults, then `--v
 - `--prompt-file`: Read task prompt from a file path; use `-` to read from stdin (mutually exclusive with `--prompt`)
 - `--type, -t`: Agent type (default: `claude-code`)
 - `--model`: Model override
+- `--effort`: Agent reasoning effort
 - `--image`: Custom agent image
 - `--name`: Task name (auto-generated if omitted)
 - `--workspace`: Workspace resource name

--- a/gemini/kelos_entrypoint.sh
+++ b/gemini/kelos_entrypoint.sh
@@ -18,14 +18,101 @@ ARGS=(
   "-p" "$PROMPT"
 )
 
-if [ -n "${KELOS_MODEL:-}" ]; then
-  ARGS+=("--model" "$KELOS_MODEL")
+MODEL_ARG="${KELOS_MODEL:-}"
+NATIVE_EFFORT_CONFIGURED=""
+
+if [ -n "${KELOS_EFFORT:-}" ]; then
+  mkdir -p ~/.gemini
+  if [ -n "${KELOS_MODEL:-}" ]; then
+    EFFORT_MODEL_ALIAS="kelos-effort-${KELOS_MODEL//[^A-Za-z0-9_-]/-}"
+    KELOS_EFFORT_MODEL="$EFFORT_MODEL_ALIAS" node -e '
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const cfgPath = path.join(os.homedir(), ".gemini", "settings.json");
+let existing = {};
+try { existing = JSON.parse(fs.readFileSync(cfgPath, "utf8")); } catch {}
+const model = process.env.KELOS_MODEL;
+const effort = process.env.KELOS_EFFORT;
+const alias = process.env.KELOS_EFFORT_MODEL;
+const normalized = effort.toLowerCase();
+function budget(value) {
+  if (/^-?\d+$/.test(value)) return Number(value);
+  switch (value) {
+    case "minimal": return 512;
+    case "low": return 1024;
+    case "medium": return 4096;
+    case "high": return 8192;
+    case "xhigh": return 16384;
+    case "max": return 24576;
+    default: return undefined;
+  }
+}
+function level(value) {
+  switch (value) {
+    case "minimal":
+    case "low":
+      return "LOW";
+    case "medium":
+    case "high":
+    case "xhigh":
+    case "max":
+      return "HIGH";
+    default:
+      return undefined;
+  }
+}
+let thinkingConfig;
+if (model.includes("gemini-3") || model.includes("3.")) {
+  const thinkingLevel = level(normalized);
+  if (thinkingLevel) thinkingConfig = { thinkingLevel };
+} else if (model.includes("gemini-2.5") || model.includes("2.5")) {
+  const thinkingBudget = budget(normalized);
+  if (thinkingBudget !== undefined) thinkingConfig = { thinkingBudget };
+}
+if (!thinkingConfig) process.exit(2);
+existing.modelConfigs = existing.modelConfigs || {};
+existing.modelConfigs.customAliases = existing.modelConfigs.customAliases || {};
+existing.modelConfigs.customAliases[alias] = {
+  modelConfig: {
+    model,
+    generateContentConfig: { thinkingConfig },
+  },
+};
+fs.writeFileSync(cfgPath, JSON.stringify(existing, null, 2));
+'
+    case "$?" in
+      0)
+        MODEL_ARG="$EFFORT_MODEL_ALIAS"
+        NATIVE_EFFORT_CONFIGURED="true"
+        ;;
+      2)
+        echo "Warning: KELOS_EFFORT '$KELOS_EFFORT' cannot be mapped to Gemini model '$KELOS_MODEL'; using prompt steering" >&2
+        ;;
+      *)
+        echo "Warning: failed to write Gemini effort config; using prompt steering" >&2
+        ;;
+    esac
+  else
+    echo "Warning: KELOS_EFFORT requires KELOS_MODEL for native Gemini config; using prompt steering" >&2
+  fi
+fi
+
+if [ -n "$MODEL_ARG" ]; then
+  ARGS+=("--model" "$MODEL_ARG")
 fi
 
 # Write user-level instructions (global scope read by Gemini CLI)
-if [ -n "${KELOS_AGENTS_MD:-}" ]; then
+if [ -n "${KELOS_AGENTS_MD:-}" ] || { [ -n "${KELOS_EFFORT:-}" ] && [ -z "$NATIVE_EFFORT_CONFIGURED" ]; }; then
   mkdir -p ~/.gemini
-  printf '%s' "$KELOS_AGENTS_MD" >~/.gemini/GEMINI.md
+  {
+    if [ -n "${KELOS_AGENTS_MD:-}" ]; then
+      printf '%s\n' "$KELOS_AGENTS_MD"
+    fi
+    if [ -n "${KELOS_EFFORT:-}" ] && [ -z "$NATIVE_EFFORT_CONFIGURED" ]; then
+      printf '\n# Kelos Effort\nUse %s reasoning effort for this task.\n' "$KELOS_EFFORT"
+    fi
+  } >~/.gemini/GEMINI.md
 fi
 
 # Install each plugin as a Gemini extension with skills and agents

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	CredentialType string          `json:"credentialType,omitempty"`
 	Type           string          `json:"type,omitempty"`
 	Model          string          `json:"model,omitempty"`
+	Effort         string          `json:"effort,omitempty"`
 	Namespace      string          `json:"namespace,omitempty"`
 	Workspace      WorkspaceConfig `json:"workspace,omitempty"`
 	AgentConfig    string          `json:"agentConfig,omitempty"`

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -14,6 +14,7 @@ secret: my-secret
 credentialType: oauth
 type: codex
 model: claude-sonnet-4-5-20250929
+effort: high
 namespace: my-namespace
 workspace:
   name: my-workspace
@@ -38,6 +39,9 @@ workspace:
 	}
 	if cfg.Model != "claude-sonnet-4-5-20250929" {
 		t.Errorf("Model = %q, want %q", cfg.Model, "claude-sonnet-4-5-20250929")
+	}
+	if cfg.Effort != "high" {
+		t.Errorf("Effort = %q, want %q", cfg.Effort, "high")
 	}
 	if cfg.Namespace != "my-namespace" {
 		t.Errorf("Namespace = %q, want %q", cfg.Namespace, "my-namespace")

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -53,6 +53,7 @@ func TestRunCommand_DryRun(t *testing.T) {
 		"--prompt", "hello world",
 		"--name", "test-task",
 		"--namespace", "test-ns",
+		"--effort", "xhigh",
 	})
 
 	// Capture stdout.
@@ -84,12 +85,47 @@ func TestRunCommand_DryRun(t *testing.T) {
 	if !strings.Contains(output, "prompt: hello world") {
 		t.Errorf("expected YAML output to contain 'prompt: hello world', got:\n%s", output)
 	}
+	if !strings.Contains(output, "effort: xhigh") {
+		t.Errorf("expected YAML output to contain 'effort: xhigh', got:\n%s", output)
+	}
 	if !strings.Contains(output, "my-secret") {
 		t.Errorf("expected YAML output to contain secret name 'my-secret', got:\n%s", output)
 	}
 	// Ensure no "created" message is printed.
 	if strings.Contains(output, "created") {
 		t.Errorf("dry-run should not print 'created' message, got:\n%s", output)
+	}
+}
+
+func TestRunCommand_DryRun_ConfigEffort(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("secret: my-secret\neffort: high\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	cmd := NewRootCommand()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--dry-run",
+		"--prompt", "hello world",
+		"--name", "test-task",
+		"--namespace", "test-ns",
+	})
+
+	var execErr error
+	output := captureStdout(t, func() {
+		execErr = cmd.Execute()
+	})
+	if execErr != nil {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+
+	if !strings.Contains(output, "effort: high") {
+		t.Errorf("expected YAML output to contain config effort, got:\n%s", output)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -41,6 +41,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		secret          string
 		credentialType  string
 		model           string
+		effort          string
 		image           string
 		name            string
 		watch           bool
@@ -70,6 +71,9 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				}
 				if !cmd.Flags().Changed("model") && c.Model != "" {
 					model = c.Model
+				}
+				if !cmd.Flags().Changed("effort") && c.Effort != "" {
+					effort = c.Effort
 				}
 				if !cmd.Flags().Changed("workspace") && c.Workspace.Name != "" {
 					workspace = c.Workspace.Name
@@ -241,6 +245,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 					Prompt:      prompt,
 					Credentials: creds,
 					Model:       model,
+					Effort:      effort,
 					Image:       image,
 				},
 			}
@@ -330,6 +335,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
 	cmd.Flags().StringVar(&credentialType, "credential-type", "api-key", "credential type (api-key, oauth, none)")
 	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&effort, "effort", "", "agent reasoning effort")
 	cmd.Flags().StringVar(&image, "image", "", "custom agent image (must implement agent image interface)")
 	cmd.Flags().StringVar(&name, "name", "", "task name (auto-generated if omitted)")
 	cmd.Flags().StringVar(&workspace, "workspace", "", "name of Workspace resource to use")

--- a/internal/controller/entrypoint_test.go
+++ b/internal/controller/entrypoint_test.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentEntrypointsHandleKelosEffort(t *testing.T) {
+	tests := []struct {
+		path  string
+		parts []string
+	}{
+		{
+			path: "../..//codex/kelos_entrypoint.sh",
+			parts: []string{
+				"KELOS_EFFORT",
+				"model_reasoning_effort",
+			},
+		},
+		{
+			path: "../..//claude-code/kelos_entrypoint.sh",
+			parts: []string{
+				"KELOS_EFFORT",
+				"--effort",
+			},
+		},
+		{
+			path: "../..//gemini/kelos_entrypoint.sh",
+			parts: []string{
+				"KELOS_EFFORT",
+				"thinkingConfig",
+				"thinkingBudget",
+				"thinkingLevel",
+			},
+		},
+		{
+			path: "../..//opencode/kelos_entrypoint.sh",
+			parts: []string{
+				"KELOS_EFFORT",
+				"reasoningEffort",
+				"variant",
+			},
+		},
+		{
+			path: "../..//cursor/kelos_entrypoint.sh",
+			parts: []string{
+				"KELOS_EFFORT",
+				"Kelos Effort",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.path, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Clean(tt.path))
+			if err != nil {
+				t.Fatalf("reading entrypoint: %v", err)
+			}
+			content := string(data)
+			for _, part := range tt.parts {
+				if !strings.Contains(content, part) {
+					t.Fatalf("expected %s to contain %q", tt.path, part)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -261,6 +261,13 @@ func (b *JobBuilder) buildAgentJob(task *kelosv1alpha1.Task, workspace *kelosv1a
 		})
 	}
 
+	if task.Spec.Effort != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "KELOS_EFFORT",
+			Value: task.Spec.Effort,
+		})
+	}
+
 	if task.Spec.Branch != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "KELOS_BRANCH",

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -156,6 +156,41 @@ func TestBuildClaudeCodeJob_NoModel(t *testing.T) {
 	}
 }
 
+func TestBuildAgentJob_WithEffort(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &kelosv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-effort",
+			Namespace: "default",
+		},
+		Spec: kelosv1alpha1.TaskSpec{
+			Type:   AgentTypeCodex,
+			Prompt: "Hello",
+			Credentials: kelosv1alpha1.Credentials{
+				Type:      kelosv1alpha1.CredentialTypeAPIKey,
+				SecretRef: &kelosv1alpha1.SecretReference{Name: "my-secret"},
+			},
+			Effort: "xhigh",
+		},
+	}
+
+	job, err := builder.Build(task, nil, nil, task.Spec.Prompt)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+	for _, env := range container.Env {
+		if env.Name == "KELOS_EFFORT" {
+			if env.Value != "xhigh" {
+				t.Errorf("KELOS_EFFORT value: expected %q, got %q", "xhigh", env.Value)
+			}
+			return
+		}
+	}
+	t.Fatal("Expected KELOS_EFFORT env var to be set")
+}
+
 func TestBuildClaudeCodeJob_WorkspaceWithRef(t *testing.T) {
 	builder := NewJobBuilder()
 	task := &kelosv1alpha1.Task{

--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -80,6 +80,51 @@ func TestKelosAPIReviewerTriggerableByBot(t *testing.T) {
 	assertReviewerTriggerableByBot(t, "kelos-api-reviewer.yaml", "/kelos api-review")
 }
 
+func TestDevelopmentTaskSpawnersSetExpectedEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dir    string
+		file   string
+		effort string
+	}{
+		{dir: "self-development", file: "kelos-api-reviewer.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-workers.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-planner.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-reviewer.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-self-update.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-fake-strategist.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-triage.yaml", effort: "high"},
+		{dir: "self-development", file: "kelos-pr-responder.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-config-update.yaml", effort: "xhigh"},
+		{dir: "self-development", file: "kelos-image-update.yaml", effort: "medium"},
+		{dir: "self-development", file: "kelos-fake-user.yaml", effort: "medium"},
+		{dir: "self-development", file: "kelos-squash-commits.yaml", effort: "medium"},
+		{dir: "kanon-development", file: "kanon-workers.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-planner.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-reviewer.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-self-update.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-fake-strategist.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-triage.yaml", effort: "high"},
+		{dir: "kanon-development", file: "kanon-pr-responder.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-config-update.yaml", effort: "xhigh"},
+		{dir: "kanon-development", file: "kanon-fake-user.yaml", effort: "medium"},
+		{dir: "kanon-development", file: "kanon-squash-commits.yaml", effort: "medium"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.dir+"/"+tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			ts := readTaskSpawnerFromDir(t, tt.dir, tt.file)
+			if ts.Spec.TaskTemplate.Effort != tt.effort {
+				t.Fatalf("TaskTemplate.Effort = %q, want %q", ts.Spec.TaskTemplate.Effort, tt.effort)
+			}
+		})
+	}
+}
+
 // assertReviewerTriggerableByBot checks that the given reviewer spawner triggers
 // for both the Kelos bot and a maintainer posting bodyPattern on an open PR, but
 // not for an unauthorized user.
@@ -139,7 +184,13 @@ func assertReviewerTriggerableByBot(t *testing.T, file, bodyPattern string) {
 func readSelfDevelopmentTaskSpawner(t *testing.T, file string) *kelosv1alpha1.TaskSpawner {
 	t.Helper()
 
-	path := filepath.Join("..", "..", "self-development", file)
+	return readTaskSpawnerFromDir(t, "self-development", file)
+}
+
+func readTaskSpawnerFromDir(t *testing.T, dir, file string) *kelosv1alpha1.TaskSpawner {
+	t.Helper()
+
+	path := filepath.Join("..", "..", dir, file)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)

--- a/internal/manifests/charts/kelos/templates/crds/task-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/task-crd.yaml
@@ -128,6 +128,11 @@ spec:
                 items:
                   type: string
                 type: array
+              effort:
+                description: |-
+                  Effort optionally controls how much reasoning effort the agent should use.
+                  Values are agent-specific and passed through without validation.
+                type: string
               image:
                 description: |-
                   Image optionally overrides the default agent container image.

--- a/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
@@ -327,6 +327,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  effort:
+                    description: |-
+                      Effort optionally controls how much reasoning effort spawned agents should use.
+                      Values are agent-specific and passed through without validation.
+                    type: string
                   image:
                     description: |-
                       Image optionally overrides the default agent container image.

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -352,6 +352,11 @@ spec:
                 items:
                   type: string
                 type: array
+              effort:
+                description: |-
+                  Effort optionally controls how much reasoning effort the agent should use.
+                  Values are agent-specific and passed through without validation.
+                type: string
               image:
                 description: |-
                   Image optionally overrides the default agent container image.
@@ -7555,6 +7560,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  effort:
+                    description: |-
+                      Effort optionally controls how much reasoning effort spawned agents should use.
+                      Values are agent-specific and passed through without validation.
+                    type: string
                   image:
                     description: |-
                       Image optionally overrides the default agent container image.

--- a/internal/taskbuilder/builder.go
+++ b/internal/taskbuilder/builder.go
@@ -79,6 +79,9 @@ func (tb *TaskBuilder) BuildTask(
 	if taskTemplate.Model != "" {
 		task.Spec.Model = taskTemplate.Model
 	}
+	if taskTemplate.Effort != "" {
+		task.Spec.Effort = taskTemplate.Effort
+	}
 	if taskTemplate.Image != "" {
 		task.Spec.Image = taskTemplate.Image
 	}

--- a/internal/taskbuilder/builder_test.go
+++ b/internal/taskbuilder/builder_test.go
@@ -1,0 +1,36 @@
+package taskbuilder
+
+import (
+	"testing"
+
+	"github.com/kelos-dev/kelos/api/v1alpha1"
+)
+
+func TestBuildTask_ForwardsEffort(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &v1alpha1.TaskTemplate{
+		Type: "codex",
+		Credentials: v1alpha1.Credentials{
+			Type: v1alpha1.CredentialTypeAPIKey,
+			SecretRef: &v1alpha1.SecretReference{
+				Name: "credentials",
+			},
+		},
+		Effort:         "high",
+		PromptTemplate: "Fix {{.Title}}",
+	}
+
+	task, err := tb.BuildTask("task-1", "default", template, map[string]interface{}{
+		"Title": "the bug",
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildTask() returned error: %v", err)
+	}
+
+	if task.Spec.Effort != "high" {
+		t.Fatalf("task.Spec.Effort = %q, want %q", task.Spec.Effort, "high")
+	}
+	if task.Spec.Prompt != "Fix the bug" {
+		t.Fatalf("task.Spec.Prompt = %q, want %q", task.Spec.Prompt, "Fix the bug")
+	}
+}

--- a/kanon-development/kanon-config-update.yaml
+++ b/kanon-development/kanon-config-update.yaml
@@ -14,6 +14,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-fake-strategist.yaml
+++ b/kanon-development/kanon-fake-strategist.yaml
@@ -39,6 +39,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-fake-user.yaml
+++ b/kanon-development/kanon-fake-user.yaml
@@ -39,6 +39,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.4-mini
+    effort: medium
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-planner.yaml
+++ b/kanon-development/kanon-planner.yaml
@@ -45,6 +45,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-pr-responder.yaml
+++ b/kanon-development/kanon-pr-responder.yaml
@@ -32,6 +32,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-reviewer.yaml
+++ b/kanon-development/kanon-reviewer.yaml
@@ -62,6 +62,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-self-update.yaml
+++ b/kanon-development/kanon-self-update.yaml
@@ -14,6 +14,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-squash-commits.yaml
+++ b/kanon-development/kanon-squash-commits.yaml
@@ -29,6 +29,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.4-mini
+    effort: medium
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-triage.yaml
+++ b/kanon-development/kanon-triage.yaml
@@ -28,6 +28,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.5
+    effort: high
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/kanon-development/kanon-workers.yaml
+++ b/kanon-development/kanon-workers.yaml
@@ -56,6 +56,7 @@ spec:
     workspaceRef:
       name: kanon-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/opencode/kelos_entrypoint.sh
+++ b/opencode/kelos_entrypoint.sh
@@ -44,7 +44,41 @@ ARGS=(
   "$PROMPT"
 )
 
-if [ -n "${KELOS_MODEL:-}" ]; then
+if [ -n "${KELOS_EFFORT:-}" ]; then
+  mkdir -p ~/.config/opencode
+  node -e '
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const cfgPath = path.join(os.homedir(), ".config", "opencode", "opencode.json");
+let existing = {};
+try { existing = JSON.parse(fs.readFileSync(cfgPath, "utf8")); } catch {}
+const model = process.env.KELOS_MODEL || existing.model;
+const effort = process.env.KELOS_EFFORT;
+const provider = model ? model.split("/")[0] : "";
+const normalized = effort.toLowerCase();
+function variantFor(provider, effort) {
+  if (provider === "anthropic") {
+    return effort === "max" || effort === "xhigh" ? "max" : "high";
+  }
+  if (provider === "google") {
+    return effort === "minimal" || effort === "low" ? "low" : "high";
+  }
+  return effort;
+}
+if (model) existing.model = model;
+existing.agent = existing.agent || {};
+existing.agent.build = Object.assign({}, existing.agent.build || {}, {
+  mode: "primary",
+  variant: variantFor(provider, normalized),
+  options: Object.assign({}, (existing.agent.build && existing.agent.build.options) || {}, {
+    reasoningEffort: effort,
+  }),
+});
+if (model) existing.agent.build.model = model;
+fs.writeFileSync(cfgPath, JSON.stringify(existing, null, 2));
+'
+elif [ -n "${KELOS_MODEL:-}" ]; then
   ARGS+=("--model" "$KELOS_MODEL")
 fi
 

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -456,17 +456,19 @@ To adapt these examples for your own repository:
    - Retrigger an existing issue or PR with a fresh comment or relabel after deployment
    - Duplicate a filter if you need to allow multiple specific GitHub usernames
 
-5. **Adjust the Codex model:**
+5. **Adjust the Codex model and effort:**
    ```yaml
    spec:
      taskTemplate:
        model: gpt-5.5
+       effort: xhigh
    ```
 
    The checked-in spawners use `gpt-5.5` for the tasks that previously used
    Opus, and `gpt-5.4-mini` for the tasks that previously used Sonnet.
-   Codex reasoning effort is configured through Codex `config.toml`; Kelos does
-   not currently expose it as a Task or TaskSpawner field.
+   They set `effort` by role: `xhigh` for complex planning, coding, strategy,
+   review, PR update, and configuration update workflows; `high` for triage;
+   and `medium` for routine image, fake-user, and squash workflows.
 
 ## Feedback Loop Pattern
 

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -70,6 +70,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -11,6 +11,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -43,6 +43,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -43,6 +43,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.4-mini
+    effort: medium
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -32,6 +32,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.4-mini
+    effort: medium
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -45,6 +45,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -32,6 +32,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -71,6 +71,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -43,6 +43,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -29,6 +29,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.4-mini
+    effort: medium
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -28,6 +28,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: high
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -75,6 +75,7 @@ spec:
     workspaceRef:
       name: kelos-agent
     model: gpt-5.5
+    effort: xhigh
     type: codex
     ttlSecondsAfterFinished: 864000
     credentials:

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -8,6 +8,7 @@ spec:
   workspaceRef:
     name: kelos-agent
   model: gpt-5.5
+  effort: xhigh
   type: codex
   ttlSecondsAfterFinished: 864000
   credentials:

--- a/skills/kelos/SKILL.md
+++ b/skills/kelos/SKILL.md
@@ -53,6 +53,7 @@ A Task runs an AI agent with a prompt. Key fields:
 - `spec.dependsOn`: Task names that must succeed first
 - `spec.ttlSecondsAfterFinished`: Auto-delete after completion (seconds)
 - `spec.model`: Model override
+- `spec.effort`: Agent reasoning effort
 - `spec.podOverrides`: Resource limits, timeout, env vars, node selector
 
 Task status phases: `Pending` -> `Running` -> `Succeeded` or `Failed`.
@@ -117,7 +118,7 @@ kelos run -p "Fix the login bug" --type claude-code
 kelos run -p "Add tests" --workspace my-ws --agent-config my-ac
 
 # With model override and branch
-kelos run -p "Refactor auth" --model opus --branch feature/auth
+kelos run -p "Refactor auth" --model opus --effort high --branch feature/auth
 
 # Watch task progress
 kelos run -p "Fix bug" -w
@@ -179,6 +180,7 @@ Config file at `~/.kelos/config.yaml`:
 ```yaml
 oauthToken: <token>       # or apiKey: <key>
 model: sonnet                   # or a versioned ID like 'claude-sonnet-4-6' — value is passed to the agent as KELOS_MODEL
+effort: high
 namespace: default
 workspace:
   repo: https://github.com/org/repo.git

--- a/skills/kelos/references/task.yaml
+++ b/skills/kelos/references/task.yaml
@@ -35,6 +35,7 @@ spec:
   type: claude-code
   prompt: "Review the latest PR and provide feedback using /review."
   model: opus
+  effort: high
   credentials:
     type: oauth
     secretRef:

--- a/skills/kelos/references/taskspawner.yaml
+++ b/skills/kelos/references/taskspawner.yaml
@@ -13,6 +13,7 @@ spec:
       state: open
   taskTemplate:
     type: claude-code
+    effort: high
     workspaceRef:
       name: my-workspace
     credentials:

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -27,6 +27,7 @@ var _ = Describe("CLI", func() {
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
 			"--model", testModel,
+			"--effort", "high",
 			"--name", "cli-task",
 		)
 
@@ -37,17 +38,24 @@ var _ = Describe("CLI", func() {
 		output := framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace)
 		Expect(output).To(ContainSubstring("Succeeded"))
 
+		By("verifying task effort was persisted")
+		task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), "cli-task", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(task.Spec.Effort).To(Equal("high"))
+
 		By("verifying YAML output for a single task")
 		output = framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "yaml")
 		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
 		Expect(output).To(ContainSubstring("kind: Task"))
 		Expect(output).To(ContainSubstring("name: cli-task"))
+		Expect(output).To(ContainSubstring("effort: high"))
 
 		By("verifying JSON output for a single task")
 		output = framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "json")
 		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
 		Expect(output).To(ContainSubstring(`"kind": "Task"`))
 		Expect(output).To(ContainSubstring(`"name": "cli-task"`))
+		Expect(output).To(ContainSubstring(`"effort": "high"`))
 
 		By("verifying task logs via CLI")
 		logs := framework.KelosOutput("logs", "cli-task", "-n", f.Namespace)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds first-class agent reasoning effort configuration to Kelos:

- Adds optional `spec.effort` on Tasks and `spec.taskTemplate.effort` on TaskSpawners.
- Adds `kelos run --effort` and `effort` config-file defaulting.
- Propagates effort through TaskSpawner-created Tasks and injects `KELOS_EFFORT` into agent Jobs.
- Wires bundled agent images to native effort controls where available, with best-effort instruction steering where no native CLI control exists.
- Updates self-development and Kanon TaskSpawner manifests with role-based effort levels.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Cursor currently receives effort as instruction steering because its CLI does not expose a documented effort flag. Gemini uses generated `thinkingConfig` aliases when the model family can be mapped, and falls back to instruction steering otherwise.

Validated with:

- `make update`
- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
Add optional Task and TaskSpawner template effort fields plus kelos run --effort to configure agent reasoning effort.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class control over agent reasoning effort. You can now set effort on Tasks, TaskSpawners, and via the CLI/config, with values propagated to agent jobs and mapped to each agent’s native controls where possible.

- **New Features**
  - Task `spec.effort` and TaskSpawner `spec.taskTemplate.effort` added; CRDs, README, and docs updated.
  - `kelos run --effort` and `effort` in `~/.kelos/config.yaml`; included in dry-run and `get -o` YAML/JSON output.
  - Controller injects `KELOS_EFFORT`; TaskBuilder forwards template effort to Tasks; reserved env var docs updated.
  - Agent mappings:
    - `claude-code`: passes `--effort`.
    - `codex`: sets `model_reasoning_effort`.
    - `gemini`: creates a model alias with `thinkingConfig` (`thinkingLevel` for 3.x, `thinkingBudget` for 2.5) when supported; otherwise adds effort guidance to user-level instructions.
    - `opencode`: writes `~/.config/opencode/opencode.json` with `reasoningEffort` and provider-aware variants.
    - `cursor`: adds effort guidance to `~/.cursor/AGENTS.md`.
  - Self-development and Kanon TaskSpawner manifests set role-based efforts.

- **Migration**
  - Set effort on Tasks or TaskSpawners, or use `kelos run --effort` or `effort` in config.
  - Use values like `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Values are passed through as-is.
  - No breaking changes; omit effort to keep current behavior.

<sup>Written for commit d22961764cbe4e76e91e649d588d84c25370c2d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

