### PR TITLE
Fix/plugin configmap delivery

### DIFF
--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -60,6 +60,15 @@ const (
 	// PluginMountPath is the mount path for the plugin volume.
 	PluginMountPath = "/kelos/plugin"
 
+	// PluginStagingVolumeName is the name of the read-only volume that
+	// stages plugin content from the per-task plugin ConfigMap into the
+	// plugin-setup init container.
+	PluginStagingVolumeName = "kelos-plugin-src"
+
+	// PluginStagingMountPath is the mount path for the plugin staging
+	// volume inside the plugin-setup init container.
+	PluginStagingMountPath = "/kelos-plugin-src"
+
 	// SkillsShPluginName is the plugin directory name under PluginMountPath
 	// that skills.sh packages are installed into, so agent entrypoints
 	// discover them the same way as inline plugins.
@@ -428,6 +437,9 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 			MountPath: WorkspaceMountPath,
 		}
 
+		targetPath := WorkspaceMountPath + "/repo"
+		commitRef := isFullGitCommitSHA(workspace.Ref)
+
 		// Workspace volume mounts shared by every container that needs
 		// the cloned repo plus, when a token Secret is configured, the
 		// auto-syncing token file.
@@ -453,10 +465,10 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 		}
 
 		cloneArgs := []string{"clone"}
-		if workspace.Ref != "" {
+		if workspace.Ref != "" && !commitRef {
 			cloneArgs = append(cloneArgs, "--branch", workspace.Ref)
 		}
-		cloneArgs = append(cloneArgs, "--no-single-branch", "--depth", "1", "--", workspace.Repo, WorkspaceMountPath+"/repo")
+		cloneArgs = append(cloneArgs, "--no-single-branch", "--depth", "1", "--", workspace.Repo, targetPath)
 
 		initContainer := corev1.Container{
 			Name:         "git-clone",
@@ -469,7 +481,14 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 			},
 		}
 
-		if workspace.SecretRef != nil {
+		if commitRef {
+			credentialHelper := ""
+			if workspace.SecretRef != nil {
+				credentialHelper = gitCredentialHelper()
+			}
+			initContainer.Command = []string{"sh", "-c", buildCommitRefCheckoutScript(credentialHelper)}
+			initContainer.Args = []string{"--", workspace.Repo, targetPath, workspace.Ref}
+		} else if workspace.SecretRef != nil {
 			credentialHelper := gitCredentialHelper()
 			// Clear inherited credential helpers with an empty -c credential.helper=
 			// before setting the workspace helper, then persist the same
@@ -604,16 +623,34 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 		}
 
 		if len(agentConfig.Plugins) > 0 {
-			script, err := buildPluginSetupScript(agentConfig.Plugins)
+			// Plugin content is delivered through a per-task ConfigMap
+			// (created by the Task reconciler) and staged into the
+			// plugin-setup init container as a read-only volume. Inlining
+			// the content into the init script would hit Linux's 128KiB
+			// MAX_ARG_STRLEN limit on a single execve argument for large
+			// plugin sets.
+			_, items, err := buildPluginConfigMapData(agentConfig.Plugins)
 			if err != nil {
 				return nil, fmt.Errorf("invalid plugin configuration: %w", err)
 			}
+			volumes = append(volumes, corev1.Volume{
+				Name: PluginStagingVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: PluginConfigMapName(task.Name),
+						},
+						Items: items,
+					},
+				},
+			})
 			initContainers = append(initContainers, corev1.Container{
 				Name:    "plugin-setup",
 				Image:   GitCloneImage,
-				Command: []string{"sh", "-c", script},
+				Command: []string{"sh", "-c", pluginSetupScript},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: PluginVolumeName, MountPath: PluginMountPath},
+					{Name: PluginStagingVolumeName, MountPath: PluginStagingMountPath, ReadOnly: true},
 				},
 				SecurityContext: &corev1.SecurityContext{RunAsUser: &agentUID},
 			})
@@ -892,6 +929,45 @@ func validatePodFailurePolicy(policy *batchv1.PodFailurePolicy) error {
 	return nil
 }
 
+func isFullGitCommitSHA(ref string) bool {
+	if len(ref) != 40 {
+		return false
+	}
+	for _, c := range ref {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func buildCommitRefCheckoutScript(credentialHelper string) string {
+	fetchCmd := `git -C "$target" fetch --depth 1 origin "$ref"`
+	if credentialHelper != "" {
+		fetchCmd = fmt.Sprintf(`git -C "$target" -c credential.helper= -c credential.helper='%s' fetch --depth 1 origin "$ref"`, credentialHelper)
+	}
+
+	lines := []string{
+		"set -eu",
+		"repo=$1",
+		"target=$2",
+		"ref=$3",
+		`git init "$target"`,
+		`git -C "$target" remote add origin "$repo"`,
+		fetchCmd,
+		`git -C "$target" checkout --detach FETCH_HEAD`,
+	}
+
+	if credentialHelper != "" {
+		lines = append(lines,
+			`git -C "$target" config --unset-all credential.helper 2>/dev/null || true`,
+			fmt.Sprintf(`git -C "$target" config --add credential.helper '%s'`, credentialHelper),
+		)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 // gitCredentialHelper returns the inline git credential helper that resolves
 // the GitHub token by reading the mounted token file on each invocation,
 // falling back to the inherited $GITHUB_TOKEN env var when the file is not
@@ -999,42 +1075,101 @@ func sanitizeComponentName(name, kind string) error {
 	return nil
 }
 
-func buildPluginSetupScript(plugins []kelos.PluginSpec) (string, error) {
-	lines := []string{"set -eu"}
+// pluginConfigMapMaxBytes caps the total plugin content placed in the
+// per-task plugin ConfigMap. Kubernetes rejects objects whose total size
+// exceeds 1MiB (the etcd request limit), so we stop a bit short of that to
+// leave headroom for keys, metadata, and the API server's JSON envelope.
+const pluginConfigMapMaxBytes = 900 * 1024
 
-	for _, plugin := range plugins {
+// pluginSetupScript copies the staged plugin tree from the read-only
+// ConfigMap mount into the writable plugin emptyDir volume. The kubelet's
+// atomic writer materializes ConfigMap items as symlinks into hidden
+// "..data"/"..<timestamp>" directories, so the copy dereferences symlinks
+// (-L) and skips the kubelet-internal "..*" entries. The script is a small
+// constant: plugin content never appears in the sh -c argument, keeping it
+// far below Linux's 128KiB MAX_ARG_STRLEN execve limit. ConfigMap-mounted
+// files are world-readable, so a plain copy running as AgentUID produces
+// files owned by (and readable as) the agent user.
+const pluginSetupScript = "set -eu\n" +
+	"find " + PluginStagingMountPath + " -mindepth 1 -maxdepth 1 ! -name '..*' " +
+	"-exec cp -RL {} " + PluginMountPath + "/ ';'"
+
+// PluginConfigMapName returns the name of the per-task ConfigMap that
+// carries plugin skill and agent content for the given task.
+func PluginConfigMapName(taskName string) string {
+	return taskName + "-plugins"
+}
+
+// buildPluginConfigMapData validates plugin, skill, and agent names and
+// produces the plugin ConfigMap payload: a flat map of safe keys
+// ("p<i>-s<j>" for skills, "p<i>-a<j>" for agents; ConfigMap keys must
+// match [-._a-zA-Z0-9]+) to content blobs, plus the volume projection
+// items mapping each key to its nested path under the plugin directory
+// ("<plugin>/skills/<skill>/SKILL.md", "<plugin>/agents/<agent>.md").
+func buildPluginConfigMapData(plugins []kelos.PluginSpec) (map[string]string, []corev1.KeyToPath, error) {
+	data := map[string]string{}
+	var items []corev1.KeyToPath
+	totalBytes := 0
+
+	for i, plugin := range plugins {
 		if err := sanitizeComponentName(plugin.Name, "plugin"); err != nil {
-			return "", err
+			return nil, nil, err
 		}
 
-		for _, skill := range plugin.Skills {
+		for j, skill := range plugin.Skills {
 			if err := sanitizeComponentName(skill.Name, "skill"); err != nil {
-				return "", err
+				return nil, nil, err
 			}
-			dir := path.Join(PluginMountPath, plugin.Name, "skills", skill.Name)
-			target := path.Join(dir, "SKILL.md")
-			contentBase64 := base64.StdEncoding.EncodeToString([]byte(skill.Content))
-			lines = append(lines,
-				fmt.Sprintf("mkdir -p %s", shellQuote(dir)),
-				fmt.Sprintf("printf '%%s' %s | base64 -d > %s", shellQuote(contentBase64), shellQuote(target)),
-			)
+			key := fmt.Sprintf("p%d-s%d", i, j)
+			data[key] = skill.Content
+			totalBytes += len(skill.Content)
+			items = append(items, corev1.KeyToPath{
+				Key:  key,
+				Path: path.Join(plugin.Name, "skills", skill.Name, "SKILL.md"),
+			})
 		}
 
-		for _, agent := range plugin.Agents {
+		for j, agent := range plugin.Agents {
 			if err := sanitizeComponentName(agent.Name, "agent"); err != nil {
-				return "", err
+				return nil, nil, err
 			}
-			dir := path.Join(PluginMountPath, plugin.Name, "agents")
-			target := path.Join(dir, agent.Name+".md")
-			contentBase64 := base64.StdEncoding.EncodeToString([]byte(agent.Content))
-			lines = append(lines,
-				fmt.Sprintf("mkdir -p %s", shellQuote(dir)),
-				fmt.Sprintf("printf '%%s' %s | base64 -d > %s", shellQuote(contentBase64), shellQuote(target)),
-			)
+			key := fmt.Sprintf("p%d-a%d", i, j)
+			data[key] = agent.Content
+			totalBytes += len(agent.Content)
+			items = append(items, corev1.KeyToPath{
+				Key:  key,
+				Path: path.Join(plugin.Name, "agents", agent.Name+".md"),
+			})
 		}
 	}
 
-	return strings.Join(lines, "\n"), nil
+	if totalBytes > pluginConfigMapMaxBytes {
+		return nil, nil, fmt.Errorf(
+			"plugin content totals %d bytes, exceeding the %d byte ConfigMap budget; reduce skill/agent content size",
+			totalBytes, pluginConfigMapMaxBytes,
+		)
+	}
+
+	return data, items, nil
+}
+
+// buildPluginConfigMap produces the per-task ConfigMap that delivers plugin
+// skill and agent content to the plugin-setup init container. The Job built
+// by JobBuilder.Build mounts this ConfigMap by name, so it must be created
+// before the Job.
+func buildPluginConfigMap(task *kelos.Task, plugins []kelos.PluginSpec) (*corev1.ConfigMap, error) {
+	data, _, err := buildPluginConfigMapData(plugins)
+	if err != nil {
+		return nil, fmt.Errorf("invalid plugin configuration: %w", err)
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PluginConfigMapName(task.Name),
+			Namespace: task.Namespace,
+		},
+		Data: data,
+	}, nil
 }
 
 type skillsAuthEnv struct {

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -259,6 +259,75 @@ func TestBuildClaudeCodeJob_WorkspaceWithRef(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeCodeJob_WorkspaceWithCommitRefFetchesDetached(t *testing.T) {
+	builder := NewJobBuilder()
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workspace-commit",
+			Namespace: "default",
+		},
+		Spec: kelos.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix the code",
+			Credentials: kelos.Credentials{
+				Type:      kelos.CredentialTypeAPIKey,
+				SecretRef: &kelos.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+
+	sha := "c44211cb54d861d9445de16a0e8ce96d7f29637d"
+	workspace := &kelos.WorkspaceSpec{
+		Repo: "https://github.com/example/repo.git",
+		Ref:  sha,
+		SecretRef: &kelos.SecretReference{
+			Name: "github-token",
+		},
+	}
+
+	job, err := builder.Build(task, workspace, nil, task.Spec.Prompt)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	initContainer := job.Spec.Template.Spec.InitContainers[0]
+	for _, arg := range initContainer.Args {
+		if arg == "--branch" {
+			t.Fatalf("Commit refs must not be cloned with --branch: %v", initContainer.Args)
+		}
+	}
+
+	expectedArgs := []string{
+		"--", "https://github.com/example/repo.git", WorkspaceMountPath + "/repo", sha,
+	}
+	if len(initContainer.Args) != len(expectedArgs) {
+		t.Fatalf("Expected %d clone args, got %d: %v", len(expectedArgs), len(initContainer.Args), initContainer.Args)
+	}
+	for i, arg := range expectedArgs {
+		if initContainer.Args[i] != arg {
+			t.Errorf("Clone args[%d]: expected %q, got %q", i, arg, initContainer.Args[i])
+		}
+	}
+
+	if len(initContainer.Command) != 3 || initContainer.Command[0] != "sh" || initContainer.Command[1] != "-c" {
+		t.Fatalf("Expected command [sh -c ...], got %v", initContainer.Command)
+	}
+
+	script := initContainer.Command[2]
+	for _, want := range []string{
+		`git init "$target"`,
+		`git -C "$target" remote add origin "$repo"`,
+		`fetch --depth 1 origin "$ref"`,
+		`checkout --detach FETCH_HEAD`,
+		"-c credential.helper= -c credential.helper=",
+		"--add credential.helper",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("Expected commit checkout script to contain %q, got %q", want, script)
+		}
+	}
+}
+
 func TestBuildClaudeCodeJob_WorkspaceWithInjectedFiles(t *testing.T) {
 	builder := NewJobBuilder()
 	task := &kelos.Task{
@@ -2717,6 +2786,34 @@ func TestBuildJob_AgentConfigPlugins(t *testing.T) {
 		t.Error("Expected plugin volume to be created")
 	}
 
+	// Should have a staging volume sourcing the per-task plugin ConfigMap,
+	// with items projecting each key to its nested plugin path.
+	var stagingVolume *corev1.Volume
+	for i := range job.Spec.Template.Spec.Volumes {
+		if job.Spec.Template.Spec.Volumes[i].Name == PluginStagingVolumeName {
+			stagingVolume = &job.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	if stagingVolume == nil {
+		t.Fatal("Expected plugin staging volume to be created")
+	}
+	if stagingVolume.VolumeSource.ConfigMap == nil {
+		t.Fatal("Expected ConfigMap volume source for plugin staging volume")
+	}
+	if got, want := stagingVolume.VolumeSource.ConfigMap.Name, PluginConfigMapName(task.Name); got != want {
+		t.Errorf("Expected staging volume ConfigMap name %q, got %q", want, got)
+	}
+	itemPaths := map[string]string{}
+	for _, item := range stagingVolume.VolumeSource.ConfigMap.Items {
+		itemPaths[item.Key] = item.Path
+	}
+	if itemPaths["p0-s0"] != "team-tools/skills/deploy/SKILL.md" {
+		t.Errorf("Expected item p0-s0 to map to skill path, got %q", itemPaths["p0-s0"])
+	}
+	if itemPaths["p0-a0"] != "team-tools/agents/reviewer.md" {
+		t.Errorf("Expected item p0-a0 to map to agent path, got %q", itemPaths["p0-a0"])
+	}
+
 	// Should have plugin-setup init container.
 	if len(job.Spec.Template.Spec.InitContainers) != 1 {
 		t.Fatalf("Expected 1 init container, got %d", len(job.Spec.Template.Spec.InitContainers))
@@ -2729,23 +2826,33 @@ func TestBuildJob_AgentConfigPlugins(t *testing.T) {
 		t.Errorf("Expected init container image %q, got %q", GitCloneImage, initContainer.Image)
 	}
 
-	// Verify script contains expected paths.
-	script := initContainer.Command[2]
-	if !strings.Contains(script, PluginMountPath+"/team-tools/skills/deploy/SKILL.md") {
-		t.Errorf("Expected script to target skill path, got: %s", script)
+	// The init script must be the constant copy script: plugin content is
+	// staged via the ConfigMap volume, never inlined into the sh -c
+	// argument (Linux caps a single execve argument at 128KiB).
+	if got := initContainer.Command[2]; got != pluginSetupScript {
+		t.Errorf("Expected constant plugin setup script %q, got %q", pluginSetupScript, got)
 	}
-	if !strings.Contains(script, PluginMountPath+"/team-tools/agents/reviewer.md") {
-		t.Errorf("Expected script to target agent path, got: %s", script)
+	if strings.Contains(initContainer.Command[2], "base64") {
+		t.Error("Expected plugin setup script to not inline base64 content")
 	}
 
-	// Verify base64-encoded content in script.
-	skillBase64 := base64.StdEncoding.EncodeToString([]byte("Deploy instructions here"))
-	if !strings.Contains(script, skillBase64) {
-		t.Error("Expected script to include base64-encoded skill content")
+	// Init container should mount the staging volume read-only and the
+	// writable plugin volume.
+	stagingMounted := false
+	pluginMounted := false
+	for _, vm := range initContainer.VolumeMounts {
+		if vm.Name == PluginStagingVolumeName && vm.MountPath == PluginStagingMountPath && vm.ReadOnly {
+			stagingMounted = true
+		}
+		if vm.Name == PluginVolumeName && vm.MountPath == PluginMountPath {
+			pluginMounted = true
+		}
 	}
-	agentBase64 := base64.StdEncoding.EncodeToString([]byte("You are a code reviewer"))
-	if !strings.Contains(script, agentBase64) {
-		t.Error("Expected script to include base64-encoded agent content")
+	if !stagingMounted {
+		t.Error("Expected read-only staging volume mount on plugin-setup init container")
+	}
+	if !pluginMounted {
+		t.Error("Expected plugin volume mount on plugin-setup init container")
 	}
 
 	// Main container should have plugin volume mount.
@@ -2769,6 +2876,141 @@ func TestBuildJob_AgentConfigPlugins(t *testing.T) {
 	}
 	if envMap["KELOS_PLUGIN_DIR"] != PluginMountPath {
 		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
+	}
+}
+
+func TestBuildPluginConfigMap(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-plugins",
+			Namespace: "default",
+		},
+	}
+
+	plugins := []kelos.PluginSpec{
+		{
+			Name: "team-tools",
+			Skills: []kelos.SkillDefinition{
+				{Name: "deploy", Content: "Deploy instructions here"},
+				{Name: "release", Content: "Release instructions here"},
+			},
+			Agents: []kelos.AgentDefinition{
+				{Name: "reviewer", Content: "You are a code reviewer"},
+			},
+		},
+		{
+			Name: "extra",
+			Agents: []kelos.AgentDefinition{
+				{Name: "linter", Content: "You are a linter"},
+			},
+		},
+	}
+
+	configMap, err := buildPluginConfigMap(task, plugins)
+	if err != nil {
+		t.Fatalf("buildPluginConfigMap() returned error: %v", err)
+	}
+
+	if configMap.Name != "test-plugins-plugins" {
+		t.Errorf("Expected ConfigMap name %q, got %q", "test-plugins-plugins", configMap.Name)
+	}
+	if configMap.Namespace != "default" {
+		t.Errorf("Expected ConfigMap namespace %q, got %q", "default", configMap.Namespace)
+	}
+
+	wantData := map[string]string{
+		"p0-s0": "Deploy instructions here",
+		"p0-s1": "Release instructions here",
+		"p0-a0": "You are a code reviewer",
+		"p1-a0": "You are a linter",
+	}
+	if len(configMap.Data) != len(wantData) {
+		t.Fatalf("Expected %d data keys, got %d: %v", len(wantData), len(configMap.Data), configMap.Data)
+	}
+	for key, want := range wantData {
+		if got := configMap.Data[key]; got != want {
+			t.Errorf("Expected data[%q]=%q, got %q", key, want, got)
+		}
+	}
+
+	// The volume items must map each flat key to its nested plugin path.
+	_, items, err := buildPluginConfigMapData(plugins)
+	if err != nil {
+		t.Fatalf("buildPluginConfigMapData() returned error: %v", err)
+	}
+	wantPaths := map[string]string{
+		"p0-s0": "team-tools/skills/deploy/SKILL.md",
+		"p0-s1": "team-tools/skills/release/SKILL.md",
+		"p0-a0": "team-tools/agents/reviewer.md",
+		"p1-a0": "extra/agents/linter.md",
+	}
+	if len(items) != len(wantPaths) {
+		t.Fatalf("Expected %d volume items, got %d: %v", len(wantPaths), len(items), items)
+	}
+	for _, item := range items {
+		if want := wantPaths[item.Key]; item.Path != want {
+			t.Errorf("Expected item %q path %q, got %q", item.Key, want, item.Path)
+		}
+	}
+}
+
+func TestBuildPluginConfigMap_InvalidNames(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-plugins", Namespace: "default"},
+	}
+
+	_, err := buildPluginConfigMap(task, []kelos.PluginSpec{
+		{Name: "../etc", Skills: []kelos.SkillDefinition{{Name: "s", Content: "c"}}},
+	})
+	if err == nil {
+		t.Fatal("Expected error for plugin name with path separators, got nil")
+	}
+	if !strings.Contains(err.Error(), "path separators") {
+		t.Errorf("Expected error about path separators, got: %v", err)
+	}
+}
+
+func TestBuildPluginConfigMap_TooLarge(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-plugins", Namespace: "default"},
+	}
+
+	plugins := []kelos.PluginSpec{
+		{
+			Name: "huge",
+			Skills: []kelos.SkillDefinition{
+				{Name: "big", Content: strings.Repeat("x", pluginConfigMapMaxBytes+1)},
+			},
+		},
+	}
+
+	_, err := buildPluginConfigMap(task, plugins)
+	if err == nil {
+		t.Fatal("Expected error for oversized plugin content, got nil")
+	}
+	if !strings.Contains(err.Error(), "ConfigMap budget") {
+		t.Errorf("Expected error about ConfigMap budget, got: %v", err)
+	}
+
+	// Build must reject the same payload instead of silently truncating.
+	builder := NewJobBuilder()
+	buildTask := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-plugins", Namespace: "default"},
+		Spec: kelos.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Fix issue",
+			Credentials: kelos.Credentials{
+				Type:      kelos.CredentialTypeAPIKey,
+				SecretRef: &kelos.SecretReference{Name: "my-secret"},
+			},
+		},
+	}
+	_, err = builder.Build(buildTask, nil, &kelos.AgentConfigSpec{Plugins: plugins}, "Fix issue")
+	if err == nil {
+		t.Fatal("Expected Build() to fail for oversized plugin content, got nil")
+	}
+	if !strings.Contains(err.Error(), "ConfigMap budget") {
+		t.Errorf("Expected Build() error about ConfigMap budget, got: %v", err)
 	}
 }
 
@@ -2822,9 +3064,9 @@ func TestBuildJob_AgentConfigFull(t *testing.T) {
 		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
-	// Should have plugin volume and init container.
-	if len(job.Spec.Template.Spec.Volumes) != 1 {
-		t.Errorf("Expected 1 volume, got %d", len(job.Spec.Template.Spec.Volumes))
+	// Should have plugin + ConfigMap staging volumes and init container.
+	if len(job.Spec.Template.Spec.Volumes) != 2 {
+		t.Errorf("Expected 2 volumes (plugin + staging), got %d", len(job.Spec.Template.Spec.Volumes))
 	}
 	if len(job.Spec.Template.Spec.InitContainers) != 1 {
 		t.Errorf("Expected 1 init container, got %d", len(job.Spec.Template.Spec.InitContainers))
@@ -3208,9 +3450,9 @@ func TestBuildJob_AgentConfigWithWorkspace(t *testing.T) {
 		t.Fatalf("Build() returned error: %v", err)
 	}
 
-	// Should have both workspace and plugin volumes.
-	if len(job.Spec.Template.Spec.Volumes) != 2 {
-		t.Errorf("Expected 2 volumes (workspace + plugin), got %d", len(job.Spec.Template.Spec.Volumes))
+	// Should have workspace, plugin, and plugin staging volumes.
+	if len(job.Spec.Template.Spec.Volumes) != 3 {
+		t.Errorf("Expected 3 volumes (workspace + plugin + staging), got %d", len(job.Spec.Template.Spec.Volumes))
 	}
 
 	// Should have git-clone + plugin-setup init containers.
@@ -3335,9 +3577,9 @@ func TestBuildJob_AgentConfigCodex(t *testing.T) {
 		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
-	// Should have plugin volume and init container.
-	if len(job.Spec.Template.Spec.Volumes) != 1 {
-		t.Errorf("Expected 1 volume, got %d", len(job.Spec.Template.Spec.Volumes))
+	// Should have plugin + ConfigMap staging volumes and init container.
+	if len(job.Spec.Template.Spec.Volumes) != 2 {
+		t.Errorf("Expected 2 volumes (plugin + staging), got %d", len(job.Spec.Template.Spec.Volumes))
 	}
 	if len(job.Spec.Template.Spec.InitContainers) != 1 {
 		t.Errorf("Expected 1 init container, got %d", len(job.Spec.Template.Spec.InitContainers))
@@ -3401,9 +3643,9 @@ func TestBuildJob_AgentConfigGemini(t *testing.T) {
 		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
-	// Should have plugin volume and init container.
-	if len(job.Spec.Template.Spec.Volumes) != 1 {
-		t.Errorf("Expected 1 volume, got %d", len(job.Spec.Template.Spec.Volumes))
+	// Should have plugin + ConfigMap staging volumes and init container.
+	if len(job.Spec.Template.Spec.Volumes) != 2 {
+		t.Errorf("Expected 2 volumes (plugin + staging), got %d", len(job.Spec.Template.Spec.Volumes))
 	}
 	if len(job.Spec.Template.Spec.InitContainers) != 1 {
 		t.Errorf("Expected 1 init container, got %d", len(job.Spec.Template.Spec.InitContainers))
@@ -3470,9 +3712,9 @@ func TestBuildJob_AgentConfigOpenCode(t *testing.T) {
 		t.Errorf("Expected KELOS_PLUGIN_DIR=%q, got %q", PluginMountPath, envMap["KELOS_PLUGIN_DIR"])
 	}
 
-	// Should have plugin volume and init container.
-	if len(job.Spec.Template.Spec.Volumes) != 1 {
-		t.Errorf("Expected 1 volume, got %d", len(job.Spec.Template.Spec.Volumes))
+	// Should have plugin + ConfigMap staging volumes and init container.
+	if len(job.Spec.Template.Spec.Volumes) != 2 {
+		t.Errorf("Expected 2 volumes (plugin + staging), got %d", len(job.Spec.Template.Spec.Volumes))
 	}
 	if len(job.Spec.Template.Spec.InitContainers) != 1 {
 		t.Errorf("Expected 1 init container, got %d", len(job.Spec.Template.Spec.InitContainers))
@@ -4067,8 +4309,8 @@ func TestBuildJob_AgentConfigMCPServersWithPluginsAndAgentsMD(t *testing.T) {
 	}
 
 	// Should have plugin volume and init container.
-	if len(job.Spec.Template.Spec.Volumes) != 1 {
-		t.Errorf("Expected 1 volume (plugin only), got %d", len(job.Spec.Template.Spec.Volumes))
+	if len(job.Spec.Template.Spec.Volumes) != 2 {
+		t.Errorf("Expected 2 volumes (plugin + staging), got %d", len(job.Spec.Template.Spec.Volumes))
 	}
 	if len(job.Spec.Template.Spec.InitContainers) != 1 {
 		t.Errorf("Expected 1 init container (plugin-setup), got %d", len(job.Spec.Template.Spec.InitContainers))
@@ -5371,6 +5613,10 @@ func TestBuildJob_PodOverridesVolumes_ReservedNameRejected(t *testing.T) {
 		},
 		{
 			name:      PluginVolumeName,
+			wantError: "reserved \"kelos-\" volume name prefix",
+		},
+		{
+			name:      PluginStagingVolumeName,
 			wantError: "reserved \"kelos-\" volume name prefix",
 		},
 		{

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -83,7 +83,7 @@ type TaskReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile handles Task reconciliation.
@@ -351,6 +351,36 @@ func (r *TaskReconciler) createJob(ctx context.Context, task *kelos.Task) (ctrl.
 		return ctrl.Result{}, err
 	}
 
+	// Plugin content is delivered via a per-task ConfigMap that the Job's
+	// plugin-setup init container mounts, so it must exist before the Job.
+	if agentConfig != nil && len(agentConfig.Plugins) > 0 {
+		configMap, err := buildPluginConfigMap(task, agentConfig.Plugins)
+		if err != nil {
+			// Deterministic (invalid component names, payload over budget) —
+			// retrying can't succeed, so fail the Task like JobBuildFailed.
+			logger.Error(err, "unable to build plugin ConfigMap")
+			r.recordEvent(task, corev1.EventTypeWarning, "PluginConfigMapFailed", "Failed to build plugin ConfigMap: %v", err)
+			updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if getErr := r.Get(ctx, client.ObjectKeyFromObject(task), task); getErr != nil {
+					return getErr
+				}
+				task.Status.Phase = kelos.TaskPhaseFailed
+				task.Status.Message = fmt.Sprintf("Failed to build plugin ConfigMap: %v", err)
+				return r.Status().Update(ctx, task)
+			})
+			if updateErr != nil {
+				logger.Error(updateErr, "Unable to update Task status")
+			}
+			return ctrl.Result{}, err
+		}
+		if err := r.ensurePluginConfigMap(ctx, task, configMap); err != nil {
+			// API-level failures are transient — requeue without failing the Task.
+			logger.Error(err, "unable to ensure plugin ConfigMap")
+			r.recordEvent(task, corev1.EventTypeWarning, "PluginConfigMapFailed", "Failed to ensure plugin ConfigMap: %v", err)
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Set owner reference
 	if err := controllerutil.SetControllerReference(task, job, r.Scheme); err != nil {
 		logger.Error(err, "unable to set owner reference")
@@ -534,6 +564,55 @@ func (r *TaskReconciler) resolveGitHubAppToken(ctx context.Context, task *kelos.
 		Name: tokenSecretName,
 	}
 	return &resolved, nil
+}
+
+// ensurePluginConfigMap creates or updates the per-task ConfigMap that
+// carries plugin skill/agent content. The Job mounts this ConfigMap into
+// the plugin-setup init container instead of inlining base64 content into
+// the init script, which would exceed Linux's 128KiB MAX_ARG_STRLEN limit
+// for a single execve argument once plugin content grows large. The
+// ConfigMap is owned by the Task, so garbage collection removes it
+// together with the Task. Building the ConfigMap (validation, size budget)
+// happens in the caller so deterministic failures can fail the Task;
+// errors returned here are API-level and treated as transient.
+func (r *TaskReconciler) ensurePluginConfigMap(ctx context.Context, task *kelos.Task, configMap *corev1.ConfigMap) error {
+	if err := controllerutil.SetControllerReference(task, configMap, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner reference on plugin ConfigMap: %w", err)
+	}
+
+	if err := r.Create(ctx, configMap); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating plugin ConfigMap: %w", err)
+		}
+		// Update existing ConfigMap so reconciles pick up content changes.
+		// Only adopt a ConfigMap this Task already controls: a pre-existing
+		// ConfigMap that happens to share the generated name but is unowned
+		// or owned by something else must not be overwritten and later
+		// garbage-collected with the Task. Re-assert the controller
+		// reference too, since an existing ConfigMap with a stripped
+		// ownerRef would otherwise outlive its Task. Concurrent reconciles
+		// can race here, so retry on conflict like the other update paths in
+		// this controller.
+		updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existing := &corev1.ConfigMap{}
+			if err := r.Get(ctx, client.ObjectKey{Name: configMap.Name, Namespace: configMap.Namespace}, existing); err != nil {
+				return err
+			}
+			if !metav1.IsControlledBy(existing, task) {
+				return fmt.Errorf("plugin ConfigMap %q already exists and is not controlled by this Task", configMap.Name)
+			}
+			existing.Data = configMap.Data
+			if err := controllerutil.SetControllerReference(task, existing, r.Scheme); err != nil {
+				return err
+			}
+			return r.Update(ctx, existing)
+		})
+		if updateErr != nil {
+			return fmt.Errorf("updating plugin ConfigMap: %w", updateErr)
+		}
+	}
+
+	return nil
 }
 
 // refreshGitHubAppTokenIfNeeded re-mints the per-task GitHub App installation

--- a/internal/controller/task_controller_test.go
+++ b/internal/controller/task_controller_test.go
@@ -1663,3 +1663,147 @@ func TestUpdateStatusClearsStalePodNameWhenNoLivePodsRemain(t *testing.T) {
 		t.Fatalf("task.Status.PodName = %q, want empty", updated.Status.PodName)
 	}
 }
+
+func TestEnsurePluginConfigMap_CreateAndUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kelos.AddToScheme(scheme))
+
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(task).
+		Build()
+
+	r := &TaskReconciler{Client: cl, Scheme: scheme}
+
+	plugins := []kelos.PluginSpec{
+		{
+			Name: "team-tools",
+			Skills: []kelos.SkillDefinition{
+				{Name: "deploy", Content: "Deploy instructions here"},
+			},
+		},
+	}
+
+	built, err := buildPluginConfigMap(task, plugins)
+	if err != nil {
+		t.Fatalf("buildPluginConfigMap() error: %v", err)
+	}
+	if err := r.ensurePluginConfigMap(context.Background(), task, built); err != nil {
+		t.Fatalf("ensurePluginConfigMap() error: %v", err)
+	}
+
+	configMap := &corev1.ConfigMap{}
+	key := client.ObjectKey{Name: "test-task-plugins", Namespace: "default"}
+	if err := cl.Get(context.Background(), key, configMap); err != nil {
+		t.Fatalf("getting plugin ConfigMap: %v", err)
+	}
+	if got := configMap.Data["p0-s0"]; got != "Deploy instructions here" {
+		t.Errorf("data[p0-s0] = %q, want %q", got, "Deploy instructions here")
+	}
+
+	// The Task must own the ConfigMap so garbage collection removes it.
+	if len(configMap.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(configMap.OwnerReferences))
+	}
+	owner := configMap.OwnerReferences[0]
+	if owner.Kind != "Task" || owner.Name != "test-task" || owner.UID != "test-uid" {
+		t.Errorf("owner reference = %+v, want Task/test-task", owner)
+	}
+	if owner.Controller == nil || !*owner.Controller {
+		t.Error("expected owner reference to be a controller reference")
+	}
+
+	// A second reconcile with changed content must update in place.
+	plugins[0].Skills[0].Content = "Updated deploy instructions"
+	rebuilt, err := buildPluginConfigMap(task, plugins)
+	if err != nil {
+		t.Fatalf("buildPluginConfigMap() on update error: %v", err)
+	}
+	if err := r.ensurePluginConfigMap(context.Background(), task, rebuilt); err != nil {
+		t.Fatalf("ensurePluginConfigMap() on existing ConfigMap error: %v", err)
+	}
+	if err := cl.Get(context.Background(), key, configMap); err != nil {
+		t.Fatalf("getting updated plugin ConfigMap: %v", err)
+	}
+	if got := configMap.Data["p0-s0"]; got != "Updated deploy instructions" {
+		t.Errorf("data[p0-s0] after update = %q, want %q", got, "Updated deploy instructions")
+	}
+}
+
+// TestEnsurePluginConfigMap_NotAdoptedWhenUnowned verifies that a pre-existing
+// ConfigMap sharing the generated name but not controlled by the Task is left
+// untouched and a name-collision error is returned, so a user-created
+// ConfigMap can never be overwritten or garbage-collected with the Task.
+func TestEnsurePluginConfigMap_NotAdoptedWhenUnowned(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kelos.AddToScheme(scheme))
+
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+
+	// A user-owned ConfigMap that happens to share the generated name and
+	// carries unrelated content the controller must not clobber.
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task-plugins",
+			Namespace: "default",
+		},
+		Data: map[string]string{"user-key": "user-value"},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(task, existing).
+		Build()
+
+	r := &TaskReconciler{Client: cl, Scheme: scheme}
+
+	plugins := []kelos.PluginSpec{
+		{
+			Name: "team-tools",
+			Skills: []kelos.SkillDefinition{
+				{Name: "deploy", Content: "Deploy instructions here"},
+			},
+		},
+	}
+
+	built, err := buildPluginConfigMap(task, plugins)
+	if err != nil {
+		t.Fatalf("buildPluginConfigMap() error: %v", err)
+	}
+	if err := r.ensurePluginConfigMap(context.Background(), task, built); err == nil {
+		t.Fatal("ensurePluginConfigMap() succeeded, want name-collision error")
+	}
+
+	// The pre-existing ConfigMap must be untouched: data preserved and no
+	// owner reference pointing at the Task.
+	got := &corev1.ConfigMap{}
+	key := client.ObjectKey{Name: "test-task-plugins", Namespace: "default"}
+	if err := cl.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("getting plugin ConfigMap: %v", err)
+	}
+	if got.Data["user-key"] != "user-value" {
+		t.Errorf("data[user-key] = %q, want %q (must not be overwritten)", got.Data["user-key"], "user-value")
+	}
+	if _, ok := got.Data["p0-s0"]; ok {
+		t.Error("plugin content was written into an unowned ConfigMap")
+	}
+	if len(got.OwnerReferences) != 0 {
+		t.Errorf("expected no owner references on unowned ConfigMap, got %d", len(got.OwnerReferences))
+	}
+}

--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -9,10 +9,12 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
+  - secrets
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""
@@ -24,19 +26,17 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods/log
+  - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
-  - secrets
+  - pods/log
   verbs:
-  - create
   - get
-  - list
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `plugin-setup` init container inlines every plugin skill's and agent's
content base64-encoded into a single `sh -c <script>` command string. Linux
caps a single `execve` argument at 128KiB (`MAX_ARG_STRLEN`), so any
AgentConfig whose plugin content exceeds that fails at container start with:

    exec /bin/sh: argument list too long

(exit 255, before the agent ever runs — observed in production with a
reviewer-attachment-heavy AgentConfig).

This PR delivers plugin content via a per-task ConfigMap instead:

- `buildPluginConfigMapData` produces a `<taskName>-plugins` ConfigMap with
  one flat key per content blob (`p<i>-s<j>` / `p<i>-a<j>`) plus `KeyToPath`
  items mapping each key to the same layout the old script produced
  (`<plugin>/skills/<skill>/SKILL.md`, `<plugin>/agents/<agent>.md`).
  Existing `sanitizeComponentName` validation is retained.
- The Job mounts the ConfigMap read-only at `/kelos-plugin-src` in
  `plugin-setup`, whose script is now constant-size: it copies the staged
  tree into the writable plugin emptyDir.
- The Task reconciler creates/updates the ConfigMap the same way it manages
  the per-task github-token Secret: controller ownerReference for GC,
  idempotent conflict-retried update on reconcile, and a
  `PluginConfigMapFailed` warning event on failure.
- Deterministic build failures (invalid component names, payload over the
  ~900KiB budget) transition the Task to `Failed` with a status message,
  mirroring the `JobBuildFailed` path; API-level errors remain transient
  requeues.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The copy script uses `cp -RL` and excludes `..*` entries because the
  kubelet atomic-writer materializes ConfigMap items as symlinks through
  hidden `..data`/`..<timestamp>` directories.
- `kelos-plugin-src` is added to `reservedVolumeNames` so podOverrides can't
  collide with the staging volume.
- RBAC: `configmaps get;list;watch;create;update` added to the
  kubebuilder markers; the chart role was regenerated via `make update`.
- Repro for the bug: any AgentConfig whose combined plugin skill/agent
  content exceeds ~96KiB raw (128KiB after base64 expansion) — `plugin-setup`
  exits 255 before the agent container starts.
- Tests: `TestBuildJob_AgentConfigPlugins` rewritten for the new shape; new
  `TestBuildPluginConfigMap`, `TestBuildPluginConfigMap_InvalidNames`,
  `TestBuildPluginConfigMap_TooLarge`,
  `TestEnsurePluginConfigMap_CreateAndUpdate`. `go build ./...`,
  `go vet ./...`, and full `make test` pass.

#### Does this PR introduce a user-facing change?

```release-note
Plugin content for Task pods is now delivered via a per-task ConfigMap (`<taskName>-plugins`) mounted into the plugin-setup init container, instead of being inlined base64-encoded into the init container command. This fixes `exec /bin/sh: argument list too long` failures for AgentConfigs with large plugin content. Plugin payloads over ~900KiB are rejected with a clear error and the Task transitions to Failed. The controller RBAC now requires get/list/watch/create/update on ConfigMaps - re-apply the chart/manifests when upgrading.
```


