### PR TITLE
Use v1alpha2 for CLI resources

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {
@@ -24,7 +24,7 @@ func completeTaskNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		taskList := &kelosv1alpha1.TaskList{}
+		taskList := &kelos.TaskList{}
 		if err := cl.List(ctx, taskList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -51,7 +51,7 @@ func completeTaskSpawnerNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		tsList := &kelosv1alpha1.TaskSpawnerList{}
+		tsList := &kelos.TaskSpawnerList{}
 		if err := cl.List(ctx, tsList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -105,7 +105,7 @@ func completeWorkspaceNames(cfg *ClientConfig) cobra.CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		wsList := &kelosv1alpha1.WorkspaceList{}
+		wsList := &kelos.WorkspaceList{}
 		if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func newCreateCommand(cfg *ClientConfig) *cobra.Command {
@@ -62,12 +62,12 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 				return err
 			}
 
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: ns,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: repo,
 					Ref:  ref,
 				},
@@ -80,16 +80,16 @@ func newCreateWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 						return err
 					}
 				}
-				ws.Spec.SecretRef = &kelosv1alpha1.SecretReference{
+				ws.Spec.SecretRef = &kelos.SecretReference{
 					Name: secretName,
 				}
 			} else if secret != "" {
-				ws.Spec.SecretRef = &kelosv1alpha1.SecretReference{
+				ws.Spec.SecretRef = &kelos.SecretReference{
 					Name: secret,
 				}
 			}
 
-			ws.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Workspace"))
+			ws.SetGroupVersionKind(kelos.GroupVersion.WithKind("Workspace"))
 
 			if dryRun {
 				return printYAML(os.Stdout, ws)

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
@@ -60,7 +60,7 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				taskList := &kelosv1alpha1.TaskList{}
+				taskList := &kelos.TaskList{}
 				if err := cl.List(ctx, taskList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing tasks: %w", err)
 				}
@@ -77,7 +77,7 @@ func newDeleteTaskCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,
@@ -128,7 +128,7 @@ func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				wsList := &kelosv1alpha1.WorkspaceList{}
+				wsList := &kelos.WorkspaceList{}
 				if err := cl.List(ctx, wsList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing workspaces: %w", err)
 				}
@@ -145,7 +145,7 @@ func newDeleteWorkspaceCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,
@@ -196,7 +196,7 @@ func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 
 			if all {
-				tsList := &kelosv1alpha1.TaskSpawnerList{}
+				tsList := &kelos.TaskSpawnerList{}
 				if err := cl.List(ctx, tsList, client.InNamespace(ns)); err != nil {
 					return fmt.Errorf("listing task spawners: %w", err)
 				}
@@ -213,7 +213,7 @@ func newDeleteTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 				return nil
 			}
 
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      args[0],
 					Namespace: ns,

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func newGetCommand(cfg *ClientConfig) *cobra.Command {
@@ -59,12 +59,12 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				ts := &kelosv1alpha1.TaskSpawner{}
+				ts := &kelos.TaskSpawner{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, ts); err != nil {
 					return fmt.Errorf("getting task spawner: %w", err)
 				}
 
-				ts.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("TaskSpawner"))
+				ts.SetGroupVersionKind(kelos.GroupVersion.WithKind("TaskSpawner"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, ts)
@@ -74,13 +74,13 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 					if detail {
 						printTaskSpawnerDetail(os.Stdout, ts)
 					} else {
-						printTaskSpawnerTable(os.Stdout, []kelosv1alpha1.TaskSpawner{*ts}, false)
+						printTaskSpawnerTable(os.Stdout, []kelos.TaskSpawner{*ts}, false)
 					}
 					return nil
 				}
 			}
 
-			tsList := &kelosv1alpha1.TaskSpawnerList{}
+			tsList := &kelos.TaskSpawnerList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -89,7 +89,7 @@ func newGetTaskSpawnerCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Com
 				return fmt.Errorf("listing task spawners: %w", err)
 			}
 
-			tsList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("TaskSpawnerList"))
+			tsList.SetGroupVersionKind(kelos.GroupVersion.WithKind("TaskSpawnerList"))
 			switch output {
 			case "yaml":
 				return printYAML(os.Stdout, tsList)
@@ -142,12 +142,12 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				task := &kelosv1alpha1.Task{}
+				task := &kelos.Task{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, task); err != nil {
 					return fmt.Errorf("getting task: %w", err)
 				}
 
-				task.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Task"))
+				task.SetGroupVersionKind(kelos.GroupVersion.WithKind("Task"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, task)
@@ -157,13 +157,13 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 					if detail {
 						printTaskDetail(os.Stdout, task)
 					} else {
-						printTaskTable(os.Stdout, []kelosv1alpha1.Task{*task}, false)
+						printTaskTable(os.Stdout, []kelos.Task{*task}, false)
 					}
 					return nil
 				}
 			}
 
-			taskList := &kelosv1alpha1.TaskList{}
+			taskList := &kelos.TaskList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -172,7 +172,7 @@ func newGetTaskCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
 				return fmt.Errorf("listing tasks: %w", err)
 			}
 
-			taskList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("TaskList"))
+			taskList.SetGroupVersionKind(kelos.GroupVersion.WithKind("TaskList"))
 
 			if len(phases) > 0 {
 				taskList.Items = filterTasksByPhase(taskList.Items, phases)
@@ -230,12 +230,12 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 			ctx := context.Background()
 
 			if len(args) == 1 {
-				ws := &kelosv1alpha1.Workspace{}
+				ws := &kelos.Workspace{}
 				if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, ws); err != nil {
 					return fmt.Errorf("getting workspace: %w", err)
 				}
 
-				ws.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Workspace"))
+				ws.SetGroupVersionKind(kelos.GroupVersion.WithKind("Workspace"))
 				switch output {
 				case "yaml":
 					return printYAML(os.Stdout, ws)
@@ -245,13 +245,13 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 					if detail {
 						printWorkspaceDetail(os.Stdout, ws)
 					} else {
-						printWorkspaceTable(os.Stdout, []kelosv1alpha1.Workspace{*ws}, false)
+						printWorkspaceTable(os.Stdout, []kelos.Workspace{*ws}, false)
 					}
 					return nil
 				}
 			}
 
-			wsList := &kelosv1alpha1.WorkspaceList{}
+			wsList := &kelos.WorkspaceList{}
 			var listOpts []client.ListOption
 			if !*allNamespaces {
 				listOpts = append(listOpts, client.InNamespace(ns))
@@ -260,7 +260,7 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 				return fmt.Errorf("listing workspaces: %w", err)
 			}
 
-			wsList.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("WorkspaceList"))
+			wsList.SetGroupVersionKind(kelos.GroupVersion.WithKind("WorkspaceList"))
 			switch output {
 			case "yaml":
 				return printYAML(os.Stdout, wsList)
@@ -282,29 +282,29 @@ func newGetWorkspaceCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Comma
 	return cmd
 }
 
-var validTaskPhases = map[kelosv1alpha1.TaskPhase]bool{
-	kelosv1alpha1.TaskPhasePending:   true,
-	kelosv1alpha1.TaskPhaseRunning:   true,
-	kelosv1alpha1.TaskPhaseWaiting:   true,
-	kelosv1alpha1.TaskPhaseSucceeded: true,
-	kelosv1alpha1.TaskPhaseFailed:    true,
+var validTaskPhases = map[kelos.TaskPhase]bool{
+	kelos.TaskPhasePending:   true,
+	kelos.TaskPhaseRunning:   true,
+	kelos.TaskPhaseWaiting:   true,
+	kelos.TaskPhaseSucceeded: true,
+	kelos.TaskPhaseFailed:    true,
 }
 
 func validatePhases(phases []string) error {
 	for _, p := range phases {
-		if !validTaskPhases[kelosv1alpha1.TaskPhase(p)] {
+		if !validTaskPhases[kelos.TaskPhase(p)] {
 			return fmt.Errorf("unknown phase %q: must be one of Pending, Running, Waiting, Succeeded, Failed", p)
 		}
 	}
 	return nil
 }
 
-func filterTasksByPhase(tasks []kelosv1alpha1.Task, phases []string) []kelosv1alpha1.Task {
-	phaseSet := make(map[kelosv1alpha1.TaskPhase]bool, len(phases))
+func filterTasksByPhase(tasks []kelos.Task, phases []string) []kelos.Task {
+	phaseSet := make(map[kelos.TaskPhase]bool, len(phases))
 	for _, p := range phases {
-		phaseSet[kelosv1alpha1.TaskPhase(p)] = true
+		phaseSet[kelos.TaskPhase(p)] = true
 	}
-	filtered := make([]kelosv1alpha1.Task, 0, len(tasks))
+	filtered := make([]kelos.Task, 0, len(tasks))
 	for _, t := range tasks {
 		if phaseSet[t.Status.Phase] {
 			filtered = append(filtered, t)

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"testing"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func TestDetailFlagRegistered(t *testing.T) {
@@ -74,43 +74,43 @@ func TestValidatePhases(t *testing.T) {
 }
 
 func TestFilterTasksByPhase(t *testing.T) {
-	tasks := []kelosv1alpha1.Task{
-		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhasePending}},
-		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseRunning}},
-		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseSucceeded}},
-		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseFailed}},
-		{Status: kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseWaiting}},
+	tasks := []kelos.Task{
+		{Status: kelos.TaskStatus{Phase: kelos.TaskPhasePending}},
+		{Status: kelos.TaskStatus{Phase: kelos.TaskPhaseRunning}},
+		{Status: kelos.TaskStatus{Phase: kelos.TaskPhaseSucceeded}},
+		{Status: kelos.TaskStatus{Phase: kelos.TaskPhaseFailed}},
+		{Status: kelos.TaskStatus{Phase: kelos.TaskPhaseWaiting}},
 	}
 
 	tests := []struct {
 		name       string
 		phases     []string
 		wantCount  int
-		wantPhases []kelosv1alpha1.TaskPhase
+		wantPhases []kelos.TaskPhase
 	}{
 		{
 			name:       "filter Running only",
 			phases:     []string{"Running"},
 			wantCount:  1,
-			wantPhases: []kelosv1alpha1.TaskPhase{kelosv1alpha1.TaskPhaseRunning},
+			wantPhases: []kelos.TaskPhase{kelos.TaskPhaseRunning},
 		},
 		{
 			name:      "filter non-completed",
 			phases:    []string{"Pending", "Running", "Waiting"},
 			wantCount: 3,
-			wantPhases: []kelosv1alpha1.TaskPhase{
-				kelosv1alpha1.TaskPhasePending,
-				kelosv1alpha1.TaskPhaseRunning,
-				kelosv1alpha1.TaskPhaseWaiting,
+			wantPhases: []kelos.TaskPhase{
+				kelos.TaskPhasePending,
+				kelos.TaskPhaseRunning,
+				kelos.TaskPhaseWaiting,
 			},
 		},
 		{
 			name:      "filter completed",
 			phases:    []string{"Succeeded", "Failed"},
 			wantCount: 2,
-			wantPhases: []kelosv1alpha1.TaskPhase{
-				kelosv1alpha1.TaskPhaseSucceeded,
-				kelosv1alpha1.TaskPhaseFailed,
+			wantPhases: []kelos.TaskPhase{
+				kelos.TaskPhaseSucceeded,
+				kelos.TaskPhaseFailed,
 			},
 		},
 		{

--- a/internal/cli/install_compat_test.go
+++ b/internal/cli/install_compat_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestListKelosResource_FallsBackToV1alpha1(t *testing.T) {
+	scheme := runtime.NewScheme()
+	// Both list kinds must be registered or the fake client panics before any
+	// reactor runs; the reactor below makes v1alpha2 behave as if unserved.
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "kelos.dev", Version: "v1alpha1", Resource: "tasks"}: "TaskList",
+		{Group: "kelos.dev", Version: "v1alpha2", Resource: "tasks"}: "TaskList",
+	}
+	task := &unstructured.Unstructured{}
+	task.SetGroupVersionKind(schema.GroupVersionKind{Group: "kelos.dev", Version: "v1alpha1", Kind: "Task"})
+	task.SetName("legacy-task")
+	task.SetNamespace("default")
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, task)
+	// Simulate a cluster whose CRDs predate v1alpha2: listing the v1alpha2
+	// version returns NoMatch, so listKelosResource must fall back to v1alpha1.
+	client.PrependReactor("list", "tasks", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource().Version == "v1alpha2" {
+			return true, nil, &meta.NoResourceMatchError{PartialResource: action.GetResource()}
+		}
+		return false, nil, nil
+	})
+
+	gvr, list, ok, err := listKelosResource(context.Background(), client, "tasks", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true when only v1alpha1 is served")
+	}
+	if gvr.Version != "v1alpha1" {
+		t.Errorf("resolved version = %q, want v1alpha1", gvr.Version)
+	}
+	if list == nil || len(list.Items) != 1 {
+		t.Fatalf("expected 1 item listed via v1alpha1, got %v", list)
+	}
+
+	taskGVR := schema.GroupVersionResource{Group: "kelos.dev", Version: "v1alpha1", Resource: "tasks"}
+	got, err := client.Resource(taskGVR).Namespace("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing fallback resource: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("fallback resource count = %d, want 1", len(got.Items))
+	}
+}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1084,43 +1083,6 @@ func TestDeleteAllCustomResources_SkipsAlreadyDeletingResources(t *testing.T) {
 	}
 	if len(list.Items) != 1 {
 		t.Errorf("expected 1 task (still deleting), got %d", len(list.Items))
-	}
-}
-
-func TestListKelosResource_FallsBackToV1alpha1(t *testing.T) {
-	scheme := runtime.NewScheme()
-	// Both list kinds must be registered or the fake client panics before any
-	// reactor runs; the reactor below makes v1alpha2 behave as if unserved.
-	listKinds := map[schema.GroupVersionResource]string{
-		{Group: "kelos.dev", Version: "v1alpha1", Resource: "tasks"}: "TaskList",
-		{Group: "kelos.dev", Version: "v1alpha2", Resource: "tasks"}: "TaskList",
-	}
-	task := &unstructured.Unstructured{}
-	task.SetGroupVersionKind(schema.GroupVersionKind{Group: "kelos.dev", Version: "v1alpha1", Kind: "Task"})
-	task.SetName("legacy-task")
-	task.SetNamespace("default")
-	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, task)
-	// Simulate a cluster whose CRDs predate v1alpha2: listing the v1alpha2
-	// version returns NoMatch, so listKelosResource must fall back to v1alpha1.
-	client.PrependReactor("list", "tasks", func(action clienttesting.Action) (bool, runtime.Object, error) {
-		if action.GetResource().Version == "v1alpha2" {
-			return true, nil, &meta.NoResourceMatchError{PartialResource: action.GetResource()}
-		}
-		return false, nil, nil
-	})
-
-	gvr, list, ok, err := listKelosResource(context.Background(), client, "tasks", 0)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !ok {
-		t.Fatal("expected ok=true when only v1alpha1 is served")
-	}
-	if gvr.Version != "v1alpha1" {
-		t.Errorf("resolved version = %q, want v1alpha1", gvr.Version)
-	}
-	if list == nil || len(list.Items) != 1 {
-		t.Fatalf("expected 1 item listed via v1alpha1, got %v", list)
 	}
 }
 

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func newLogsCommand(cfg *ClientConfig) *cobra.Command {
@@ -44,7 +44,7 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 			}
 
 			ctx := context.Background()
-			task := &kelosv1alpha1.Task{}
+			task := &kelos.Task{}
 			if err := cl.Get(ctx, client.ObjectKey{Name: args[0], Namespace: ns}, task); err != nil {
 				return fmt.Errorf("getting task: %w", err)
 			}
@@ -76,7 +76,7 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 				}
 			}
 
-			containerName := kelosv1alpha1.AgentContainerName
+			containerName := kelos.AgentContainerName
 
 			if follow && task.Spec.WorkspaceRef != nil {
 				fmt.Fprintf(os.Stderr, "Streaming init container (git-clone) logs...\n")
@@ -99,10 +99,10 @@ func newLogsCommand(cfg *ClientConfig) *cobra.Command {
 	return cmd
 }
 
-func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (*kelosv1alpha1.Task, error) {
-	var lastPhase kelosv1alpha1.TaskPhase
+func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (*kelos.Task, error) {
+	var lastPhase kelos.TaskPhase
 	for {
-		task := &kelosv1alpha1.Task{}
+		task := &kelos.Task{}
 		if err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, task); err != nil {
 			return nil, fmt.Errorf("getting task: %w", err)
 		}
@@ -112,7 +112,7 @@ func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (
 			lastPhase = task.Status.Phase
 		}
 
-		if task.Status.Phase == kelosv1alpha1.TaskPhaseFailed {
+		if task.Status.Phase == kelos.TaskPhaseFailed {
 			msg := "unknown error"
 			if task.Status.Message != "" {
 				msg = task.Status.Message
@@ -128,7 +128,7 @@ func waitForPod(ctx context.Context, cl client.Client, name, namespace string) (
 	}
 }
 
-func resolveTaskPodName(ctx context.Context, cl client.Client, namespace string, task *kelosv1alpha1.Task) (string, error) {
+func resolveTaskPodName(ctx context.Context, cl client.Client, namespace string, task *kelos.Task) (string, error) {
 	var pods corev1.PodList
 	if err := cl.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
 		"kelos.dev/task": task.Name,
@@ -155,8 +155,8 @@ func resolveTaskPodName(ctx context.Context, cl client.Client, namespace string,
 	return pods.Items[len(pods.Items)-1].Name, nil
 }
 
-func isTerminalTaskPhase(phase kelosv1alpha1.TaskPhase) bool {
-	return phase == kelosv1alpha1.TaskPhaseSucceeded || phase == kelosv1alpha1.TaskPhaseFailed
+func isTerminalTaskPhase(phase kelos.TaskPhase) bool {
+	return phase == kelos.TaskPhaseSucceeded || phase == kelos.TaskPhaseFailed
 }
 
 func streamLogs(ctx context.Context, cs *kubernetes.Clientset, namespace, podName, container string, follow bool) error {

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func TestResolveTaskPodName(t *testing.T) {
@@ -19,16 +19,16 @@ func TestResolveTaskPodName(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		task    *kelosv1alpha1.Task
+		task    *kelos.Task
 		objects []client.Object
 		want    string
 		wantErr bool
 	}{
 		{
 			name: "uses newest live pod",
-			task: &kelosv1alpha1.Task{
+			task: &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
-				Status: kelosv1alpha1.TaskStatus{
+				Status: kelos.TaskStatus{
 					PodName: "task-pod-old",
 				},
 			},
@@ -58,11 +58,11 @@ func TestResolveTaskPodName(t *testing.T) {
 		},
 		{
 			name: "returns empty when no live pod remains",
-			task: &kelosv1alpha1.Task{
+			task: &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
-				Status: kelosv1alpha1.TaskStatus{
+				Status: kelos.TaskStatus{
 					PodName: "task-pod-old",
-					Phase:   kelosv1alpha1.TaskPhaseFailed,
+					Phase:   kelos.TaskPhaseFailed,
 				},
 			},
 			want: "",
@@ -90,13 +90,13 @@ func TestResolveTaskPodName(t *testing.T) {
 
 func TestIsTerminalTaskPhase(t *testing.T) {
 	tests := []struct {
-		phase kelosv1alpha1.TaskPhase
+		phase kelos.TaskPhase
 		want  bool
 	}{
-		{phase: kelosv1alpha1.TaskPhasePending, want: false},
-		{phase: kelosv1alpha1.TaskPhaseRunning, want: false},
-		{phase: kelosv1alpha1.TaskPhaseSucceeded, want: true},
-		{phase: kelosv1alpha1.TaskPhaseFailed, want: true},
+		{phase: kelos.TaskPhasePending, want: false},
+		{phase: kelos.TaskPhaseRunning, want: false},
+		{phase: kelos.TaskPhaseSucceeded, want: true},
+		{phase: kelos.TaskPhaseFailed, want: true},
 	}
 
 	for _, tt := range tests {
@@ -107,10 +107,10 @@ func TestIsTerminalTaskPhase(t *testing.T) {
 }
 
 func TestResolveTaskPodNameAfterWait(t *testing.T) {
-	task := &kelosv1alpha1.Task{
+	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
-		Status: kelosv1alpha1.TaskStatus{
-			Phase:   kelosv1alpha1.TaskPhaseRunning,
+		Status: kelos.TaskStatus{
+			Phase:   kelos.TaskPhaseRunning,
 			PodName: "task-pod-old",
 		},
 	}

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -12,11 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"sigs.k8s.io/yaml"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
-func taskDuration(status *kelosv1alpha1.TaskStatus) string {
+func taskDuration(status *kelos.TaskStatus) string {
 	if status.StartTime == nil {
 		return "-"
 	}
@@ -26,7 +25,7 @@ func taskDuration(status *kelosv1alpha1.TaskStatus) string {
 	return duration.HumanDuration(time.Since(status.StartTime.Time))
 }
 
-func printTaskTable(w io.Writer, tasks []kelosv1alpha1.Task, allNamespaces bool) {
+func printTaskTable(w io.Writer, tasks []kelos.Task, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tTYPE\tPHASE\tBRANCH\tWORKSPACE\tAGENT CONFIG\tDURATION\tAGE")
@@ -50,8 +49,6 @@ func printTaskTable(w io.Writer, tasks []kelosv1alpha1.Task, allNamespaces bool)
 				names[i] = ref.Name
 			}
 			agentConfig = strings.Join(names, ",")
-		} else if t.Spec.AgentConfigRef != nil {
-			agentConfig = t.Spec.AgentConfigRef.Name
 		}
 		dur := taskDuration(&t.Status)
 		if allNamespaces {
@@ -65,7 +62,7 @@ func printTaskTable(w io.Writer, tasks []kelosv1alpha1.Task, allNamespaces bool)
 	tw.Flush()
 }
 
-func printTaskDetail(w io.Writer, t *kelosv1alpha1.Task) {
+func printTaskDetail(w io.Writer, t *kelos.Task) {
 	printField(w, "Name", t.Name)
 	printField(w, "Namespace", t.Namespace)
 	printField(w, "Type", t.Spec.Type)
@@ -96,8 +93,6 @@ func printTaskDetail(w io.Writer, t *kelosv1alpha1.Task) {
 			names[i] = ref.Name
 		}
 		printField(w, "Agent Configs", strings.Join(names, ", "))
-	} else if t.Spec.AgentConfigRef != nil {
-		printField(w, "Agent Config", t.Spec.AgentConfigRef.Name)
 	}
 	if t.Spec.TTLSecondsAfterFinished != nil {
 		printField(w, "TTL", fmt.Sprintf("%ds", *t.Spec.TTLSecondsAfterFinished))
@@ -147,7 +142,7 @@ func printTaskDetail(w io.Writer, t *kelosv1alpha1.Task) {
 	}
 }
 
-func printTaskSpawnerTable(w io.Writer, spawners []kelosv1alpha1.TaskSpawner, allNamespaces bool) {
+func printTaskSpawnerTable(w io.Writer, spawners []kelos.TaskSpawner, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tSOURCE\tPHASE\tDISCOVERED\tTASKS\tAGE")
@@ -192,8 +187,8 @@ func printTaskSpawnerTable(w io.Writer, spawners []kelosv1alpha1.TaskSpawner, al
 
 // effectivePollInterval returns the poll interval that the spawner actually
 // uses, mirroring the resolution in cmd/kelos-spawner: the active source's
-// pollInterval takes precedence over the deprecated spec.pollInterval.
-func effectivePollInterval(ts *kelosv1alpha1.TaskSpawner) string {
+// pollInterval takes precedence over the default interval.
+func effectivePollInterval(ts *kelos.TaskSpawner) string {
 	switch {
 	case ts.Spec.When.GitHubIssues != nil && ts.Spec.When.GitHubIssues.PollInterval != "":
 		return ts.Spec.When.GitHubIssues.PollInterval
@@ -202,10 +197,10 @@ func effectivePollInterval(ts *kelosv1alpha1.TaskSpawner) string {
 	case ts.Spec.When.Jira != nil && ts.Spec.When.Jira.PollInterval != "":
 		return ts.Spec.When.Jira.PollInterval
 	}
-	return ts.Spec.PollInterval
+	return "5m"
 }
 
-func printTaskSpawnerDetail(w io.Writer, ts *kelosv1alpha1.TaskSpawner) {
+func printTaskSpawnerDetail(w io.Writer, ts *kelos.TaskSpawner) {
 	printField(w, "Name", ts.Name)
 	printField(w, "Namespace", ts.Namespace)
 	printField(w, "Phase", string(ts.Status.Phase))
@@ -299,7 +294,7 @@ func printTaskSpawnerDetail(w io.Writer, ts *kelosv1alpha1.TaskSpawner) {
 	}
 }
 
-func printWorkspaceTable(w io.Writer, workspaces []kelosv1alpha1.Workspace, allNamespaces bool) {
+func printWorkspaceTable(w io.Writer, workspaces []kelos.Workspace, allNamespaces bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	if allNamespaces {
 		fmt.Fprintln(tw, "NAMESPACE\tNAME\tREPO\tREF\tAGE")
@@ -317,7 +312,7 @@ func printWorkspaceTable(w io.Writer, workspaces []kelosv1alpha1.Workspace, allN
 	tw.Flush()
 }
 
-func printWorkspaceDetail(w io.Writer, ws *kelosv1alpha1.Workspace) {
+func printWorkspaceDetail(w io.Writer, ws *kelos.Workspace) {
 	printField(w, "Name", ws.Name)
 	printField(w, "Namespace", ws.Namespace)
 	printField(w, "Repo", ws.Spec.Repo)

--- a/internal/cli/printer_test.go
+++ b/internal/cli/printer_test.go
@@ -8,18 +8,17 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func TestPrintWorkspaceTable(t *testing.T) {
-	workspaces := []kelosv1alpha1.Workspace{
+	workspaces := []kelos.Workspace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "ws-one",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/org/repo.git",
 				Ref:  "main",
 			},
@@ -29,7 +28,7 @@ func TestPrintWorkspaceTable(t *testing.T) {
 				Name:              "ws-two",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/org/other.git",
 			},
 		},
@@ -60,14 +59,14 @@ func TestPrintWorkspaceTable(t *testing.T) {
 }
 
 func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
-	workspaces := []kelosv1alpha1.Workspace{
+	workspaces := []kelos.Workspace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "ws-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/org/repo.git",
 				Ref:  "main",
 			},
@@ -78,7 +77,7 @@ func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/org/other.git",
 			},
 		},
@@ -102,25 +101,23 @@ func TestPrintWorkspaceTableAllNamespaces(t *testing.T) {
 func TestPrintTaskTable(t *testing.T) {
 	now := time.Now()
 	startTime := metav1.NewTime(now.Add(-30 * time.Minute))
-	tasks := []kelosv1alpha1.Task{
+	tasks := []kelos.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-one",
 				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  "claude-sonnet-4-20250514",
 				Branch: "feature/test",
-				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+				WorkspaceRef: &kelos.WorkspaceReference{
 					Name: "my-ws",
 				},
-				AgentConfigRef: &kelosv1alpha1.AgentConfigReference{
-					Name: "my-config",
-				},
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "my-config"}},
 			},
-			Status: kelosv1alpha1.TaskStatus{
-				Phase:     kelosv1alpha1.TaskPhaseRunning,
+			Status: kelos.TaskStatus{
+				Phase:     kelos.TaskPhaseRunning,
 				StartTime: &startTime,
 			},
 		},
@@ -149,19 +146,19 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 	now := time.Now()
 	startTime := metav1.NewTime(now.Add(-90 * time.Minute))
 	completionTime := metav1.NewTime(now.Add(-60 * time.Minute))
-	tasks := []kelosv1alpha1.Task{
+	tasks := []kelos.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "task-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Branch: "feat/one",
 			},
-			Status: kelosv1alpha1.TaskStatus{
-				Phase: kelosv1alpha1.TaskPhaseRunning,
+			Status: kelos.TaskStatus{
+				Phase: kelos.TaskPhaseRunning,
 			},
 		},
 		{
@@ -170,11 +167,11 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type: "codex",
 			},
-			Status: kelosv1alpha1.TaskStatus{
-				Phase:          kelosv1alpha1.TaskPhaseSucceeded,
+			Status: kelos.TaskStatus{
+				Phase:          kelos.TaskPhaseSucceeded,
 				StartTime:      &startTime,
 				CompletionTime: &completionTime,
 			},
@@ -198,21 +195,21 @@ func TestPrintTaskTableAllNamespaces(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTable(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "spawner-one",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					Cron: &kelosv1alpha1.Cron{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Cron: &kelos.Cron{
 						Schedule: "*/5 * * * *",
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -233,22 +230,22 @@ func TestPrintTaskSpawnerTable(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "spawner-one",
 				Namespace:         "ns-a",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					Cron: &kelosv1alpha1.Cron{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Cron: &kelos.Cron{
 						Schedule: "*/5 * * * *",
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 		{
@@ -257,18 +254,18 @@ func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
 				Namespace:         "ns-b",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubIssues: &kelos.GitHubIssues{},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+				TaskTemplate: kelos.TaskTemplate{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "my-ws",
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -289,24 +286,24 @@ func TestPrintTaskSpawnerTableAllNamespaces(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableGitHubPullRequests(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "pr-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubPullRequests: &kelosv1alpha1.GitHubPullRequests{},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubPullRequests: &kelos.GitHubPullRequests{},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+				TaskTemplate: kelos.TaskTemplate{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "my-ws",
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -324,24 +321,24 @@ func TestPrintTaskSpawnerTableGitHubPullRequests(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableGitHubIssuesWithWorkspace(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "issue-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubIssues: &kelos.GitHubIssues{},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+				TaskTemplate: kelos.TaskTemplate{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "my-ws",
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -359,21 +356,21 @@ func TestPrintTaskSpawnerTableGitHubIssuesWithWorkspace(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableSlack(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "chat-trigger",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					Slack: &kelosv1alpha1.Slack{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Slack: &kelos.Slack{
 						Channels: []string{"C0123456789"},
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -388,29 +385,28 @@ func TestPrintTaskSpawnerTableSlack(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailSlack(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "slack-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				Slack: &kelosv1alpha1.Slack{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				Slack: &kelos.Slack{
 					Channels: []string{"C0123456789", "C9876543210"},
-					Triggers: []kelosv1alpha1.SlackTrigger{
+					Triggers: []kelos.SlackTrigger{
 						{Pattern: "deploy"},
 						{Pattern: "rollback"},
 					},
 					ExcludePatterns: []string{"^ignore"},
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   1,
 			TotalTasksCreated: 1,
 		},
@@ -433,19 +429,19 @@ func TestPrintTaskSpawnerDetailSlack(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableGitHubPullRequestsNoWorkspace(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "pr-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubPullRequests: &kelosv1alpha1.GitHubPullRequests{},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubPullRequests: &kelos.GitHubPullRequests{},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -460,25 +456,25 @@ func TestPrintTaskSpawnerTableGitHubPullRequestsNoWorkspace(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableJira(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "jira-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					Jira: &kelosv1alpha1.Jira{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Jira: &kelos.Jira{
 						BaseURL: "https://mycompany.atlassian.net",
 						Project: "PROJ",
-						SecretRef: kelosv1alpha1.SecretReference{
+						SecretRef: kelos.SecretReference{
 							Name: "jira-secret",
 						},
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -493,22 +489,22 @@ func TestPrintTaskSpawnerTableJira(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableGitHubWebhook(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "webhook-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubWebhook: &kelosv1alpha1.GitHubWebhook{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubWebhook: &kelos.GitHubWebhook{
 						Events:     []string{"issue_comment", "push"},
 						Repository: "org/repo",
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -523,21 +519,21 @@ func TestPrintTaskSpawnerTableGitHubWebhook(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableGitHubWebhookNoRepo(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "webhook-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubWebhook: &kelosv1alpha1.GitHubWebhook{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubWebhook: &kelos.GitHubWebhook{
 						Events: []string{"push"},
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -555,21 +551,21 @@ func TestPrintTaskSpawnerTableGitHubWebhookNoRepo(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableLinearWebhook(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "linear-spawner",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					LinearWebhook: &kelosv1alpha1.LinearWebhook{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					LinearWebhook: &kelos.LinearWebhook{
 						Types: []string{"Issue", "Comment"},
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -584,26 +580,25 @@ func TestPrintTaskSpawnerTableLinearWebhook(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailGitHubWebhook(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "webhook-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				GitHubWebhook: &kelosv1alpha1.GitHubWebhook{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				GitHubWebhook: &kelos.GitHubWebhook{
 					Events:         []string{"issue_comment", "push"},
 					Repository:     "org/repo",
 					ExcludeAuthors: []string{"bot-user"},
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   3,
 			TotalTasksCreated: 2,
 		},
@@ -626,24 +621,23 @@ func TestPrintTaskSpawnerDetailGitHubWebhook(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailLinearWebhook(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "linear-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				LinearWebhook: &kelosv1alpha1.LinearWebhook{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				LinearWebhook: &kelos.LinearWebhook{
 					Types: []string{"Issue", "Comment"},
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   1,
 			TotalTasksCreated: 1,
 		},
@@ -664,22 +658,22 @@ func TestPrintTaskSpawnerDetailLinearWebhook(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableGenericWebhook(t *testing.T) {
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "sentry-fixer",
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GenericWebhook: &kelosv1alpha1.GenericWebhook{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GenericWebhook: &kelos.GenericWebhook{
 						Source:       "sentry",
 						FieldMapping: map[string]string{"id": "$.id"},
 					},
 				},
 			},
-			Status: kelosv1alpha1.TaskSpawnerStatus{
-				Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+			Status: kelos.TaskSpawnerStatus{
+				Phase: kelos.TaskSpawnerPhaseRunning,
 			},
 		},
 	}
@@ -694,25 +688,24 @@ func TestPrintTaskSpawnerTableGenericWebhook(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailGenericWebhook(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sentry-fixer",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				GenericWebhook: &kelosv1alpha1.GenericWebhook{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				GenericWebhook: &kelos.GenericWebhook{
 					Source:       "sentry",
 					FieldMapping: map[string]string{"id": "$.id"},
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   1,
 			TotalTasksCreated: 1,
 		},
@@ -733,29 +726,28 @@ func TestPrintTaskSpawnerDetailGenericWebhook(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailGitHubPullRequests(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pr-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				GitHubPullRequests: &kelosv1alpha1.GitHubPullRequests{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				GitHubPullRequests: &kelos.GitHubPullRequests{
 					State:       "open",
 					Labels:      []string{"bug", "help-wanted"},
 					ReviewState: "changes_requested",
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
-				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+				WorkspaceRef: &kelos.WorkspaceReference{
 					Name: "my-ws",
 				},
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   3,
 			TotalTasksCreated: 2,
 		},
@@ -778,29 +770,28 @@ func TestPrintTaskSpawnerDetailGitHubPullRequests(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailJira(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "jira-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				Jira: &kelosv1alpha1.Jira{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				Jira: &kelos.Jira{
 					BaseURL: "https://mycompany.atlassian.net",
 					Project: "PROJ",
 					JQL:     "status = Open",
-					SecretRef: kelosv1alpha1.SecretReference{
+					SecretRef: kelos.SecretReference{
 						Name: "jira-secret",
 					},
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
 			},
-			PollInterval: "10m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   5,
 			TotalTasksCreated: 3,
 		},
@@ -822,15 +813,15 @@ func TestPrintTaskSpawnerDetailJira(t *testing.T) {
 }
 
 func TestPrintWorkspaceDetail(t *testing.T) {
-	ws := &kelosv1alpha1.Workspace{
+	ws := &kelos.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-workspace",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.WorkspaceSpec{
+		Spec: kelos.WorkspaceSpec{
 			Repo: "https://github.com/org/repo.git",
 			Ref:  "main",
-			SecretRef: &kelosv1alpha1.SecretReference{
+			SecretRef: &kelos.SecretReference{
 				Name: "gh-token",
 			},
 		},
@@ -855,21 +846,21 @@ func TestPrintWorkspaceDetail(t *testing.T) {
 }
 
 func TestPrintTaskTableSingleItem(t *testing.T) {
-	task := kelosv1alpha1.Task{
+	task := kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-task",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-30 * time.Minute)),
 		},
-		Spec: kelosv1alpha1.TaskSpec{
+		Spec: kelos.TaskSpec{
 			Type: "claude-code",
 		},
-		Status: kelosv1alpha1.TaskStatus{
-			Phase: kelosv1alpha1.TaskPhaseSucceeded,
+		Status: kelos.TaskStatus{
+			Phase: kelos.TaskPhaseSucceeded,
 		},
 	}
 
 	var buf bytes.Buffer
-	printTaskTable(&buf, []kelosv1alpha1.Task{task}, false)
+	printTaskTable(&buf, []kelos.Task{task}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -881,7 +872,7 @@ func TestPrintTaskTableSingleItem(t *testing.T) {
 	if !strings.Contains(output, "claude-code") {
 		t.Errorf("expected type claude-code in output, got %q", output)
 	}
-	if !strings.Contains(output, string(kelosv1alpha1.TaskPhaseSucceeded)) {
+	if !strings.Contains(output, string(kelos.TaskPhaseSucceeded)) {
 		t.Errorf("expected phase Succeeded in output, got %q", output)
 	}
 	if strings.Contains(output, "Prompt:") {
@@ -890,27 +881,27 @@ func TestPrintTaskTableSingleItem(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerTableSingleItem(t *testing.T) {
-	spawner := kelosv1alpha1.TaskSpawner{
+	spawner := kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-spawner",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				Cron: &kelosv1alpha1.Cron{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				Cron: &kelos.Cron{
 					Schedule: "0 * * * *",
 				},
 			},
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			TotalDiscovered:   5,
 			TotalTasksCreated: 3,
 		},
 	}
 
 	var buf bytes.Buffer
-	printTaskSpawnerTable(&buf, []kelosv1alpha1.TaskSpawner{spawner}, false)
+	printTaskSpawnerTable(&buf, []kelos.TaskSpawner{spawner}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -928,19 +919,19 @@ func TestPrintTaskSpawnerTableSingleItem(t *testing.T) {
 }
 
 func TestPrintWorkspaceTableSingleItem(t *testing.T) {
-	ws := kelosv1alpha1.Workspace{
+	ws := kelos.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "my-workspace",
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 		},
-		Spec: kelosv1alpha1.WorkspaceSpec{
+		Spec: kelos.WorkspaceSpec{
 			Repo: "https://github.com/org/repo.git",
 			Ref:  "main",
 		},
 	}
 
 	var buf bytes.Buffer
-	printWorkspaceTable(&buf, []kelosv1alpha1.Workspace{ws}, false)
+	printWorkspaceTable(&buf, []kelos.Workspace{ws}, false)
 	output := buf.String()
 
 	if !strings.Contains(output, "NAME") {
@@ -959,25 +950,24 @@ func TestPrintWorkspaceTableSingleItem(t *testing.T) {
 
 func TestPrintTaskSpawnerDetail(t *testing.T) {
 	lastDiscovery := metav1.NewTime(time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC))
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				Cron: &kelosv1alpha1.Cron{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				Cron: &kelos.Cron{
 					Schedule: "0 * * * *",
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type:  "claude-code",
 				Model: "claude-sonnet-4-20250514",
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase:             kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase:             kelos.TaskSpawnerPhaseRunning,
 			DeploymentName:    "my-spawner-deploy",
 			TotalDiscovered:   10,
 			TotalTasksCreated: 7,
@@ -1008,12 +998,12 @@ func TestPrintTaskSpawnerDetail(t *testing.T) {
 }
 
 func TestPrintWorkspaceDetailWithoutOptionalFields(t *testing.T) {
-	ws := &kelosv1alpha1.Workspace{
+	ws := &kelos.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "minimal-ws",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.WorkspaceSpec{
+		Spec: kelos.WorkspaceSpec{
 			Repo: "https://github.com/org/repo.git",
 		},
 	}
@@ -1040,17 +1030,17 @@ func TestTaskDuration(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		status kelosv1alpha1.TaskStatus
+		status kelos.TaskStatus
 		want   string
 	}{
 		{
 			name:   "no start time",
-			status: kelosv1alpha1.TaskStatus{},
+			status: kelos.TaskStatus{},
 			want:   "-",
 		},
 		{
 			name: "completed task",
-			status: kelosv1alpha1.TaskStatus{
+			status: kelos.TaskStatus{
 				StartTime:      &startTime,
 				CompletionTime: &completionTime,
 			},
@@ -1058,7 +1048,7 @@ func TestTaskDuration(t *testing.T) {
 		},
 		{
 			name: "running task",
-			status: kelosv1alpha1.TaskStatus{
+			status: kelos.TaskStatus{
 				StartTime: &startTime,
 			},
 			want: "30m",
@@ -1082,35 +1072,33 @@ func TestPrintTaskDetail(t *testing.T) {
 	ttl := int32(3600)
 	timeout := int64(7200)
 
-	task := &kelosv1alpha1.Task{
+	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "full-task",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpec{
+		Spec: kelos.TaskSpec{
 			Type:   "claude-code",
 			Prompt: "Fix the bug",
-			Credentials: kelosv1alpha1.Credentials{
-				Type:      kelosv1alpha1.CredentialTypeAPIKey,
-				SecretRef: &kelosv1alpha1.SecretReference{Name: "my-secret"},
+			Credentials: kelos.Credentials{
+				Type:      kelos.CredentialTypeAPIKey,
+				SecretRef: &kelos.SecretReference{Name: "my-secret"},
 			},
 			Model:     "claude-sonnet-4-20250514",
 			Image:     "custom-image:latest",
 			Branch:    "feature/fix",
 			DependsOn: []string{"task-a", "task-b"},
-			WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+			WorkspaceRef: &kelos.WorkspaceReference{
 				Name: "my-ws",
 			},
-			AgentConfigRef: &kelosv1alpha1.AgentConfigReference{
-				Name: "my-config",
-			},
+			AgentConfigRefs:         []kelos.AgentConfigReference{{Name: "my-config"}},
 			TTLSecondsAfterFinished: &ttl,
-			PodOverrides: &kelosv1alpha1.PodOverrides{
+			PodOverrides: &kelos.PodOverrides{
 				ActiveDeadlineSeconds: &timeout,
 			},
 		},
-		Status: kelosv1alpha1.TaskStatus{
-			Phase:          kelosv1alpha1.TaskPhaseSucceeded,
+		Status: kelos.TaskStatus{
+			Phase:          kelos.TaskPhaseSucceeded,
 			JobName:        "full-task-job",
 			PodName:        "full-task-pod",
 			StartTime:      &startTime,
@@ -1336,21 +1324,21 @@ func TestPrintAgentConfigDetailMinimal(t *testing.T) {
 }
 
 func TestPrintTaskDetailMinimal(t *testing.T) {
-	task := &kelosv1alpha1.Task{
+	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "minimal-task",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpec{
+		Spec: kelos.TaskSpec{
 			Type:   "claude-code",
 			Prompt: "Do something",
-			Credentials: kelosv1alpha1.Credentials{
-				Type:      kelosv1alpha1.CredentialTypeAPIKey,
-				SecretRef: &kelosv1alpha1.SecretReference{Name: "secret"},
+			Credentials: kelos.Credentials{
+				Type:      kelos.CredentialTypeAPIKey,
+				SecretRef: &kelos.SecretReference{Name: "secret"},
 			},
 		},
-		Status: kelosv1alpha1.TaskStatus{
-			Phase: kelosv1alpha1.TaskPhasePending,
+		Status: kelos.TaskStatus{
+			Phase: kelos.TaskPhasePending,
 		},
 	}
 
@@ -1368,7 +1356,7 @@ func TestPrintTaskDetailMinimal(t *testing.T) {
 		"Branch:",
 		"Depends On:",
 		"Workspace:",
-		"Agent Config:",
+		"Agent Configs:",
 		"TTL:",
 		"Timeout:",
 		"Job:",
@@ -1389,68 +1377,63 @@ func TestPrintTaskDetailMinimal(t *testing.T) {
 func TestEffectivePollInterval(t *testing.T) {
 	tests := []struct {
 		name string
-		ts   *kelosv1alpha1.TaskSpawner
+		ts   *kelos.TaskSpawner
 		want string
 	}{
 		{
-			name: "github issues source override wins over top-level",
-			ts: &kelosv1alpha1.TaskSpawner{
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{PollInterval: "2m"},
+			name: "github issues source override wins over default",
+			ts: &kelos.TaskSpawner{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{PollInterval: "2m"},
 					},
-					PollInterval: "5m",
 				},
 			},
 			want: "2m",
 		},
 		{
-			name: "github issues falls back to top-level when source empty",
-			ts: &kelosv1alpha1.TaskSpawner{
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+			name: "github issues falls back to default when source empty",
+			ts: &kelos.TaskSpawner{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{},
 					},
-					PollInterval: "5m",
 				},
 			},
 			want: "5m",
 		},
 		{
-			name: "github pull requests source override wins over top-level",
-			ts: &kelosv1alpha1.TaskSpawner{
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubPullRequests: &kelosv1alpha1.GitHubPullRequests{PollInterval: "45s"},
+			name: "github pull requests source override wins over default",
+			ts: &kelos.TaskSpawner{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubPullRequests: &kelos.GitHubPullRequests{PollInterval: "45s"},
 					},
-					PollInterval: "5m",
 				},
 			},
 			want: "45s",
 		},
 		{
-			name: "jira source override wins over top-level",
-			ts: &kelosv1alpha1.TaskSpawner{
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						Jira: &kelosv1alpha1.Jira{PollInterval: "1m"},
+			name: "jira source override wins over default",
+			ts: &kelos.TaskSpawner{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						Jira: &kelos.Jira{PollInterval: "1m"},
 					},
-					PollInterval: "10m",
 				},
 			},
 			want: "1m",
 		},
 		{
-			name: "cron source uses top-level since it has no per-source override",
-			ts: &kelosv1alpha1.TaskSpawner{
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						Cron: &kelosv1alpha1.Cron{Schedule: "*/5 * * * *"},
+			name: "cron source uses default since it has no per-source override",
+			ts: &kelos.TaskSpawner{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						Cron: &kelos.Cron{Schedule: "*/5 * * * *"},
 					},
-					PollInterval: "3m",
 				},
 			},
-			want: "3m",
+			want: "5m",
 		},
 	}
 
@@ -1464,25 +1447,24 @@ func TestEffectivePollInterval(t *testing.T) {
 }
 
 func TestPrintTaskSpawnerDetailShowsPerSourcePollInterval(t *testing.T) {
-	spawner := &kelosv1alpha1.TaskSpawner{
+	spawner := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			When: kelosv1alpha1.When{
-				GitHubIssues: &kelosv1alpha1.GitHubIssues{
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				GitHubIssues: &kelos.GitHubIssues{
 					PollInterval: "2m",
 					Labels:       []string{"bug"},
 				},
 			},
-			TaskTemplate: kelosv1alpha1.TaskTemplate{
+			TaskTemplate: kelos.TaskTemplate{
 				Type: "claude-code",
 			},
-			PollInterval: "5m",
 		},
-		Status: kelosv1alpha1.TaskSpawnerStatus{
-			Phase: kelosv1alpha1.TaskSpawnerPhaseRunning,
+		Status: kelos.TaskSpawnerStatus{
+			Phase: kelos.TaskSpawnerPhaseRunning,
 		},
 	}
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 // credentialNone is a reserved value for apiKey or oauthToken in the config
@@ -170,12 +170,12 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 					}
 
 					wsName := "kelos-workspace"
-					ws := &kelosv1alpha1.Workspace{
+					ws := &kelos.Workspace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      wsName,
 							Namespace: ns,
 						},
-						Spec: kelosv1alpha1.WorkspaceSpec{
+						Spec: kelos.WorkspaceSpec{
 							Repo: wsCfg.Repo,
 							Ref:  wsCfg.Ref,
 						},
@@ -184,14 +184,14 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 						if err := ensureCredentialSecret(cfg, "kelos-workspace-credentials", "GITHUB_TOKEN", wsCfg.Token, yes); err != nil {
 							return err
 						}
-						ws.Spec.SecretRef = &kelosv1alpha1.SecretReference{
+						ws.Spec.SecretRef = &kelos.SecretReference{
 							Name: "kelos-workspace-credentials",
 						}
 					} else if wsCfg.GitHubApp != nil {
 						if err := ensureGitHubAppSecret(cfg, "kelos-workspace-credentials", wsCfg.GitHubApp, yes); err != nil {
 							return err
 						}
-						ws.Spec.SecretRef = &kelosv1alpha1.SecretReference{
+						ws.Spec.SecretRef = &kelos.SecretReference{
 							Name: "kelos-workspace-credentials",
 						}
 					}
@@ -200,7 +200,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 						if !apierrors.IsAlreadyExists(err) {
 							return fmt.Errorf("creating workspace: %w", err)
 						}
-						existing := &kelosv1alpha1.Workspace{}
+						existing := &kelos.Workspace{}
 						if err := cl.Get(ctx, client.ObjectKey{Name: wsName, Namespace: ns}, existing); err != nil {
 							return fmt.Errorf("fetching existing workspace: %w", err)
 						}
@@ -228,19 +228,19 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				name = "task-" + rand.String(5)
 			}
 
-			creds := kelosv1alpha1.Credentials{
-				Type: kelosv1alpha1.CredentialType(credentialType),
+			creds := kelos.Credentials{
+				Type: kelos.CredentialType(credentialType),
 			}
 			if secret != "" {
-				creds.SecretRef = &kelosv1alpha1.SecretReference{Name: secret}
+				creds.SecretRef = &kelos.SecretReference{Name: secret}
 			}
 
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: ns,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:        agentType,
 					Prompt:      prompt,
 					Credentials: creds,
@@ -258,25 +258,21 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 			}
 
 			if workspace != "" {
-				task.Spec.WorkspaceRef = &kelosv1alpha1.WorkspaceReference{
+				task.Spec.WorkspaceRef = &kelos.WorkspaceReference{
 					Name: workspace,
 				}
 			}
 
-			if len(agentConfigRefs) == 1 {
-				task.Spec.AgentConfigRef = &kelosv1alpha1.AgentConfigReference{
-					Name: agentConfigRefs[0],
-				}
-			} else if len(agentConfigRefs) > 1 {
+			if len(agentConfigRefs) > 0 {
 				for _, name := range agentConfigRefs {
-					task.Spec.AgentConfigRefs = append(task.Spec.AgentConfigRefs, kelosv1alpha1.AgentConfigReference{
+					task.Spec.AgentConfigRefs = append(task.Spec.AgentConfigRefs, kelos.AgentConfigReference{
 						Name: name,
 					})
 				}
 			}
 
 			// Build PodOverrides from --timeout and --env flags.
-			var po *kelosv1alpha1.PodOverrides
+			var po *kelos.PodOverrides
 			if timeout != "" {
 				d, err := time.ParseDuration(timeout)
 				if err != nil {
@@ -287,13 +283,13 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 					return fmt.Errorf("--timeout must be at least 1s")
 				}
 				if po == nil {
-					po = &kelosv1alpha1.PodOverrides{}
+					po = &kelos.PodOverrides{}
 				}
 				po.ActiveDeadlineSeconds = &secs
 			}
 			if len(envFlags) > 0 {
 				if po == nil {
-					po = &kelosv1alpha1.PodOverrides{}
+					po = &kelos.PodOverrides{}
 				}
 				for _, e := range envFlags {
 					parts := strings.SplitN(e, "=", 2)
@@ -310,7 +306,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 				task.Spec.PodOverrides = po
 			}
 
-			task.SetGroupVersionKind(kelosv1alpha1.GroupVersion.WithKind("Task"))
+			task.SetGroupVersionKind(kelos.GroupVersion.WithKind("Task"))
 
 			if dryRun {
 				return printYAML(os.Stdout, task)
@@ -357,9 +353,9 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 }
 
 func watchTask(ctx context.Context, cl client.Client, name, namespace string, out, errOut io.Writer) error {
-	var lastPhase kelosv1alpha1.TaskPhase
+	var lastPhase kelos.TaskPhase
 	for {
-		task := &kelosv1alpha1.Task{}
+		task := &kelos.Task{}
 		if err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, task); err != nil {
 			return fmt.Errorf("getting task: %w", err)
 		}
@@ -370,9 +366,9 @@ func watchTask(ctx context.Context, cl client.Client, name, namespace string, ou
 		}
 
 		switch task.Status.Phase {
-		case kelosv1alpha1.TaskPhaseSucceeded:
+		case kelos.TaskPhaseSucceeded:
 			return nil
-		case kelosv1alpha1.TaskPhaseFailed:
+		case kelos.TaskPhaseFailed:
 			fmt.Fprintf(errOut, "Run 'kelos logs %s' to view agent output, or 'kelos get tasks %s -d' for details.\n", name, name)
 			return fmt.Errorf("task %s failed", name)
 		}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -10,17 +10,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func TestWatchTask_SucceededReturnsNil(t *testing.T) {
-	task := &kelosv1alpha1.Task{
+	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "task-ok",
 			Namespace: "default",
 		},
-		Status: kelosv1alpha1.TaskStatus{
-			Phase: kelosv1alpha1.TaskPhaseSucceeded,
+		Status: kelos.TaskStatus{
+			Phase: kelos.TaskPhaseSucceeded,
 		},
 	}
 
@@ -40,13 +40,13 @@ func TestWatchTask_SucceededReturnsNil(t *testing.T) {
 }
 
 func TestWatchTask_FailedReturnsError(t *testing.T) {
-	task := &kelosv1alpha1.Task{
+	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "task-bad",
 			Namespace: "default",
 		},
-		Status: kelosv1alpha1.TaskStatus{
-			Phase: kelosv1alpha1.TaskPhaseFailed,
+		Status: kelos.TaskStatus{
+			Phase: kelos.TaskPhaseFailed,
 		},
 	}
 

--- a/internal/cli/suspend.go
+++ b/internal/cli/suspend.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func newSuspendCommand(cfg *ClientConfig) *cobra.Command {
@@ -49,7 +49,7 @@ func newSuspendTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 			key := client.ObjectKey{Name: args[0], Namespace: ns}
 
-			ts := &kelosv1alpha1.TaskSpawner{}
+			ts := &kelos.TaskSpawner{}
 			if err := cl.Get(ctx, key, ts); err != nil {
 				return fmt.Errorf("getting task spawner: %w", err)
 			}
@@ -114,7 +114,7 @@ func newResumeTaskSpawnerCommand(cfg *ClientConfig) *cobra.Command {
 			ctx := context.Background()
 			key := client.ObjectKey{Name: args[0], Namespace: ns}
 
-			ts := &kelosv1alpha1.TaskSpawner{}
+			ts := &kelos.TaskSpawner{}
 			if err := cl.Get(ctx, key, ts); err != nil {
 				return fmt.Errorf("getting task spawner: %w", err)
 			}

--- a/internal/cli/suspend_test.go
+++ b/internal/cli/suspend_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 func TestSuspendCommand_MissingName(t *testing.T) {
@@ -93,13 +93,12 @@ func TestResumeCommand_NoResourceType(t *testing.T) {
 
 func TestSuspendTaskSpawner_PatchPreservesFields(t *testing.T) {
 	maxConc := int32(5)
-	ts := &kelosv1alpha1.TaskSpawner{
+	ts := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			PollInterval:   "10m",
+		Spec: kelos.TaskSpawnerSpec{
 			MaxConcurrency: &maxConc,
 			Suspend:        ptr.To(false),
 		},
@@ -110,7 +109,7 @@ func TestSuspendTaskSpawner_PatchPreservesFields(t *testing.T) {
 	key := client.ObjectKey{Name: "my-spawner", Namespace: "default"}
 
 	// Get, patch suspend=true (same logic as the CLI command)
-	fetched := &kelosv1alpha1.TaskSpawner{}
+	fetched := &kelos.TaskSpawner{}
 	if err := cl.Get(ctx, key, fetched); err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -121,15 +120,12 @@ func TestSuspendTaskSpawner_PatchPreservesFields(t *testing.T) {
 	}
 
 	// Verify suspend changed and other fields preserved
-	updated := &kelosv1alpha1.TaskSpawner{}
+	updated := &kelos.TaskSpawner{}
 	if err := cl.Get(ctx, key, updated); err != nil {
 		t.Fatalf("Get after patch: %v", err)
 	}
 	if updated.Spec.Suspend == nil || !*updated.Spec.Suspend {
 		t.Error("Expected TaskSpawner to be suspended")
-	}
-	if updated.Spec.PollInterval != "10m" {
-		t.Errorf("PollInterval = %q, want %q", updated.Spec.PollInterval, "10m")
 	}
 	if updated.Spec.MaxConcurrency == nil || *updated.Spec.MaxConcurrency != 5 {
 		t.Error("MaxConcurrency was not preserved")
@@ -138,13 +134,12 @@ func TestSuspendTaskSpawner_PatchPreservesFields(t *testing.T) {
 
 func TestResumeTaskSpawner_PatchPreservesFields(t *testing.T) {
 	maxConc := int32(3)
-	ts := &kelosv1alpha1.TaskSpawner{
+	ts := &kelos.TaskSpawner{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-spawner",
 			Namespace: "default",
 		},
-		Spec: kelosv1alpha1.TaskSpawnerSpec{
-			PollInterval:   "2m",
+		Spec: kelos.TaskSpawnerSpec{
 			MaxConcurrency: &maxConc,
 			Suspend:        ptr.To(true),
 		},
@@ -155,7 +150,7 @@ func TestResumeTaskSpawner_PatchPreservesFields(t *testing.T) {
 	key := client.ObjectKey{Name: "my-spawner", Namespace: "default"}
 
 	// Get, patch suspend=false (same logic as the CLI command)
-	fetched := &kelosv1alpha1.TaskSpawner{}
+	fetched := &kelos.TaskSpawner{}
 	if err := cl.Get(ctx, key, fetched); err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -166,15 +161,12 @@ func TestResumeTaskSpawner_PatchPreservesFields(t *testing.T) {
 	}
 
 	// Verify suspend changed and other fields preserved
-	updated := &kelosv1alpha1.TaskSpawner{}
+	updated := &kelos.TaskSpawner{}
 	if err := cl.Get(ctx, key, updated); err != nil {
 		t.Fatalf("Get after patch: %v", err)
 	}
 	if updated.Spec.Suspend == nil || *updated.Spec.Suspend {
 		t.Error("Expected TaskSpawner to not be suspended")
-	}
-	if updated.Spec.PollInterval != "2m" {
-		t.Errorf("PollInterval = %q, want %q", updated.Spec.PollInterval, "2m")
 	}
 	if updated.Spec.MaxConcurrency == nil || *updated.Spec.MaxConcurrency != 3 {
 		t.Error("MaxConcurrency was not preserved")

--- a/internal/controller/taskspawner_controller_test.go
+++ b/internal/controller/taskspawner_controller_test.go
@@ -212,7 +212,7 @@ func TestReconcileWebhook(t *testing.T) {
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: "kelos.dev/v1alpha1",
+								APIVersion: "kelos.dev/v1alpha2",
 								Kind:       "TaskSpawner",
 								Name:       "test-webhook",
 								Controller: func() *bool { b := true; return &b }(),
@@ -251,7 +251,7 @@ func TestReconcileWebhook(t *testing.T) {
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: "kelos.dev/v1alpha1",
+								APIVersion: "kelos.dev/v1alpha2",
 								Kind:       "TaskSpawner",
 								Name:       "test-webhook",
 								Controller: func() *bool { b := true; return &b }(),

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -1886,7 +1886,7 @@ func TestReconcileCronJob_DeletesStaleDeployment(t *testing.T) {
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "kelos.dev/v1alpha1",
+					APIVersion: "kelos.dev/v1alpha2",
 					Kind:       "TaskSpawner",
 					Name:       "my-spawner",
 					Controller: func() *bool { b := true; return &b }(),
@@ -1965,7 +1965,7 @@ func TestReconcileDeployment_DeletesStaleCronJob(t *testing.T) {
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "kelos.dev/v1alpha1",
+					APIVersion: "kelos.dev/v1alpha2",
 					Kind:       "TaskSpawner",
 					Name:       "my-spawner",
 					Controller: func() *bool { b := true; return &b }(),

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -194,8 +194,7 @@ func TestRender_TaskSpawnerTemplatePlaceholdersRemainLiteral(t *testing.T) {
 		t.Error("expected branch placeholder example to remain literal in rendered CRD output")
 	}
 	// Each placeholder appears in the Branch and PromptTemplate godoc of
-	// TaskTemplate, which is present in both the v1alpha1 and v1alpha2
-	// TaskSpawner CRD schemas (2 fields x 2 versions = 4).
+	// TaskTemplate across the served TaskSpawner CRD schemas.
 	for _, expected := range []string{
 		"Available variables (all sources): {{.ID}}, {{.Title}}, {{.Kind}}",
 		"GitHub issue/Jira sources: {{.Number}}, {{.Body}}, {{.URL}}, {{.Labels}}, {{.Comments}}",

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/version"
 )
@@ -144,7 +143,7 @@ func collect(ctx context.Context, c client.Client, clientset kubernetes.Interfac
 	// Collect task data.
 	namespaces := make(map[string]struct{})
 
-	var tasks kelosv1alpha1.TaskList
+	var tasks kelos.TaskList
 	if err := c.List(ctx, &tasks); err != nil {
 		return nil, fmt.Errorf("listing tasks: %w", err)
 	}
@@ -177,7 +176,7 @@ func collect(ctx context.Context, c client.Client, clientset kubernetes.Interfac
 	}
 
 	// Collect TaskSpawner data.
-	var spawners kelosv1alpha1.TaskSpawnerList
+	var spawners kelos.TaskSpawnerList
 	if err := c.List(ctx, &spawners); err != nil {
 		return nil, fmt.Errorf("listing task spawners: %w", err)
 	}
@@ -211,7 +210,7 @@ func collect(ctx context.Context, c client.Client, clientset kubernetes.Interfac
 	}
 
 	// Collect Workspace data.
-	var workspaces kelosv1alpha1.WorkspaceList
+	var workspaces kelos.WorkspaceList
 	if err := c.List(ctx, &workspaces); err != nil {
 		return nil, fmt.Errorf("listing workspaces: %w", err)
 	}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -15,7 +15,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
@@ -48,9 +47,6 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	if err := clientgoscheme.AddToScheme(s); err != nil {
 		t.Fatal(err)
 	}
-	if err := kelosv1alpha1.AddToScheme(s); err != nil {
-		t.Fatal(err)
-	}
 	if err := kelos.AddToScheme(s); err != nil {
 		t.Fatalf("failed to add v1alpha2 scheme: %v", err)
 	}
@@ -60,12 +56,12 @@ func newScheme(t *testing.T) *runtime.Scheme {
 func TestCollect(t *testing.T) {
 	s := newScheme(t)
 
-	tasks := []kelosv1alpha1.Task{
+	tasks := []kelos.Task{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "ns-a"},
-			Spec:       kelosv1alpha1.TaskSpec{Type: "claude-code"},
-			Status: kelosv1alpha1.TaskStatus{
-				Phase: kelosv1alpha1.TaskPhaseSucceeded,
+			Spec:       kelos.TaskSpec{Type: "claude-code"},
+			Status: kelos.TaskStatus{
+				Phase: kelos.TaskPhaseSucceeded,
 				Results: map[string]string{
 					"cost_usd":      "1.50",
 					"input_tokens":  "1000",
@@ -75,9 +71,9 @@ func TestCollect(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "task-2", Namespace: "ns-a"},
-			Spec:       kelosv1alpha1.TaskSpec{Type: "claude-code"},
-			Status: kelosv1alpha1.TaskStatus{
-				Phase: kelosv1alpha1.TaskPhaseFailed,
+			Spec:       kelos.TaskSpec{Type: "claude-code"},
+			Status: kelos.TaskStatus{
+				Phase: kelos.TaskPhaseFailed,
 				Results: map[string]string{
 					"cost_usd":      "0.50",
 					"input_tokens":  "200",
@@ -87,22 +83,22 @@ func TestCollect(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "task-3", Namespace: "ns-b"},
-			Spec:       kelosv1alpha1.TaskSpec{Type: "codex"},
-			Status:     kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseRunning},
+			Spec:       kelos.TaskSpec{Type: "codex"},
+			Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseRunning},
 		},
 	}
 
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "spawner-1", Namespace: "ns-a"},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{GitHubIssues: &kelosv1alpha1.GitHubIssues{}},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{GitHubIssues: &kelos.GitHubIssues{}},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "spawner-2", Namespace: "ns-b"},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{Cron: &kelosv1alpha1.Cron{Schedule: "0 * * * *"}},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{Cron: &kelos.Cron{Schedule: "0 * * * *"}},
 			},
 		},
 	}
@@ -111,7 +107,7 @@ func TestCollect(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "config-1", Namespace: "ns-a"}},
 	}
 
-	workspaces := []kelosv1alpha1.Workspace{
+	workspaces := []kelos.Workspace{
 		{ObjectMeta: metav1.ObjectMeta{Name: "ws-1", Namespace: "ns-a"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "ws-2", Namespace: "ns-c"}},
 	}
@@ -374,34 +370,34 @@ func TestGetOrCreateInstallationIDExistingEmptyConfigMap(t *testing.T) {
 func TestSourceTypeExtraction(t *testing.T) {
 	s := newScheme(t)
 
-	spawners := []kelosv1alpha1.TaskSpawner{
+	spawners := []kelos.TaskSpawner{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "ns"},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{GitHubIssues: &kelosv1alpha1.GitHubIssues{}},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{GitHubIssues: &kelos.GitHubIssues{}},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "s2", Namespace: "ns"},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{Cron: &kelosv1alpha1.Cron{Schedule: "0 * * * *"}},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{Cron: &kelos.Cron{Schedule: "0 * * * *"}},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "s3", Namespace: "ns"},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{Jira: &kelosv1alpha1.Jira{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{Jira: &kelos.Jira{
 					BaseURL:   "https://jira.example.com",
 					Project:   "PROJ",
-					SecretRef: kelosv1alpha1.SecretReference{Name: "jira-secret"},
+					SecretRef: kelos.SecretReference{Name: "jira-secret"},
 				}},
 			},
 		},
 		// Duplicate GitHub source type — should only appear once.
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "s4", Namespace: "ns"},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{GitHubIssues: &kelosv1alpha1.GitHubIssues{}},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{GitHubIssues: &kelos.GitHubIssues{}},
 			},
 		},
 	}
@@ -443,10 +439,10 @@ func TestRun(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: systemNamespace},
 			Data:       map[string]string{installationIDKey: "run-test-id"},
 		},
-		&kelosv1alpha1.Task{
+		&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{Name: "t1", Namespace: "default"},
-			Spec:       kelosv1alpha1.TaskSpec{Type: "claude-code"},
-			Status:     kelosv1alpha1.TaskStatus{Phase: kelosv1alpha1.TaskPhaseSucceeded},
+			Spec:       kelos.TaskSpec{Type: "claude-code"},
+			Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseSucceeded},
 		},
 	).Build()
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -39,20 +39,20 @@ var _ = Describe("CLI", func() {
 		Expect(output).To(ContainSubstring("Succeeded"))
 
 		By("verifying task effort was persisted")
-		task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), "cli-task", metav1.GetOptions{})
+		task, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Get(context.TODO(), "cli-task", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(task.Spec.Effort).To(Equal("high"))
 
 		By("verifying YAML output for a single task")
 		output = framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha2"))
 		Expect(output).To(ContainSubstring("kind: Task"))
 		Expect(output).To(ContainSubstring("name: cli-task"))
 		Expect(output).To(ContainSubstring("effort: high"))
 
 		By("verifying JSON output for a single task")
 		output = framework.KelosOutput("get", "task", "cli-task", "-n", f.Namespace, "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha2"`))
 		Expect(output).To(ContainSubstring(`"kind": "Task"`))
 		Expect(output).To(ContainSubstring(`"name": "cli-task"`))
 		Expect(output).To(ContainSubstring(`"effort": "high"`))
@@ -99,11 +99,11 @@ var _ = Describe("CLI", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace resource")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-cli-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/kelos-dev/kelos.git",
 				Ref:  "main",
 			},
@@ -197,25 +197,25 @@ var _ = Describe("get", func() {
 
 	It("should output task list in YAML format", func() {
 		output := framework.KelosOutput("get", "tasks", "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha2"))
 		Expect(output).To(ContainSubstring("kind: TaskList"))
 	})
 
 	It("should output task list in JSON format", func() {
 		output := framework.KelosOutput("get", "tasks", "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha2"`))
 		Expect(output).To(ContainSubstring(`"kind": "TaskList"`))
 	})
 
 	It("should output workspace list in YAML format", func() {
 		output := framework.KelosOutput("get", "workspaces", "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha2"))
 		Expect(output).To(ContainSubstring("kind: WorkspaceList"))
 	})
 
 	It("should output workspace list in JSON format", func() {
 		output := framework.KelosOutput("get", "workspaces", "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha2"`))
 		Expect(output).To(ContainSubstring(`"kind": "WorkspaceList"`))
 	})
 
@@ -246,13 +246,13 @@ var _ = Describe("workspace CRUD", func() {
 
 		By("verifying YAML output")
 		output = framework.KelosOutput("get", "workspace", "test-ws", "-n", f.Namespace, "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha2"))
 		Expect(output).To(ContainSubstring("kind: Workspace"))
 		Expect(output).To(ContainSubstring("name: test-ws"))
 
 		By("verifying JSON output")
 		output = framework.KelosOutput("get", "workspace", "test-ws", "-n", f.Namespace, "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha2"`))
 		Expect(output).To(ContainSubstring(`"kind": "Workspace"`))
 
 		By("deleting workspace via CLI")
@@ -274,7 +274,7 @@ var _ = Describe("agentconfig CRUD", func() {
 		)
 
 		By("verifying agentconfig exists via typed client")
-		ac, err := f.KelosClientset.ApiV1alpha1().AgentConfigs(f.Namespace).Get(
+		ac, err := f.KelosClientset.ApiV1alpha2().AgentConfigs(f.Namespace).Get(
 			context.TODO(), "test-ac", metav1.GetOptions{},
 		)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -50,11 +50,11 @@ var _ = Describe("Config", func() {
 
 	It("should allow CLI flags to override config file", func() {
 		By("creating a Workspace resource for override")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-config-ws-override",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/kelos-dev/kelos.git",
 				Ref:  "main",
 			},

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	kelosclientset "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned"
 )
 
@@ -128,7 +128,7 @@ func (f *Framework) collectDebugInfo() {
 	ctx := context.TODO()
 
 	// List tasks
-	tasks, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).List(ctx, metav1.ListOptions{})
+	tasks, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
 		for _, t := range tasks.Items {
 			fmt.Fprintf(GinkgoWriter, "Task %s: phase=%s\n", t.Name, t.Status.Phase)
@@ -136,7 +136,7 @@ func (f *Framework) collectDebugInfo() {
 	}
 
 	// List taskspawners
-	spawners, err := f.KelosClientset.ApiV1alpha1().TaskSpawners(f.Namespace).List(ctx, metav1.ListOptions{})
+	spawners, err := f.KelosClientset.ApiV1alpha2().TaskSpawners(f.Namespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
 		for _, s := range spawners.Items {
 			fmt.Fprintf(GinkgoWriter, "TaskSpawner %s: phase=%s\n", s.Name, s.Status.Phase)
@@ -218,47 +218,47 @@ func (f *Framework) CreateSecret(name string, literals ...string) {
 }
 
 // CreateTask creates a Task in the test namespace using the kelos clientset.
-func (f *Framework) CreateTask(task *kelosv1alpha1.Task) {
+func (f *Framework) CreateTask(task *kelos.Task) {
 	if task.Namespace == "" {
 		task.Namespace = f.Namespace
 	}
-	_, err := f.KelosClientset.ApiV1alpha1().Tasks(task.Namespace).Create(context.TODO(), task, metav1.CreateOptions{})
+	_, err := f.KelosClientset.ApiV1alpha2().Tasks(task.Namespace).Create(context.TODO(), task, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to create task %s", task.Name)
 }
 
 // CreateWorkspace creates a Workspace in the test namespace using the kelos clientset.
-func (f *Framework) CreateWorkspace(ws *kelosv1alpha1.Workspace) {
+func (f *Framework) CreateWorkspace(ws *kelos.Workspace) {
 	if ws.Namespace == "" {
 		ws.Namespace = f.Namespace
 	}
-	_, err := f.KelosClientset.ApiV1alpha1().Workspaces(ws.Namespace).Create(context.TODO(), ws, metav1.CreateOptions{})
+	_, err := f.KelosClientset.ApiV1alpha2().Workspaces(ws.Namespace).Create(context.TODO(), ws, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to create workspace %s", ws.Name)
 }
 
 // CreateTaskSpawner creates a TaskSpawner in the test namespace using the kelos clientset.
-func (f *Framework) CreateTaskSpawner(ts *kelosv1alpha1.TaskSpawner) {
+func (f *Framework) CreateTaskSpawner(ts *kelos.TaskSpawner) {
 	if ts.Namespace == "" {
 		ts.Namespace = f.Namespace
 	}
-	_, err := f.KelosClientset.ApiV1alpha1().TaskSpawners(ts.Namespace).Create(context.TODO(), ts, metav1.CreateOptions{})
+	_, err := f.KelosClientset.ApiV1alpha2().TaskSpawners(ts.Namespace).Create(context.TODO(), ts, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to create taskspawner %s", ts.Name)
 }
 
 // DeleteTask deletes a Task by name from the test namespace using the kelos clientset.
 func (f *Framework) DeleteTask(name string) {
-	err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to delete task %s", name)
 }
 
 // DeleteWorkspace deletes a Workspace by name from the test namespace using the kelos clientset.
 func (f *Framework) DeleteWorkspace(name string) {
-	err := f.KelosClientset.ApiV1alpha1().Workspaces(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := f.KelosClientset.ApiV1alpha2().Workspaces(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to delete workspace %s", name)
 }
 
 // DeleteTaskSpawner deletes a TaskSpawner by name from the test namespace using the kelos clientset.
 func (f *Framework) DeleteTaskSpawner(name string) {
-	err := f.KelosClientset.ApiV1alpha1().TaskSpawners(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := f.KelosClientset.ApiV1alpha2().TaskSpawners(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to delete taskspawner %s", name)
 }
 
@@ -343,7 +343,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 
 // GetTaskPhase returns the phase of a Task.
 func (f *Framework) GetTaskPhase(name string) string {
-	task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	task, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to get task %s", name)
 	return string(task.Status.Phase)
 }
@@ -353,7 +353,7 @@ func (f *Framework) GetTaskPhase(name string) string {
 // transitions, so callers must poll rather than read once.
 func (f *Framework) WaitForTaskPhase(name, phase string) {
 	Eventually(func() string {
-		task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		task, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return ""
 		}
@@ -363,28 +363,28 @@ func (f *Framework) WaitForTaskPhase(name, phase string) {
 
 // GetTaskOutputs returns the outputs of a Task as a joined string.
 func (f *Framework) GetTaskOutputs(name string) string {
-	task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	task, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to get task %s", name)
 	return strings.Join(task.Status.Outputs, "\n")
 }
 
 // GetTaskResults returns the Results map of a Task.
 func (f *Framework) GetTaskResults(name string) map[string]string {
-	task, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	task, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to get task %s", name)
 	return task.Status.Results
 }
 
 // GetTaskSpawnerPhase returns the phase of a TaskSpawner.
 func (f *Framework) GetTaskSpawnerPhase(name string) string {
-	ts, err := f.KelosClientset.ApiV1alpha1().TaskSpawners(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	ts, err := f.KelosClientset.ApiV1alpha2().TaskSpawners(f.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Failed to get taskspawner %s", name)
 	return string(ts.Status.Phase)
 }
 
 // ListTaskNames returns the names of all Tasks matching the given label selector.
 func (f *Framework) ListTaskNames(labelSelector string) []string {
-	tasks, err := f.KelosClientset.ApiV1alpha1().Tasks(f.Namespace).List(context.TODO(), metav1.ListOptions{
+	tasks, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	Expect(err).NotTo(HaveOccurred(), "Failed to list tasks")

--- a/test/e2e/opencode_test.go
+++ b/test/e2e/opencode_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -20,17 +20,17 @@ var _ = Describe("OpenCode Task", func() {
 			"OPENCODE_API_KEY=")
 
 		By("creating an OpenCode Task")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "opencode-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "opencode",
 				Model:  openCodeTestModel,
 				Prompt: "Print 'Hello from OpenCode e2e test' to stdout",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeAPIKey,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "opencode-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeAPIKey,
+					SecretRef: &kelos.SecretReference{Name: "opencode-credentials"},
 				},
 			},
 		})

--- a/test/e2e/setup_command_test.go
+++ b/test/e2e/setup_command_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -26,11 +26,11 @@ var _ = Describe("Workspace setupCommand", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace with a setupCommand that writes a sentinel file")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-setup-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/kelos-dev/kelos.git",
 				Ref:  "main",
 				SetupCommand: []string{
@@ -41,19 +41,19 @@ var _ = Describe("Workspace setupCommand", func() {
 		})
 
 		By("creating a Task that asks the agent to read the sentinel file")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "setup-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  claudeCodeModel,
 				Prompt: "Print the contents of .kelos-setup-sentinel verbatim, then print 'done'",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeOAuth,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 				},
-				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-setup-workspace"},
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "e2e-setup-workspace"},
 			},
 		})
 
@@ -83,11 +83,11 @@ var _ = Describe("Workspace setupCommand", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace whose setupCommand drops an executable into $HOME/.local/bin")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-setup-path-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/kelos-dev/kelos.git",
 				Ref:  "main",
 				SetupCommand: []string{
@@ -104,19 +104,19 @@ chmod +x "$HOME/.local/bin/kelos-setup-probe"`,
 		})
 
 		By("creating a Task that invokes the installed binary by name")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "setup-path-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  claudeCodeModel,
 				Prompt: "Run the command 'kelos-setup-probe' and print its output verbatim.",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeOAuth,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 				},
-				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-setup-path-workspace"},
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "e2e-setup-path-workspace"},
 			},
 		})
 
@@ -142,11 +142,11 @@ chmod +x "$HOME/.local/bin/kelos-setup-probe"`,
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace whose setupCommand always fails")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-setup-failing-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/kelos-dev/kelos.git",
 				Ref:  "main",
 				SetupCommand: []string{
@@ -156,19 +156,19 @@ chmod +x "$HOME/.local/bin/kelos-setup-probe"`,
 		})
 
 		By("creating a Task referencing the failing workspace")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "setup-fail-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  claudeCodeModel,
 				Prompt: "Print 'agent should never run'",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeOAuth,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 				},
-				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-setup-failing-workspace"},
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "e2e-setup-failing-workspace"},
 			},
 		})
 

--- a/test/e2e/skills_test.go
+++ b/test/e2e/skills_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -25,7 +25,7 @@ var _ = Describe("AgentConfig with skills.sh", func() {
 		)
 
 		By("verifying agentconfig exists via typed client")
-		ac, err := f.KelosClientset.ApiV1alpha1().AgentConfigs(f.Namespace).Get(
+		ac, err := f.KelosClientset.ApiV1alpha2().AgentConfigs(f.Namespace).Get(
 			context.TODO(), "skills-ac", metav1.GetOptions{},
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -76,22 +76,20 @@ var _ = Describe("Task with skills.sh AgentConfig", func() {
 		)
 
 		By("creating a Task referencing the AgentConfig")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "skills-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  claudeCodeModel,
 				Prompt: "Use the kelos-e2e skill and show its output.",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeOAuth,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 				},
-				AgentConfigRef: &kelosv1alpha1.AgentConfigReference{
-					Name: "skills-ac",
-				},
-				PodOverrides: &kelosv1alpha1.PodOverrides{
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "skills-ac"}},
+				PodOverrides: &kelos.PodOverrides{
 					// Deterministic install check: this runs after the
 					// built-in skills-install init container and fails the
 					// Job when the skill is not in the plugin layout,
@@ -151,21 +149,19 @@ func describePluginTaskTests(cfg agentTestConfig) {
 			)
 
 			By("creating a Task referencing the AgentConfig")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: taskName,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'Hello from plugin e2e test' to stdout",
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{
-						Name: "plugin-ac",
-					},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "plugin-ac"}},
 				},
 			})
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 const (
@@ -23,7 +23,7 @@ var (
 
 type agentTestConfig struct {
 	AgentType        string
-	CredentialType   kelosv1alpha1.CredentialType
+	CredentialType   kelos.CredentialType
 	SecretName       string
 	SecretKey        string
 	SecretValue      *string
@@ -36,7 +36,7 @@ type agentTestConfig struct {
 var agentConfigs = []agentTestConfig{
 	{
 		AgentType:        "claude-code",
-		CredentialType:   kelosv1alpha1.CredentialTypeOAuth,
+		CredentialType:   kelos.CredentialTypeOAuth,
 		SecretName:       "claude-credentials",
 		SecretKey:        "CLAUDE_CODE_OAUTH_TOKEN",
 		SecretValue:      &oauthToken,
@@ -47,7 +47,7 @@ var agentConfigs = []agentTestConfig{
 	},
 	{
 		AgentType:        "codex",
-		CredentialType:   kelosv1alpha1.CredentialTypeOAuth,
+		CredentialType:   kelos.CredentialTypeOAuth,
 		SecretName:       "codex-credentials",
 		SecretKey:        "CODEX_AUTH_JSON",
 		SecretValue:      &codexAuthJSON,

--- a/test/e2e/task_test.go
+++ b/test/e2e/task_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -27,17 +27,17 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Task")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "basic-task",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'Hello from Kelos e2e test' to stdout",
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
@@ -71,30 +71,30 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Workspace resource")
-			f.CreateWorkspace(&kelosv1alpha1.Workspace{
+			f.CreateWorkspace(&kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "e2e-workspace",
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
 			})
 
 			By("creating a Task with workspace ref")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ws-task",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Create a file called 'test.txt' with the content 'hello' in the current directory and print 'done'",
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-workspace"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "e2e-workspace"},
 				},
 			})
 
@@ -132,30 +132,30 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Workspace resource")
-			f.CreateWorkspace(&kelosv1alpha1.Workspace{
+			f.CreateWorkspace(&kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "e2e-outputs-workspace",
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
 			})
 
 			By("creating a Task with workspace ref")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "outputs-task",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'hello' to stdout",
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-outputs-workspace"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "e2e-outputs-workspace"},
 				},
 			})
 
@@ -226,34 +226,34 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating Task A")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dep-chain-a",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'Task A done' to stdout",
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
 
 			By("creating Task B that depends on Task A")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dep-chain-b",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      cfg.AgentType,
 					Model:     cfg.Model,
 					Prompt:    "Print 'Task B done' to stdout",
 					DependsOn: []string{"dep-chain-a"},
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
@@ -287,17 +287,17 @@ func describeAgentTests(cfg agentTestConfig) {
 			f.CreateSecret(cfg.SecretName, cfg.SecretKey+"="+*cfg.SecretValue)
 
 			By("creating a Task")
-			f.CreateTask(&kelosv1alpha1.Task{
+			f.CreateTask(&kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cleanup-task",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   cfg.AgentType,
 					Model:  cfg.Model,
 					Prompt: "Print 'Hello' to stdout",
-					Credentials: kelosv1alpha1.Credentials{
+					Credentials: kelos.Credentials{
 						Type:      cfg.CredentialType,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: cfg.SecretName},
+						SecretRef: &kelos.SecretReference{Name: cfg.SecretName},
 					},
 				},
 			})
@@ -335,17 +335,17 @@ var _ = Describe("Task with make available", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Task that uses make")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "make-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  claudeCodeModel,
 				Prompt: "Run 'make --version' and print the output",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeOAuth,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 				},
 			},
 		})
@@ -387,31 +387,31 @@ var _ = Describe("Task with workspace and secretRef", func() {
 			"GITHUB_TOKEN="+githubToken)
 
 		By("creating a Workspace resource with secretRef")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-github-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo:      "https://github.com/kelos-dev/kelos.git",
 				Ref:       "main",
-				SecretRef: &kelosv1alpha1.SecretReference{Name: "workspace-credentials"},
+				SecretRef: &kelos.SecretReference{Name: "workspace-credentials"},
 			},
 		})
 
 		By("creating a Task with workspace ref")
-		f.CreateTask(&kelosv1alpha1.Task{
+		f.CreateTask(&kelos.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "github-task",
 			},
-			Spec: kelosv1alpha1.TaskSpec{
+			Spec: kelos.TaskSpec{
 				Type:   "claude-code",
 				Model:  claudeCodeModel,
 				Prompt: "Run 'gh auth status' and print the output",
-				Credentials: kelosv1alpha1.Credentials{
-					Type:      kelosv1alpha1.CredentialTypeOAuth,
-					SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+				Credentials: kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 				},
-				WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "e2e-github-workspace"},
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "e2e-github-workspace"},
 			},
 		})
 

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
@@ -32,42 +32,42 @@ var _ = Describe("TaskSpawner", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a Workspace resource with secretRef")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-spawner-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo:      "https://github.com/kelos-dev/kelos.git",
 				Ref:       "main",
-				SecretRef: &kelosv1alpha1.SecretReference{Name: "github-token"},
+				SecretRef: &kelos.SecretReference{Name: "github-token"},
 			},
 		})
 
 		By("creating a TaskSpawner")
-		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelos.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "spawner",
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubIssues: &kelosv1alpha1.GitHubIssues{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubIssues: &kelos.GitHubIssues{
 						Labels:        []string{"do-not-remove/e2e-anchor"},
 						ExcludeLabels: []string{"e2e-exclude-placeholder"},
 						State:         "open",
+						PollInterval:  "1m",
 					},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
+				TaskTemplate: kelos.TaskTemplate{
 					Type: "claude-code",
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "e2e-spawner-workspace",
 					},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeOAuth,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 					},
 					PromptTemplate: "Fix: {{.Title}}\n{{.Body}}",
 				},
-				PollInterval: "1m",
 			},
 		})
 
@@ -87,35 +87,36 @@ var _ = Describe("TaskSpawner", func() {
 
 	It("should be accessible via CLI", func() {
 		By("creating a Workspace resource")
-		f.CreateWorkspace(&kelosv1alpha1.Workspace{
+		f.CreateWorkspace(&kelos.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-spawner-workspace",
 			},
-			Spec: kelosv1alpha1.WorkspaceSpec{
+			Spec: kelos.WorkspaceSpec{
 				Repo: "https://github.com/kelos-dev/kelos.git",
 			},
 		})
 
 		By("creating a TaskSpawner")
-		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelos.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "spawner",
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					GitHubIssues: &kelos.GitHubIssues{
+						PollInterval: "5m",
+					},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
+				TaskTemplate: kelos.TaskTemplate{
 					Type: "claude-code",
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "e2e-spawner-workspace",
 					},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeOAuth,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 					},
 				},
-				PollInterval: "5m",
 			},
 		})
 
@@ -130,13 +131,13 @@ var _ = Describe("TaskSpawner", func() {
 
 		By("verifying YAML output for a single taskspawner")
 		output = framework.KelosOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha2"))
 		Expect(output).To(ContainSubstring("kind: TaskSpawner"))
 		Expect(output).To(ContainSubstring("name: spawner"))
 
 		By("verifying JSON output for a single taskspawner")
 		output = framework.KelosOutput("get", "taskspawner", "spawner", "-n", f.Namespace, "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha2"`))
 		Expect(output).To(ContainSubstring(`"kind": "TaskSpawner"`))
 		Expect(output).To(ContainSubstring(`"name": "spawner"`))
 
@@ -159,26 +160,25 @@ var _ = Describe("Cron TaskSpawner", func() {
 			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
 
 		By("creating a cron TaskSpawner with every-minute schedule")
-		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelos.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cron-spawner",
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					Cron: &kelosv1alpha1.Cron{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Cron: &kelos.Cron{
 						Schedule: "* * * * *",
 					},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
+				TaskTemplate: kelos.TaskTemplate{
 					Type:  "claude-code",
 					Model: claudeCodeModel,
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeOAuth,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 					},
 					PromptTemplate: "Cron triggered at {{.Time}} (schedule: {{.Schedule}}). Print 'Hello from cron'",
 				},
-				PollInterval: "1m",
 			},
 		})
 
@@ -198,24 +198,23 @@ var _ = Describe("Cron TaskSpawner", func() {
 
 	It("should be accessible via CLI with cron source info", func() {
 		By("creating a cron TaskSpawner")
-		f.CreateTaskSpawner(&kelosv1alpha1.TaskSpawner{
+		f.CreateTaskSpawner(&kelos.TaskSpawner{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cron-spawner",
 			},
-			Spec: kelosv1alpha1.TaskSpawnerSpec{
-				When: kelosv1alpha1.When{
-					Cron: &kelosv1alpha1.Cron{
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Cron: &kelos.Cron{
 						Schedule: "0 9 * * 1",
 					},
 				},
-				TaskTemplate: kelosv1alpha1.TaskTemplate{
+				TaskTemplate: kelos.TaskTemplate{
 					Type: "claude-code",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeOAuth,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "claude-credentials"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
 					},
 				},
-				PollInterval: "5m",
 			},
 		})
 
@@ -258,13 +257,13 @@ var _ = Describe("get taskspawner", func() {
 
 	It("should output taskspawner list in YAML format", func() {
 		output := framework.KelosOutput("get", "taskspawners", "-o", "yaml")
-		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha1"))
+		Expect(output).To(ContainSubstring("apiVersion: kelos.dev/v1alpha2"))
 		Expect(output).To(ContainSubstring("kind: TaskSpawnerList"))
 	})
 
 	It("should output taskspawner list in JSON format", func() {
 		output := framework.KelosOutput("get", "taskspawners", "-o", "json")
-		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha1"`))
+		Expect(output).To(ContainSubstring(`"apiVersion": "kelos.dev/v1alpha2"`))
 		Expect(output).To(ContainSubstring(`"kind": "TaskSpawnerList"`))
 	})
 

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/cli"
 )
 
@@ -44,7 +44,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the workspace exists in the cluster")
-			ws := &kelosv1alpha1.Workspace{}
+			ws := &kelos.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "my-ws", Namespace: ns.Name}, ws)).To(Succeed())
 			Expect(ws.Spec.Repo).To(Equal("https://github.com/org/repo.git"))
 			Expect(ws.Spec.Ref).To(Equal("main"))
@@ -96,7 +96,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the workspace has secretRef")
-			ws := &kelosv1alpha1.Workspace{}
+			ws := &kelos.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "secret-ws", Namespace: ns.Name}, ws)).To(Succeed())
 			Expect(ws.Spec.SecretRef).NotTo(BeNil())
 			Expect(ws.Spec.SecretRef.Name).To(Equal("my-gh-secret"))
@@ -123,7 +123,7 @@ var _ = Describe("CLI Workspace Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying workspace exists")
-			ws := &kelosv1alpha1.Workspace{}
+			ws := &kelos.Workspace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alias-ws", Namespace: ns.Name}, ws)).To(Succeed())
 
 			By("Getting workspace using 'ws' alias succeeds")
@@ -152,12 +152,12 @@ var _ = Describe("CLI Workspace Commands", func() {
 
 			By("Creating workspaces")
 			for _, name := range []string{"ws-alpha", "ws-beta"} {
-				ws := &kelosv1alpha1.Workspace{
+				ws := &kelos.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: kelosv1alpha1.WorkspaceSpec{
+					Spec: kelos.WorkspaceSpec{
 						Repo: "https://github.com/org/repo.git",
 					},
 				}
@@ -188,17 +188,17 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Creating multiple tasks directly")
 			for _, name := range []string{"task-a", "task-b", "task-c"} {
-				task := &kelosv1alpha1.Task{
+				task := &kelos.Task{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: kelosv1alpha1.TaskSpec{
+					Spec: kelos.TaskSpec{
 						Type:   "claude-code",
 						Prompt: "test",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -213,7 +213,7 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Verifying all tasks are deleted")
 			Eventually(func() int {
-				taskList := &kelosv1alpha1.TaskList{}
+				taskList := &kelos.TaskList{}
 				Expect(k8sClient.List(ctx, taskList, client.InNamespace(ns.Name))).To(Succeed())
 				count := 0
 				for _, t := range taskList.Items {
@@ -240,12 +240,12 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Creating multiple workspaces directly")
 			for _, name := range []string{"ws-a", "ws-b"} {
-				ws := &kelosv1alpha1.Workspace{
+				ws := &kelos.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: kelosv1alpha1.WorkspaceSpec{
+					Spec: kelos.WorkspaceSpec{
 						Repo: "https://github.com/org/repo.git",
 					},
 				}
@@ -258,7 +258,7 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Verifying all workspaces are deleted")
 			Eventually(func() int {
-				wsList := &kelosv1alpha1.WorkspaceList{}
+				wsList := &kelos.WorkspaceList{}
 				Expect(k8sClient.List(ctx, wsList, client.InNamespace(ns.Name))).To(Succeed())
 				return len(wsList.Items)
 			}, 10*time.Second, 250*time.Millisecond).Should(Equal(0))
@@ -279,17 +279,17 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Creating multiple task spawners directly")
 			for _, name := range []string{"ts-a", "ts-b"} {
-				ts := &kelosv1alpha1.TaskSpawner{
+				ts := &kelos.TaskSpawner{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: kelosv1alpha1.TaskSpawnerSpec{
-						TaskTemplate: kelosv1alpha1.TaskTemplate{
+					Spec: kelos.TaskSpawnerSpec{
+						TaskTemplate: kelos.TaskTemplate{
 							Type: "claude-code",
-							Credentials: kelosv1alpha1.Credentials{
-								Type: kelosv1alpha1.CredentialTypeAPIKey,
-								SecretRef: &kelosv1alpha1.SecretReference{
+							Credentials: kelos.Credentials{
+								Type: kelos.CredentialTypeAPIKey,
+								SecretRef: &kelos.SecretReference{
 									Name: "test-secret",
 								},
 							},
@@ -305,7 +305,7 @@ var _ = Describe("CLI Delete All Commands", func() {
 
 			By("Verifying all task spawners are deleted")
 			Eventually(func() bool {
-				tsList := &kelosv1alpha1.TaskSpawnerList{}
+				tsList := &kelos.TaskSpawnerList{}
 				Expect(k8sClient.List(ctx, tsList, client.InNamespace(ns.Name))).To(Succeed())
 				for _, ts := range tsList.Items {
 					if ts.DeletionTimestamp == nil {
@@ -369,17 +369,17 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner directly")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -396,7 +396,7 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 
 			By("Verifying the task spawner is deleted")
 			Eventually(func() bool {
-				ts2 := &kelosv1alpha1.TaskSpawner{}
+				ts2 := &kelos.TaskSpawner{}
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: "my-spawner", Namespace: ns.Name}, ts2)
 				if err == nil {
 					return ts2.DeletionTimestamp != nil
@@ -417,17 +417,17 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner directly")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "alias-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -444,7 +444,7 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 
 			By("Verifying the task spawner is deleted")
 			Eventually(func() bool {
-				ts2 := &kelosv1alpha1.TaskSpawner{}
+				ts2 := &kelos.TaskSpawner{}
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: "alias-spawner", Namespace: ns.Name}, ts2)
 				if err == nil {
 					return ts2.DeletionTimestamp != nil
@@ -465,17 +465,17 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-del",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -502,12 +502,12 @@ var _ = Describe("CLI Delete TaskSpawner Command", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ws-del",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/org/repo.git",
 				},
 			}
@@ -533,17 +533,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-suspend-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -559,7 +559,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner has suspend=true")
-			updatedTS := &kelosv1alpha1.TaskSpawner{}
+			updatedTS := &kelos.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cli-suspend-spawner", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeTrue())
@@ -578,18 +578,18 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 
 			By("Creating a TaskSpawner already suspended")
 			suspend := true
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-suspend-idem",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
+				Spec: kelos.TaskSpawnerSpec{
 					Suspend: &suspend,
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -605,7 +605,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner is still suspended")
-			updatedTS := &kelosv1alpha1.TaskSpawner{}
+			updatedTS := &kelos.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cli-suspend-idem", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeTrue())
@@ -624,18 +624,18 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 
 			By("Creating a suspended TaskSpawner")
 			suspend := true
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-resume-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
+				Spec: kelos.TaskSpawnerSpec{
 					Suspend: &suspend,
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -651,7 +651,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner has suspend=false")
-			updatedTS := &kelosv1alpha1.TaskSpawner{}
+			updatedTS := &kelos.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cli-resume-spawner", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeFalse())
@@ -669,17 +669,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner (not suspended)")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cli-resume-idem",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -707,17 +707,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "alias-suspend",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -733,7 +733,7 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the TaskSpawner is suspended")
-			updatedTS := &kelosv1alpha1.TaskSpawner{}
+			updatedTS := &kelos.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alias-suspend", Namespace: ns.Name}, updatedTS)).To(Succeed())
 			Expect(updatedTS.Spec.Suspend).NotTo(BeNil())
 			Expect(*updatedTS.Spec.Suspend).To(BeTrue())
@@ -760,17 +760,17 @@ var _ = Describe("CLI Suspend/Resume Commands", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-suspend-comp",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},

--- a/test/integration/completion_test.go
+++ b/test/integration/completion_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/cli"
 )
 
@@ -58,17 +58,17 @@ var _ = Describe("Completion", func() {
 
 			By("Creating Tasks")
 			for _, name := range []string{"task-alpha", "task-beta"} {
-				task := &kelosv1alpha1.Task{
+				task := &kelos.Task{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: ns.Name,
 					},
-					Spec: kelosv1alpha1.TaskSpec{
+					Spec: kelos.TaskSpec{
 						Type:   "claude-code",
 						Prompt: "test",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -96,17 +96,17 @@ var _ = Describe("Completion", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-one",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+				Spec: kelos.TaskSpawnerSpec{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeAPIKey,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeAPIKey,
+							SecretRef: &kelos.SecretReference{
 								Name: "test-secret",
 							},
 						},
@@ -133,17 +133,17 @@ var _ = Describe("Completion", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-gamma",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "test",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "test-secret",
 						},
 					},

--- a/test/integration/conversion_test.go
+++ b/test/integration/conversion_test.go
@@ -12,10 +12,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
+
+func init() {
+	if err := kelosv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+}
 
 // kelosCRDNames are the kelos CRDs that serve two versions with a conversion
 // webhook.

--- a/test/integration/install/conversion_test.go
+++ b/test/integration/install/conversion_test.go
@@ -1,0 +1,13 @@
+package install
+
+import (
+	"k8s.io/client-go/kubernetes/scheme"
+
+	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+)
+
+func init() {
+	if err := kelosv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+}

--- a/test/integration/install/install_test.go
+++ b/test/integration/install/install_test.go
@@ -22,18 +22,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/cli"
 	"github.com/kelos-dev/kelos/internal/codexauth"
 	"github.com/kelos-dev/kelos/internal/controller"
 )
 
 // controllerSettleTimeout bounds Eventually blocks that wait for the in-process
-// controller to reconcile after an install. The controllers read the v1alpha1
-// view of Tasks/TaskSpawners, so every watch event round-trips through the
-// conversion webhook; right after install (which re-applies the CRDs and
-// re-points their conversion config) the informers re-establish their watches,
-// so reconciles need more headroom than a non-converted resource would.
+// controller to reconcile after install re-applies the CRDs and re-points their
+// conversion config. The informers re-establish their watches, so reconciles
+// need more headroom than a stable resource would.
 const controllerSettleTimeout = 60 * time.Second
 
 // kelosCRDNames are the kelos CRDs that serve two versions with a conversion
@@ -383,13 +381,13 @@ func restoreCRDs(kubeconfigPath string) {
 	// Wait for all CRDs to be fully established before subsequent tests
 	// can create custom resources. We verify by attempting to list each type.
 	Eventually(func() error {
-		return k8sClient.List(ctx, &kelosv1alpha1.TaskList{})
+		return k8sClient.List(ctx, &kelos.TaskList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 	Eventually(func() error {
-		return k8sClient.List(ctx, &kelosv1alpha1.TaskSpawnerList{})
+		return k8sClient.List(ctx, &kelos.TaskSpawnerList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 	Eventually(func() error {
-		return k8sClient.List(ctx, &kelosv1alpha1.WorkspaceList{})
+		return k8sClient.List(ctx, &kelos.WorkspaceList{})
 	}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 
 	deleteControllerResources()
@@ -751,17 +749,17 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 			pointConversionToEnvtest()
 
 			By("Creating a Task with required fields")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-uninstall-task",
 					Namespace: "default",
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "test prompt",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "fake-secret"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "fake-secret"},
 					},
 				},
 			}
@@ -769,7 +767,7 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 
 			By("Waiting for the controller to add the finalizer")
 			Eventually(func() bool {
-				var t kelosv1alpha1.Task
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, types.NamespacedName{
 					Name: "test-uninstall-task", Namespace: "default",
 				}, &t); err != nil {
@@ -790,7 +788,7 @@ var _ = Describe("Install/Uninstall", Ordered, func() {
 
 			By("Verifying custom resources are gone")
 			Eventually(func() bool {
-				var taskList kelosv1alpha1.TaskList
+				var taskList kelos.TaskList
 				err := k8sClient.List(ctx, &taskList)
 				// After CRDs are deleted, listing will fail
 				return err != nil || len(taskList.Items) == 0

--- a/test/integration/install/suite_test.go
+++ b/test/integration/install/suite_test.go
@@ -27,7 +27,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/controller"
 	"github.com/kelos-dev/kelos/internal/conversion"
@@ -80,8 +79,6 @@ var _ = BeforeEach(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = kelosv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
 	err = kelos.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -24,7 +24,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/controller"
 	"github.com/kelos-dev/kelos/internal/conversion"
@@ -83,8 +82,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = kelosv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
 	err = kelos.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -121,7 +118,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	// Register the conversion webhooks (v1alpha1 <-> v1alpha2) for every kelos kind.
+	// Register the conversion webhooks for every Kelos kind.
 	for _, registration := range conversion.WebhookRegistrations() {
 		Expect(ctrl.NewWebhookManagedBy(mgr, registration.Object).
 			WithConverter(registration.Converter).

--- a/test/integration/task_test.go
+++ b/test/integration/task_test.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,17 +69,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Create a hello world program",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -90,7 +89,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			By("Verifying the Task has a finalizer")
 			Eventually(func() bool {
@@ -121,7 +120,7 @@ var _ = Describe("Task Controller", func() {
 			By("Verifying the Job spec")
 			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := createdJob.Spec.Template.Spec.Containers[0]
-			Expect(container.Name).To(Equal(kelosv1alpha1.AgentContainerName))
+			Expect(container.Name).To(Equal(kelos.AgentContainerName))
 			Expect(container.Command).To(Equal([]string{"/kelos_entrypoint.sh"}))
 			Expect(container.Args).To(Equal([]string{"Create a hello world program"}))
 
@@ -158,13 +157,13 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Verifying Task status is Running")
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			Eventually(func() kelos.TaskPhase {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseRunning))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseRunning))
 
 			By("Simulating Job completion")
 			Eventually(func() error {
@@ -177,13 +176,13 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Verifying Task status is Succeeded")
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			Eventually(func() kelos.TaskPhase {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseSucceeded))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseSucceeded))
 
 			By("Verifying Task has completion time")
 			Expect(createdTask.Status.CompletionTime).NotTo(BeNil())
@@ -225,17 +224,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task with OAuth")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-oauth-task",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Create a hello world program",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeOAuth,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{
 							Name: "claude-oauth",
 						},
 					},
@@ -330,19 +329,19 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-headers-from",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Resolve MCP headersFrom",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-headers-from-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-headers-from-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
@@ -436,19 +435,19 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-env-from",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Resolve MCP envFrom",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-env-from-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-env-from-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
@@ -525,32 +524,32 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-missing-secret",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fail on missing MCP secret",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-missing-secret-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-missing-secret-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			By("Verifying the Task transitions to Failed")
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			createdTask := &kelos.Task{}
+			Eventually(func() kelos.TaskPhase {
 				if err := k8sClient.Get(ctx, taskLookupKey, createdTask); err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseFailed))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseFailed))
 
 			By("Verifying the error mentions the missing secret")
 			Expect(createdTask.Status.Message).To(ContainSubstring("missing-secret"))
@@ -620,19 +619,19 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-precedence",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Prefer MCP secret values",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-precedence-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-precedence-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
@@ -745,19 +744,19 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-value-from",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Resolve MCP env valueFrom",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-value-from-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-value-from-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
@@ -836,32 +835,32 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-fieldref",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fail on unsupported MCP env valueFrom",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-fieldref-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-fieldref-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			By("Verifying the Task transitions to Failed with a clear message")
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			createdTask := &kelos.Task{}
+			Eventually(func() kelos.TaskPhase {
 				if err := k8sClient.Get(ctx, taskLookupKey, createdTask); err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseFailed))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseFailed))
 			Expect(createdTask.Status.Message).To(ContainSubstring("secretKeyRef and configMapKeyRef"))
 		})
 
@@ -985,19 +984,19 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, agentConfig)).Should(Succeed())
 
 			By("Creating a Task referencing the AgentConfig")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-mcp-optional-missing",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Resolve MCP env optional valueFrom",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRef: &kelosv1alpha1.AgentConfigReference{Name: "mcp-optional-missing-config"},
+					AgentConfigRefs: []kelos.AgentConfigReference{{Name: "mcp-optional-missing-config"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
@@ -1055,12 +1054,12 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace resource")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -1068,21 +1067,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task with workspace ref")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-ref",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace",
 					},
 				},
@@ -1175,15 +1174,15 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ghSecret)).Should(Succeed())
 
 			By("Creating a Workspace resource with secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-secret",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "github-token",
 					},
 				},
@@ -1191,21 +1190,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task with workspace ref")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-secret",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Create a PR",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace-secret",
 					},
 				},
@@ -1298,33 +1297,33 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace resource without ref")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-noref",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task with workspace ref but no git ref")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-noref",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Review the code",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace-noref",
 					},
 				},
@@ -1387,17 +1386,17 @@ var _ = Describe("Task Controller", func() {
 
 			By("Creating a Task with TTL")
 			ttl := int32(3) // 3 second TTL
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-ttl",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Create a hello world program",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -1407,7 +1406,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			By("Verifying a Job is created")
 			jobLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
@@ -1434,7 +1433,7 @@ var _ = Describe("Task Controller", func() {
 					// Task already deleted by TTL, which implies it reached a terminal phase
 					return true
 				}
-				return createdTask.Status.Phase == kelosv1alpha1.TaskPhaseSucceeded
+				return createdTask.Status.Phase == kelos.TaskPhaseSucceeded
 			}, timeout, interval).Should(BeTrue())
 
 			By("Verifying the Task is automatically deleted after TTL")
@@ -1469,17 +1468,17 @@ var _ = Describe("Task Controller", func() {
 
 			By("Creating a Task with TTL=0")
 			ttl := int32(0)
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-ttl-zero",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Create a hello world program",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -1489,7 +1488,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			By("Verifying a Job is created")
 			jobLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
@@ -1540,17 +1539,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task without TTL")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-no-ttl",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Create a hello world program",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -1559,7 +1558,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			By("Verifying a Job is created")
 			jobLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
@@ -1580,13 +1579,13 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Verifying Task reaches Succeeded")
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			Eventually(func() kelos.TaskPhase {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseSucceeded))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseSucceeded))
 
 			By("Verifying the Task is NOT deleted after waiting")
 			Consistently(func() error {
@@ -1618,12 +1617,12 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace resource")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -1631,23 +1630,23 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task with custom image")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-custom-image",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
 					Model: "gpt-4",
 					Image: "my-custom-agent:v1",
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace",
 					},
 				},
@@ -1727,15 +1726,15 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ghSecret)).Should(Succeed())
 
 			By("Creating a Workspace resource with GitHub Enterprise URL")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ghe-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.example.com/my-org/my-repo.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "github-token",
 					},
 				},
@@ -1743,21 +1742,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task referencing the GHE workspace")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ghe-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-ghe-workspace",
 					},
 				},
@@ -1838,17 +1837,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Codex Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-codex-task",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "codex",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "codex-api-key",
 						},
 					},
@@ -1858,7 +1857,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			By("Verifying the Task has a finalizer")
 			Eventually(func() bool {
@@ -1889,7 +1888,7 @@ var _ = Describe("Task Controller", func() {
 			By("Verifying the Job spec")
 			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := createdJob.Spec.Template.Spec.Containers[0]
-			Expect(container.Name).To(Equal(kelosv1alpha1.AgentContainerName))
+			Expect(container.Name).To(Equal(kelos.AgentContainerName))
 			Expect(container.Image).To(Equal(controller.CodexImage))
 			Expect(container.Command).To(Equal([]string{"/kelos_entrypoint.sh"}))
 			Expect(container.Args).To(Equal([]string{"Fix the bug"}))
@@ -1934,12 +1933,12 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace resource")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-codex-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -1947,21 +1946,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Codex Task with workspace ref")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-codex-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "codex",
 					Prompt: "Refactor the module",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "codex-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-codex-workspace",
 					},
 				},
@@ -1982,7 +1981,7 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying the main container uses codex image with uniform interface")
 			mainContainer := createdJob.Spec.Template.Spec.Containers[0]
-			Expect(mainContainer.Name).To(Equal(kelosv1alpha1.AgentContainerName))
+			Expect(mainContainer.Name).To(Equal(kelos.AgentContainerName))
 			Expect(mainContainer.Command).To(Equal([]string{"/kelos_entrypoint.sh"}))
 			Expect(mainContainer.Args).To(Equal([]string{"Refactor the module"}))
 
@@ -2031,17 +2030,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Codex Task with OAuth credentials")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-codex-oauth",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "codex",
 					Prompt: "Review the code",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeOAuth,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{
 							Name: "codex-oauth-secret",
 						},
 					},
@@ -2063,7 +2062,7 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying the Job has CODEX_AUTH_JSON env var")
 			container := createdJob.Spec.Template.Spec.Containers[0]
-			Expect(container.Name).To(Equal(kelosv1alpha1.AgentContainerName))
+			Expect(container.Name).To(Equal(kelos.AgentContainerName))
 			Expect(container.Env).To(HaveLen(2))
 			Expect(container.Env[0].Name).To(Equal("KELOS_AGENT_TYPE"))
 			Expect(container.Env[0].Value).To(Equal("codex"))
@@ -2096,17 +2095,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating an OpenCode Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-opencode-task",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "opencode",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "opencode-api-key",
 						},
 					},
@@ -2116,7 +2115,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			By("Verifying the Task has a finalizer")
 			Eventually(func() bool {
@@ -2147,7 +2146,7 @@ var _ = Describe("Task Controller", func() {
 			By("Verifying the Job spec")
 			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := createdJob.Spec.Template.Spec.Containers[0]
-			Expect(container.Name).To(Equal(kelosv1alpha1.AgentContainerName))
+			Expect(container.Name).To(Equal(kelos.AgentContainerName))
 			Expect(container.Image).To(Equal(controller.OpenCodeImage))
 			Expect(container.Command).To(Equal([]string{"/kelos_entrypoint.sh"}))
 			Expect(container.Args).To(Equal([]string{"Fix the bug"}))
@@ -2192,21 +2191,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task referencing a nonexistent Workspace")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-missing",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "nonexistent-workspace",
 					},
 				},
@@ -2224,23 +2223,23 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying the Task is not marked as Failed")
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 
 			Consistently(func() bool {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return true
 				}
-				return createdTask.Status.Phase != kelosv1alpha1.TaskPhaseFailed
+				return createdTask.Status.Phase != kelos.TaskPhaseFailed
 			}, 3*time.Second, interval).Should(BeTrue())
 
 			By("Creating the Workspace and verifying the Job is eventually created")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "nonexistent-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -2299,15 +2298,15 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ghAppSecret)).Should(Succeed())
 
 			By("Creating a Workspace with GitHub App secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-app",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "github-app-creds",
 					},
 				},
@@ -2315,21 +2314,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task with workspace ref")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-github-app",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Fix the bug",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace-app",
 					},
 				},
@@ -2405,17 +2404,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-events",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Test events",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -2424,7 +2423,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
 
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 			jobLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
 			createdJob := &batchv1.Job{}
 
@@ -2453,13 +2452,13 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Verifying Task status is Running")
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			Eventually(func() kelos.TaskPhase {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseRunning))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseRunning))
 
 			By("Verifying TaskRunning event is emitted")
 			Eventually(func() *corev1.Event {
@@ -2480,13 +2479,13 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Verifying Task status is Succeeded")
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			Eventually(func() kelos.TaskPhase {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseSucceeded))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseSucceeded))
 
 			By("Verifying TaskSucceeded event is emitted")
 			Eventually(func() *corev1.Event {
@@ -2521,17 +2520,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-fail-event",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Test failure event",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -2563,14 +2562,14 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task status is Failed")
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
-			Eventually(func() kelosv1alpha1.TaskPhase {
+			createdTask := &kelos.Task{}
+			Eventually(func() kelos.TaskPhase {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
 					return ""
 				}
 				return createdTask.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseFailed))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseFailed))
 
 			By("Verifying TaskFailed event is emitted")
 			Eventually(func() *corev1.Event {
@@ -2605,35 +2604,35 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating dependency Task A")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Do something",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskA)).Should(Succeed())
 
 			By("Creating Task B that depends on Task A")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      "claude-code",
 					Prompt:    "Continue work",
 					DependsOn: []string{"task-a"},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -2641,13 +2640,13 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task B enters Waiting phase")
 			taskBKey := types.NamespacedName{Name: "task-b", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskBKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseWaiting))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseWaiting))
 
 			By("Verifying no Job is created for Task B while dependency is not met")
 			jobBKey := types.NamespacedName{Name: "task-b", Namespace: ns.Name}
@@ -2682,13 +2681,13 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task A reaches Succeeded")
 			taskAKey := types.NamespacedName{Name: "task-a", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseSucceeded))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseSucceeded))
 
 			By("Verifying Task B Job is eventually created")
 			Eventually(func() bool {
@@ -2721,35 +2720,35 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating dependency Task A")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dep-task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Do something",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskA)).Should(Succeed())
 
 			By("Creating Task B that depends on Task A")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dep-task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      "claude-code",
 					Prompt:    "Continue work",
 					DependsOn: []string{"dep-task-a"},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -2776,25 +2775,25 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task A reaches Failed")
 			taskAKey := types.NamespacedName{Name: "dep-task-a", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseFailed))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseFailed))
 
 			By("Verifying Task B transitions to Failed with dependency message")
 			taskBKey := types.NamespacedName{Name: "dep-task-b", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskBKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, 2*timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseFailed))
+			}, 2*timeout, interval).Should(Equal(kelos.TaskPhaseFailed))
 
-			var taskBFinal kelosv1alpha1.Task
+			var taskBFinal kelos.Task
 			Expect(k8sClient.Get(ctx, taskBKey, &taskBFinal)).Should(Succeed())
 			Expect(taskBFinal.Status.Message).To(ContainSubstring("dep-task-a"))
 		})
@@ -2823,18 +2822,18 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating Task A with branch feature-1")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "branch-task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Task A",
 					Branch: "feature-1",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -2857,27 +2856,27 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task A is Running")
 			taskAKey := types.NamespacedName{Name: "branch-task-a", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseRunning))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseRunning))
 
 			By("Creating Task B with the same branch")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "branch-task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Task B",
 					Branch: "feature-1",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -2885,16 +2884,16 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task B enters Waiting phase")
 			taskBKey := types.NamespacedName{Name: "branch-task-b", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskBKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseWaiting))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseWaiting))
 
 			By("Verifying Task B message mentions branch lock")
-			var taskBWaiting kelosv1alpha1.Task
+			var taskBWaiting kelos.Task
 			Expect(k8sClient.Get(ctx, taskBKey, &taskBWaiting)).Should(Succeed())
 			Expect(taskBWaiting.Status.Message).To(ContainSubstring("feature-1"))
 
@@ -2940,12 +2939,12 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace resource")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -2953,20 +2952,20 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task with branch and workspace")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "branch-init-task",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Work on branch",
 					Branch: "feature-x",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace",
 					},
 				},
@@ -3045,24 +3044,24 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating two Workspace resources")
-			wsA := &kelosv1alpha1.Workspace{
+			wsA := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "workspace-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/org/repo-a.git",
 					Ref:  "main",
 				},
 			}
 			Expect(k8sClient.Create(ctx, wsA)).Should(Succeed())
 
-			wsB := &kelosv1alpha1.Workspace{
+			wsB := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "workspace-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/org/repo-b.git",
 					Ref:  "main",
 				},
@@ -3070,20 +3069,20 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, wsB)).Should(Succeed())
 
 			By("Creating Task A on workspace-a with branch feature-1")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "diff-ws-task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Task A",
 					Branch: "feature-1",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "workspace-a"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "workspace-a"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskA)).Should(Succeed())
@@ -3105,29 +3104,29 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying Task A is Running")
 			taskAKey := types.NamespacedName{Name: "diff-ws-task-a", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseRunning))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseRunning))
 
 			By("Creating Task B on workspace-b with the same branch name")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "diff-ws-task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Task B",
 					Branch: "feature-1",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "workspace-b"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "workspace-b"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskB)).Should(Succeed())
@@ -3164,36 +3163,36 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating Task A that depends on Task B")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cycle-task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      "claude-code",
 					Prompt:    "Task A",
 					DependsOn: []string{"cycle-task-b"},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskA)).Should(Succeed())
 
 			By("Creating Task B that depends on Task A")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cycle-task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      "claude-code",
 					Prompt:    "Task B",
 					DependsOn: []string{"cycle-task-a"},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -3201,12 +3200,12 @@ var _ = Describe("Task Controller", func() {
 
 			By("Verifying at least one task fails with circular dependency message")
 			Eventually(func() bool {
-				var tA kelosv1alpha1.Task
-				var tB kelosv1alpha1.Task
+				var tA kelos.Task
+				var tB kelos.Task
 				k8sClient.Get(ctx, types.NamespacedName{Name: "cycle-task-a", Namespace: ns.Name}, &tA)
 				k8sClient.Get(ctx, types.NamespacedName{Name: "cycle-task-b", Namespace: ns.Name}, &tB)
-				aFailed := tA.Status.Phase == kelosv1alpha1.TaskPhaseFailed && tA.Status.Message != "" && strings.Contains(tA.Status.Message, "Circular dependency")
-				bFailed := tB.Status.Phase == kelosv1alpha1.TaskPhaseFailed && tB.Status.Message != "" && strings.Contains(tB.Status.Message, "Circular dependency")
+				aFailed := tA.Status.Phase == kelos.TaskPhaseFailed && tA.Status.Message != "" && strings.Contains(tA.Status.Message, "Circular dependency")
+				bFailed := tB.Status.Phase == kelos.TaskPhaseFailed && tB.Status.Message != "" && strings.Contains(tB.Status.Message, "Circular dependency")
 				return aFailed || bFailed
 			}, 2*timeout, interval).Should(BeTrue())
 		})
@@ -3235,17 +3234,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating Task A and simulating it succeeding with outputs")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tmpl-task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Generate outputs",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -3266,17 +3265,17 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			taskAKey := types.NamespacedName{Name: "tmpl-task-a", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseSucceeded))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseSucceeded))
 
 			By("Manually setting outputs on Task A")
 			Eventually(func() error {
-				var t kelosv1alpha1.Task
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return err
 				}
@@ -3285,18 +3284,18 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Creating Task B with prompt template")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tmpl-task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      "claude-code",
 					Prompt:    `Review outputs: {{ index .Deps "tmpl-task-a" "Outputs" }}`,
 					DependsOn: []string{"tmpl-task-a"},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -3337,17 +3336,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating Task A and simulating it succeeding with results")
-			taskA := &kelosv1alpha1.Task{
+			taskA := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "results-task-a",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Generate results",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -3368,17 +3367,17 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			taskAKey := types.NamespacedName{Name: "results-task-a", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseSucceeded))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseSucceeded))
 
 			By("Manually setting outputs on Task A (results are derived from key: value lines)")
 			Eventually(func() error {
-				var t kelosv1alpha1.Task
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskAKey, &t); err != nil {
 					return err
 				}
@@ -3391,18 +3390,18 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Creating Task B with prompt template referencing results")
-			taskB := &kelosv1alpha1.Task{
+			taskB := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "results-task-b",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:      "claude-code",
 					Prompt:    `Review branch {{ index .Deps "results-task-a" "Results" "branch" }}`,
 					DependsOn: []string{"results-task-a"},
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
 				},
 			}
@@ -3443,12 +3442,12 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -3456,7 +3455,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating Task for issue #42 with rendered branch kelos-task-42")
-			task42 := &kelosv1alpha1.Task{
+			task42 := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-42",
 					Namespace: ns.Name,
@@ -3464,21 +3463,21 @@ var _ = Describe("Task Controller", func() {
 						"kelos.dev/taskspawner": "my-spawner",
 					},
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Issue #42: Fix login bug",
 					Branch: "kelos-task-42",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "test-workspace"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "test-workspace"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task42)).Should(Succeed())
 
 			By("Creating Task for issue #99 with rendered branch kelos-task-99")
-			task99 := &kelosv1alpha1.Task{
+			task99 := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-99",
 					Namespace: ns.Name,
@@ -3486,15 +3485,15 @@ var _ = Describe("Task Controller", func() {
 						"kelos.dev/taskspawner": "my-spawner",
 					},
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Issue #99: Add feature",
 					Branch: "kelos-task-99",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "test-workspace"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "test-workspace"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, task99)).Should(Succeed())
@@ -3592,12 +3591,12 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "lock-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/example/repo.git",
 					Ref:  "main",
 				},
@@ -3605,7 +3604,7 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating first Task with branch kelos-task-42")
-			taskFirst := &kelosv1alpha1.Task{
+			taskFirst := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-42-first",
 					Namespace: ns.Name,
@@ -3613,15 +3612,15 @@ var _ = Describe("Task Controller", func() {
 						"kelos.dev/taskspawner": "my-spawner",
 					},
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "First attempt at issue #42",
 					Branch: "kelos-task-42",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "lock-workspace"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "lock-workspace"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskFirst)).Should(Succeed())
@@ -3642,16 +3641,16 @@ var _ = Describe("Task Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			taskFirstKey := types.NamespacedName{Name: "spawner-42-first", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskFirstKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseRunning))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseRunning))
 
 			By("Creating second Task with same branch kelos-task-42")
-			taskSecond := &kelosv1alpha1.Task{
+			taskSecond := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-42-second",
 					Namespace: ns.Name,
@@ -3659,31 +3658,31 @@ var _ = Describe("Task Controller", func() {
 						"kelos.dev/taskspawner": "my-spawner",
 					},
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Second attempt at issue #42",
 					Branch: "kelos-task-42",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{Name: "lock-workspace"},
+					WorkspaceRef: &kelos.WorkspaceReference{Name: "lock-workspace"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, taskSecond)).Should(Succeed())
 
 			By("Verifying second Task enters Waiting phase due to branch lock")
 			taskSecondKey := types.NamespacedName{Name: "spawner-42-second", Namespace: ns.Name}
-			Eventually(func() kelosv1alpha1.TaskPhase {
-				var t kelosv1alpha1.Task
+			Eventually(func() kelos.TaskPhase {
+				var t kelos.Task
 				if err := k8sClient.Get(ctx, taskSecondKey, &t); err != nil {
 					return ""
 				}
 				return t.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskPhaseWaiting))
+			}, timeout, interval).Should(Equal(kelos.TaskPhaseWaiting))
 
 			By("Verifying waiting message references the branch")
-			var taskSecondWaiting kelosv1alpha1.Task
+			var taskSecondWaiting kelos.Task
 			Expect(k8sClient.Get(ctx, taskSecondKey, &taskSecondWaiting)).Should(Succeed())
 			Expect(taskSecondWaiting.Status.Message).To(ContainSubstring("kelos-task-42"))
 
@@ -3729,17 +3728,17 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Task")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-immutable",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Original prompt",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
@@ -3749,7 +3748,7 @@ var _ = Describe("Task Controller", func() {
 
 			By("Waiting for the Task to be reconciled with a finalizer")
 			taskLookupKey := types.NamespacedName{Name: task.Name, Namespace: ns.Name}
-			createdTask := &kelosv1alpha1.Task{}
+			createdTask := &kelos.Task{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, taskLookupKey, createdTask)
 				if err != nil {
@@ -3794,15 +3793,15 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace with remotes")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-remotes",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/org/repo.git",
 					Ref:  "main",
-					Remotes: []kelosv1alpha1.GitRemote{
+					Remotes: []kelos.GitRemote{
 						{Name: "private", URL: "https://github.com/user/repo.git"},
 						{Name: "downstream", URL: "https://github.com/vendor/repo.git"},
 					},
@@ -3811,21 +3810,21 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a Task referencing the workspace")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-task-remotes",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Work on feature",
-					Credentials: kelosv1alpha1.Credentials{
-						Type: kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{
+					Credentials: kelos.Credentials{
+						Type: kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{
 							Name: "anthropic-api-key",
 						},
 					},
-					WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+					WorkspaceRef: &kelos.WorkspaceReference{
 						Name: "test-workspace-remotes",
 					},
 				},
@@ -3924,19 +3923,19 @@ var _ = Describe("Task Controller", func() {
 			Expect(k8sClient.Create(ctx, roleConfig)).Should(Succeed())
 
 			By("Creating a Task referencing both AgentConfigs")
-			task := &kelosv1alpha1.Task{
+			task := &kelos.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-multi-agentconfig",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpec{
+				Spec: kelos.TaskSpec{
 					Type:   "claude-code",
 					Prompt: "Test multi agentconfig merge",
-					Credentials: kelosv1alpha1.Credentials{
-						Type:      kelosv1alpha1.CredentialTypeAPIKey,
-						SecretRef: &kelosv1alpha1.SecretReference{Name: "anthropic-api-key"},
+					Credentials: kelos.Credentials{
+						Type:      kelos.CredentialTypeAPIKey,
+						SecretRef: &kelos.SecretReference{Name: "anthropic-api-key"},
 					},
-					AgentConfigRefs: []kelosv1alpha1.AgentConfigReference{
+					AgentConfigRefs: []kelos.AgentConfigReference{
 						{Name: "base-config"},
 						{Name: "role-config"},
 					},

--- a/test/integration/taskspawner_test.go
+++ b/test/integration/taskspawner_test.go
@@ -17,17 +17,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kelosv1alpha1 "github.com/kelos-dev/kelos/api/v1alpha1"
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/controller"
 )
 
 var _ = Describe("TaskSpawner Controller", func() {
 	const (
-		// The spawner controller reads the v1alpha1 view of TaskSpawners, so
-		// every watch event round-trips through the conversion webhook. Right
-		// after the install/uninstall specs churn the CRDs, the in-process
-		// informer re-establishes its watch through that webhook, so reconciles
-		// need more headroom than a non-converted resource would.
+		// Right after the install/uninstall specs churn the CRDs, the
+		// in-process informer re-establishes its watch, so reconciles need more
+		// headroom than a stable resource would.
 		timeout  = time.Second * 60
 		interval = time.Millisecond * 250
 	)
@@ -43,12 +41,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -56,36 +54,35 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 
 			By("Verifying the TaskSpawner has a finalizer")
 			Eventually(func() bool {
@@ -149,7 +146,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(Equal(ts.Name))
 
 			By("Verifying TaskSpawner phase is Pending")
-			Expect(createdTS.Status.Phase).To(Equal(kelosv1alpha1.TaskSpawnerPhasePending))
+			Expect(createdTS.Status.Phase).To(Equal(kelos.TaskSpawnerPhasePending))
 		})
 	})
 
@@ -176,15 +173,15 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 			By("Creating a Workspace with secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-token",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "github-token",
 					},
 				},
@@ -192,26 +189,26 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with workspace secretRef")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-token",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							Reporting: &kelosv1alpha1.GitHubReporting{Enabled: true},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							Reporting: &kelos.GitHubReporting{Enabled: true},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-token",
 						},
 					},
@@ -248,36 +245,36 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-delete",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-delete",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-delete",
 						},
 					},
@@ -286,7 +283,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 
 			By("Waiting for the Deployment to be created")
 			deployLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
@@ -318,36 +315,36 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-idempotent",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-idempotent",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-idempotent",
 						},
 					},
@@ -373,7 +370,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Triggering re-reconcile by updating TaskSpawner")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			updatedTS := &kelosv1alpha1.TaskSpawner{}
+			updatedTS := &kelos.TaskSpawner{}
 			Expect(k8sClient.Get(ctx, tsLookupKey, updatedTS)).Should(Succeed())
 			if updatedTS.Annotations == nil {
 				updatedTS.Annotations = map[string]string{}
@@ -407,12 +404,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-types",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -420,38 +417,37 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with types=[issues, pulls]")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-types",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							Types: []string{"issues", "pulls"},
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-types",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying the TaskSpawner spec preserves types")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
@@ -480,24 +476,24 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner referencing a nonexistent Workspace")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-no-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "nonexistent-workspace",
 						},
 					},
@@ -516,23 +512,23 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Verifying the TaskSpawner is not marked as Failed")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 
 			Consistently(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				if err != nil {
 					return true
 				}
-				return createdTS.Status.Phase != kelosv1alpha1.TaskSpawnerPhaseFailed
+				return createdTS.Status.Phase != kelos.TaskSpawnerPhaseFailed
 			}, 3*time.Second, interval).Should(BeTrue())
 
 			By("Creating the Workspace and verifying the Deployment is eventually created")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "nonexistent-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -557,12 +553,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-maxconc",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -571,30 +567,29 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Creating a TaskSpawner with maxConcurrency=3")
 			maxConc := int32(3)
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-maxconc",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-maxconc",
 						},
 					},
-					PollInterval:   "5m",
 					MaxConcurrency: &maxConc,
 				},
 			}
@@ -602,7 +597,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Verifying maxConcurrency is stored in spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
@@ -629,7 +624,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Verifying activeTasks is stored in status")
-			updatedTS := &kelosv1alpha1.TaskSpawner{}
+			updatedTS := &kelos.TaskSpawner{}
 			Eventually(func() int {
 				err := k8sClient.Get(ctx, tsLookupKey, updatedTS)
 				if err != nil {
@@ -651,33 +646,32 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a TaskSpawner with cron source")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-cron",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						Cron: &kelosv1alpha1.Cron{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						Cron: &kelos.Cron{
 							Schedule: "0 9 * * 1",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 
 			By("Verifying the TaskSpawner has a finalizer")
 			Eventually(func() bool {
@@ -741,7 +735,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(Equal(ts.Name))
 
 			By("Verifying TaskSpawner phase is Running")
-			Expect(createdTS.Status.Phase).To(Equal(kelosv1alpha1.TaskSpawnerPhaseRunning))
+			Expect(createdTS.Status.Phase).To(Equal(kelos.TaskSpawnerPhaseRunning))
 		})
 	})
 
@@ -778,15 +772,15 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ghAppSecret)).Should(Succeed())
 
 			By("Creating a Workspace with GitHub App secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-app",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "github-app-creds",
 					},
 				},
@@ -794,31 +788,30 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-app",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State:     "open",
-							Reporting: &kelosv1alpha1.GitHubReporting{Enabled: true},
+							Reporting: &kelos.GitHubReporting{Enabled: true},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-app",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
@@ -878,12 +871,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-suspend",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -892,31 +885,30 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Creating a TaskSpawner with suspend=true")
 			suspend := true
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-suspend",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-suspend",
 						},
 					},
-					PollInterval: "5m",
-					Suspend:      &suspend,
+					Suspend: &suspend,
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
@@ -935,14 +927,14 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Verifying TaskSpawner phase is Suspended")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
-			Eventually(func() kelosv1alpha1.TaskSpawnerPhase {
+			createdTS := &kelos.TaskSpawner{}
+			Eventually(func() kelos.TaskSpawnerPhase {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				if err != nil {
 					return ""
 				}
 				return createdTS.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskSpawnerPhaseSuspended))
+			}, timeout, interval).Should(Equal(kelos.TaskSpawnerPhaseSuspended))
 
 			Expect(createdTS.Status.Message).To(Equal("Suspended by user"))
 		})
@@ -959,12 +951,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-resume",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -973,31 +965,30 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Creating a TaskSpawner with suspend=true")
 			suspend := true
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-resume",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-resume",
 						},
 					},
-					PollInterval: "5m",
-					Suspend:      &suspend,
+					Suspend: &suspend,
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
@@ -1016,14 +1007,14 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Waiting for phase to be Suspended")
-			createdTS := &kelosv1alpha1.TaskSpawner{}
-			Eventually(func() kelosv1alpha1.TaskSpawnerPhase {
+			createdTS := &kelos.TaskSpawner{}
+			Eventually(func() kelos.TaskSpawnerPhase {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				if err != nil {
 					return ""
 				}
 				return createdTS.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskSpawnerPhaseSuspended))
+			}, timeout, interval).Should(Equal(kelos.TaskSpawnerPhaseSuspended))
 
 			By("Resuming the TaskSpawner by setting suspend=false")
 			Eventually(func() error {
@@ -1046,13 +1037,13 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(Equal(int32(1)))
 
 			By("Verifying TaskSpawner phase is Running")
-			Eventually(func() kelosv1alpha1.TaskSpawnerPhase {
+			Eventually(func() kelos.TaskSpawnerPhase {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				if err != nil {
 					return ""
 				}
 				return createdTS.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskSpawnerPhaseRunning))
+			}, timeout, interval).Should(Equal(kelos.TaskSpawnerPhaseRunning))
 
 			Expect(createdTS.Status.Message).To(Equal("Resumed"))
 		})
@@ -1069,12 +1060,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-maxtotal",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -1083,30 +1074,29 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Creating a TaskSpawner with maxTotalTasks=10")
 			maxTotal := int32(10)
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-maxtotal",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-maxtotal",
 						},
 					},
-					PollInterval:  "5m",
 					MaxTotalTasks: &maxTotal,
 				},
 			}
@@ -1114,7 +1104,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Verifying maxTotalTasks is stored in spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
@@ -1143,12 +1133,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-suspend-running",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -1156,30 +1146,29 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner (not suspended)")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-suspend-running",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-suspend-running",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
@@ -1198,14 +1187,14 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Waiting for phase to be Pending")
-			createdTS := &kelosv1alpha1.TaskSpawner{}
-			Eventually(func() kelosv1alpha1.TaskSpawnerPhase {
+			createdTS := &kelos.TaskSpawner{}
+			Eventually(func() kelos.TaskSpawnerPhase {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				if err != nil {
 					return ""
 				}
 				return createdTS.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskSpawnerPhasePending))
+			}, timeout, interval).Should(Equal(kelos.TaskSpawnerPhasePending))
 
 			By("Suspending the TaskSpawner")
 			Eventually(func() error {
@@ -1228,13 +1217,13 @@ var _ = Describe("TaskSpawner Controller", func() {
 			}, timeout, interval).Should(Equal(int32(0)))
 
 			By("Verifying TaskSpawner phase is Suspended")
-			Eventually(func() kelosv1alpha1.TaskSpawnerPhase {
+			Eventually(func() kelos.TaskSpawnerPhase {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				if err != nil {
 					return ""
 				}
 				return createdTS.Status.Phase
-			}, timeout, interval).Should(Equal(kelosv1alpha1.TaskSpawnerPhaseSuspended))
+			}, timeout, interval).Should(Equal(kelos.TaskSpawnerPhaseSuspended))
 
 			By("Verifying DeploymentUpdated event is emitted")
 			Eventually(func() bool {
@@ -1264,12 +1253,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-events",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -1277,30 +1266,29 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-events",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-events",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
@@ -1343,12 +1331,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -1356,38 +1344,37 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with branch template")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "spawner-branch-tmpl",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace",
 						},
 						Branch: "kelos-task-{{.Number}}",
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying the branch template is stored in the spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
@@ -1419,12 +1406,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace pointing to the fork")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-fork",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/my-fork/my-repo.git",
 					Ref:  "main",
 				},
@@ -1432,31 +1419,30 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with githubIssues.repo pointing to upstream")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-fork",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							Repo:  "https://github.com/upstream-org/my-repo.git",
 							State: "open",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-fork",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
@@ -1501,15 +1487,15 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, patSecret)).Should(Succeed())
 
 			By("Creating a Workspace with PAT secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-switch",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "switch-secret",
 					},
 				},
@@ -1517,26 +1503,26 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner referencing the workspace")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-switch",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							Reporting: &kelosv1alpha1.GitHubReporting{Enabled: true},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							Reporting: &kelos.GitHubReporting{Enabled: true},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-switch",
 						},
 					},
@@ -1650,15 +1636,15 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, appSecret)).Should(Succeed())
 
 			By("Creating a Workspace with GitHub App secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-switch-2",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "switch-secret-2",
 					},
 				},
@@ -1666,26 +1652,26 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner referencing the workspace")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-switch-2",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							Reporting: &kelosv1alpha1.GitHubReporting{Enabled: true},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							Reporting: &kelos.GitHubReporting{Enabled: true},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-switch-2",
 						},
 					},
@@ -1805,15 +1791,15 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, appSecret)).Should(Succeed())
 
 			By("Creating a Workspace with PAT secretRef")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-ws-change",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
-					SecretRef: &kelosv1alpha1.SecretReference{
+					SecretRef: &kelos.SecretReference{
 						Name: "pat-secret-ws",
 					},
 				},
@@ -1821,26 +1807,26 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner referencing the workspace")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-ws-change",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							Reporting: &kelosv1alpha1.GitHubReporting{Enabled: true},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							Reporting: &kelos.GitHubReporting{Enabled: true},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-ws-change",
 						},
 					},
@@ -1861,11 +1847,11 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Updating workspace to point to GitHub App secret")
 			Eventually(func() error {
-				wsObj := &kelosv1alpha1.Workspace{}
+				wsObj := &kelos.Workspace{}
 				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-workspace-ws-change", Namespace: ns.Name}, wsObj); err != nil {
 					return err
 				}
-				wsObj.Spec.SecretRef = &kelosv1alpha1.SecretReference{
+				wsObj.Spec.SecretRef = &kelos.SecretReference{
 					Name: "app-secret-ws",
 				}
 				return k8sClient.Update(ctx, wsObj)
@@ -1891,7 +1877,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 	})
 
 	Context("When creating a TaskSpawner with comment-based workflow control", func() {
-		It("Should store triggerComment and excludeComments in spec and create a Deployment", func() {
+		It("Should store triggerComment and excludeComments in commentPolicy and create a Deployment", func() {
 			By("Creating a namespace")
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1901,12 +1887,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-comments",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -1914,48 +1900,47 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with triggerComment and excludeComments")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-comments",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							State:           "open",
-							TriggerComment:  "/kelos pick-up",
-							ExcludeComments: []string{"/kelos needs-input", "/kelos pause"},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							State: "open",
+							CommentPolicy: &kelos.GitHubCommentPolicy{
+								TriggerComment:  "/kelos pick-up",
+								ExcludeComments: []string{"/kelos needs-input", "/kelos pause"},
+							},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-comments",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying the comment fields are stored in spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			// The v1alpha2 storage form uses commentPolicy; the v1alpha1 view
-			// backfills the deprecated fields for older clients.
-			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy).To(BeNil())
-			Expect(createdTS.Spec.When.GitHubIssues.TriggerComment).To(Equal("/kelos pick-up"))
-			Expect(createdTS.Spec.When.GitHubIssues.ExcludeComments).To(ConsistOf("/kelos needs-input", "/kelos pause"))
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy).ToNot(BeNil())
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.TriggerComment).To(Equal("/kelos pick-up"))
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.ExcludeComments).To(ConsistOf("/kelos needs-input", "/kelos pause"))
 
 			By("Verifying a Deployment is created")
 			deployLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
@@ -1980,12 +1965,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-trigger-only",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -1993,45 +1978,46 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with only triggerComment")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-trigger-only",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							State:          "open",
-							TriggerComment: "/kelos pick-up",
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							State: "open",
+							CommentPolicy: &kelos.GitHubCommentPolicy{
+								TriggerComment: "/kelos pick-up",
+							},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-trigger-only",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying triggerComment is stored and excludeComments is empty")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy).To(BeNil())
-			Expect(createdTS.Spec.When.GitHubIssues.TriggerComment).To(Equal("/kelos pick-up"))
-			Expect(createdTS.Spec.When.GitHubIssues.ExcludeComments).To(BeEmpty())
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy).ToNot(BeNil())
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.TriggerComment).To(Equal("/kelos pick-up"))
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.ExcludeComments).To(BeEmpty())
 
 			By("Verifying a Deployment is created")
 			deployLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
@@ -2052,12 +2038,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-exclude-only",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -2065,45 +2051,46 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with only excludeComments")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-exclude-only",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							State:           "open",
-							ExcludeComments: []string{"/kelos needs-input"},
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
+							State: "open",
+							CommentPolicy: &kelos.GitHubCommentPolicy{
+								ExcludeComments: []string{"/kelos needs-input"},
+							},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-exclude-only",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying excludeComments is stored and triggerComment is empty")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy).To(BeNil())
-			Expect(createdTS.Spec.When.GitHubIssues.TriggerComment).To(BeEmpty())
-			Expect(createdTS.Spec.When.GitHubIssues.ExcludeComments).To(ConsistOf("/kelos needs-input"))
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy).ToNot(BeNil())
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.TriggerComment).To(BeEmpty())
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.ExcludeComments).To(ConsistOf("/kelos needs-input"))
 
 			By("Verifying a Deployment is created")
 			deployLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
@@ -2124,12 +2111,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-comment-policy",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -2137,44 +2124,43 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with commentPolicy")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-comment-policy",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
-							CommentPolicy: &kelosv1alpha1.GitHubCommentPolicy{
+							CommentPolicy: &kelos.GitHubCommentPolicy{
 								TriggerComment:    "/kelos pick-up",
 								ExcludeComments:   []string{"/kelos needs-input"},
 								AllowedUsers:      []string{"alice"},
-								AllowedTeams:      []kelosv1alpha1.GitHubTeamRef{"my-org/platform"},
+								AllowedTeams:      []kelos.GitHubTeamRef{"my-org/platform"},
 								MinimumPermission: "write",
 							},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-comment-policy",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying commentPolicy is stored in spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
@@ -2183,7 +2169,7 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.TriggerComment).To(Equal("/kelos pick-up"))
 			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.ExcludeComments).To(ConsistOf("/kelos needs-input"))
 			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.AllowedUsers).To(ConsistOf("alice"))
-			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.AllowedTeams).To(ConsistOf(kelosv1alpha1.GitHubTeamRef("my-org/platform")))
+			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.AllowedTeams).To(ConsistOf(kelos.GitHubTeamRef("my-org/platform")))
 			Expect(createdTS.Spec.When.GitHubIssues.CommentPolicy.MinimumPermission).To(Equal("write"))
 
 			By("Verifying a Deployment is created")
@@ -2193,64 +2179,6 @@ var _ = Describe("TaskSpawner Controller", func() {
 				err := k8sClient.Get(ctx, deployLookupKey, createdDeploy)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-		})
-
-		It("Should reject mixing commentPolicy with legacy comment fields", func() {
-			By("Creating a namespace")
-			ns := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-taskspawner-comment-policy-invalid",
-				},
-			}
-			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
-
-			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-workspace-comment-policy-invalid",
-					Namespace: ns.Name,
-				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
-					Repo: "https://github.com/kelos-dev/kelos.git",
-					Ref:  "main",
-				},
-			}
-			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
-
-			By("Creating an invalid TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-spawner-comment-policy-invalid",
-					Namespace: ns.Name,
-				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
-							State:          "open",
-							TriggerComment: "/kelos pick-up",
-							CommentPolicy: &kelosv1alpha1.GitHubCommentPolicy{
-								AllowedUsers: []string{"alice"},
-							},
-						},
-					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
-						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
-								Name: "claude-credentials",
-							},
-						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
-							Name: "test-workspace-comment-policy-invalid",
-						},
-					},
-					PollInterval: "5m",
-				},
-			}
-			err := k8sClient.Create(ctx, ts)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsInvalid(err)).To(BeTrue())
 		})
 
 		It("Should reject commentPolicy with invalid allowedTeams format", func() {
@@ -2263,12 +2191,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-comment-policy-invalid-team",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -2276,33 +2204,32 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating an invalid TaskSpawner")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-comment-policy-invalid-team",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							State: "open",
-							CommentPolicy: &kelosv1alpha1.GitHubCommentPolicy{
-								AllowedTeams: []kelosv1alpha1.GitHubTeamRef{"platform"},
+							CommentPolicy: &kelos.GitHubCommentPolicy{
+								AllowedTeams: []kelos.GitHubTeamRef{"platform"},
 							},
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-comment-policy-invalid-team",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			err := k8sClient.Create(ctx, ts)
@@ -2322,12 +2249,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-github-prs",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -2336,50 +2263,51 @@ var _ = Describe("TaskSpawner Controller", func() {
 
 			By("Creating a TaskSpawner with githubPullRequests")
 			draft := false
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-github-prs",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubPullRequests: &kelosv1alpha1.GitHubPullRequests{
-							State:           "open",
-							ReviewState:     "changes_requested",
-							TriggerComment:  "/kelos pick-up",
-							Labels:          []string{"generated-by-kelos"},
-							ExcludeComments: []string{"/kelos needs-input"},
-							Draft:           &draft,
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubPullRequests: &kelos.GitHubPullRequests{
+							State:       "open",
+							ReviewState: "changes_requested",
+							CommentPolicy: &kelos.GitHubCommentPolicy{
+								TriggerComment:  "/kelos pick-up",
+								ExcludeComments: []string{"/kelos needs-input"},
+							},
+							Labels: []string{"generated-by-kelos"},
+							Draft:  &draft,
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-github-prs",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying the githubPullRequests fields are stored in spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			Expect(createdTS.Spec.When.GitHubPullRequests.ReviewState).To(Equal("changes_requested"))
-			Expect(createdTS.Spec.When.GitHubPullRequests.CommentPolicy).To(BeNil())
-			Expect(createdTS.Spec.When.GitHubPullRequests.TriggerComment).To(Equal("/kelos pick-up"))
-			Expect(createdTS.Spec.When.GitHubPullRequests.ExcludeComments).To(ConsistOf("/kelos needs-input"))
+			Expect(createdTS.Spec.When.GitHubPullRequests.CommentPolicy).ToNot(BeNil())
+			Expect(createdTS.Spec.When.GitHubPullRequests.CommentPolicy.TriggerComment).To(Equal("/kelos pick-up"))
+			Expect(createdTS.Spec.When.GitHubPullRequests.CommentPolicy.ExcludeComments).To(ConsistOf("/kelos needs-input"))
 			Expect(createdTS.Spec.When.GitHubPullRequests.Labels).To(ConsistOf("generated-by-kelos"))
 			Expect(createdTS.Spec.When.GitHubPullRequests.Draft).ToNot(BeNil())
 			Expect(*createdTS.Spec.When.GitHubPullRequests.Draft).To(BeFalse())
@@ -2405,12 +2333,12 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 			By("Creating a Workspace")
-			ws := &kelosv1alpha1.Workspace{
+			ws := &kelos.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-source-poll",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.WorkspaceSpec{
+				Spec: kelos.WorkspaceSpec{
 					Repo: "https://github.com/kelos-dev/kelos.git",
 					Ref:  "main",
 				},
@@ -2418,44 +2346,41 @@ var _ = Describe("TaskSpawner Controller", func() {
 			Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 			By("Creating a TaskSpawner with per-source pollInterval")
-			ts := &kelosv1alpha1.TaskSpawner{
+			ts := &kelos.TaskSpawner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-spawner-source-poll",
 					Namespace: ns.Name,
 				},
-				Spec: kelosv1alpha1.TaskSpawnerSpec{
-					When: kelosv1alpha1.When{
-						GitHubIssues: &kelosv1alpha1.GitHubIssues{
+				Spec: kelos.TaskSpawnerSpec{
+					When: kelos.When{
+						GitHubIssues: &kelos.GitHubIssues{
 							Labels:       []string{"bug"},
 							PollInterval: "30s",
 						},
 					},
-					TaskTemplate: kelosv1alpha1.TaskTemplate{
+					TaskTemplate: kelos.TaskTemplate{
 						Type: "claude-code",
-						Credentials: kelosv1alpha1.Credentials{
-							Type: kelosv1alpha1.CredentialTypeOAuth,
-							SecretRef: &kelosv1alpha1.SecretReference{
+						Credentials: kelos.Credentials{
+							Type: kelos.CredentialTypeOAuth,
+							SecretRef: &kelos.SecretReference{
 								Name: "claude-credentials",
 							},
 						},
-						WorkspaceRef: &kelosv1alpha1.WorkspaceReference{
+						WorkspaceRef: &kelos.WorkspaceReference{
 							Name: "test-workspace-source-poll",
 						},
 					},
-					PollInterval: "5m",
 				},
 			}
 			Expect(k8sClient.Create(ctx, ts)).Should(Succeed())
 
 			By("Verifying the per-source pollInterval is stored in spec")
 			tsLookupKey := types.NamespacedName{Name: ts.Name, Namespace: ns.Name}
-			createdTS := &kelosv1alpha1.TaskSpawner{}
+			createdTS := &kelos.TaskSpawner{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, tsLookupKey, createdTS)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
-			// Per-source pollInterval is retained; the deprecated root
-			// pollInterval is dropped by the v1alpha1->v1alpha2 conversion.
 			Expect(createdTS.Spec.When.GitHubIssues.PollInterval).To(Equal("30s"))
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the kelos CLI Task, Workspace, and TaskSpawner paths to use `kelos.dev/v1alpha2` objects instead of requesting and printing `kelos.dev/v1alpha1` objects. `kelos run` now creates v1alpha2 Tasks and writes agent config references to `spec.agentConfigRefs`.

This fixes the CLI interpreting current resources as v1alpha1 because the command implementations were still importing v1alpha1 types and setting v1alpha1 GVKs.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Non-conversion/non-compat e2e and integration tests now use v1alpha2 fixtures. v1alpha1 references are preserved only for conversion and compatibility coverage.

Validation:
- `GOCACHE=/private/tmp/kelos-v1alpha2-gocache go test ./internal/cli ./internal/telemetry ./internal/controller ./internal/helmchart ./test/e2e/... ./test/integration/... -run '^$'`
- `go test ./internal/cli`
- `make test`
- `make verify`
- `make test-integration`

#### Does this PR introduce a user-facing change?

```release-note
kelos CLI now creates, reads, and prints Task, Workspace, and TaskSpawner resources using kelos.dev/v1alpha2.
```
