### PR TITLE
Update self-development issue publication policy

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -8,6 +8,15 @@ This directory contains real-world orchestration patterns used by the Kelos proj
 
 Each TaskSpawner references an `AgentConfig` that defines git identity, comment signatures, and standard constraints. Some agents (triage, pr-responder, squash-commits, config-update) share the base `agentconfig.yaml` (`kelos-dev-agent`), while others (workers, planner, fake-user, fake-strategist, self-update, image-update) define their own `AgentConfig` inline.
 
+Autonomous discovery agents that publish GitHub issues maintain at most one
+open `generated-by-kelos` issue slot per TaskSpawner. The issue body includes a
+`kelos-taskspawner=<name>` marker so later runs can find it. A run may update
+the unassigned slot when it finds a clearly more impactful or important
+candidate, but it exits without changes when the slot has assignees. Assigned
+issues and PRs are treated as ongoing human or agent work and are not updated by
+autonomous discovery jobs. This cap does not apply to follow-up issues created
+while a worker or PR responder is handling an explicitly requested issue or PR.
+
 ## TaskSpawners
 
 | TaskSpawner | Trigger | Agent | Description |
@@ -18,11 +27,11 @@ Each TaskSpawner references an `AgentConfig` that defines git identity, comment 
 | **kelos-api-reviewer** | Webhook: issue/PR comment `/kelos api-review` | Codex | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
 | **kelos-pr-responder** | Webhook: PR review/comment on `generated-by-kelos` PRs | Codex | Re-engages on PR review feedback and updates the existing branch incrementally |
 | **kelos-triage** | Webhook: issue opened/labeled/reopened (`needs-actor`) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
-| **kelos-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
-| **kelos-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integration opportunities, and CRD/API extensions |
-| **kelos-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent PR feedback and updates agent configuration (conventions, prompts, configs) accordingly |
-| **kelos-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes prompts, configs, and workflow files — the pipeline improves itself |
-| **kelos-image-update** | Cron (daily 03:00 UTC) | Codex | Checks for newer agent image versions (Claude Code, Codex, Gemini, etc.) and creates PRs to update them |
+| **kelos-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user and maintains one unassigned issue slot for the highest-impact problem found |
+| **kelos-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integrations, and API ideas while maintaining one unassigned strategic issue slot |
+| **kelos-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent PR feedback and creates or updates unassigned configuration PRs accordingly |
+| **kelos-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews prompts, configs, and workflow files while maintaining one unassigned improvement issue slot |
+| **kelos-image-update** | Cron (daily 03:00 UTC) | Codex | Checks for newer agent image versions and creates or updates unassigned PRs for them |
 | **kelos-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Codex | Rebases and squashes PR branch commits into a single clean commit |
 
 ### kelos-workers.yaml
@@ -41,6 +50,8 @@ Picks up open GitHub issues when a maintainer posts `/kelos pick-up` and creates
 - Ensures CI passes before completion
 - Requires a `/kelos pick-up` comment to pick up an issue (maintainer approval gate)
 - Hands off PR review feedback to `kelos-pr-responder`
+- May create separate follow-up issues for out-of-scope discoveries; those
+  follow-ups are exempt from the per-TaskSpawner issue slot cap
 
 **Deploy:**
 ```bash
@@ -145,6 +156,8 @@ Picks up open GitHub pull requests labeled `generated-by-kelos` when a reviewer 
 - Reads review comments and PR conversation before making incremental changes
 - Lets the maintainer stay on the PR page for the common review-feedback loop
 - Requires `/kelos pick-up` PR comment or review body to be picked up
+- May create separate follow-up issues for out-of-scope discoveries; those
+  follow-ups are exempt from the per-TaskSpawner issue slot cap
 
 **Deploy:**
 ```bash
@@ -191,7 +204,9 @@ Each run picks one focus area:
 - **Developer Experience** — review error messages, test common workflows
 - **Examples & Use Cases** — verify manifests, identify missing examples
 
-Creates GitHub issues for any problems found.
+Creates or updates the single unassigned `kelos-fake-user` issue slot for the
+highest-impact problem found. If that issue is assigned, the run treats it as
+ongoing and exits without editing it or creating another issue.
 
 **Deploy:**
 ```bash
@@ -213,7 +228,9 @@ Each run picks one focus area:
 - **Integration Opportunities** — identify tools/platforms Kelos could integrate with
 - **New CRDs & API Extensions** — propose new CRDs or extensions to existing ones
 
-Creates GitHub issues for actionable insights.
+Creates or updates the single unassigned `kelos-fake-strategist` issue slot for
+the highest-impact actionable insight. If that issue is assigned, the run treats
+it as ongoing and exits without editing it or creating another issue.
 
 **Deploy:**
 ```bash
@@ -234,7 +251,8 @@ Reviews recent PRs and their review comments to identify recurring feedback patt
 - **Project-level changes** — updates `AGENTS.md` or `self-development/agentconfig.yaml` for conventions that apply to all agents
 - **Task-specific changes** — updates TaskSpawner prompts in `self-development/*.yaml` or creates/updates AgentConfig for specific agents
 
-Creates PRs with changes for maintainer review. Skips uncertain or contradictory feedback.
+Creates PRs with changes for maintainer review. Skips uncertain or contradictory
+feedback, and skips an existing configuration PR when it has assignees.
 
 **Deploy:**
 ```bash
@@ -257,7 +275,9 @@ Each run picks one focus area:
 - **Workflow Completeness** — check that agent prompts reflect current project conventions and Makefile targets
 - **Task Template Maintenance** — keep one-off task definitions in sync with their TaskSpawner counterparts
 
-Creates GitHub issues for actionable improvements found.
+Creates or updates the single unassigned `kelos-self-update` issue slot for the
+highest-impact actionable improvement. If that issue is assigned, the run treats
+it as ongoing and exits without editing it or creating another issue.
 
 **Deploy:**
 ```bash
@@ -281,7 +301,8 @@ Checks the following coding agents for updates:
 - **opencode** — `opencode-ai` npm package
 - **cursor** — binary download, version discovered from `https://cursor.com/install`
 
-Creates at most one PR per agent. Skips agents that are already up to date or already have an open update PR.
+Creates at most one PR per agent. Skips agents that are already up to date or
+already have an assigned open update PR.
 
 **Deploy:**
 ```bash

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -99,8 +99,11 @@ spec:
       - Keep changes minimal and focused — one PR per run, touching only what the evidence supports
       - Do not create duplicate changes — check the current content of config files before modifying
       - Before creating a PR, check for existing open PRs from this agent:
-        `gh pr list --state open --search "head:kelos-config-update" --json number,title,headRefName`
-        If one exists, update that existing PR branch and push your changes there instead of creating a new one
+        `gh pr list --state open --search "head:kelos-config-update" --json number,title,headRefName,assignees`
+        If one exists and has assignees, treat it as ongoing: do not update
+        the PR, do not force-push its branch, and exit cleanly. If one exists
+        and has no assignees, update that existing PR branch and push your
+        changes there instead of creating a new one.
       - Do not create a PR if no actionable changes are found — exit cleanly instead
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back every change with a specific reference to the PR review that motivated it

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -96,11 +96,28 @@ spec:
          - Consider backward compatibility and incremental adoption
 
       Actions:
-      - Create a GitHub issue with your findings and proposals:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of strategic impact, project importance,
+        actionability, and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-fake-strategist in:body" --json number,title,body,assignees
         ```
-      - Do NOT create PRs. Only create issues
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, compare your candidate with the
+          existing issue. Update the issue only when the candidate is clearly
+          more impactful or important than the current issue; otherwise exit
+          without creating or editing anything.
+        - If no open slot exists, create exactly one GitHub issue.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=kelos-fake-strategist -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+        to create the first slot.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
       Constraints:
@@ -108,7 +125,7 @@ spec:
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - The following areas are handled by other agents — do not create issues about them:
         - Self-development workflow improvements, prompt tuning, config alignment → kelos-self-update
         - Documentation, CLI UX, error messages → kelos-fake-user

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -93,17 +93,34 @@ spec:
          - Identify missing examples that would help new users
 
       Actions:
-      - If you find an issue, create a GitHub issue:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of user impact, project importance, actionability,
+        and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-fake-user in:body" --json number,title,body,assignees
         ```
-      - Do NOT create PRs. Only create issues
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, compare your candidate with the
+          existing issue. Update the issue only when the candidate is clearly
+          more impactful or important than the current issue; otherwise exit
+          without creating or editing anything.
+        - If no open slot exists, create exactly one GitHub issue.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=kelos-fake-user -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+        to create the first slot.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
       - Focus on ONE area per run, do it thoroughly
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - The following areas are handled by other agents — do not create issues about them:
         - Strategic proposals, new use cases, integrations, CRD extensions → kelos-fake-strategist
         - Self-development workflow improvements, prompt tuning, config alignment → kelos-self-update

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -104,13 +104,15 @@ spec:
       Then for each agent that has a newer version available:
       1. First check if an open PR already exists for updating that agent:
          ```
-         gh pr list --state open --label generated-by-kelos --search "update <agent-name> image" --json number,title,headRefName
+         gh pr list --state open --label generated-by-kelos --search "update <agent-name> image" --json number,title,headRefName,assignees
          ```
       2. If an open PR already exists:
-         a. Extract the version from the existing PR title (the version after "to ")
-         b. Compare it with the latest available version
-         c. If the existing PR already targets the latest version, skip it — no update needed
-         d. If the existing PR targets an older version, update it:
+         a. If the PR has assignees, treat it as ongoing: do not update the
+            PR, do not force-push its branch, and skip that agent for this run.
+         b. Extract the version from the existing PR title (the version after "to ")
+         c. Compare it with the latest available version
+         d. If the existing PR already targets the latest version, skip it — no update needed
+         e. If the existing PR targets an older version, update it:
             i. Check out the existing PR branch, resetting it to origin/main:
                ```
                git checkout -B <existing-branch> origin/main

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -105,5 +105,8 @@ spec:
 
       Post-checklist:
       - If the PR is ready for human review, you need more information, or you cannot make progress, post a plain-English PR comment explaining the current state. Maintainers can resume the PR later with `/kelos pick-up`. When all review feedback was already addressed in previous commits and no new comments require action, keep the explanation brief (e.g. "All review feedback was addressed in previous commits. Ready for re-review.") instead of repeating a full status breakdown. Never post duplicate or near-identical status messages.
-      - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
-        - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+      - If you find follow-up work outside the current PR scope, you may create
+        a separate GitHub issue:
+        - First check existing issues with `gh issue list` to avoid duplicates.
+        - Keep the follow-up narrowly scoped and label it `generated-by-kelos`.
+        - Follow-up issues are exempt from the per-TaskSpawner issue slot cap.

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -106,11 +106,28 @@ spec:
          - Verify that GitHub Actions workflows that reference self-development files are up to date
 
       Actions:
-      - If you find improvements, create a GitHub issue with your findings and proposals:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of workflow impact, project importance,
+        actionability, and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-self-update in:body" --json number,title,body,assignees
         ```
-      - Do NOT create PRs. Only create issues
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, compare your candidate with the
+          existing issue. Update the issue only when the candidate is clearly
+          more impactful or important than the current issue; otherwise exit
+          without creating or editing anything.
+        - If no open slot exists, create exactly one GitHub issue.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=kelos-self-update -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+        to create the first slot.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
       - Focus on ONE area per run, do it thoroughly
@@ -118,7 +135,7 @@ spec:
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence from the codebase and recent agent activity
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title`) to avoid overlap
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap
       - The following areas are handled by other agents — do not create issues about them:
         - Strategic proposals, new use cases, integrations, CRD extensions → kelos-fake-strategist
         - Documentation, CLI UX, error messages → kelos-fake-user

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -165,5 +165,8 @@ spec:
         - The PR is ready for review.
         - You commented on the issue or the PR for more information.
         - You cannot make any progress on the issue, explain why.
-      - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
-        - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+      - If you find follow-up work outside the current issue scope, you may
+        create a separate GitHub issue:
+        - First check existing issues with `gh issue list` to avoid duplicates.
+        - Keep the follow-up narrowly scoped and label it `generated-by-kelos`.
+        - Follow-up issues are exempt from the per-TaskSpawner issue slot cap.

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -67,9 +67,26 @@ spec:
        - Consider backward compatibility and incremental adoption
 
     Actions:
-    - Create a GitHub issue with your findings and proposals:
-      gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
-    - Do NOT create PRs. Only create issues
+    - If you find multiple candidates, choose the single candidate with the
+      highest combination of strategic impact, project importance,
+      actionability, and confidence.
+    - Publish the candidate through the kelos-fake-strategist issue slot.
+      Find the current open issue slot with:
+      gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-fake-strategist in:body" --json number,title,body,assignees
+      - If an open slot exists and has assignees, treat it as ongoing. Do not
+        edit it, do not update related PRs, and do not create another issue.
+      - If an open unassigned slot exists, compare your candidate with the
+        existing issue. Update the issue only when the candidate is clearly
+        more impactful or important than the current issue; otherwise exit
+        without creating or editing anything.
+      - If no open slot exists, create exactly one GitHub issue.
+    - Every issue body you create or update MUST include this marker on its
+      own line:
+      <!-- kelos-taskspawner=kelos-fake-strategist -->
+    - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+      to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      to create the first slot.
+    - Do NOT create PRs. Only create or update this issue slot
     - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
     Constraints:
@@ -77,5 +94,5 @@ spec:
     - Do not create duplicate issues — check existing issues first with `gh issue list`
     - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
     - Keep changes minimal and focused
-    - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --limit 10`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+    - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
     - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Updates self-development agents so discovery TaskSpawners maintain at most one open generated issue slot each. Existing assigned issues are treated as ongoing work and are not edited.

Also keeps follow-up issues from worker and PR responder workflows exempt from that cap, and makes autonomous config/image PR updaters skip assigned PRs.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Only files under `self-development/` are changed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a one-issue-per-TaskSpawner policy for autonomous discovery agents and make them skip editing assigned issues/PRs to reduce churn and keep work focused.

- **Behavior**
  - Discovery TaskSpawners now maintain a single unassigned `generated-by-kelos` issue slot, marked with `<!-- kelos-taskspawner=<name> -->`; update it only if a clearly better candidate appears, and never edit when assigned.
  - Follow-up issues created by `kelos-workers` and `kelos-pr-responder` are exempt from this cap.
  - `kelos-config-update` and `kelos-image-update` skip updating existing PRs when they have assignees; only update unassigned PRs or create one if none exist.
  - All workflows now check assignees in `gh` queries and document the slot policy; only files under `self-development/` were changed.

<sup>Written for commit b527fdef36a574f70689ebb987ff3cb5773bc08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

