### PR TITLE
fix(chart): slack-server RBAC to allow updating tasks

### DIFF
--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -317,6 +317,8 @@ rules:
       - create
       - get
       - list
+      - update
+      - watch
   - apiGroups:
       - kelos.dev
     resources:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `kelos-slack-server` service account cannot update Task objects in agent namespaces, causing the Slack reporting cycle to fail with a forbidden error when persisting annotations:

```
tasks.kelos.dev "slack-general-slack-97c6684a8a42" is forbidden:
User "system:serviceaccount:kelos-system:kelos-slack-server" cannot update
resource "tasks" in API group "kelos.dev" in the namespace "kelos-agents"
```

This adds `update` and `watch` verbs to the `kelos-slack-server-role` ClusterRole's tasks rule

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RBAC so the Slack server can update Task objects. This unblocks the Slack reporting cycle by allowing annotations to be persisted.

- **Bug Fixes**
  - Added update and watch verbs to `kelos-slack-server-role` for `tasks.kelos.dev` in agent namespaces.

<sup>Written for commit f09ab3f2c51aa8c1bab2385d534df6df17865def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

