### PR TITLE
Fix dev cert-manager install

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -33,6 +33,8 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: azure/setup-helm@v4
+
       - name: Build CLI
         run: make build WHAT=cmd/kelos
 
@@ -48,6 +50,18 @@ jobs:
           cluster_name: ${{ env.GKE_CLUSTER_NAME }}
           location: ${{ env.GKE_CLUSTER_LOCATION }}
           project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Install cert-manager
+        run: |
+          helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+            --version v1.20.2 \
+            --namespace cert-manager \
+            --create-namespace \
+            --set crds.enabled=true \
+            --set global.leaderElection.namespace=cert-manager
+          kubectl rollout status deployment/cert-manager -n cert-manager --timeout=300s
+          kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=300s
+          kubectl rollout status deployment/cert-manager-cainjector -n cert-manager --timeout=300s
 
       - name: Apply github-webhook-secret
         env:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Installs cert-manager in the dev deploy workflow before running `kelos install`, using the cert-manager Helm chart with leader election in the `cert-manager` namespace. This avoids GKE Autopilot denying cert-manager cainjector lease creation in the managed `kube-system` namespace, which left cert-manager webhook CA injection broken.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated locally with `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `cert-manager` via Helm in the dev deploy workflow to fix webhook CA injection failures on GKE Autopilot. Leader election now runs in the `cert-manager` namespace to avoid lease denial in `kube-system`.

- **Bug Fixes**
  - Add `azure/setup-helm@v4` and install `cert-manager` v1.20.2 with CRDs enabled and leader election scoped to `cert-manager`.
  - Wait for `cert-manager`, `cert-manager-webhook`, and `cert-manager-cainjector` deployments to complete before continuing.

<sup>Written for commit 5816ba3236981cdebb5378d18753146f8aebc6c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

