### PR TITLE
Allow CRLF pick-up command lines

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -160,6 +160,7 @@ func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
 						{name: "embedded in sentence", body: "Please run " + tt.command, want: false},
 						{name: "trailing text", body: tt.command + " after CI passes", want: false},
 						{name: "following line prose", body: tt.command + "\nRebase on origin/main", want: allowsCommandLine},
+						{name: "following line prose with CRLF", body: tt.command + "\r\nRebase on origin/main", want: allowsCommandLine},
 						{name: "quoted markdown", body: "> " + tt.command, want: false},
 						{name: "inline code", body: "`" + tt.command + "`", want: false},
 						{name: "command line after prose", body: "Please run:\n" + tt.command, want: allowsCommandLine},

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -414,7 +414,7 @@ To adapt these examples for your own repository:
          filters:
            - event: issue_comment
              action: created
-             bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
+             bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
              commentOn: Issue          # or PullRequest, depending on spawner
              author: your-maintainer   # maintainer-approval gate
              labels: [your-label]

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -14,13 +14,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
+          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
+          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
           state: open
           draft: false
           author: gjkim42

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -64,7 +64,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*$'
+          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
           commentOn: Issue
           state: open
           author: gjkim42


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Allows the self-development /kelos pick-up bodyPattern filters to match GitHub comment bodies delivered with CRLF line endings. GitHub delivered a PR comment as /kelos pick-up followed by CRLF and prose, and the current [ \t]*$ suffix rejected the command line because of the carriage return before the newline.

Adds a regression case for command-line pick-up comments followed by CRLF prose.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verified with make test and make verify.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the `/kelos pick-up` command to match when comments use CRLF line endings, fixing missed command detection on some GitHub events.

- **Bug Fixes**
  - Updated `bodyPattern` to `(?m)^[ \t]*/kelos pick-up[ \t]*\r?$` in `self-development/README.md`, `self-development/kelos-pr-responder.yaml`, and `self-development/kelos-workers.yaml`.
  - Added a regression test for CRLF after the command in `internal/examples/self_development_test.go`.

<sup>Written for commit 869af860ac85a2a58cd4f5e34a641499cb310f74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

