### PR TITLE
Add --deny-slack-connect-channels option to slack server

### DIFF
--- a/cmd/kelos-slack-server/main.go
+++ b/cmd/kelos-slack-server/main.go
@@ -37,11 +37,12 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr          string
-		probeAddr            string
-		enableLeaderElection bool
-		reportingInterval    time.Duration
-		activityInterval     time.Duration
+		metricsAddr              string
+		probeAddr                string
+		enableLeaderElection     bool
+		reportingInterval        time.Duration
+		activityInterval         time.Duration
+		denySlackConnectChannels bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -49,6 +50,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager.")
 	flag.DurationVar(&reportingInterval, "reporting-interval", 30*time.Second, "How often to run the Slack reporting cycle.")
 	flag.DurationVar(&activityInterval, "activity-interval", 5*time.Second, "How often to update Slack activity indicators.")
+	flag.BoolVar(&denySlackConnectChannels, "deny-slack-connect-channels", false, "Deny service to externally shared (Slack Connect) channels. The bot will leave on invite and skip processing when channel status cannot be verified.")
 
 	opts, applyVerbosity := logging.SetupZapOptions(flag.CommandLine)
 	flag.Parse()
@@ -105,6 +107,7 @@ func main() {
 		botToken,
 		appToken,
 		joinMessageFile,
+		denySlackConnectChannels,
 		ctrl.Log.WithName("slack"),
 	)
 	if err != nil {

--- a/internal/manifests/charts/kelos/templates/slack-server.yaml
+++ b/internal/manifests/charts/kelos/templates/slack-server.yaml
@@ -33,6 +33,9 @@ spec:
             - --leader-elect
             - --metrics-bind-address=:8080
             - --health-probe-bind-address=:8081
+            {{- if .Values.slackServer.denySlackConnectChannels }}
+            - --deny-slack-connect-channels
+            {{- end }}
           env:
             - name: SLACK_BOT_TOKEN
               valueFrom:

--- a/internal/manifests/charts/kelos/values.yaml
+++ b/internal/manifests/charts/kelos/values.yaml
@@ -116,6 +116,8 @@ slackServer:
   secretName: ""
   # Message posted when the bot joins a channel. Leave empty to disable.
   joinMessage: ""
+  # Deny service to externally shared (Slack Connect) channels.
+  denySlackConnectChannels: false
   resources:
     limits:
       cpu: 500m

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -31,20 +31,23 @@ const (
 // matching TaskSpawners. It is the centralized equivalent of the per-TaskSpawner
 // SlackSource that previously ran in each spawner pod.
 type SlackHandler struct {
-	client      client.Client
-	log         logr.Logger
-	taskBuilder *taskbuilder.TaskBuilder
-	api         *goslack.Client
-	sm          *socketmode.Client
-	botUserID   string
-	botID       string
-	joinMessage string
-	cancel      context.CancelFunc
+	client                   client.Client
+	log                      logr.Logger
+	taskBuilder              *taskbuilder.TaskBuilder
+	api                      *goslack.Client
+	sm                       *socketmode.Client
+	botUserID                string
+	botID                    string
+	joinMessage              string
+	denySlackConnectChannels bool
+	cancel                   context.CancelFunc
 }
 
 // NewSlackHandler creates a new handler. Call Start to begin listening.
 // If joinMessageFile is non-empty, the bot posts its contents when added to a channel.
-func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken, joinMessageFile string, log logr.Logger) (*SlackHandler, error) {
+// If denySlackConnectChannels is true, the bot denies service to Slack Connect
+// (externally shared) channels, leaving on invite and failing closed on lookup errors.
+func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken, joinMessageFile string, denySlackConnectChannels bool, log logr.Logger) (*SlackHandler, error) {
 	api := goslack.New(botToken, goslack.OptionAppLevelToken(appToken))
 
 	authResp, err := api.AuthTestContext(ctx)
@@ -72,14 +75,15 @@ func NewSlackHandler(ctx context.Context, cl client.Client, botToken, appToken, 
 	}
 
 	return &SlackHandler{
-		client:      cl,
-		log:         log,
-		taskBuilder: tb,
-		api:         api,
-		sm:          newSocketModeClient(api),
-		botUserID:   authResp.UserID,
-		botID:       authResp.BotID,
-		joinMessage: joinMessage,
+		client:                   cl,
+		log:                      log,
+		taskBuilder:              tb,
+		api:                      api,
+		sm:                       newSocketModeClient(api),
+		botUserID:                authResp.UserID,
+		botID:                    authResp.BotID,
+		joinMessage:              joinMessage,
+		denySlackConnectChannels: denySlackConnectChannels,
 	}, nil
 }
 
@@ -143,13 +147,18 @@ func (h *SlackHandler) handleEventsAPI(ctx context.Context, evt socketmode.Event
 	}
 }
 
-// handleMemberJoinedChannel posts a welcome message when the bot itself is
-// added to a channel. The message text is read from the file pointed to by
-// joinMessageFile. If the file is not configured or cannot be read, the
-// event is silently ignored.
+// handleMemberJoinedChannel is called when any user joins a channel. When the
+// bot itself is added, it denies Slack Connect channels if configured (leaving
+// and skipping the join message). Otherwise it posts the configured welcome message.
 func (h *SlackHandler) handleMemberJoinedChannel(ctx context.Context, evt *slackevents.MemberJoinedChannelEvent) {
 	if evt.User != h.botUserID {
 		return
+	}
+
+	if h.denySlackConnectChannels {
+		if h.shouldDenySlackConnect(ctx, evt.Channel) {
+			return
+		}
 	}
 
 	if h.joinMessage == "" {
@@ -163,6 +172,42 @@ func (h *SlackHandler) handleMemberJoinedChannel(ctx context.Context, evt *slack
 	if _, _, err := h.api.PostMessageContext(postCtx, evt.Channel, goslack.MsgOptionText(h.joinMessage, false)); err != nil {
 		h.log.Error(err, "Failed to post join message", "channel", evt.Channel)
 	}
+}
+
+// shouldDenySlackConnect checks if a channel is externally shared (Slack Connect)
+// and leaves it if so. Returns true if the channel is denied — either because it
+// was confirmed external and left, or because the status could not be determined
+// (fail closed).
+func (h *SlackHandler) shouldDenySlackConnect(ctx context.Context, channelID string) bool {
+	infoCtx, cancel := context.WithTimeout(ctx, enrichCallTimeout)
+	defer cancel()
+
+	info, err := h.api.GetConversationInfoContext(infoCtx, &goslack.GetConversationInfoInput{
+		ChannelID: channelID,
+	})
+	if err != nil {
+		h.log.Error(err, "Failed to get channel info, denying channel (fail closed)", "channel", channelID)
+		return true
+	}
+
+	if !info.IsExtShared && !info.IsPendingExtShared {
+		return false
+	}
+
+	h.log.Info("Denying Slack Connect channel, leaving", "channel", channelID,
+		"isExtShared", info.IsExtShared, "isPendingExtShared", info.IsPendingExtShared)
+
+	leaveCtx, leaveCancel := context.WithTimeout(ctx, postMessageTimeout)
+	defer leaveCancel()
+
+	notInChannel, err := h.api.LeaveConversationContext(leaveCtx, channelID)
+	if err != nil {
+		h.log.Error(err, "Failed to leave denied Slack Connect channel", "channel", channelID)
+	} else if notInChannel {
+		h.log.Info("Bot was already not in channel", "channel", channelID)
+	}
+
+	return true
 }
 
 func (h *SlackHandler) handleMessageEvent(ctx context.Context, innerEvent *slackevents.MessageEvent) {

--- a/internal/slack/handler_test.go
+++ b/internal/slack/handler_test.go
@@ -3,9 +3,13 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	goslack "github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -498,4 +502,173 @@ func TestHandleMemberJoinedChannelSkipsEmptyMessage(t *testing.T) {
 	}
 
 	h.handleMemberJoinedChannel(context.Background(), evt)
+}
+
+func TestDenySlackConnectChannels(t *testing.T) {
+	tests := []struct {
+		name           string
+		channelResp    string
+		expectLeave    bool
+		expectJoinPost bool
+	}{
+		{
+			name:        "leaves externally shared channel",
+			channelResp: `{"ok":true,"channel":{"id":"C123","is_ext_shared":true,"is_pending_ext_shared":false}}`,
+			expectLeave: true,
+		},
+		{
+			name:        "leaves pending externally shared channel",
+			channelResp: `{"ok":true,"channel":{"id":"C123","is_ext_shared":false,"is_pending_ext_shared":true}}`,
+			expectLeave: true,
+		},
+		{
+			name:           "stays in internal channel",
+			channelResp:    `{"ok":true,"channel":{"id":"C123","is_ext_shared":false,"is_pending_ext_shared":false}}`,
+			expectLeave:    false,
+			expectJoinPost: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var leaveCalled, postCalled bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "conversations.info"):
+					w.Write([]byte(tt.channelResp))
+				case strings.Contains(r.URL.Path, "conversations.leave"):
+					leaveCalled = true
+					w.Write([]byte(`{"ok":true}`))
+				case strings.Contains(r.URL.Path, "chat.postMessage"):
+					postCalled = true
+					w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1.1"}`))
+				default:
+					w.Write([]byte(`{"ok":true}`))
+				}
+			}))
+			defer srv.Close()
+
+			api := goslack.New("xoxb-test", goslack.OptionAPIURL(srv.URL+"/"))
+
+			h := &SlackHandler{
+				log:                      logr.Discard(),
+				api:                      api,
+				botUserID:                "UBOT",
+				joinMessage:              "Welcome!",
+				denySlackConnectChannels: true,
+			}
+
+			evt := &slackevents.MemberJoinedChannelEvent{
+				User:    "UBOT",
+				Channel: "C123",
+			}
+
+			h.handleMemberJoinedChannel(context.Background(), evt)
+
+			if leaveCalled != tt.expectLeave {
+				t.Errorf("conversations.leave called = %v, want %v", leaveCalled, tt.expectLeave)
+			}
+			if postCalled != tt.expectJoinPost {
+				t.Errorf("chat.postMessage called = %v, want %v", postCalled, tt.expectJoinPost)
+			}
+		})
+	}
+}
+
+func TestDenySlackConnectDisabledDoesNotCheck(t *testing.T) {
+	// With denySlackConnectChannels=false and api=nil, calling handleMemberJoinedChannel
+	// for an external channel should NOT call conversations.info (would panic on nil api).
+	h := &SlackHandler{
+		log:                      logr.Discard(),
+		botUserID:                "UBOT",
+		denySlackConnectChannels: false,
+		// api is nil — would panic if shouldDenySlackConnect were called.
+	}
+
+	evt := &slackevents.MemberJoinedChannelEvent{
+		User:    "UBOT",
+		Channel: "C123",
+	}
+
+	// Should not panic — autoleave check is skipped.
+	h.handleMemberJoinedChannel(context.Background(), evt)
+}
+
+func TestDenySlackConnectAPIErrorFailsClosed(t *testing.T) {
+	var postCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "conversations.info"):
+			w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+		case strings.Contains(r.URL.Path, "conversations.leave"):
+			t.Error("conversations.leave should not be called when info fails")
+			w.Write([]byte(`{"ok":true}`))
+		case strings.Contains(r.URL.Path, "chat.postMessage"):
+			postCalled = true
+			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1.1"}`))
+		default:
+			w.Write([]byte(`{"ok":true}`))
+		}
+	}))
+	defer srv.Close()
+
+	api := goslack.New("xoxb-test", goslack.OptionAPIURL(srv.URL+"/"))
+
+	h := &SlackHandler{
+		log:                      logr.Discard(),
+		api:                      api,
+		botUserID:                "UBOT",
+		joinMessage:              "Welcome!",
+		denySlackConnectChannels: true,
+	}
+
+	evt := &slackevents.MemberJoinedChannelEvent{
+		User:    "UBOT",
+		Channel: "C123",
+	}
+
+	h.handleMemberJoinedChannel(context.Background(), evt)
+
+	if postCalled {
+		t.Error("Join message should not be posted when conversations.info fails (fail closed)")
+	}
+}
+
+func TestDenySlackConnectLeaveFailureDoesNotPostJoinMessage(t *testing.T) {
+	var postCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "conversations.info"):
+			w.Write([]byte(`{"ok":true,"channel":{"id":"C123","is_ext_shared":true}}`))
+		case strings.Contains(r.URL.Path, "conversations.leave"):
+			w.Write([]byte(`{"ok":false,"error":"not_allowed"}`))
+		case strings.Contains(r.URL.Path, "chat.postMessage"):
+			postCalled = true
+			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1.1"}`))
+		default:
+			w.Write([]byte(`{"ok":true}`))
+		}
+	}))
+	defer srv.Close()
+
+	api := goslack.New("xoxb-test", goslack.OptionAPIURL(srv.URL+"/"))
+
+	h := &SlackHandler{
+		log:                      logr.Discard(),
+		api:                      api,
+		botUserID:                "UBOT",
+		joinMessage:              "Welcome!",
+		denySlackConnectChannels: true,
+	}
+
+	evt := &slackevents.MemberJoinedChannelEvent{
+		User:    "UBOT",
+		Channel: "C123",
+	}
+
+	h.handleMemberJoinedChannel(context.Background(), evt)
+
+	if postCalled {
+		t.Error("Join message should not be posted when channel is external, even if leave fails")
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a `--deny-slack-connect-channels` flag to the shared Slack server. When enabled, the bot denies service to Slack Connect (externally shared) channels — leaving on invite and failing closed when channel status cannot be verified.

We found an issue where someone accidentally invited and exposed internal docs and bot access to external channels. This flag guards against that by treating any channel that cannot be confirmed as internal as denied.

**How it works:**

1. Listens for the `member_joined_channel` event (filtered to the bot's own user ID).
2. Calls `conversations.info` to check `is_ext_shared` and `is_pending_ext_shared`.
3. If either is true, calls `conversations.leave` and skips posting the join message.
4. If the `conversations.info` call fails (missing scopes, rate limits, timeouts, channel lookup errors), the channel is denied as well (fail closed).
5. If the channel is confirmed internal, proceeds with normal behavior (posting the welcome message if configured).

The flag defaults to `false` so existing deployments are unaffected.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Renamed from `--auto-leave-ext-channels` to `--deny-slack-connect-channels` to better reflect intent — this is a server-level policy, not just a leave action.
- The `shouldDenySlackConnect` method returns `true` whenever the channel is identified as external OR when the status cannot be determined (fail closed). This ensures we never post into a channel whose Slack Connect status is unknown.
- Uses the existing `enrichCallTimeout` (5s) for the `conversations.info` call and `postMessageTimeout` (5s) for the leave call.

#### Does this PR introduce a user-facing change?

```release-note
Add --deny-slack-connect-channels flag to kelos-slack-server to deny service to externally shared (Slack Connect) channels. The bot leaves on invite and fails closed when channel status cannot be verified.
```