### PR TITLE
fix: grant list/watch on secrets for webhook RBAC and fall back to global GitHub token resolver

### DIFF
--- a/api/v1alpha2/taskspawner_types.go
+++ b/api/v1alpha2/taskspawner_types.go
@@ -469,8 +469,10 @@ type GitHubWebhookFilter struct {
 
 	// FilePatterns filters events by changed file paths.
 	// For push events, file paths are extracted directly from the payload.
-	// For pull_request events, the file list is fetched from the GitHub API
-	// using the workspace's secretRef for authentication.
+	// For pull_request events, the file list is fetched from the GitHub API.
+	// Authentication is resolved in order: workspace secretRef (PAT via
+	// GITHUB_TOKEN key, or GitHub App via appID/installationID/privateKey
+	// keys), then the webhook server's global GitHub token resolver.
 	// +optional
 	FilePatterns *FilePatterns `json:"filePatterns,omitempty"`
 }

--- a/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
@@ -15885,8 +15885,10 @@ spec:
                               description: |-
                                 FilePatterns filters events by changed file paths.
                                 For push events, file paths are extracted directly from the payload.
-                                For pull_request events, the file list is fetched from the GitHub API
-                                using the workspace's secretRef for authentication.
+                                For pull_request events, the file list is fetched from the GitHub API.
+                                Authentication is resolved in order: workspace secretRef (PAT via
+                                GITHUB_TOKEN key, or GitHub App via appID/installationID/privateKey
+                                keys), then the webhook server's global GitHub token resolver.
                               properties:
                                 exclude:
                                   description: |-

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -30628,8 +30628,10 @@ spec:
                               description: |-
                                 FilePatterns filters events by changed file paths.
                                 For push events, file paths are extracted directly from the payload.
-                                For pull_request events, the file list is fetched from the GitHub API
-                                using the workspace's secretRef for authentication.
+                                For pull_request events, the file list is fetched from the GitHub API.
+                                Authentication is resolved in order: workspace secretRef (PAT via
+                                GITHUB_TOKEN key, or GitHub App via appID/installationID/privateKey
+                                keys), then the webhook server's global GitHub token resolver.
                               properties:
                                 exclude:
                                   description: |-

--- a/internal/webhook/github_files.go
+++ b/internal/webhook/github_files.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/githubapp"
 )
 
 const (
@@ -27,11 +28,19 @@ type githubFile struct {
 
 // fetchPRChangedFiles fetches the list of changed files for a pull request
 // from the GitHub API. It resolves the GitHub token from the workspace's
-// secretRef.
+// secretRef, falling back to the global token resolver when the workspace
+// does not provide one.
 func fetchPRChangedFiles(ctx context.Context, cl client.Client, spawner *kelos.TaskSpawner, apiBaseURL, owner, repo string, number int) ([]string, error) {
-	token, err := resolveGitHubTokenFromWorkspace(ctx, cl, spawner)
+	token, err := resolveGitHubTokenFromWorkspace(ctx, cl, spawner, apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("resolving GitHub token for PR files: %w", err)
+	}
+
+	if token == "" && githubTokenResolver != nil {
+		token, err = githubTokenResolver(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolving GitHub token for PR files: %w", err)
+		}
 	}
 
 	if apiBaseURL == "" {
@@ -66,10 +75,11 @@ func fetchPRChangedFiles(ctx context.Context, cl client.Client, spawner *kelos.T
 	return paths, nil
 }
 
-// resolveGitHubTokenFromWorkspace reads the GITHUB_TOKEN from the workspace's
-// secretRef. Returns an empty string (no auth) if no workspace or secret is
-// configured.
-func resolveGitHubTokenFromWorkspace(ctx context.Context, cl client.Client, spawner *kelos.TaskSpawner) (string, error) {
+// resolveGitHubTokenFromWorkspace resolves a GitHub token from the workspace's
+// secretRef. It supports both PAT (GITHUB_TOKEN key) and GitHub App credentials
+// (appID, installationID, privateKey keys). Returns an empty string if no
+// workspace or secret is configured.
+func resolveGitHubTokenFromWorkspace(ctx context.Context, cl client.Client, spawner *kelos.TaskSpawner, apiBaseURL string) (string, error) {
 	wsRef := spawner.Spec.TaskTemplate.WorkspaceRef
 	if wsRef == nil {
 		return "", nil
@@ -95,7 +105,28 @@ func resolveGitHubTokenFromWorkspace(ctx context.Context, cl client.Client, spaw
 		return "", fmt.Errorf("fetching secret %s: %w", ws.Spec.SecretRef.Name, err)
 	}
 
-	return string(secret.Data["GITHUB_TOKEN"]), nil
+	if pat := string(secret.Data["GITHUB_TOKEN"]); pat != "" {
+		return pat, nil
+	}
+
+	if githubapp.IsGitHubApp(secret.Data) {
+		creds, err := githubapp.ParseCredentials(secret.Data)
+		if err != nil {
+			return "", fmt.Errorf("parsing GitHub App credentials from secret %s: %w", ws.Spec.SecretRef.Name, err)
+		}
+		tc := githubapp.NewTokenClient()
+		if apiBaseURL != "" {
+			tc.BaseURL = apiBaseURL
+		}
+		tp := githubapp.NewTokenProvider(tc, creds)
+		token, err := tp.Token(ctx)
+		if err != nil {
+			return "", fmt.Errorf("generating GitHub App token from secret %s: %w", ws.Spec.SecretRef.Name, err)
+		}
+		return token, nil
+	}
+
+	return "", fmt.Errorf("secret %s referenced by workspace %s contains neither a GITHUB_TOKEN key nor valid GitHub App credentials (appID, installationID, privateKey)", ws.Spec.SecretRef.Name, wsRef.Name)
 }
 
 func fetchGitHubFilesPage(ctx context.Context, httpClient *http.Client, pageURL, token string, out *[]githubFile) (string, error) {

--- a/internal/webhook/github_files_test.go
+++ b/internal/webhook/github_files_test.go
@@ -1,0 +1,248 @@
+package webhook
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+)
+
+func TestFetchPRChangedFiles_FallsBackToGlobalResolver(t *testing.T) {
+	origResolver := githubTokenResolver
+	defer func() { githubTokenResolver = origResolver }()
+
+	// Set up a test server that requires auth and returns file list.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "token global-test-token" {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"message":"Bad credentials"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]githubFile{
+			{Filename: "pkg/main.go"},
+			{Filename: "README.md"},
+		})
+	}))
+	defer srv.Close()
+
+	// Spawner with no workspace ref — resolveGitHubTokenFromWorkspace returns "".
+	spawner := &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-spawner", Namespace: "default"},
+		Spec: kelos.TaskSpawnerSpec{
+			TaskTemplate: kelos.TaskTemplate{},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = kelos.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Set global resolver.
+	githubTokenResolver = func(context.Context) (string, error) {
+		return "global-test-token", nil
+	}
+
+	files, err := fetchPRChangedFiles(context.Background(), cl, spawner, srv.URL, "org", "repo", 1)
+	if err != nil {
+		t.Fatalf("fetchPRChangedFiles() error = %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	if files[0] != "pkg/main.go" || files[1] != "README.md" {
+		t.Errorf("unexpected files: %v", files)
+	}
+}
+
+func TestFetchPRChangedFiles_PrefersWorkspaceToken(t *testing.T) {
+	origResolver := githubTokenResolver
+	defer func() { githubTokenResolver = origResolver }()
+
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]githubFile{{Filename: "a.go"}})
+	}))
+	defer srv.Close()
+
+	// Set up workspace with a secret containing a token.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-secret", Namespace: "default"},
+		Data:       map[string][]byte{"GITHUB_TOKEN": []byte("workspace-token")},
+	}
+	ws := &kelos.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ws", Namespace: "default"},
+		Spec: kelos.WorkspaceSpec{
+			SecretRef: &kelos.SecretReference{Name: "ws-secret"},
+		},
+	}
+	spawner := &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-spawner", Namespace: "default"},
+		Spec: kelos.TaskSpawnerSpec{
+			TaskTemplate: kelos.TaskTemplate{
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "test-ws"},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = kelos.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ws).Build()
+
+	// Set global resolver — should NOT be used since workspace provides a token.
+	githubTokenResolver = func(context.Context) (string, error) {
+		return "global-token-should-not-be-used", nil
+	}
+
+	_, err := fetchPRChangedFiles(context.Background(), cl, spawner, srv.URL, "org", "repo", 1)
+	if err != nil {
+		t.Fatalf("fetchPRChangedFiles() error = %v", err)
+	}
+	if receivedAuth != "token workspace-token" {
+		t.Errorf("expected workspace token to be used, got Authorization: %q", receivedAuth)
+	}
+}
+
+func TestFetchPRChangedFiles_ResolvesGitHubAppFromWorkspace(t *testing.T) {
+	origResolver := githubTokenResolver
+	defer func() { githubTokenResolver = origResolver }()
+
+	// Generate a test RSA key for GitHub App auth.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	// Set up a test server that:
+	// 1. Responds to token creation (POST /app/installations/.../access_tokens)
+	// 2. Responds to the files endpoint with an auth check
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/app/installations/67890/access_tokens" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"token":      "ghs_app_installation_token",
+				"expires_at": time.Now().Add(time.Hour).Format(time.RFC3339),
+			})
+			return
+		}
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]githubFile{{Filename: "app.go"}})
+	}))
+	defer srv.Close()
+
+	// Workspace secret with GitHub App credentials (no GITHUB_TOKEN).
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-secret", Namespace: "default"},
+		Data: map[string][]byte{
+			"appID":          []byte("12345"),
+			"installationID": []byte("67890"),
+			"privateKey":     keyPEM,
+		},
+	}
+	ws := &kelos.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-ws", Namespace: "default"},
+		Spec: kelos.WorkspaceSpec{
+			SecretRef: &kelos.SecretReference{Name: "app-secret"},
+		},
+	}
+	spawner := &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-spawner", Namespace: "default"},
+		Spec: kelos.TaskSpawnerSpec{
+			TaskTemplate: kelos.TaskTemplate{
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "app-ws"},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = kelos.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ws).Build()
+
+	// Global resolver should NOT be used since workspace has GitHub App credentials.
+	githubTokenResolver = func(context.Context) (string, error) {
+		return "global-token-should-not-be-used", nil
+	}
+
+	files, err := fetchPRChangedFiles(context.Background(), cl, spawner, srv.URL, "org", "repo", 1)
+	if err != nil {
+		t.Fatalf("fetchPRChangedFiles() error = %v", err)
+	}
+	if len(files) != 1 || files[0] != "app.go" {
+		t.Errorf("unexpected files: %v", files)
+	}
+	if receivedAuth != "token ghs_app_installation_token" {
+		t.Errorf("expected GitHub App installation token, got Authorization: %q", receivedAuth)
+	}
+}
+
+func TestFetchPRChangedFiles_ErrorsOnInvalidWorkspaceSecret(t *testing.T) {
+	origResolver := githubTokenResolver
+	defer func() { githubTokenResolver = origResolver }()
+
+	// Workspace secret exists but contains no GITHUB_TOKEN and no GitHub App keys.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-secret", Namespace: "default"},
+		Data:       map[string][]byte{"unrelated-key": []byte("some-value")},
+	}
+	ws := &kelos.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-ws", Namespace: "default"},
+		Spec: kelos.WorkspaceSpec{
+			SecretRef: &kelos.SecretReference{Name: "bad-secret"},
+		},
+	}
+	spawner := &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-spawner", Namespace: "default"},
+		Spec: kelos.TaskSpawnerSpec{
+			TaskTemplate: kelos.TaskTemplate{
+				WorkspaceRef: &kelos.WorkspaceReference{Name: "bad-ws"},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = kelos.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, ws).Build()
+
+	// Global resolver should NOT be reached — the invalid secret must cause an error.
+	githubTokenResolver = func(context.Context) (string, error) {
+		t.Fatal("global resolver should not be called when workspace secret is invalid")
+		return "", nil
+	}
+
+	_, err := fetchPRChangedFiles(context.Background(), cl, spawner, "http://unused", "org", "repo", 1)
+	if err == nil {
+		t.Fatal("expected error for workspace secret with no valid credentials, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-secret") {
+		t.Errorf("error should reference the secret name, got: %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes two issues causing the webhook server to fail when fetching PR changed files:

1. **RBAC**: The `kelos-webhook-role` ClusterRole only granted `get` on secrets, but the controller-runtime informer cache requires `list` and `watch` to sync. This caused `Timeout: failed waiting for *v1.Secret Informer to sync` errors.

2. **Token fallback**: `fetchPRChangedFiles` resolved the GitHub token exclusively from the spawner's workspace secretRef. When no workspace secret was configured, the request went out unauthenticated and hit GitHub's 60 req/hr rate limit (`API rate limit exceeded`). Now falls back to the global token resolver (configured via `GITHUB_TOKEN` env var or GitHub App credentials).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed webhook server failing to fetch PR changed files due to insufficient RBAC permissions on secrets and missing fallback to the global GitHub token resolver.
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes webhook PR file fetching by preferring workspace credentials (PAT or GitHub App) and falling back to the global resolver to avoid unauthenticated GitHub calls. RBAC now grants list/watch on secrets so the informer cache can sync.

- **Bug Fixes**
  - Auth: Resolves credentials in order — workspace `GITHUB_TOKEN`, then GitHub App (`appID`/`installationID`/`privateKey`), then the global resolver. Honors custom API base URL for GitHub App tokens. Returns a clear error when a workspace secret exists but has no valid creds. Adds tests for fallback, PAT, GitHub App, and invalid secret cases.
  - RBAC: Update `kelos-webhook-role` to include `list`/`watch` on `secrets`.

<sup>Written for commit e9c6c9f8ffdde6545bc0a2cc1f0b5d642ccd619c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



