### PR TITLE
Allow self-development pick-up from multiline comments

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -64,7 +64,7 @@ func TestSelfDevelopmentGitHubSpawnersUseWebhooks(t *testing.T) {
 	}
 }
 
-func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
+func TestDevelopmentCommandPatternsMatchExpectedCommandLines(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -103,6 +103,7 @@ func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
 					continue
 				}
 				foundBodyPattern = true
+				allowsCommandLine := tt.dir == "self-development" && tt.command == "/kelos pick-up"
 
 				t.Run(filter.Event+"/"+filter.Author, func(t *testing.T) {
 					bodyTests := []struct {
@@ -114,9 +115,10 @@ func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
 						{name: "surrounding whitespace", body: "\n\t " + tt.command + " \n", want: true},
 						{name: "embedded in sentence", body: "Please run " + tt.command, want: false},
 						{name: "trailing text", body: tt.command + " after CI passes", want: false},
+						{name: "following line prose", body: tt.command + "\nRebase on origin/main", want: allowsCommandLine},
 						{name: "quoted markdown", body: "> " + tt.command, want: false},
 						{name: "inline code", body: "`" + tt.command + "`", want: false},
-						{name: "command line with prose", body: "Please run:\n" + tt.command, want: false},
+						{name: "command line after prose", body: "Please run:\n" + tt.command, want: allowsCommandLine},
 					}
 
 					for _, bodyTest := range bodyTests {

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -414,7 +414,7 @@ To adapt these examples for your own repository:
          filters:
            - event: issue_comment
              action: created
-             bodyPattern: '^\s*/kelos pick-up\s*$'
+             bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
              commentOn: Issue          # or PullRequest, depending on spawner
              author: your-maintainer   # maintainer-approval gate
              labels: [your-label]

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -14,13 +14,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos pick-up\s*$'
+          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos pick-up\s*$'
+          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
           state: open
           draft: false
           author: gjkim42

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -64,7 +64,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos pick-up\s*$'
+          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
           commentOn: Issue
           state: open
           author: gjkim42


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the self-development /kelos pick-up webhook filters so they match a clean command line anywhere in a comment or PR review body. This lets comments like:

```text
/kelos pick-up
Rebase on origin/main
```

trigger the worker while still rejecting same-line trailing text such as /kelos pick-up after CI passes.

The previous regex required the entire body to be only /kelos pick-up, so multiline maintainer comments were ignored.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with make test and make verify.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loosened the webhook filter so `/kelos pick-up` is recognized when it appears on its own line within multi-line comments or reviews. This fixes missed triggers while still blocking same-line trailing text.

- **Bug Fixes**
  - Updated regex from `^\s*/kelos pick-up\s*$` to `(?m)^[ \t]*/kelos pick-up[ \t]*$` in `self-development/kelos-pr-responder.yaml`, `self-development/kelos-workers.yaml`, and the README example.
  - Expanded tests to allow the command after or before prose on separate lines, and to keep rejecting inline mentions and quoted/code cases.

<sup>Written for commit 12526e286d94d1295fbfa6d9de5a1bb3fad61ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

