### PR TITLE
Refresh e2e Codex auth.json secret on a schedule

### DIFF
--- a/.github/workflows/refresh-codex-auth.yaml
+++ b/.github/workflows/refresh-codex-auth.yaml
@@ -1,0 +1,97 @@
+name: Refresh Codex Auth
+
+# Refreshes the CODEX_AUTH_JSON secret (repository copy and ok-to-test
+# environment copy) that e2e uses: Codex rotates file-backed auth.json and the
+# result is written back with a kelos-secret-manager App installation token.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# Refreshing rotates the shared OAuth refresh_token, so concurrent runs would
+# invalidate each other. Never run more than one at a time.
+concurrency:
+  group: refresh-codex-auth
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Codex CLI
+        run: |
+          version=$(grep -oP 'ARG CODEX_VERSION=\K[0-9.]+' codex/Dockerfile)
+          npm install -g @openai/codex@"${version}"
+
+      - name: Mint secret-manager token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        with:
+          app-id: ${{ secrets.KELOS_SECRET_MANAGER_APP_ID }}
+          private-key: ${{ secrets.KELOS_SECRET_MANAGER_PRIVATE_KEY }}
+
+      - name: Verify secret write access
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          probe_secret="CODEX_AUTH_REFRESH_WRITE_PROBE"
+          probe_value="write-probe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          # Prove both secret targets are writable before Codex rotates the
+          # refresh_token; read/list access is not enough for this workflow.
+          gh secret set "${probe_secret}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${probe_value}"
+          gh secret delete "${probe_secret}" \
+            --repo "${GITHUB_REPOSITORY}"
+          gh secret set "${probe_secret}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --env ok-to-test \
+            --body "${probe_value}"
+          gh secret delete "${probe_secret}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --env ok-to-test
+
+      - name: Refresh Codex auth.json
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -z "${CODEX_AUTH_JSON}" ]; then
+            echo "::error::CODEX_AUTH_JSON secret is required"
+            exit 1
+          fi
+
+          mkdir -p ~/.codex
+          # Seed last_refresh to the epoch so Codex force-refreshes the token.
+          jq '.last_refresh = "1970-01-01T00:00:00Z"' <<<"${CODEX_AUTH_JSON}" >~/.codex/auth.json
+          printf 'cli_auth_credentials_store = "file"\n' >~/.codex/config.toml
+
+          codex exec --skip-git-repo-check --sandbox read-only \
+            --ask-for-approval never "Reply with the single word OK."
+
+          last_refresh=$(jq -r '.last_refresh' ~/.codex/auth.json)
+          if [ "${last_refresh}" = "1970-01-01T00:00:00Z" ] || [ -z "${last_refresh}" ]; then
+            echo "::error::Codex did not refresh auth.json"
+            exit 1
+          fi
+
+      - name: Update CODEX_AUTH_JSON secrets
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Both secrets back the same Codex account; write the one refreshed
+          # bundle to both so neither copy goes stale.
+          gh secret set CODEX_AUTH_JSON \
+            --repo "${GITHUB_REPOSITORY}" \
+            <~/.codex/auth.json
+          gh secret set CODEX_AUTH_JSON \
+            --repo "${GITHUB_REPOSITORY}" \
+            --env ok-to-test \
+            <~/.codex/auth.json


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a scheduled and manually dispatchable GitHub Actions workflow that keeps the e2e `CODEX_AUTH_JSON` secrets fresh. The workflow installs the repo-pinned Codex CLI, mints a kelos-secret-manager GitHub App installation token, proves repository and `ok-to-test` environment secret write access with temporary probe secrets before Codex can rotate credentials, refreshes file-backed `auth.json`, and writes the refreshed bundle back to both secret targets.

This covers the GitHub Actions secret path separately from the in-cluster Codex auth refresher, which only refreshes Kubernetes Secrets.

#### Which issue(s) this PR is related to:

Fixes #1260

#### Special notes for your reviewer:

Requires `KELOS_SECRET_MANAGER_APP_ID` and `KELOS_SECRET_MANAGER_PRIVATE_KEY` repository secrets for a GitHub App installation token with read/write access to repository Actions secrets and the `ok-to-test` environment secrets. The source `CODEX_AUTH_JSON` repository secret must already exist.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
