### PR TITLE
Use OAuth endpoint for Codex auth refresh

### DIFF
--- a/.github/workflows/refresh-codex-auth.yaml
+++ b/.github/workflows/refresh-codex-auth.yaml
@@ -25,11 +25,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Codex CLI
-        run: |
-          version=$(grep -oP 'ARG CODEX_VERSION=\K[0-9.]+' codex/Dockerfile)
-          npm install -g @openai/codex@"${version}"
-
       - name: Mint secret-manager token
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
@@ -60,7 +55,6 @@ jobs:
             --env ok-to-test
 
       - name: Refresh Codex auth.json
-        id: refresh-auth
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         run: |
@@ -69,26 +63,88 @@ jobs:
             exit 1
           fi
 
+          refresh_token=$(jq -r '.tokens.refresh_token // ""' <<<"${CODEX_AUTH_JSON}")
+          if [ -z "${refresh_token}" ] || [ "${refresh_token}" = "null" ]; then
+            echo "::error::CODEX_AUTH_JSON is missing tokens.refresh_token"
+            exit 1
+          fi
+
+          client_id=$(jq -r '.client_id // .tokens.client_id // ""' <<<"${CODEX_AUTH_JSON}")
+          if [ -z "${client_id}" ] || [ "${client_id}" = "null" ]; then
+            # OpenAI's public Codex OAuth client id. This is a public identifier
+            # used by Codex CLI for refresh_token exchange when no client_id is
+            # embedded in the auth JSON bundle.
+            client_id="app_EMoamEEZ73f0CkXaXp7hrann"
+          fi
+
           mkdir -p ~/.codex
           chmod 700 ~/.codex
-          # Seed last_refresh to the epoch so Codex force-refreshes the token.
-          jq '.last_refresh = "1970-01-01T00:00:00Z"' <<<"${CODEX_AUTH_JSON}" >~/.codex/auth.json
-          chmod 600 ~/.codex/auth.json
-          printf 'cli_auth_credentials_store = "file"\n' >~/.codex/config.toml
 
-          codex exec --skip-git-repo-check --sandbox read-only \
-            "Reply with the single word OK."
-
-          last_refresh=$(jq -r '.last_refresh // ""' ~/.codex/auth.json)
-          if [ "${last_refresh}" = "1970-01-01T00:00:00Z" ] || [ -z "${last_refresh}" ]; then
-            echo "::notice::Codex did not refresh auth.json; leaving CODEX_AUTH_JSON secrets unchanged"
-            echo "refreshed=false" >>"${GITHUB_OUTPUT}"
-            exit 0
+          response_file="$(mktemp)"
+          if ! http_status=$(curl -sS \
+            --request POST \
+            --header "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "grant_type=refresh_token" \
+            --data-urlencode "refresh_token=${refresh_token}" \
+            --data-urlencode "client_id=${client_id}" \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            "https://auth.openai.com/oauth/token"); then
+            rm -f "${response_file}"
+            echo "::error::OAuth token endpoint request failed"
+            exit 1
           fi
-          echo "refreshed=true" >>"${GITHUB_OUTPUT}"
+          response="$(cat "${response_file}")"
+          rm -f "${response_file}"
+          if [ "${http_status}" != "200" ]; then
+            echo "::error::OAuth token endpoint returned HTTP ${http_status}"
+            echo "${response}"
+            exit 1
+          fi
+          if [ -z "${response}" ]; then
+            echo "::error::OAuth token endpoint returned an empty response"
+            exit 1
+          fi
+          if ! jq -e 'type == "object"' >/dev/null <<<"${response}" 2>&1; then
+            echo "::error::OAuth token response is invalid JSON"
+            echo "${response}"
+            exit 1
+          fi
+          access_token=$(jq -r 'if (.access_token | type) == "string" then .access_token else "" end' <<<"${response}")
+          if [ -z "${access_token}" ] || [ "${access_token}" = "null" ]; then
+            echo "::error::OAuth token response is missing access_token"
+            exit 1
+          fi
+
+          jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson refreshed "${response}" \
+            '.last_refresh = $now
+             | .tokens = (.tokens // {})
+             | if ($refreshed.expires_at == null and $refreshed.expires_in != null)
+               then del(.tokens.expires_at)
+               else .
+               end
+             | .tokens |= . + (
+                 $refreshed
+                 | to_entries
+                 | map(select(
+                     .value != null and
+                     ((.value | type) != "string" or .value != "") and (
+                       .key == "access_token" or
+                       .key == "id_token" or
+                       .key == "refresh_token" or
+                       .key == "token_type" or
+                       .key == "scope" or
+                       .key == "expires_at" or
+                       .key == "expires_in"
+                     )
+                   ))
+                 | from_entries
+               )' \
+            <<<"${CODEX_AUTH_JSON}" > ~/.codex/auth.json
+          chmod 600 ~/.codex/auth.json
 
       - name: Update CODEX_AUTH_JSON secrets
-        if: steps.refresh-auth.outputs.refreshed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/internal/codexauth/refresher.go
+++ b/internal/codexauth/refresher.go
@@ -1,5 +1,5 @@
 // Package codexauth refreshes Codex OAuth credentials stored in Kubernetes
-// Secrets by running the Codex CLI against a file-backed auth.json.
+// Secrets by calling the OpenAI OAuth token endpoint with the refresh token.
 package codexauth
 
 import (
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
+	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,12 +26,17 @@ const (
 	// scheduled Codex OAuth refresh.
 	RefreshLabel = "kelos.dev/codex-oauth-refresh"
 
-	secretKey    = "CODEX_AUTH_JSON"
-	staleRefresh = "1970-01-01T00:00:00Z"
+	secretKey               = "CODEX_AUTH_JSON"
+	oauthTokenURL           = "https://auth.openai.com/oauth/token"
+	oauthTokenMethod        = http.MethodPost
+	oauthGrantType          = "refresh_token"
+	oauthClientIDKey        = "client_id"
+	oauthContentType        = "application/x-www-form-urlencoded"
+	defaultOAuthClientID    = "app_EMoamEEZ73f0CkXaXp7hrann"
+	defaultOAuthHTTPTimeout = 30 * time.Second
 )
 
-// Runner invokes Codex with seeded auth.json bytes and returns the auth.json
-// bytes Codex wrote back.
+// Runner refreshes auth.json bytes and returns the bytes that should be stored.
 type Runner func(context.Context, []byte) ([]byte, error)
 
 // Options configures a refresh run.
@@ -87,7 +95,7 @@ func refreshSecret(ctx context.Context, clientset kubernetes.Interface, s *corev
 		return false, nil
 	}
 
-	seeded, ok, err := seedAuth(raw)
+	refreshable, ok, err := authWithRefreshToken(raw)
 	if err != nil {
 		return false, err
 	}
@@ -95,16 +103,9 @@ func refreshSecret(ctx context.Context, clientset kubernetes.Interface, s *corev
 		return false, nil
 	}
 
-	updated, err := runner(ctx, seeded)
+	updated, err := runner(ctx, refreshable)
 	if err != nil {
 		return false, err
-	}
-	refreshed, err := verifyRefreshed(updated)
-	if err != nil {
-		return false, err
-	}
-	if !refreshed {
-		return false, nil
 	}
 	if bytes.Equal(bytes.TrimSpace(updated), bytes.TrimSpace(raw)) {
 		return false, nil
@@ -132,7 +133,7 @@ func refreshSecret(ctx context.Context, clientset kubernetes.Interface, s *corev
 	return true, nil
 }
 
-func seedAuth(raw []byte) ([]byte, bool, error) {
+func authWithRefreshToken(raw []byte) ([]byte, bool, error) {
 	var bundle map[string]any
 	if err := json.Unmarshal(raw, &bundle); err != nil {
 		return nil, false, fmt.Errorf("parsing auth.json bundle: %w", err)
@@ -145,77 +146,102 @@ func seedAuth(raw []byte) ([]byte, bool, error) {
 	if refreshToken == "" {
 		return nil, false, nil
 	}
-	bundle["last_refresh"] = staleRefresh
-
-	seeded, err := json.Marshal(bundle)
-	if err != nil {
-		return nil, false, fmt.Errorf("building seeded auth.json bundle: %w", err)
-	}
-	return seeded, true, nil
+	return raw, true, nil
 }
 
-// DefaultRunner refreshes auth.json by invoking the Codex CLI with
-// cli_auth_credentials_store=file.
-func DefaultRunner(ctx context.Context, seeded []byte) ([]byte, error) {
-	root, err := os.MkdirTemp("", "kelos-codex-auth-")
+// DefaultRunner refreshes auth.json by refreshing the OAuth access token against
+// the OpenAI token endpoint.
+func DefaultRunner(ctx context.Context, authJSON []byte) ([]byte, error) {
+	return refreshWithOAuthToken(ctx, authJSON, oauthTokenURL, &http.Client{Timeout: defaultOAuthHTTPTimeout})
+}
+
+func refreshWithOAuthToken(ctx context.Context, authJSON []byte, tokenEndpoint string, client *http.Client) ([]byte, error) {
+	if client == nil {
+		return nil, fmt.Errorf("http client is required")
+	}
+
+	var bundle map[string]any
+	if err := json.Unmarshal(authJSON, &bundle); err != nil {
+		return nil, fmt.Errorf("parsing auth.json bundle: %w", err)
+	}
+
+	tokens, ok := bundle["tokens"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("auth.json missing tokens object")
+	}
+	refreshToken, _ := tokens["refresh_token"].(string)
+	if refreshToken == "" {
+		return nil, fmt.Errorf("auth.json missing refresh_token")
+	}
+	clientID, _ := bundle[oauthClientIDKey].(string)
+	if clientID == "" {
+		clientID, _ = tokens["client_id"].(string)
+	}
+	if clientID == "" {
+		clientID = defaultOAuthClientID
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", oauthGrantType)
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", clientID)
+
+	request, err := http.NewRequestWithContext(ctx, oauthTokenMethod, tokenEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("creating temp dir: %w", err)
+		return nil, fmt.Errorf("building OAuth refresh request: %w", err)
 	}
-	defer os.RemoveAll(root)
+	request.Header.Set("Content-Type", oauthContentType)
 
-	codexHome := filepath.Join(root, ".codex")
-	workdir := filepath.Join(root, "workspace")
-	if err := os.MkdirAll(codexHome, 0o700); err != nil {
-		return nil, fmt.Errorf("creating Codex home: %w", err)
-	}
-	if err := os.MkdirAll(workdir, 0o700); err != nil {
-		return nil, fmt.Errorf("creating workspace: %w", err)
-	}
-
-	authPath := filepath.Join(codexHome, "auth.json")
-	if err := os.WriteFile(authPath, seeded, 0o600); err != nil {
-		return nil, fmt.Errorf("writing auth.json: %w", err)
-	}
-	configPath := filepath.Join(codexHome, "config.toml")
-	if err := os.WriteFile(configPath, []byte("cli_auth_credentials_store = \"file\"\n"), 0o600); err != nil {
-		return nil, fmt.Errorf("writing Codex config: %w", err)
-	}
-
-	cmd := exec.CommandContext(ctx, "codex", codexRefreshCommandArgs(workdir)...)
-	cmd.Env = append(os.Environ(), "CODEX_HOME="+codexHome, "HOME="+root)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("running Codex refresh command: %w", err)
-	}
-
-	refreshed, err := os.ReadFile(authPath)
+	response, err := client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("reading refreshed auth.json: %w", err)
+		return nil, fmt.Errorf("calling OAuth refresh endpoint: %w", err)
+	}
+	responseBody, err := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading OAuth refresh response: %w", err)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("closing OAuth refresh response: %w", closeErr)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OAuth refresh endpoint returned %s: %s", response.Status, strings.TrimSpace(string(responseBody)))
+	}
+
+	var tokenResponse map[string]any
+	if err := json.Unmarshal(responseBody, &tokenResponse); err != nil {
+		return nil, fmt.Errorf("parsing OAuth refresh response: %w", err)
+	}
+
+	accessToken, _ := tokenResponse["access_token"].(string)
+	if accessToken == "" {
+		return nil, fmt.Errorf("OAuth response is missing access_token")
+	}
+
+	expiresAt, hasExpiresAt := tokenResponse["expires_at"]
+	_, hasExpiresIn := tokenResponse["expires_in"]
+	if (!hasExpiresAt || expiresAt == nil) && hasExpiresIn {
+		delete(tokens, "expires_at")
+	}
+
+	for _, key := range []string{"access_token", "id_token", "refresh_token", "token_type", "scope", "expires_at", "expires_in"} {
+		value, ok := tokenResponse[key]
+		if !ok || value == nil {
+			continue
+		}
+		if text, ok := value.(string); ok && text == "" {
+			continue
+		}
+		tokens[key] = value
+	}
+
+	bundle["last_refresh"] = time.Now().UTC().Format(time.RFC3339)
+
+	refreshed, err := json.Marshal(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("building refreshed auth.json bundle: %w", err)
 	}
 	return refreshed, nil
-}
-
-func codexRefreshCommandArgs(workdir string) []string {
-	return []string{
-		"exec",
-		"--skip-git-repo-check",
-		"--sandbox", "read-only",
-		"-C", workdir,
-		"Reply with the single word OK.",
-	}
-}
-
-func verifyRefreshed(raw []byte) (bool, error) {
-	var bundle map[string]any
-	if err := json.Unmarshal(raw, &bundle); err != nil {
-		return false, fmt.Errorf("parsing refreshed auth.json bundle: %w", err)
-	}
-	lastRefresh, _ := bundle["last_refresh"].(string)
-	if lastRefresh == "" || lastRefresh == staleRefresh {
-		return false, nil
-	}
-	return true, nil
 }
 
 func log(message string, fields ...any) {

--- a/internal/codexauth/refresher_test.go
+++ b/internal/codexauth/refresher_test.go
@@ -3,8 +3,14 @@ package codexauth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,15 +48,26 @@ func TestRunRefreshesLabeledOAuthSecret(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	if seeded["last_refresh"] != staleRefresh {
-		t.Fatalf("seeded last_refresh = %v, want %s", seeded["last_refresh"], staleRefresh)
+	if seeded["last_refresh"] != "2026-01-01T00:00:00Z" {
+		t.Fatalf("seeded last_refresh = %v, want original value", seeded["last_refresh"])
 	}
 	updated, err := clientset.CoreV1().Secrets("default").Get(ctx, "codex", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("getting Secret: %v", err)
 	}
-	if got := string(updated.Data[secretKey]); got != `{"tokens":{"access_token":"new","id_token":"id","refresh_token":"refresh"},"last_refresh":"2026-06-02T00:00:00Z"}` {
-		t.Fatalf("updated auth = %s", got)
+	var gotAuth map[string]any
+	if err := json.Unmarshal(updated.Data[secretKey], &gotAuth); err != nil {
+		t.Fatalf("updated auth is invalid JSON: %v", err)
+	}
+	gotTokens, ok := gotAuth["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("updated auth does not contain tokens")
+	}
+	if gotTokens["access_token"] != "new" {
+		t.Fatalf("access_token = %v, want new", gotTokens["access_token"])
+	}
+	if gotAuth["last_refresh"] != "2026-06-02T00:00:00Z" {
+		t.Fatalf("last_refresh = %v, want refreshed value", gotAuth["last_refresh"])
 	}
 	if got := string(updated.Data["other"]); got != "kept" {
 		t.Fatalf("other key = %q, want kept", got)
@@ -118,7 +135,7 @@ func TestRunSkipsSecretsWithoutRefreshLabel(t *testing.T) {
 	}
 }
 
-func TestRunSkipsUpdateWhenCodexDoesNotRefresh(t *testing.T) {
+func TestRunUpdatesSecretWhenRefreshedPayloadHasNoMarker(t *testing.T) {
 	ctx := context.Background()
 	originalAuth := `{"tokens":{"access_token":"old","id_token":"id","refresh_token":"refresh"},"last_refresh":"2026-01-01T00:00:00Z"}`
 	clientset := fake.NewSimpleClientset(&corev1.Secret{
@@ -138,7 +155,7 @@ func TestRunSkipsUpdateWhenCodexDoesNotRefresh(t *testing.T) {
 		Namespace:  "default",
 		SecretName: "codex",
 		Runner: func(context.Context, []byte) ([]byte, error) {
-			return []byte(`{"tokens":{"access_token":"old","id_token":"id","refresh_token":"refresh"},"last_refresh":"1970-01-01T00:00:00Z"}`), nil
+			return []byte(`{"tokens":{"access_token":"new","id_token":"id","refresh_token":"refresh"}}`), nil
 		},
 	})
 	if err != nil {
@@ -149,46 +166,202 @@ func TestRunSkipsUpdateWhenCodexDoesNotRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getting Secret: %v", err)
 	}
-	if got := string(updated.Data[secretKey]); got != originalAuth {
-		t.Fatalf("updated auth = %s, want original auth unchanged", got)
+	if got := string(updated.Data[secretKey]); got == originalAuth {
+		t.Fatalf("updated auth = %s, want changed payload", got)
+	}
+
+	var gotAuth map[string]any
+	if err := json.Unmarshal(updated.Data[secretKey], &gotAuth); err != nil {
+		t.Fatalf("updated auth is invalid JSON: %v", err)
+	}
+	gotTokens, ok := gotAuth["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("updated auth does not contain tokens")
+	}
+	if gotTokens["access_token"] != "new" {
+		t.Fatalf("access_token = %v, want new", gotTokens["access_token"])
 	}
 }
 
-func TestCodexRefreshCommandArgsMatchPinnedCLI(t *testing.T) {
-	args := codexRefreshCommandArgs("/tmp/workspace")
-	for _, arg := range args {
-		if arg == "--ask-for-approval" {
-			t.Fatalf("codex refresh args include unsupported flag: %v", args)
+func TestRefreshWithOAuthTokenUsesRefreshTokenEndpoint(t *testing.T) {
+	ctx := context.Background()
+	var requestMethod string
+	var requestContentType string
+	var requestPath string
+	var requestBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestMethod = r.Method
+		requestContentType = r.Header.Get("Content-Type")
+		requestPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
 		}
+		requestBody = string(body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new","id_token":"new-id","refresh_token":"new-refresh","token_type":"Bearer","scope":"openid","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	refreshed, err := refreshWithOAuthToken(ctx, []byte(`{"client_id":"test-client","tokens":{"access_token":"old","id_token":"old-id","refresh_token":"refresh","token_type":"Bearer","expires_at":"old-expiry"},"last_refresh":"2026-01-01T00:00:00Z"}`), server.URL+"/oauth/token", server.Client())
+	if err != nil {
+		t.Fatalf("refreshWithOAuthToken() error = %v", err)
 	}
-	want := []string{
-		"exec",
-		"--skip-git-repo-check",
-		"--sandbox", "read-only",
-		"-C", "/tmp/workspace",
-		"Reply with the single word OK.",
+	if requestMethod != http.MethodPost {
+		t.Fatalf("request method = %q, want %q", requestMethod, http.MethodPost)
 	}
-	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("codex refresh args = %v, want %v", args, want)
+	if requestContentType != oauthContentType {
+		t.Fatalf("request Content-Type = %q, want %s", requestContentType, oauthContentType)
+	}
+	if requestPath != "/oauth/token" {
+		t.Fatalf("request path = %q, want /oauth/token", requestPath)
+	}
+
+	requestForm, err := url.ParseQuery(requestBody)
+	if err != nil {
+		t.Fatalf("parsing refresh request form: %v", err)
+	}
+	if got := requestForm.Get("grant_type"); got != "refresh_token" {
+		t.Fatalf("grant_type = %q, want %q", got, "refresh_token")
+	}
+	if got := requestForm.Get("refresh_token"); got != "refresh" {
+		t.Fatalf("refresh_token = %q, want %q", got, "refresh")
+	}
+	if got := requestForm.Get("client_id"); got != "test-client" {
+		t.Fatalf("client_id = %q, want %q", got, "test-client")
+	}
+
+	var updated map[string]any
+	if err := json.Unmarshal(refreshed, &updated); err != nil {
+		t.Fatalf("refreshed auth is invalid JSON: %v", err)
+	}
+	updatedTokens, ok := updated["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("refreshed auth does not contain tokens")
+	}
+	if updatedTokens["access_token"] != "new" {
+		t.Fatalf("access_token = %v, want %v", updatedTokens["access_token"], "new")
+	}
+	if updatedTokens["id_token"] != "new-id" {
+		t.Fatalf("id_token = %v, want %v", updatedTokens["id_token"], "new-id")
+	}
+	if updatedTokens["refresh_token"] != "new-refresh" {
+		t.Fatalf("refresh_token = %v, want %v", updatedTokens["refresh_token"], "new-refresh")
+	}
+	if updatedTokens["token_type"] != "Bearer" {
+		t.Fatalf("token_type = %v, want %v", updatedTokens["token_type"], "Bearer")
+	}
+	if _, ok := updatedTokens["expires_at"]; ok {
+		t.Fatalf("expires_at = %v, want removed when response only has expires_in", updatedTokens["expires_at"])
+	}
+	if updatedTokens["expires_in"] != float64(3600) {
+		t.Fatalf("expires_in = %v, want %v", updatedTokens["expires_in"], float64(3600))
+	}
+	lastRefresh, ok := updated["last_refresh"].(string)
+	if !ok {
+		t.Fatalf("last_refresh has unexpected type %T", updated["last_refresh"])
+	}
+	if _, err := time.Parse(time.RFC3339, lastRefresh); err != nil {
+		t.Fatalf("last_refresh = %v, want RFC3339 timestamp: %v", lastRefresh, err)
+	}
+	if lastRefresh == "2026-01-01T00:00:00Z" {
+		t.Fatalf("last_refresh was not refreshed")
 	}
 }
 
-func TestVerifyRefreshed(t *testing.T) {
-	refreshed, err := verifyRefreshed([]byte(`{"last_refresh":"1970-01-01T00:00:00Z"}`))
+func TestRefreshWithOAuthTokenErrorsWhenAccessTokenMissing(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"refresh_token":"new-refresh"}`))
+	}))
+	defer server.Close()
+
+	_, err := refreshWithOAuthToken(ctx, []byte(`{"client_id":"test-client","tokens":{"access_token":"old","refresh_token":"refresh"},"last_refresh":"2026-01-01T00:00:00Z"}`), server.URL+"/oauth/token", server.Client())
+	if err == nil {
+		t.Fatal("refreshWithOAuthToken() succeeded without access_token")
+	}
+	if !strings.Contains(err.Error(), "missing access_token") {
+		t.Fatalf("error = %v, want message to mention missing access_token", err)
+	}
+}
+
+func TestRefreshWithOAuthTokenUsesDefaultClientID(t *testing.T) {
+	ctx := context.Background()
+	var requestBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		requestBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new","id_token":"new-id","refresh_token":"new-refresh","token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	_, err := refreshWithOAuthToken(ctx, []byte(`{"tokens":{"access_token":"old","refresh_token":"refresh"},"last_refresh":"2026-01-01T00:00:00Z"}`), server.URL+"/oauth/token", server.Client())
 	if err != nil {
-		t.Fatalf("verifyRefreshed() error = %v", err)
+		t.Fatalf("refreshWithOAuthToken() error = %v", err)
 	}
-	if refreshed {
-		t.Fatal("verifyRefreshed() = true for stale last_refresh")
-	}
-	refreshed, err = verifyRefreshed([]byte(`{"last_refresh":"2026-06-02T00:00:00Z"}`))
+	requestForm, err := url.ParseQuery(requestBody)
 	if err != nil {
-		t.Fatalf("verifyRefreshed() error = %v", err)
+		t.Fatalf("parsing refresh request form: %v", err)
 	}
-	if !refreshed {
-		t.Fatal("verifyRefreshed() = false for changed last_refresh")
+	if got := requestForm.Get("client_id"); got != defaultOAuthClientID {
+		t.Fatalf("client_id = %q, want %q", got, defaultOAuthClientID)
 	}
-	if _, err := verifyRefreshed([]byte(`{`)); err == nil {
-		t.Fatal("verifyRefreshed() succeeded for invalid JSON")
+}
+
+func TestRefreshWithOAuthTokenRefreshesEveryCall(t *testing.T) {
+	ctx := context.Background()
+	var refreshTokens []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		requestForm, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parsing refresh request form: %v", err)
+		}
+		refreshTokens = append(refreshTokens, requestForm.Get("refresh_token"))
+		count := len(refreshTokens)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":"access-%d","refresh_token":"refresh-%d","token_type":"Bearer","expires_in":3600}`, count, count+1)
+	}))
+	defer server.Close()
+
+	first, err := refreshWithOAuthToken(ctx, []byte(`{"tokens":{"access_token":"old","refresh_token":"refresh-1"},"last_refresh":"2026-01-01T00:00:00Z"}`), server.URL+"/oauth/token", server.Client())
+	if err != nil {
+		t.Fatalf("first refreshWithOAuthToken() error = %v", err)
+	}
+	second, err := refreshWithOAuthToken(ctx, first, server.URL+"/oauth/token", server.Client())
+	if err != nil {
+		t.Fatalf("second refreshWithOAuthToken() error = %v", err)
+	}
+
+	if len(refreshTokens) != 2 {
+		t.Fatalf("refresh request count = %d, want 2", len(refreshTokens))
+	}
+	if refreshTokens[0] != "refresh-1" {
+		t.Fatalf("first refresh_token = %q, want refresh-1", refreshTokens[0])
+	}
+	if refreshTokens[1] != "refresh-2" {
+		t.Fatalf("second refresh_token = %q, want refresh-2", refreshTokens[1])
+	}
+
+	var updated map[string]any
+	if err := json.Unmarshal(second, &updated); err != nil {
+		t.Fatalf("second refreshed auth is invalid JSON: %v", err)
+	}
+	updatedTokens, ok := updated["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("second refreshed auth does not contain tokens")
+	}
+	if updatedTokens["access_token"] != "access-2" {
+		t.Fatalf("access_token = %v, want access-2", updatedTokens["access_token"])
 	}
 }

--- a/internal/manifests/charts/kelos/README.md
+++ b/internal/manifests/charts/kelos/README.md
@@ -95,7 +95,7 @@ helm upgrade kelos oci://ghcr.io/kelos-dev/charts/kelos \
 
 Codex OAuth credentials are stored in the `CODEX_AUTH_JSON` key of a credentials Secret. Kelos writes this bundle to `~/.codex/auth.json` and configures Codex to use file-backed credentials (`cli_auth_credentials_store = "file"`), matching OpenAI's CI/CD auth guidance. Agent pods are ephemeral, so refreshed tokens written by the Codex CLI inside a pod are not persisted back to that source Secret.
 
-The chart includes a controller that creates one CronJob per labeled Codex OAuth credentials Secret, refreshing each bundle independently of agent activity:
+The chart includes a controller that creates one CronJob per labeled Codex OAuth credentials Secret, refreshing each bundle independently of agent activity by posting to OpenAI's OAuth token endpoint:
 
 ```yaml
 codexAuthRefresher:
@@ -110,7 +110,9 @@ kubectl label secret codex-credentials \
   -n <credentials-namespace>
 ```
 
-The controller watches Secrets labeled `kelos.dev/codex-oauth-refresh=true` and manages a dedicated CronJob for each Secret that has a non-empty `CODEX_AUTH_JSON` key. Each CronJob runs in the target Secret namespace with access limited to that Secret, lets the Codex CLI refresh that bundle, and updates only the `CODEX_AUTH_JSON` key. Removing the label or deleting the Secret removes the managed refresh resources. Secrets without `CODEX_AUTH_JSON`, API-key credentials, and OAuth bundles without a `refresh_token` are skipped. Externally managed Secrets, such as ExternalSecrets, Vault-synced Secrets, or sealed-secrets, will overwrite the refreshed value on their next sync and are not supported.
+The controller watches Secrets labeled `kelos.dev/codex-oauth-refresh=true` and manages a dedicated CronJob for each Secret that has a non-empty `CODEX_AUTH_JSON` key. Each CronJob runs in the target Secret namespace with access limited to that Secret, refreshes that bundle through the endpoint, and updates only the `CODEX_AUTH_JSON` key. Removing the label or deleting the Secret removes the managed refresh resources. Secrets without `CODEX_AUTH_JSON`, API-key credentials, and OAuth bundles without a `refresh_token` are skipped. Externally managed Secrets, such as ExternalSecrets, Vault-synced Secrets, or sealed-secrets, will overwrite the refreshed value on their next sync and are not supported.
+
+If `CODEX_AUTH_JSON` does not include `client_id` (top-level or `tokens.client_id`), Kelos uses OpenAI's public Codex OAuth client id `app_EMoamEEZ73f0CkXaXp7hrann` as the fallback for token refresh.
 
 ## Uninstall
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This changes Codex OAuth refresh to call OpenAI's OAuth token endpoint directly rather than running the Codex CLI during refresh. The change updates:

- `internal/codexauth/refresher.go`: replaces CLI-based `codex exec` refresh with `POST https://auth.openai.com/oauth/token` using `grant_type=refresh_token`.
- `internal/codexauth/refresher_test.go`: swaps CLI-arg tests for endpoint/request/response and validation tests.
- `.github/workflows/refresh-codex-auth.yaml`: updates the workflow to use the OAuth endpoint directly and refresh secrets from response payload.
- `internal/manifests/charts/kelos/README.md`: docs updated to match new refresh mechanism.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Please verify the workflow and refresher behavior in your expected OAuth environment.

#### Does this PR introduce a user-facing change?

```release-note
Kelos now refreshes Codex OAuth credentials by calling the OpenAI OAuth token endpoint directly in both the controller refresher path and refresh workflow, removing CLI dependency.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Codex OAuth refresh to call OpenAI’s OAuth token endpoint in both the controller and the GitHub workflow, removing the `@openai/codex` CLI. Writes a fresh `last_refresh` and, in the controller, updates the Secret only when content changes.

- **Bug Fixes**
  - Controller: POST `https://auth.openai.com/oauth/token` (`application/x-www-form-urlencoded` with `grant_type=refresh_token`, `refresh_token`, `client_id`); require `access_token`; whitelist token fields (`access_token`, `id_token`, `refresh_token`, `token_type`, `scope`, `expires_at`, `expires_in`); drop `expires_at` when only `expires_in` is returned; set RFC3339 `last_refresh`; skip update if bytes are unchanged; fallback `client_id` to `app_EMoamEEZ73f0CkXaXp7hrann` when missing.
  - Workflow: remove CLI; POST to the OAuth endpoint; read `tokens.refresh_token`; resolve `client_id` from bundle or default; validate HTTP 200 and JSON; require `access_token`; whitelist token fields and drop `expires_at` when only `expires_in` is returned; set RFC3339 `last_refresh`; always update the `CODEX_AUTH_JSON` secret.
  - Tests/docs: cover endpoint flow, `client_id` fallback, missing `access_token`, rolling refresh using returned `refresh_token`, and RFC3339 `last_refresh`; README updated for endpoint-based refresh and default `client_id`.

<sup>Written for commit 3b99d4a423f212833bc5275b18f32afde17adbf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

