### PR TITLE
feat(cli): Support env variables in config file

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -567,6 +567,35 @@ The `token` and `githubApp` fields are mutually exclusive. If both `name` and `r
 | `namespace` | Default Kubernetes namespace |
 | `agentConfig` | Default AgentConfig resource name |
 
+### Environment Variables
+
+The `env` field defines additional environment variables injected into task pods via `Task.spec.podOverrides.env`. CLI `--env` flags take precedence over config values on name collision.
+
+| Field | Description |
+|-------|-------------|
+| `env[].name` | Variable name (must match `[A-Za-z_][A-Za-z0-9_]*`) |
+| `env[].value` | Plain-text value (mutually exclusive with `valueFrom`) |
+| `env[].valueFrom.secretKeyRef` | Reference a Kubernetes Secret (`name` and `key` required). Resolves in the Task pod's namespace. |
+| `env[].valueFrom.configMapKeyRef` | Reference a Kubernetes ConfigMap (`name` and `key` required). Resolves in the Task pod's namespace. |
+
+```yaml
+env:
+  - name: CLAUDE_CODE_USE_BEDROCK
+    value: "1"
+  - name: AWS_REGION
+    value: us-west-2
+  - name: MY_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: my-k8s-secret
+        key: token
+  - name: APP_CONFIG
+    valueFrom:
+      configMapKeyRef:
+        name: my-configmap
+        key: app.conf
+```
+
 ## CLI Reference
 
 The `kelos` CLI lets you manage the full lifecycle without writing YAML.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
+
+var envVarNameRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // Config holds configuration loaded from the kelos config file.
 type Config struct {
@@ -20,6 +24,32 @@ type Config struct {
 	Namespace      string          `json:"namespace,omitempty"`
 	Workspace      WorkspaceConfig `json:"workspace,omitempty"`
 	AgentConfig    string          `json:"agentConfig,omitempty"`
+	Env            []EnvVar        `json:"env,omitempty"`
+}
+
+// EnvVar represents an environment variable in the config file.
+type EnvVar struct {
+	Name      string        `json:"name"`
+	Value     *string       `json:"value,omitempty"`
+	ValueFrom *EnvVarSource `json:"valueFrom,omitempty"`
+}
+
+// EnvVarSource represents a source for an environment variable's value.
+// Only secretKeyRef and configMapKeyRef are supported.
+type EnvVarSource struct {
+	SecretKeyRef    *corev1.SecretKeySelector    `json:"secretKeyRef,omitempty"`
+	ConfigMapKeyRef *corev1.ConfigMapKeySelector `json:"configMapKeyRef,omitempty"`
+}
+
+// ToCorev1EnvVarSource converts to a Kubernetes EnvVarSource.
+func (s *EnvVarSource) ToCorev1EnvVarSource() *corev1.EnvVarSource {
+	if s == nil {
+		return nil
+	}
+	return &corev1.EnvVarSource{
+		SecretKeyRef:    s.SecretKeyRef,
+		ConfigMapKeyRef: s.ConfigMapKeyRef,
+	}
 }
 
 // WorkspaceConfig holds workspace-related configuration.
@@ -73,5 +103,44 @@ func LoadConfig(path string) (*Config, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
 	}
+	if err := validateEnvVars(cfg.Env); err != nil {
+		return nil, fmt.Errorf("config file %s: %w", path, err)
+	}
 	return cfg, nil
+}
+
+func validateEnvVars(envVars []EnvVar) error {
+	for i, ev := range envVars {
+		if ev.Name == "" {
+			return fmt.Errorf("env[%d]: name is required", i)
+		}
+		if !envVarNameRegexp.MatchString(ev.Name) {
+			return fmt.Errorf("env[%d]: invalid name %q: must match [A-Za-z_][A-Za-z0-9_]*", i, ev.Name)
+		}
+		if ev.Value != nil && ev.ValueFrom != nil {
+			return fmt.Errorf("env[%d] %q: value and valueFrom are mutually exclusive", i, ev.Name)
+		}
+		if ev.Value == nil && ev.ValueFrom == nil {
+			return fmt.Errorf("env[%d] %q: one of value or valueFrom is required", i, ev.Name)
+		}
+		if ev.ValueFrom != nil {
+			if ev.ValueFrom.SecretKeyRef == nil && ev.ValueFrom.ConfigMapKeyRef == nil {
+				return fmt.Errorf("env[%d] %q: valueFrom must specify secretKeyRef or configMapKeyRef", i, ev.Name)
+			}
+			if ev.ValueFrom.SecretKeyRef != nil && ev.ValueFrom.ConfigMapKeyRef != nil {
+				return fmt.Errorf("env[%d] %q: valueFrom must specify only one of secretKeyRef or configMapKeyRef", i, ev.Name)
+			}
+			if ref := ev.ValueFrom.SecretKeyRef; ref != nil {
+				if ref.Name == "" || ref.Key == "" {
+					return fmt.Errorf("env[%d] %q: secretKeyRef requires both name and key", i, ev.Name)
+				}
+			}
+			if ref := ev.ValueFrom.ConfigMapKeyRef; ref != nil {
+				if ref.Name == "" || ref.Key == "" {
+					return fmt.Errorf("env[%d] %q: configMapKeyRef requires both name and key", i, ev.Name)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -234,6 +235,222 @@ func TestLoadConfig_AgentConfig(t *testing.T) {
 	}
 	if cfg.AgentConfig != "my-agent-config" {
 		t.Errorf("AgentConfig = %q, want %q", cfg.AgentConfig, "my-agent-config")
+	}
+}
+
+func TestLoadConfig_Env(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `env:
+  - name: CLAUDE_CODE_USE_BEDROCK
+    value: "1"
+  - name: AWS_REGION
+    value: us-west-2
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Env) != 2 {
+		t.Fatalf("Env length = %d, want 2", len(cfg.Env))
+	}
+	if cfg.Env[0].Name != "CLAUDE_CODE_USE_BEDROCK" || cfg.Env[0].Value == nil || *cfg.Env[0].Value != "1" {
+		t.Errorf("Env[0] = %+v, want CLAUDE_CODE_USE_BEDROCK=1", cfg.Env[0])
+	}
+	if cfg.Env[1].Name != "AWS_REGION" || cfg.Env[1].Value == nil || *cfg.Env[1].Value != "us-west-2" {
+		t.Errorf("Env[1] = %+v, want AWS_REGION=us-west-2", cfg.Env[1])
+	}
+}
+
+func TestLoadConfig_EnvEmptyValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `env:
+  - name: FOO
+    value: ""
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Env) != 1 {
+		t.Fatalf("Env length = %d, want 1", len(cfg.Env))
+	}
+	if cfg.Env[0].Name != "FOO" {
+		t.Errorf("Env[0].Name = %q, want FOO", cfg.Env[0].Name)
+	}
+	if cfg.Env[0].Value == nil {
+		t.Fatal("Env[0].Value is nil, want pointer to empty string")
+	}
+	if *cfg.Env[0].Value != "" {
+		t.Errorf("Env[0].Value = %q, want empty string", *cfg.Env[0].Value)
+	}
+}
+
+func TestLoadConfig_EnvValueFrom(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `env:
+  - name: MY_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: token
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Env) != 1 {
+		t.Fatalf("Env length = %d, want 1", len(cfg.Env))
+	}
+	if cfg.Env[0].Name != "MY_SECRET" {
+		t.Errorf("Env[0].Name = %q, want MY_SECRET", cfg.Env[0].Name)
+	}
+	if cfg.Env[0].ValueFrom == nil {
+		t.Fatal("Env[0].ValueFrom is nil")
+	}
+	if cfg.Env[0].ValueFrom.SecretKeyRef == nil {
+		t.Fatal("Env[0].ValueFrom.SecretKeyRef is nil")
+	}
+	if cfg.Env[0].ValueFrom.SecretKeyRef.LocalObjectReference.Name != "my-secret" {
+		t.Errorf("SecretKeyRef.Name = %q, want my-secret", cfg.Env[0].ValueFrom.SecretKeyRef.LocalObjectReference.Name)
+	}
+	if cfg.Env[0].ValueFrom.SecretKeyRef.Key != "token" {
+		t.Errorf("SecretKeyRef.Key = %q, want token", cfg.Env[0].ValueFrom.SecretKeyRef.Key)
+	}
+}
+
+func TestLoadConfig_EnvValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "empty name",
+			yaml: `env:
+  - name: ""
+    value: x
+`,
+			wantErr: "env[0]: name is required",
+		},
+		{
+			name: "invalid name",
+			yaml: `env:
+  - name: "1BAD"
+    value: x
+`,
+			wantErr: `env[0]: invalid name "1BAD"`,
+		},
+		{
+			name: "both value and valueFrom",
+			yaml: `env:
+  - name: FOO
+    value: bar
+    valueFrom:
+      secretKeyRef:
+        name: s
+        key: k
+`,
+			wantErr: `env[0] "FOO": value and valueFrom are mutually exclusive`,
+		},
+		{
+			name: "neither value nor valueFrom",
+			yaml: `env:
+  - name: FOO
+`,
+			wantErr: `env[0] "FOO": one of value or valueFrom is required`,
+		},
+		{
+			name: "valueFrom without ref",
+			yaml: `env:
+  - name: FOO
+    valueFrom: {}
+`,
+			wantErr: `env[0] "FOO": valueFrom must specify secretKeyRef or configMapKeyRef`,
+		},
+		{
+			name: "secretKeyRef missing key",
+			yaml: `env:
+  - name: FOO
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+`,
+			wantErr: `env[0] "FOO": secretKeyRef requires both name and key`,
+		},
+		{
+			name: "configMapKeyRef missing name",
+			yaml: `env:
+  - name: FOO
+    valueFrom:
+      configMapKeyRef:
+        key: k
+`,
+			wantErr: `env[0] "FOO": configMapKeyRef requires both name and key`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadConfig(path)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_EnvConfigMapKeyRef(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `env:
+  - name: APP_CONF
+    valueFrom:
+      configMapKeyRef:
+        name: my-cm
+        key: app.conf
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Env) != 1 {
+		t.Fatalf("Env length = %d, want 1", len(cfg.Env))
+	}
+	if cfg.Env[0].ValueFrom == nil || cfg.Env[0].ValueFrom.ConfigMapKeyRef == nil {
+		t.Fatal("expected ConfigMapKeyRef to be set")
+	}
+	if cfg.Env[0].ValueFrom.ConfigMapKeyRef.Name != "my-cm" {
+		t.Errorf("ConfigMapKeyRef.Name = %q, want my-cm", cfg.Env[0].ValueFrom.ConfigMapKeyRef.Name)
+	}
+	if cfg.Env[0].ValueFrom.ConfigMapKeyRef.Key != "app.conf" {
+		t.Errorf("ConfigMapKeyRef.Key = %q, want app.conf", cfg.Env[0].ValueFrom.ConfigMapKeyRef.Key)
 	}
 }
 

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -999,6 +999,131 @@ func TestRunCommand_DryRun_NoneCredentialType_ConfigFile(t *testing.T) {
 	}
 }
 
+func TestRunCommand_DryRun_EnvFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `secret: my-secret
+env:
+  - name: CLAUDE_CODE_USE_BEDROCK
+    value: "1"
+  - name: AWS_REGION
+    value: us-west-2
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--dry-run",
+		"--prompt", "hello",
+		"--name", "env-cfg-task",
+		"--namespace", "test-ns",
+	})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "CLAUDE_CODE_USE_BEDROCK") {
+		t.Errorf("expected CLAUDE_CODE_USE_BEDROCK in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "AWS_REGION") {
+		t.Errorf("expected AWS_REGION in output, got:\n%s", output)
+	}
+}
+
+func TestRunCommand_DryRun_EnvFlagOverridesConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `secret: my-secret
+env:
+  - name: AWS_REGION
+    value: us-west-2
+  - name: OTHER_VAR
+    value: keep-me
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--dry-run",
+		"--prompt", "hello",
+		"--name", "env-override-task",
+		"--namespace", "test-ns",
+		"--env", "AWS_REGION=us-east-1",
+	})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "us-east-1") {
+		t.Errorf("expected overridden AWS_REGION=us-east-1 in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "us-west-2") {
+		t.Errorf("expected config AWS_REGION=us-west-2 to be overridden, got:\n%s", output)
+	}
+	// The override should appear after OTHER_VAR (last position wins).
+	otherIdx := strings.Index(output, "OTHER_VAR")
+	regionIdx := strings.Index(output, "AWS_REGION")
+	if otherIdx >= 0 && regionIdx >= 0 && regionIdx < otherIdx {
+		t.Errorf("expected overridden AWS_REGION to appear after OTHER_VAR (last position wins), got:\n%s", output)
+	}
+	if !strings.Contains(output, "OTHER_VAR") {
+		t.Errorf("expected OTHER_VAR from config to be preserved, got:\n%s", output)
+	}
+}
+
+func TestRunCommand_DryRun_EnvValueFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `secret: my-secret
+env:
+  - name: MY_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: my-k8s-secret
+        key: token
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{
+		"run",
+		"--config", cfgPath,
+		"--dry-run",
+		"--prompt", "hello",
+		"--name", "env-vf-task",
+		"--namespace", "test-ns",
+	})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "MY_SECRET") {
+		t.Errorf("expected MY_SECRET env var in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "my-k8s-secret") {
+		t.Errorf("expected secretKeyRef name in output, got:\n%s", output)
+	}
+}
+
 func TestRunCommand_DryRun_PromptFile(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -63,6 +63,17 @@ oauthToken: ""
 # Default AgentConfig resource (optional)
 # agentConfig: my-agent-config
 
+# Additional environment variables injected into task pods (optional)
+# secretKeyRef/configMapKeyRef resolve in the Task pod's namespace.
+# env:
+#   - name: CLAUDE_CODE_USE_BEDROCK
+#     value: "1"
+#   - name: MY_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-k8s-secret
+#         key: token
+
 # Advanced: provide your own Kubernetes secret directly
 # secret: ""
 # credentialType: oauth

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -287,20 +287,52 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				}
 				po.ActiveDeadlineSeconds = &secs
 			}
-			if len(envFlags) > 0 {
-				if po == nil {
-					po = &kelos.PodOverrides{}
+			// Merge env vars: start with config file env, then --env flags override.
+			var envVars []corev1.EnvVar
+			if c := cfg.Config; c != nil && len(c.Env) > 0 {
+				for _, e := range c.Env {
+					ev := corev1.EnvVar{
+						Name:      e.Name,
+						ValueFrom: e.ValueFrom.ToCorev1EnvVarSource(),
+					}
+					if e.Value != nil {
+						ev.Value = *e.Value
+					}
+					envVars = append(envVars, ev)
 				}
+			}
+			if len(envFlags) > 0 {
 				for _, e := range envFlags {
 					parts := strings.SplitN(e, "=", 2)
 					if len(parts) != 2 || parts[0] == "" {
 						return fmt.Errorf("invalid --env value %q: must be NAME=VALUE", e)
 					}
-					po.Env = append(po.Env, corev1.EnvVar{
+					envVars = append(envVars, corev1.EnvVar{
 						Name:  parts[0],
 						Value: parts[1],
 					})
 				}
+			}
+			// Deduplicate: last occurrence wins (--env overrides config).
+			// Iterate in reverse so the last occurrence keeps its position.
+			if len(envVars) > 0 {
+				seen := make(map[string]struct{})
+				deduped := make([]corev1.EnvVar, 0, len(envVars))
+				for i := len(envVars) - 1; i >= 0; i-- {
+					if _, ok := seen[envVars[i].Name]; ok {
+						continue
+					}
+					seen[envVars[i].Name] = struct{}{}
+					deduped = append(deduped, envVars[i])
+				}
+				// Reverse to restore original relative order.
+				for i, j := 0, len(deduped)-1; i < j; i, j = i+1, j-1 {
+					deduped[i], deduped[j] = deduped[j], deduped[i]
+				}
+				if po == nil {
+					po = &kelos.PodOverrides{}
+				}
+				po.Env = deduped
 			}
 			if po != nil {
 				task.Spec.PodOverrides = po


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an `env` field to the CLI config file (`~/.kelos/config.yaml`) so users can persist environment variables that are automatically applied to every task created via `kelos run`. This removes the need to pass `--env` flags repeatedly for common variables like Bedrock configuration.

Supports:
- Plain `name: value` pairs
- `valueFrom` with `secretKeyRef` and `configMapKeyRef` for referencing Kubernetes secrets/configmaps

Merge semantics: config env vars form the base, `--env` flags override by name (last occurrence wins).

Example config:
```yaml
env:
  - name: CLAUDE_CODE_USE_BEDROCK
    value: "1"
  - name: AWS_REGION
    value: us-west-2
  - name: MY_SECRET
    valueFrom:
      secretKeyRef:
        name: my-k8s-secret
        key: token
```

#### Which issue(s) this PR is related to:

Fixes #1114

#### Special notes for your reviewer:

The `EnvVarConfig` type uses `corev1.EnvVarSource` directly for `valueFrom` to get full compatibility with Kubernetes secret/configmap references without reinventing the schema.

#### Does this PR introduce a user-facing change?

```release-note
CLI config file now supports an `env` field for persistent environment variables applied to all tasks. Supports plain values and valueFrom (secretKeyRef/configMapKeyRef). The --env flag overrides config values.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `env` field to the CLI config to persist default environment variables for all tasks. Supports plain values and Kubernetes `valueFrom` refs; `--env` flags override by name.

- **New Features**
  - `~/.kelos/config.yaml` accepts `env` entries: name/value or `valueFrom` (`secretKeyRef`/`configMapKeyRef`) with a narrow `EnvVarSource`; injected via `Task.spec.podOverrides.env`.
  - Merge rules: config first, then `--env NAME=VALUE`; last wins and deduplicates by name while keeping order. Dry-run output shows the merged env.

- **Refactors**
  - Added fail-fast validation (name regex, value/valueFrom exclusivity, single ref with required fields), updated docs and `kelos init` template, and expanded tests.

<sup>Written for commit 12ce2d941211d7a982a80f45b60eab19db4bde60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

