### PR TITLE
e2e: centralize coding agent model constants

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -26,7 +26,7 @@ var _ = Describe("CLI", func() {
 			"-p", "Print 'Hello from Kelos CLI e2e test' to stdout",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
-			"--model", testModel,
+			"--model", claudeCodeModel,
 			"--effort", "high",
 			"--name", "cli-task",
 		)
@@ -114,7 +114,7 @@ var _ = Describe("CLI", func() {
 			"-p", "Run 'git log --oneline -1' and print the output",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
-			"--model", testModel,
+			"--model", claudeCodeModel,
 			"--workspace", "e2e-cli-workspace",
 			"--name", "cli-ws-task",
 		)
@@ -294,7 +294,7 @@ var _ = Describe("CLI with namespace flag", func() {
 			"-p", "Print 'hello' to stdout",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
-			"--model", testModel,
+			"--model", claudeCodeModel,
 			"--name", "ns-task",
 		)
 

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Config with namespace", func() {
 			"-p", "Print 'hello' to stdout",
 			"--secret", "claude-credentials",
 			"--credential-type", "oauth",
-			"--model", testModel,
+			"--model", claudeCodeModel,
 			"--name", "ns-config-task",
 		)
 

--- a/test/e2e/setup_command_test.go
+++ b/test/e2e/setup_command_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Workspace setupCommand", func() {
 			},
 			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
-				Model:  testModel,
+				Model:  claudeCodeModel,
 				Prompt: "Print the contents of .kelos-setup-sentinel verbatim, then print 'done'",
 				Credentials: kelosv1alpha1.Credentials{
 					Type:      kelosv1alpha1.CredentialTypeOAuth,
@@ -110,7 +110,7 @@ chmod +x "$HOME/.local/bin/kelos-setup-probe"`,
 			},
 			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
-				Model:  testModel,
+				Model:  claudeCodeModel,
 				Prompt: "Run the command 'kelos-setup-probe' and print its output verbatim.",
 				Credentials: kelosv1alpha1.Credentials{
 					Type:      kelosv1alpha1.CredentialTypeOAuth,
@@ -162,7 +162,7 @@ chmod +x "$HOME/.local/bin/kelos-setup-probe"`,
 			},
 			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
-				Model:  testModel,
+				Model:  claudeCodeModel,
 				Prompt: "Print 'agent should never run'",
 				Credentials: kelosv1alpha1.Credentials{
 					Type:      kelosv1alpha1.CredentialTypeOAuth,

--- a/test/e2e/skills_test.go
+++ b/test/e2e/skills_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Task with skills.sh AgentConfig", func() {
 			},
 			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
-				Model:  testModel,
+				Model:  claudeCodeModel,
 				Prompt: "Print 'Hello from skills.sh e2e test' to stdout",
 				Credentials: kelosv1alpha1.Credentials{
 					Type:      kelosv1alpha1.CredentialTypeOAuth,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -10,7 +10,10 @@ import (
 	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 )
 
-const testModel = "haiku"
+const (
+	claudeCodeModel = "haiku"
+	codexModel      = "gpt-5.3-codex-spark"
+)
 
 var (
 	oauthToken    string
@@ -37,7 +40,7 @@ var agentConfigs = []agentTestConfig{
 		SecretName:       "claude-credentials",
 		SecretKey:        "CLAUDE_CODE_OAUTH_TOKEN",
 		SecretValue:      &oauthToken,
-		Model:            testModel,
+		Model:            claudeCodeModel,
 		EnvVar:           "CLAUDE_CODE_OAUTH_TOKEN",
 		SupportsResponse: true,
 		SupportsCost:     true,
@@ -48,7 +51,7 @@ var agentConfigs = []agentTestConfig{
 		SecretName:       "codex-credentials",
 		SecretKey:        "CODEX_AUTH_JSON",
 		SecretValue:      &codexAuthJSON,
-		Model:            "gpt-5.4-mini",
+		Model:            codexModel,
 		EnvVar:           "CODEX_AUTH_JSON",
 		SupportsResponse: true,
 	},

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -341,7 +341,7 @@ var _ = Describe("Task with make available", func() {
 			},
 			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
-				Model:  testModel,
+				Model:  claudeCodeModel,
 				Prompt: "Run 'make --version' and print the output",
 				Credentials: kelosv1alpha1.Credentials{
 					Type:      kelosv1alpha1.CredentialTypeOAuth,
@@ -405,7 +405,7 @@ var _ = Describe("Task with workspace and secretRef", func() {
 			},
 			Spec: kelosv1alpha1.TaskSpec{
 				Type:   "claude-code",
-				Model:  testModel,
+				Model:  claudeCodeModel,
 				Prompt: "Run 'gh auth status' and print the output",
 				Credentials: kelosv1alpha1.Credentials{
 					Type:      kelosv1alpha1.CredentialTypeOAuth,

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Cron TaskSpawner", func() {
 				},
 				TaskTemplate: kelosv1alpha1.TaskTemplate{
 					Type:  "claude-code",
-					Model: testModel,
+					Model: claudeCodeModel,
 					Credentials: kelosv1alpha1.Credentials{
 						Type:      kelosv1alpha1.CredentialTypeOAuth,
 						SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Centralize e2e coding-agent model constants and use them consistently across e2e tests.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

No functional risk expected. This is an e2e-only configuration/test refactor.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
