### PR TITLE
Deprecate v1alpha1 API

### DIFF
--- a/api/v1alpha1/agentconfig_types.go
+++ b/api/v1alpha1/agentconfig_types.go
@@ -143,6 +143,7 @@ type AgentConfigReference struct {
 // +genclient
 // +genclient:noStatus
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2"
 
 // AgentConfig is the Schema for the agentconfigs API.
 type AgentConfig struct {

--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -326,6 +326,7 @@ type TaskStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2"
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`

--- a/api/v1alpha1/taskspawner_types.go
+++ b/api/v1alpha1/taskspawner_types.go
@@ -1033,6 +1033,7 @@ type TaskSpawnerStatus struct {
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2"
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Workspace",type=string,JSONPath=`.spec.taskTemplate.workspaceRef.name`
 // +kubebuilder:printcolumn:name="Suspend",type=boolean,JSONPath=`.spec.suspend`

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -82,6 +82,7 @@ type WorkspaceSpec struct {
 // +genclient
 // +genclient:noStatus
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2"
 
 // Workspace is the Schema for the workspaces API.
 type Workspace struct {

--- a/internal/manifests/charts/kelos/templates/crds/agentconfig-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/agentconfig-crd.yaml
@@ -29,7 +29,9 @@ spec:
       conversionReviewVersions:
         - v1
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: AgentConfig is the Schema for the agentconfigs API.

--- a/internal/manifests/charts/kelos/templates/crds/task-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/task-crd.yaml
@@ -47,6 +47,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/taskspawner-crd.yaml
@@ -51,6 +51,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/internal/manifests/charts/kelos/templates/crds/workspace-crd.yaml
+++ b/internal/manifests/charts/kelos/templates/crds/workspace-crd.yaml
@@ -29,7 +29,9 @@ spec:
       conversionReviewVersions:
         - v1
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Workspace is the Schema for the workspaces API.

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -26,7 +26,9 @@ spec:
       conversionReviewVersions:
         - v1
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: AgentConfig is the Schema for the agentconfigs API.
@@ -671,6 +673,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -14797,6 +14801,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -31081,7 +31087,9 @@ spec:
       conversionReviewVersions:
         - v1
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: kelos.dev/v1alpha1 is deprecated; use kelos.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Workspace is the Schema for the workspaces API.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Deprecates the served `kelos.dev/v1alpha1` API version in the generated CRDs while keeping it served for backward compatibility. The deprecation warning points users to `kelos.dev/v1alpha2`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:
- `make update`
- `make verify`
- `make test`

#### Does this PR introduce a user-facing change?

```release-note
Mark kelos.dev/v1alpha1 API versions as deprecated in the CRDs and warn users to migrate to kelos.dev/v1alpha2.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates `kelos.dev/v1alpha1` in all CRDs and types and adds deprecation warnings pointing to `kelos.dev/v1alpha2`. `v1alpha1` remains served for backward compatibility.

- **Migration**
  - Update manifests and clients to `kelos.dev/v1alpha2`.
  - Expect `kubectl` warnings when using `v1alpha1` until migrated.

<sup>Written for commit 4f9347e755531d07b5d531fe941c81cdd4a2edd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

