### PR TITLE
Allow agent commands in multiline bodies

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -108,7 +108,7 @@ func TestDevelopmentTaskSpawnersIgnoreDisruptions(t *testing.T) {
 	}
 }
 
-func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
+func TestDevelopmentCommandPatternsMatchCommandLines(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -147,8 +147,6 @@ func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
 					continue
 				}
 				foundBodyPattern = true
-				allowsCommandLine := tt.dir == "self-development" && tt.command == "/kelos pick-up"
-
 				t.Run(filter.Event+"/"+filter.Author, func(t *testing.T) {
 					bodyTests := []struct {
 						name string
@@ -156,14 +154,15 @@ func TestDevelopmentCommandPatternsRequireExactCommandBodies(t *testing.T) {
 						want bool
 					}{
 						{name: "exact command", body: tt.command, want: true},
-						{name: "surrounding whitespace", body: "\n\t " + tt.command + " \n", want: true},
+						{name: "blank line and trailing whitespace", body: "\n" + tt.command + " \n", want: true},
+						{name: "leading whitespace before command", body: "\t " + tt.command, want: false},
 						{name: "embedded in sentence", body: "Please run " + tt.command, want: false},
 						{name: "trailing text", body: tt.command + " after CI passes", want: false},
-						{name: "following line prose", body: tt.command + "\nRebase on origin/main", want: allowsCommandLine},
-						{name: "following line prose with CRLF", body: tt.command + "\r\nRebase on origin/main", want: allowsCommandLine},
+						{name: "following line prose", body: tt.command + "\nRebase on origin/main", want: true},
+						{name: "following line prose with CRLF", body: tt.command + "\r\nRebase on origin/main", want: true},
 						{name: "quoted markdown", body: "> " + tt.command, want: false},
 						{name: "inline code", body: "`" + tt.command + "`", want: false},
-						{name: "command line after prose", body: "Please run:\n" + tt.command, want: allowsCommandLine},
+						{name: "command line after prose", body: "Please run:\n" + tt.command, want: true},
 					}
 
 					for _, bodyTest := range bodyTests {

--- a/kanon-development/kanon-planner.yaml
+++ b/kanon-development/kanon-planner.yaml
@@ -35,7 +35,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos plan\s*$'
+          bodyPattern: '(?m)^/kelos plan[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/kanon-development/kanon-pr-responder.yaml
+++ b/kanon-development/kanon-pr-responder.yaml
@@ -14,13 +14,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos pick-up\s*$'
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos pick-up\s*$'
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
           state: open
           draft: false
           author: gjkim42

--- a/kanon-development/kanon-reviewer.yaml
+++ b/kanon-development/kanon-reviewer.yaml
@@ -45,13 +45,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos review\s*$'
+          bodyPattern: '(?m)^/kelos review[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos review\s*$'
+          bodyPattern: '(?m)^/kelos review[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/kanon-development/kanon-squash-commits.yaml
+++ b/kanon-development/kanon-squash-commits.yaml
@@ -12,13 +12,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos squash-commits\s*$'
+          bodyPattern: '(?m)^/kelos squash-commits[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos squash-commits\s*$'
+          bodyPattern: '(?m)^/kelos squash-commits[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/kanon-development/kanon-workers.yaml
+++ b/kanon-development/kanon-workers.yaml
@@ -45,7 +45,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos pick-up\s*$'
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
           commentOn: Issue
           state: open
           author: gjkim42

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -435,7 +435,7 @@ To adapt these examples for your own repository:
          filters:
            - event: issue_comment
              action: created
-             bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
+             bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
              commentOn: Issue          # or PullRequest, depending on spawner
              author: your-maintainer   # maintainer-approval gate
              labels: [your-label]

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -47,19 +47,19 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos api-review\s*$'
+          bodyPattern: '(?m)^/kelos api-review[ \t]*\r?$'
           state: open
           author: gjkim42
         # Allow the Kelos bot to request an API review on the PRs it opens, e.g.
         # when a worker posts `/kelos api-review` after pushing API changes.
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos api-review\s*$'
+          bodyPattern: '(?m)^/kelos api-review[ \t]*\r?$'
           state: open
           author: kelos-bot[bot]
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos api-review\s*$'
+          bodyPattern: '(?m)^/kelos api-review[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -35,7 +35,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos plan\s*$'
+          bodyPattern: '(?m)^/kelos plan[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -14,13 +14,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
           state: open
           draft: false
           author: gjkim42

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -46,7 +46,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos review\s*$'
+          bodyPattern: '(?m)^/kelos review[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
@@ -54,13 +54,13 @@ spec:
         # when a worker posts `/kelos review` after pushing its changes.
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos review\s*$'
+          bodyPattern: '(?m)^/kelos review[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: kelos-bot[bot]
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos review\s*$'
+          bodyPattern: '(?m)^/kelos review[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -12,13 +12,13 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '^\s*/kelos squash-commits\s*$'
+          bodyPattern: '(?m)^/kelos squash-commits[ \t]*\r?$'
           commentOn: PullRequest
           state: open
           author: gjkim42
         - event: pull_request_review
           action: submitted
-          bodyPattern: '^\s*/kelos squash-commits\s*$'
+          bodyPattern: '(?m)^/kelos squash-commits[ \t]*\r?$'
           state: open
           author: gjkim42
       reporting:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -64,7 +64,7 @@ spec:
       filters:
         - event: issue_comment
           action: created
-          bodyPattern: '(?m)^[ \t]*/kelos pick-up[ \t]*\r?$'
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
           commentOn: Issue
           state: open
           author: gjkim42


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates self-development and kanon-development GitHub webhook `bodyPattern` command filters to match commands on their own line inside multi-line comment or review bodies.

This keeps same-line prose from triggering commands while allowing review bodies such as `/kelos api-review` followed by explanatory text on later lines.

The example manifest test now verifies that every self-development and kanon-development command pattern accepts a command line in a multi-line body.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with `make test` and `make verify`.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Kelos commands on their own line in multi-line comments or reviews (must start at column 1), with LF/CRLF support. Matching now ignores Markdown fenced code blocks so code examples don’t trigger commands.

- **Bug Fixes**
  - Updated webhook `bodyPattern` to `(?m)^/kelos <command>[ \t]*\r?$` across self-development and kanon-development for `plan`, `review`, `pick-up`, `squash-commits`, and `api-review`.
  - Strip fenced code blocks before applying `bodyPattern` and `excludeBodyPatterns`; updated docs and tests to allow command lines followed by/after prose and to reject commands with leading whitespace, in sentences/quotes/inline code, or inside fences.

<sup>Written for commit 8cb3861ef5a1d8a35c22e84e8e67f05347ed8abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

