### PR TITLE
Fix Codex auth refresh workflow invocation and permissions

### DIFF
--- a/.github/workflows/refresh-codex-auth.yaml
+++ b/.github/workflows/refresh-codex-auth.yaml
@@ -60,6 +60,7 @@ jobs:
             --env ok-to-test
 
       - name: Refresh Codex auth.json
+        id: refresh-auth
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         run: |
@@ -69,20 +70,25 @@ jobs:
           fi
 
           mkdir -p ~/.codex
+          chmod 700 ~/.codex
           # Seed last_refresh to the epoch so Codex force-refreshes the token.
           jq '.last_refresh = "1970-01-01T00:00:00Z"' <<<"${CODEX_AUTH_JSON}" >~/.codex/auth.json
+          chmod 600 ~/.codex/auth.json
           printf 'cli_auth_credentials_store = "file"\n' >~/.codex/config.toml
 
           codex exec --skip-git-repo-check --sandbox read-only \
-            --ask-for-approval never "Reply with the single word OK."
+            "Reply with the single word OK."
 
-          last_refresh=$(jq -r '.last_refresh' ~/.codex/auth.json)
+          last_refresh=$(jq -r '.last_refresh // ""' ~/.codex/auth.json)
           if [ "${last_refresh}" = "1970-01-01T00:00:00Z" ] || [ -z "${last_refresh}" ]; then
-            echo "::error::Codex did not refresh auth.json"
-            exit 1
+            echo "::notice::Codex did not refresh auth.json; leaving CODEX_AUTH_JSON secrets unchanged"
+            echo "refreshed=false" >>"${GITHUB_OUTPUT}"
+            exit 0
           fi
+          echo "refreshed=true" >>"${GITHUB_OUTPUT}"
 
       - name: Update CODEX_AUTH_JSON secrets
+        if: steps.refresh-auth.outputs.refreshed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Refresh Codex Auth workflow was passing `--ask-for-approval never` to `codex exec`, but the pinned Codex CLI rejects that flag for non-interactive exec runs. This removes the unsupported flag so `codex exec` can run, tightens the seeded Codex credential file permissions, and only updates `CODEX_AUTH_JSON` secrets when Codex actually refreshes `auth.json`.

#### Which issue(s) this PR is related to:

Fixes #1260

#### Special notes for your reviewer:

- Sets `~/.codex` to mode `700`
- Sets `~/.codex/auth.json` to mode `600`
- Leaves existing secrets unchanged when Codex does not refresh `auth.json`
- Keeps the branch squashed to one commit authored by Gunju Kim

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
