### PR TITLE
Isolate install integration tests

### DIFF
--- a/test/integration/install/install_test.go
+++ b/test/integration/install/install_test.go
@@ -1,4 +1,4 @@
-package integration
+package install
 
 import (
 	"os"
@@ -13,8 +13,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,123 +21,6 @@ import (
 	"github.com/kelos-dev/kelos/internal/codexauth"
 	"github.com/kelos-dev/kelos/internal/controller"
 )
-
-// clearNamespaceFinalizers removes finalizers from the kelos-system namespace
-// so it can be deleted in envtest (which has no namespace controller).
-func clearNamespaceFinalizers() {
-	ns := &corev1.Namespace{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-system"}, ns)
-	if apierrors.IsNotFound(err) {
-		return
-	}
-	Expect(err).NotTo(HaveOccurred())
-	if len(ns.Spec.Finalizers) > 0 {
-		ns.Spec.Finalizers = nil
-		Expect(k8sClient.SubResource("finalize").Update(ctx, ns)).To(Succeed())
-	}
-}
-
-// deleteControllerResources removes the non-CRD resources created by install
-// without touching the CRDs, keeping the envtest environment intact. Includes
-// optional cluster-scoped webhook RBAC so tests that enable webhook sources
-// start from a clean slate and cannot satisfy assertions against stale state
-// left by a previous test.
-func deleteControllerResources() {
-	secrets := &corev1.SecretList{}
-	_ = k8sClient.List(ctx, secrets, client.MatchingLabels{codexauth.RefreshLabel: "true"})
-	for i := range secrets.Items {
-		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, &secrets.Items[i]))
-	}
-
-	selector := client.MatchingLabels{
-		"app.kubernetes.io/component": "codex-auth-refresher",
-		"kelos.dev/managed-by":        "kelos-controller",
-	}
-	cronJobs := &batchv1.CronJobList{}
-	_ = k8sClient.List(ctx, cronJobs, selector)
-	for i := range cronJobs.Items {
-		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, &cronJobs.Items[i]))
-	}
-	roleBindings := &rbacv1.RoleBindingList{}
-	_ = k8sClient.List(ctx, roleBindings, selector)
-	for i := range roleBindings.Items {
-		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, &roleBindings.Items[i]))
-	}
-	roles := &rbacv1.RoleList{}
-	_ = k8sClient.List(ctx, roles, selector)
-	for i := range roles.Items {
-		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, &roles.Items[i]))
-	}
-	serviceAccounts := &corev1.ServiceAccountList{}
-	_ = k8sClient.List(ctx, serviceAccounts, selector)
-	for i := range serviceAccounts.Items {
-		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, &serviceAccounts.Items[i]))
-	}
-
-	for _, obj := range []client.Object{
-		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "kelos-controller-rolebinding"}},
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "kelos-controller-role"}},
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "kelos-spawner-role"}},
-		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "kelos-webhook-rolebinding"}},
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "kelos-webhook-role"}},
-	} {
-		_ = client.IgnoreNotFound(k8sClient.Delete(ctx, obj))
-	}
-
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kelos-system"}}
-	_ = client.IgnoreNotFound(k8sClient.Delete(ctx, ns))
-
-	// Clear finalizers so the namespace can be deleted in envtest.
-	clearNamespaceFinalizers()
-
-	Eventually(func() bool {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-system"}, &corev1.Namespace{})
-		return apierrors.IsNotFound(err)
-	}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
-}
-
-// restoreCRDs re-applies CRDs by running install followed by cleanup of
-// non-CRD resources. This restores the envtest environment after uninstall
-// removes CRDs that were originally loaded by the BeforeSuite.
-func restoreCRDs(kubeconfigPath string) {
-	// Wait for namespace termination to complete before re-installing.
-	clearNamespaceFinalizers()
-	Eventually(func() bool {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: "kelos-system"}, &corev1.Namespace{})
-		return apierrors.IsNotFound(err)
-	}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
-
-	// Wait for all CRDs to be fully deleted before reinstalling. If install's
-	// server-side apply patches a CRD that still has a deletionTimestamp, the
-	// patch succeeds but the CRD is still deleted, leaving the API unavailable.
-	crdGVK := schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
-	for _, name := range []string{"tasks.kelos.dev", "taskspawners.kelos.dev", "workspaces.kelos.dev"} {
-		Eventually(func() bool {
-			crd := &unstructured.Unstructured{}
-			crd.SetGroupVersionKind(crdGVK)
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, crd)
-			return apierrors.IsNotFound(err)
-		}, 30*time.Second, 100*time.Millisecond).Should(BeTrue())
-	}
-
-	reinstall := cli.NewRootCommand()
-	reinstall.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
-	Expect(reinstall.Execute()).To(Succeed())
-
-	// Wait for all CRDs to be fully established before subsequent tests
-	// can create custom resources. We verify by attempting to list each type.
-	Eventually(func() error {
-		return k8sClient.List(ctx, &kelosv1alpha1.TaskList{})
-	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
-	Eventually(func() error {
-		return k8sClient.List(ctx, &kelosv1alpha1.TaskSpawnerList{})
-	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
-	Eventually(func() error {
-		return k8sClient.List(ctx, &kelosv1alpha1.WorkspaceList{})
-	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
-
-	deleteControllerResources()
-}
 
 func clusterRoleHasVerbs(clusterRole *rbacv1.ClusterRole, apiGroup, resource string, verbs ...string) bool {
 	for _, rule := range clusterRole.Rules {
@@ -177,10 +58,6 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 	})
 
 	Context("kelos install", func() {
-		AfterEach(func() {
-			deleteControllerResources()
-		})
-
 		It("Should create kelos-system namespace and controller resources", func() {
 			root := cli.NewRootCommand()
 			root.SetArgs([]string{"install", "--kubeconfig", kubeconfigPath})
@@ -439,10 +316,6 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 	})
 
 	Context("kelos uninstall", func() {
-		AfterEach(func() {
-			restoreCRDs(kubeconfigPath)
-		})
-
 		It("Should remove controller resources", func() {
 			By("Installing first")
 			root := cli.NewRootCommand()

--- a/test/integration/install/suite_test.go
+++ b/test/integration/install/suite_test.go
@@ -1,4 +1,4 @@
-package integration
+package install
 
 import (
 	"context"
@@ -13,8 +13,11 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,22 +34,27 @@ var (
 	testEnv          *envtest.Environment
 	ctx              context.Context
 	cancel           context.CancelFunc
+	managerDone      chan error
 	mockGitHubServer *httptest.Server
 )
 
-func TestIntegration(t *testing.T) {
+func TestInstallIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Suite")
+	RunSpecs(t, "Install Integration Suite")
 }
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})
 
+var _ = BeforeEach(func() {
+	// Uninstall deletes CRDs, so these specs get a fresh envtest manager
+	// instead of restoring CRDs under an already-running manager.
 	ctx, cancel = context.WithCancel(context.Background())
 
-	By("bootstrapping test environment")
+	By("bootstrapping install test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "internal", "manifests")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "internal", "manifests")},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -62,7 +70,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// Set up mock GitHub token endpoint for integration tests
 	mockGitHubServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -71,12 +78,15 @@ var _ = BeforeSuite(func() {
 		})
 	}))
 
-	// Start controller manager
+	// Controller names remain registered in process-wide metrics after each
+	// manager stops, while this suite starts a new manager for every spec.
+	skipNameValidation := true
 	// Integration packages run concurrently, so disable the metrics listener
 	// to avoid multiple test managers contending for the default :8080 port.
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:  scheme.Scheme,
-		Metrics: metricsserver.Options{BindAddress: "0"},
+		Scheme:     scheme.Scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: config.Controller{SkipNameValidation: &skipNameValidation},
 	})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -109,16 +119,14 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	managerDone = make(chan error, 1)
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		managerDone <- mgr.Start(ctx)
 	}()
 
-	// Wait for the manager cache to sync before running any tests
 	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
 
-	// Verify all CRDs are fully established by attempting to list each custom resource type
 	Eventually(func() error {
 		return k8sClient.List(ctx, &kelosv1alpha1.TaskList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
@@ -130,12 +138,43 @@ var _ = BeforeSuite(func() {
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 })
 
-var _ = AfterSuite(func() {
-	cancel()
+var _ = AfterEach(func() {
+	if cancel != nil {
+		cancel()
+		cancel = nil
+	}
+	if managerDone != nil {
+		Eventually(managerDone, 10*time.Second).Should(Receive(Succeed()))
+		managerDone = nil
+	}
 	if mockGitHubServer != nil {
 		mockGitHubServer.Close()
+		mockGitHubServer = nil
 	}
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	if testEnv != nil {
+		By("tearing down install test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+		testEnv = nil
+	}
 })
+
+func writeEnvtestKubeconfig() string {
+	kubeconfig := clientcmdapi.NewConfig()
+	kubeconfig.Clusters["envtest"] = &clientcmdapi.Cluster{
+		Server:                   cfg.Host,
+		CertificateAuthorityData: cfg.CAData,
+	}
+	kubeconfig.AuthInfos["envtest"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: cfg.CertData,
+		ClientKeyData:         cfg.KeyData,
+	}
+	kubeconfig.Contexts["envtest"] = &clientcmdapi.Context{
+		Cluster:  "envtest",
+		AuthInfo: "envtest",
+	}
+	kubeconfig.CurrentContext = "envtest"
+
+	tmpFile := filepath.Join(GinkgoT().TempDir(), "kubeconfig")
+	Expect(clientcmd.WriteToFile(*kubeconfig, tmpFile)).To(Succeed())
+	return tmpFile
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Moves the install/uninstall integration specs into their own integration subpackage with a fresh envtest manager for each spec.

The install/uninstall specs delete Kelos CRDs as part of normal coverage. Running those specs in the same envtest process as controller and CLI specs can leave later controller/CLI specs dependent on manager/watch recovery after CRD churn. This isolates that CI-only test environment behavior in the harness instead of changing product client behavior to mask it.

The main integration suite and the new install suite also disable controller-runtime's test metrics listener so concurrently running integration packages do not contend for the default `:8080` port. The install suite skips controller name validation because it starts a new manager for each spec and controller names remain registered in process-wide metrics.

#### Which issue(s) this PR is related to:

Fixes #1349

#### Special notes for your reviewer:

Validated locally before squashing:

- `make test`
- `make verify`
- `make test-integration`

Also addressed cubic's prior P2 finding by adding `GinkgoRecover()` around the install suite manager goroutine.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
