### PR TITLE
Align Kanon issue publication policy

### DIFF
--- a/kanon-development/README.md
+++ b/kanon-development/README.md
@@ -18,6 +18,15 @@ squash-commits) share the base `agentconfig.yaml` (`kanon-dev-agent`), while
 others (workers, planner, reviewer, fake-user, fake-strategist) define their own
 `AgentConfig` inline.
 
+Autonomous discovery agents that publish GitHub issues maintain at most one
+open `generated-by-kelos` issue slot per TaskSpawner. The issue body includes a
+`kelos-taskspawner=<name>` marker so later runs can find it. A run may update
+the unassigned slot when it finds a clearly more impactful or important
+candidate, but it exits without changes when the slot has assignees. Assigned
+issues and PRs are treated as ongoing human or agent work and are not updated by
+autonomous discovery jobs. This cap does not apply to follow-up issues created
+while a worker or PR responder is handling an explicitly requested issue or PR.
+
 Eight spawners operate directly on the Kanon repository through the
 `kanon-agent` Workspace. The two meta-maintenance spawners
 (`kanon-config-update`, `kanon-self-update`) are different: the files they
@@ -35,10 +44,10 @@ maintain (`kanon-development/*`) live in *this* repository, so they use the
 | **kanon-reviewer** | Webhook: PR comment `/kelos review` | Codex | Reviews PRs on demand — analyzes code, checks conventions, and submits structured reviews |
 | **kanon-pr-responder** | Webhook: PR review/comment with `/kelos pick-up` | Codex | Re-engages on PR review feedback and updates the existing branch incrementally |
 | **kanon-triage** | Webhook: issue opened/reopened (untriaged) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
-| **kanon-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user — follows docs, tries CLI workflows, files issues for problems found |
-| **kanon-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integrations, and managed-settings types |
-| **kanon-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent Kanon PR feedback and updates the `kanon-development/` config accordingly |
-| **kanon-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes the `kanon-development/` prompts, configs, and README — the pipeline improves itself |
+| **kanon-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user and maintains one unassigned issue slot for the highest-impact problem found |
+| **kanon-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integrations, and managed-settings types while maintaining one unassigned strategic issue slot |
+| **kanon-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent Kanon PR feedback and creates or updates unassigned configuration PRs accordingly |
+| **kanon-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes the `kanon-development/` prompts, configs, and README while maintaining one unassigned improvement issue slot |
 | **kanon-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Codex | Rebases and squashes PR branch commits into a single clean commit |
 
 > **Not ported from `self-development/`:** `kelos-api-reviewer` (Kanon has no
@@ -72,6 +81,8 @@ Picks up open GitHub issues when a maintainer posts `/kelos pick-up` and creates
 - Ensures CI passes before completion
 - Requires a `/kelos pick-up` comment to pick up an issue (maintainer approval gate)
 - Hands off PR review feedback to `kanon-pr-responder`
+- May create separate follow-up issues for out-of-scope discoveries; those
+  follow-ups are exempt from the per-TaskSpawner issue slot cap
 
 **Deploy:**
 ```bash
@@ -138,6 +149,9 @@ Picks up open GitHub pull requests when a reviewer requests changes with `/kelos
 - Reuses the existing PR branch instead of starting over
 - Reads review comments and PR conversation before making incremental changes
 - Lets the maintainer stay on the PR page for the common review-feedback loop
+- Requires a `/kelos pick-up` PR comment or review body to be picked up
+- May create separate follow-up issues for out-of-scope discoveries; those
+  follow-ups are exempt from the per-TaskSpawner issue slot cap
 
 **Deploy:**
 ```bash
@@ -184,7 +198,9 @@ Each run picks one focus area:
 - **Developer Experience** — build, exercise init/validate/diff/apply/import, review error messages
 - **Examples & Use Cases** — verify example config, identify missing examples
 
-Creates GitHub issues for any problems found.
+Creates or updates the single unassigned `kanon-fake-user` issue slot for the
+highest-impact problem found. If that issue is assigned, the run treats it as
+ongoing and exits without editing it or creating another issue.
 
 **Deploy:**
 ```bash
@@ -206,7 +222,9 @@ Each run picks one focus area:
 - **Integration Opportunities** — identify agents, tools, and toolchains Kanon could integrate with
 - **New Managed-Settings Types & CLI Extensions** — propose new render targets, settings types, or `kanon.yaml` schema extensions
 
-Creates GitHub issues for actionable insights.
+Creates or updates the single unassigned `kanon-fake-strategist` issue slot for
+the highest-impact actionable insight. If that issue is assigned, the run treats
+it as ongoing and exits without editing it or creating another issue.
 
 **Deploy:**
 ```bash
@@ -225,6 +243,8 @@ Runs daily to update the Kanon agent configuration based on patterns found in Ka
 | **Concurrency** | 1 |
 
 Reviews recent `kelos-dev/kanon` PRs and their review comments to identify recurring feedback patterns, then updates the configuration under `kanon-development/` (the shared `agentconfig.yaml` or a specific TaskSpawner prompt). Opens a PR against this repository using `/kind cleanup` and `release-note: NONE`, since it only touches `kanon-development/`.
+Skips uncertain or contradictory feedback, and skips an existing configuration
+PR when it has assignees.
 
 **Deploy:**
 ```bash
@@ -242,7 +262,11 @@ Runs daily to review and improve the `kanon-development/` workflow files themsel
 | **Workspace** | `kelos-agent` (reasons about `kanon-development/` in this repo) |
 | **Concurrency** | 1 |
 
-Each run picks one focus area: **Prompt Tuning**, **Configuration Alignment**, or **Workflow Completeness**. Creates GitHub issues for actionable improvements found.
+Each run picks one focus area: **Prompt Tuning**, **Configuration Alignment**, or **Workflow Completeness**.
+
+Creates or updates the single unassigned `kanon-self-update` issue slot for the
+highest-impact actionable improvement. If that issue is assigned, the run treats
+it as ongoing and exits without editing it or creating another issue.
 
 **Deploy:**
 ```bash

--- a/kanon-development/kanon-config-update.yaml
+++ b/kanon-development/kanon-config-update.yaml
@@ -109,7 +109,11 @@ spec:
       - Keep changes minimal and focused — one PR per run, touching only what the evidence supports
       - Do not create duplicate changes — check the current content of the config files before modifying
       - Before creating a PR, check for an existing open PR from this agent:
-        `gh pr list --state open --search "head:kanon-config-update" --json number,title,headRefName`
-        If one exists, update that existing PR branch and push your changes there instead of creating a new one
+        `gh pr list --state open --search "head:kanon-config-update" --json number,title,headRefName,assignees`
+        If one exists and has assignees, treat it as ongoing: do not update
+        the PR, do not force-push its branch, and exit cleanly. If one exists
+        and has no assignees, update that existing PR branch and push your
+        changes there instead of creating a new one.
       - Do not create a PR if no actionable changes are found — exit cleanly instead
+      - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back every change with a specific reference to the Kanon PR review that motivated it

--- a/kanon-development/kanon-fake-strategist.yaml
+++ b/kanon-development/kanon-fake-strategist.yaml
@@ -92,11 +92,28 @@ spec:
          - Consider backward compatibility with existing `kanon.yaml` files and incremental adoption
 
       Actions:
-      - Create a GitHub issue with your findings and proposals:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of strategic impact, project importance,
+        actionability, and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kanon-fake-strategist in:body" --json number,title,body,assignees
         ```
-      - Do NOT create PRs. Only create issues
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, compare your candidate with the
+          existing issue. Update the issue only when the candidate is clearly
+          more impactful or important than the current issue; otherwise exit
+          without creating or editing anything.
+        - If no open slot exists, create exactly one GitHub issue.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=kanon-fake-strategist -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+        to create the first slot.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
       Constraints:
@@ -104,7 +121,7 @@ spec:
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - The following areas are handled by other agents — do not create issues about them:
         - Self-development workflow improvements, prompt tuning, config alignment → kanon-self-update
         - Documentation, CLI UX, error messages → kanon-fake-user

--- a/kanon-development/kanon-fake-user.yaml
+++ b/kanon-development/kanon-fake-user.yaml
@@ -90,17 +90,34 @@ spec:
          - Identify missing examples that would help new users (e.g., a worked multi-agent or multi-machine setup)
 
       Actions:
-      - If you find an issue, create a GitHub issue:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of user impact, project importance, actionability,
+        and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kanon-fake-user in:body" --json number,title,body,assignees
         ```
-      - Do NOT create PRs. Only create issues
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, compare your candidate with the
+          existing issue. Update the issue only when the candidate is clearly
+          more impactful or important than the current issue; otherwise exit
+          without creating or editing anything.
+        - If no open slot exists, create exactly one GitHub issue.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=kanon-fake-user -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+        to create the first slot.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
       - Focus on ONE area per run, do it thoroughly
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Keep changes minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - The following areas are handled by other agents — do not create issues about them:
         - Strategic proposals, new use cases, integrations, new managed-settings types → kanon-fake-strategist
         - Self-development workflow improvements, prompt tuning, config alignment → kanon-self-update

--- a/kanon-development/kanon-pr-responder.yaml
+++ b/kanon-development/kanon-pr-responder.yaml
@@ -100,5 +100,8 @@ spec:
 
       Post-checklist:
       - If the PR is ready for human review, you need more information, or you cannot make progress, post a plain-English PR comment explaining the current state. Maintainers can resume the PR later with `/kelos pick-up`. When all review feedback was already addressed in previous commits and no new comments require action, keep the explanation brief (e.g. "All review feedback was addressed in previous commits. Ready for re-review.") instead of repeating a full status breakdown. Never post duplicate or near-identical status messages.
-      - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
-        - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+      - If you find follow-up work outside the current PR scope, you may create
+        a separate GitHub issue:
+        - First check existing issues with `gh issue list` to avoid duplicates.
+        - Keep the follow-up narrowly scoped and label it `generated-by-kelos`.
+        - Follow-up issues are exempt from the per-TaskSpawner issue slot cap.

--- a/kanon-development/kanon-self-update.yaml
+++ b/kanon-development/kanon-self-update.yaml
@@ -79,11 +79,28 @@ spec:
          - Ensure template variables are used correctly per the documentation
 
       Actions:
-      - If you find improvements, create a GitHub issue with your findings and proposals:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of workflow impact, project importance,
+        actionability, and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
         ```
-        gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kanon-self-update in:body" --json number,title,body,assignees
         ```
-      - Do NOT create PRs. Only create issues
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, compare your candidate with the
+          existing issue. Update the issue only when the candidate is clearly
+          more impactful or important than the current issue; otherwise exit
+          without creating or editing anything.
+        - If no open slot exists, create exactly one GitHub issue.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=kanon-self-update -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+        to create the first slot.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
       - Focus on ONE area per run, do it thoroughly
@@ -91,7 +108,7 @@ spec:
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence from the config files and recent Kanon agent activity
       - Keep proposals minimal and focused
-      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title`) to avoid overlap
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap
       - The following areas are handled by other agents — do not create issues about them:
         - Strategic proposals, new use cases, integrations, new managed-settings types → kanon-fake-strategist
         - Documentation, CLI UX, error messages → kanon-fake-user

--- a/kanon-development/kanon-workers.yaml
+++ b/kanon-development/kanon-workers.yaml
@@ -146,5 +146,8 @@ spec:
         - The PR is ready for review.
         - You commented on the issue or the PR for more information.
         - You cannot make any progress on the issue, explain why.
-      - If you find anything worth considering (e.g. bugs, improvements, follow-up work), create a new issue:
-        - gh issue create --title "<title>" --body "<description>" --label generated-by-kelos
+      - If you find follow-up work outside the current issue scope, you may
+        create a separate GitHub issue:
+        - First check existing issues with `gh issue list` to avoid duplicates.
+        - Keep the follow-up narrowly scoped and label it `generated-by-kelos`.
+        - Follow-up issues are exempt from the per-TaskSpawner issue slot cap.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Aligns `kanon-development/` with the self-development issue management policy from PR #1402. Kanon discovery TaskSpawners now maintain one unassigned `generated-by-kelos` issue slot, assigned issues and config PRs are treated as ongoing work, and worker or PR-responder follow-up issues are explicitly exempt from the slot cap.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Kanon has no image-update TaskSpawner, so there is no counterpart for that part of PR #1402.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `kanon-development/` with the self-development policy by enforcing a single unassigned `generated-by-kelos` issue slot per discovery TaskSpawner and adding per-spawner issue markers. Assigned issues/PRs are treated as ongoing; `kanon-config-update` skips assigned config PRs, and worker/PR-responder follow-ups are exempt.

- **Refactors**
  - README: documents one-slot policy, per-spawner markers, and follow-up exemptions.
  - `kanon-fake-user`, `kanon-fake-strategist`, `kanon-self-update`: add slot logic (search by `kelos-taskspawner=<name>`, update only if higher-impact, include required marker, no PRs).
  - `kanon-config-update`: skips updating existing assigned PRs; assignee-aware `gh pr list`; avoids duplicate issues.
  - `kanon-workers`, `kanon-pr-responder`: allow narrowly scoped follow-up issues; explicitly exempt from slot cap.
  - Assignee-aware `gh issue list` usage added across configs to prevent duplicates.

<sup>Written for commit d03484f48dc528f67ccb12b8066da8e2facd4af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

