### PR TITLE
fix(spawner): Normalize Task names to valid RFC 1123 names

### DIFF
--- a/cmd/kelos-spawner/main.go
+++ b/cmd/kelos-spawner/main.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -301,7 +302,7 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 
 	var newItems []source.WorkItem
 	for _, item := range items {
-		taskName := fmt.Sprintf("%s-%s", ts.Name, item.ID)
+		taskName := buildTaskName(ts.Name, item.ID)
 		existing, found := existingTaskMap[taskName]
 		if !found {
 			newItems = append(newItems, item)
@@ -367,7 +368,7 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 			break
 		}
 
-		taskName := fmt.Sprintf("%s-%s", ts.Name, item.ID)
+		taskName := buildTaskName(ts.Name, item.ID)
 
 		templateVars := source.WorkItemToTemplateVars(item)
 
@@ -806,4 +807,22 @@ func parsePollInterval(s string) time.Duration {
 		return 5 * time.Minute
 	}
 	return d
+}
+
+// buildTaskName combines a spawner name and work item ID into a valid RFC 1123
+// DNS subdomain for use as a Task object name. It normalizes IDs that are not
+// name-safe on their own, such as Jira issue keys (e.g. "PROJECT-1234"), whose
+// uppercase letters would otherwise be rejected by Kubernetes. IDs that are
+// already name-safe are returned unchanged.
+func buildTaskName(spawnerName, itemID string) string {
+	combined := spawnerName + "-" + itemID
+
+	if len(validation.IsDNS1123Subdomain(combined)) == 0 {
+		return combined
+	}
+
+	segments := strings.FieldsFunc(strings.ToLower(combined), func(r rune) bool {
+		return !('a' <= r && r <= 'z' || '0' <= r && r <= '9')
+	})
+	return strings.Join(segments, "-")
 }

--- a/cmd/kelos-spawner/main.go
+++ b/cmd/kelos-spawner/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"net/http"
@@ -809,20 +811,35 @@ func parsePollInterval(s string) time.Duration {
 	return d
 }
 
+// taskNameMaxLength bounds generated Task names to a single RFC 1123 label.
+// Although a Kubernetes object name may be up to DNS1123SubdomainMaxLength, the
+// name is reused as the kelos.dev/task label value and as the Job name, both of
+// which are limited to a 63-character label.
+const taskNameMaxLength = validation.DNS1123LabelMaxLength
+
 // buildTaskName combines a spawner name and work item ID into a valid RFC 1123
-// DNS subdomain for use as a Task object name. It normalizes IDs that are not
-// name-safe on their own, such as Jira issue keys (e.g. "PROJECT-1234"), whose
-// uppercase letters would otherwise be rejected by Kubernetes. IDs that are
-// already name-safe are returned unchanged.
+// name (at most taskNameMaxLength) for use as a Task object name. It normalizes
+// IDs that are not name-safe on their own, such as Jira issue keys (e.g.
+// "PROJECT-1234"), whose uppercase letters would otherwise be rejected by
+// Kubernetes. Names that are already valid and within length are returned
+// unchanged. Over-length names are truncated with a short hash suffix so that
+// distinct names do not collide on a shared prefix.
 func buildTaskName(spawnerName, itemID string) string {
 	combined := spawnerName + "-" + itemID
 
-	if len(validation.IsDNS1123Subdomain(combined)) == 0 {
+	if len(combined) <= taskNameMaxLength && len(validation.IsDNS1123Subdomain(combined)) == 0 {
 		return combined
 	}
 
 	segments := strings.FieldsFunc(strings.ToLower(combined), func(r rune) bool {
 		return !('a' <= r && r <= 'z' || '0' <= r && r <= '9')
 	})
-	return strings.Join(segments, "-")
+	name := strings.Join(segments, "-")
+
+	if len(name) > taskNameMaxLength {
+		sum := sha256.Sum256([]byte(name))
+		suffix := "-" + hex.EncodeToString(sum[:])[:10]
+		name = strings.TrimRight(name[:taskNameMaxLength-len(suffix)], "-") + suffix
+	}
+	return name
 }

--- a/cmd/kelos-spawner/taskname_test.go
+++ b/cmd/kelos-spawner/taskname_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/source"
+)
+
+func TestBuildTaskName(t *testing.T) {
+	cases := []struct {
+		name    string
+		spawner string
+		id      string
+		want    string
+	}{
+		{"jira key is lowercased", "my-spawner", "PROJECT-1234", "my-spawner-project-1234"},
+		{"github numeric id unchanged", "spawner", "42", "spawner-42"},
+		{"cron timestamp unchanged", "spawner", "20060102-1504", "spawner-20060102-1504"},
+		{"invalid characters replaced", "spawner", "PROJ_1", "spawner-proj-1"},
+		{"consecutive dashes collapsed", "spawner", "PROJ--1", "spawner-proj-1"},
+		{"dots treated as separators", "spawner", "a..b", "spawner-a-b"},
+		{"trailing separator trimmed", "spawner", "ABC-", "spawner-abc"},
+		{"all-invalid id falls back to spawner", "spawner", "@@@", "spawner"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildTaskName(tc.spawner, tc.id)
+			if got != tc.want {
+				t.Errorf("buildTaskName(%q, %q) = %q, want %q", tc.spawner, tc.id, got, tc.want)
+			}
+			// The result must be a name the Kubernetes API server accepts.
+			if errs := validation.IsDNS1123Subdomain(got); len(errs) != 0 {
+				t.Errorf("buildTaskName(%q, %q) = %q is not a valid RFC 1123 name: %v", tc.spawner, tc.id, got, errs)
+			}
+		})
+	}
+}
+
+func TestRunCycleWithSource_NormalizesJiraKeyAndDedupes(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	cl, key := setupTest(t, ts)
+
+	src := &fakeSource{
+		items: []source.WorkItem{
+			{ID: "PROJECT-1234", Number: 1234, Title: "Fix the thing"},
+		},
+	}
+
+	// First cycle: the Task is created with a normalized name.
+	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
+		t.Fatalf("first cycle: unexpected error: %v", err)
+	}
+
+	var taskList kelos.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("after first cycle: expected 1 task, got %d", len(taskList.Items))
+	}
+	if got, want := taskList.Items[0].Name, "spawner-project-1234"; got != want {
+		t.Errorf("task name = %q, want %q", got, want)
+	}
+
+	// Second cycle, same item: must not create a duplicate. This proves the
+	// dedup lookup name and the creation name are derived identically.
+	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
+		t.Fatalf("second cycle: unexpected error: %v", err)
+	}
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("after second cycle: expected 1 task (no duplicate), got %d", len(taskList.Items))
+	}
+}

--- a/cmd/kelos-spawner/taskname_test.go
+++ b/cmd/kelos-spawner/taskname_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -39,6 +40,30 @@ func TestBuildTaskName(t *testing.T) {
 				t.Errorf("buildTaskName(%q, %q) = %q is not a valid RFC 1123 name: %v", tc.spawner, tc.id, got, errs)
 			}
 		})
+	}
+}
+
+func TestBuildTaskNameLength(t *testing.T) {
+	// A valid but over-length name (lowercase alphanumerics) must still be
+	// capped: this exercises both the length guard on the fast path and the
+	// truncation branch.
+	got := buildTaskName("spawner", strings.Repeat("a", 100))
+	if len(got) > taskNameMaxLength {
+		t.Errorf("name length = %d, want <= %d (%q)", len(got), taskNameMaxLength, got)
+	}
+	if errs := validation.IsDNS1123Subdomain(got); len(errs) != 0 {
+		t.Errorf("name %q is not a valid RFC 1123 name: %v", got, errs)
+	}
+
+	// Distinct over-length inputs that share a truncated prefix must not collide,
+	// otherwise dedup would silently skip one of them.
+	a := buildTaskName("spawner", strings.Repeat("a", 80)+"-one")
+	b := buildTaskName("spawner", strings.Repeat("a", 80)+"-two")
+	if a == b {
+		t.Errorf("distinct long inputs collided: both produced %q", a)
+	}
+	if len(a) > taskNameMaxLength || len(b) > taskNameMaxLength {
+		t.Errorf("truncated names exceed %d: %q (%d), %q (%d)", taskNameMaxLength, a, len(a), b, len(b))
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A `TaskSpawner` with a Jira source fails to create any Task. The spawner builds each Task's name as `<spawner>-<item.ID>`, and for Jira sources `item.ID` is the issue key (e.g. `PROJECT-1234`). Kubernetes object names must be valid RFC 1123 DNS subdomains (lowercase only), so the uppercase key makes every generated name invalid and the API server rejects the create — Jira `TaskSpawner`s never produce Tasks.

GitHub issue/PR and Cron sources are unaffected because their IDs are already name-safe (numeric / timestamp).

This adds a `buildTaskName` helper and routes both task-name construction sites through it (the dedup lookup and the creation call), so the two derivations stay identical. The helper returns already-valid names unchanged and otherwise normalizes the combined name to a valid RFC 1123 name (lowercase, non-alphanumeric runs collapsed to `-`, leading/trailing separators trimmed). The raw issue key is preserved everywhere else it is used (prompt variables, browse URL, logs).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- No API/CRD or generated-code changes — a spawner-side fix only.
- `buildTaskName` is a no-op for already-valid names (GitHub numeric IDs, Cron timestamps), enforced via `validation.IsDNS1123Subdomain`, so existing Task names and the name-based dedup that keys on them are unaffected. Existing spawner tests asserting names like `spawner-42` pass unchanged.
- Tests: `TestBuildTaskName` covers the Jira fix, the GitHub/Cron no-ops, and normalization edge cases; `TestRunCycleWithSource_NormalizesJiraKeyAndDedupes` runs two spawn cycles to verify normalization and that no duplicate Task is created.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Jira `TaskSpawner` failing to create Tasks because issue keys produced invalid (uppercase) Kubernetes object names. Task names are now normalized to valid RFC 1123 names.
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira Task creation by normalizing Task names to valid RFC 1123 labels and capping them to 63 characters with a short hash when needed. GitHub and Cron names stay unchanged when already valid and within length; dedup and creation now use the same builder.

- **Bug Fixes**
  - Added `buildTaskName` to lowercase and normalize `<spawner>-<item.ID>`, collapse separators, trim, and enforce a 63-char max; on truncation, append a 10-char hash to avoid collisions.
  - Routed both dedup lookup and Task creation through `buildTaskName` to keep names consistent.
  - Added tests for Jira keys, no-op cases (GitHub/Cron), edge cases, over-length handling, and collision avoidance.

<sup>Written for commit 821970010beed8523501d5e51b01b1081acdd276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



