### PR TITLE
Reuse GitHub status comments

### DIFF
--- a/cmd/kelos-spawner/main_test.go
+++ b/cmd/kelos-spawner/main_test.go
@@ -2291,8 +2291,14 @@ func TestRunReportingCycle_ReportsForAnnotatedTasks(t *testing.T) {
 
 	// Set up a fake GitHub server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(map[string]int64{"id": 999})
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]string{})
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]int64{"id": 999})
+		}
 	}))
 	defer server.Close()
 
@@ -2413,8 +2419,14 @@ func TestRunOnce_UsesTokenResolverForReporting(t *testing.T) {
 	var gotAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
-		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(map[string]int64{"id": 999})
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]string{})
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]int64{"id": 999})
+		}
 	}))
 	defer server.Close()
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -106,7 +106,7 @@ spec:
 
 **Status reporting:** Two independent options:
 
-- `reporting.enabled: true` posts status comments (started, succeeded, failed) on the PR.
+- `reporting.enabled: true` creates or updates one status comment on the PR as the task state changes.
 - `reporting.checks.name` creates a GitHub Check Run for each PR task, so the run can be required by branch protection rules or referenced from a merge queue. The Check Run starts as `in_progress` when the task begins and is updated to `success` or `failure` on completion. The name defaults to `"Kelos: <taskspawner-name>"` and appears in branch protection rule configuration and the PR Checks tab; the token referenced by the workspace must have `checks:write` permission.
 
 ```yaml
@@ -115,7 +115,7 @@ spec:
     githubPullRequests:
       labels: [needs-review]
       reporting:
-        enabled: true            # status comments on the PR
+        enabled: true            # status comment on the PR
         checks:
           name: kelos/pr-review  # required-status-check name (optional override)
 ```
@@ -190,7 +190,7 @@ spec:
 
 **Filtering options:** `events` (required), `repository`, `excludeAuthors`, and per-filter fields: `action`, `labels`, `excludeLabels`, `state`, `branch`, `draft`, `author`, `bodyPattern`, `excludeBodyPatterns`, `commentOn` (scopes `issue_comment` events to `"Issue"` or `"PullRequest"`). The legacy `bodyContains` substring filter is **deprecated** — use `bodyPattern` (Go re2 regular expression) instead.
 
-**Status reporting:** Like `githubPullRequests`, the webhook source supports `reporting.enabled` (status comments back to the originating issue or PR) and `reporting.checks.name` (GitHub Check Runs for branch protection). Check Runs require `events` to include at least one pull-request event type (`pull_request`, `pull_request_review`, `pull_request_review_comment`, or `pull_request_target`); the configuration is rejected at admission otherwise.
+**Status reporting:** Like `githubPullRequests`, the webhook source supports `reporting.enabled` (one status comment back to the originating issue or PR) and `reporting.checks.name` (GitHub Check Runs for branch protection). Check Runs require `events` to include at least one pull-request event type (`pull_request`, `pull_request_review`, `pull_request_review_comment`, or `pull_request_target`); the configuration is rejected at admission otherwise.
 
 **Webhook-specific variables:** `{{.Event}}`, `{{.Action}}`, `{{.Sender}}`, `{{.Ref}}`, `{{.Repository}}`, `{{.Payload}}` (full payload access).
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -282,7 +282,7 @@ The installation token is minted to a per-task Secret (`<task-name>-github-token
 | `spec.when.githubIssues.author` | Filter by issue author username | No |
 | `spec.when.githubIssues.excludeAuthors` | Exclude issues created by any of these usernames (client-side) | No |
 | `spec.when.githubIssues.priorityLabels` | Priority-order labels for task selection when `maxConcurrency` is set; index 0 is highest priority | No |
-| `spec.when.githubIssues.reporting.enabled` | Post status comments (started, succeeded, failed) back to the GitHub issue | No |
+| `spec.when.githubIssues.reporting.enabled` | Create or update one status comment back to the GitHub issue | No |
 | `spec.when.githubIssues.pollInterval` | Per-source poll interval (e.g., `"30s"`, `"5m"`). Defaults to `5m` when omitted | No |
 | `spec.when.githubPullRequests.repo` | Override repository to poll for PRs (in `owner/repo` format or full URL); defaults to workspace repo URL | No |
 | `spec.when.githubPullRequests.labels` | Filter pull requests by labels | No |
@@ -298,7 +298,7 @@ The installation token is minted to a per-task Secret (`<task-name>-github-token
 | `spec.when.githubPullRequests.excludeAuthors` | Exclude PRs opened by any of these usernames (client-side) | No |
 | `spec.when.githubPullRequests.draft` | Filter by draft state | No |
 | `spec.when.githubPullRequests.priorityLabels` | Priority-order labels for task selection when `maxConcurrency` is set; index 0 is highest priority | No |
-| `spec.when.githubPullRequests.reporting.enabled` | Post status comments (started, succeeded, failed) back to the GitHub pull request | No |
+| `spec.when.githubPullRequests.reporting.enabled` | Create or update one status comment back to the GitHub pull request | No |
 | `spec.when.githubPullRequests.reporting.checks.name` | Creates a GitHub Check Run for each PR task, enabling branch protection and merge queue integration. Sets the Check Run name (defaults to `"Kelos: <taskspawner-name>"`, max 100 chars). The token used by the workspace must have `checks:write` permission. Not supported on `githubIssues` (rejected by CEL validation). | No |
 | `spec.when.githubPullRequests.pollInterval` | Per-source poll interval (e.g., `"30s"`, `"5m"`). Defaults to `5m` when omitted | No |
 | `spec.when.githubWebhook.events` | GitHub event types to listen for (e.g., `"issues"`, `"pull_request"`, `"push"`, `"issue_comment"`) | Yes (when using githubWebhook) |
@@ -318,7 +318,7 @@ The installation token is minted to a per-task Secret (`<task-name>-github-token
 | `spec.when.githubWebhook.filters[].bodyPattern` | Require the comment/review body to match a Go re2 regular expression. When combined with `excludeBodyPatterns`, the body must match this pattern AND not match any exclude entry | No |
 | `spec.when.githubWebhook.filters[].excludeBodyPatterns` | Exclude events whose comment/review body matches any of these Go re2 regular expressions (OR semantics) | No |
 | `spec.when.githubWebhook.filters[].commentOn` | Scope `issue_comment` events to comments posted on a specific subject: `"Issue"` matches plain issues, `"PullRequest"` matches pull requests. Empty matches both. Ignored for other events | No |
-| `spec.when.githubWebhook.reporting.enabled` | Post status comments (started, succeeded, failed) back to the originating issue or PR | No |
+| `spec.when.githubWebhook.reporting.enabled` | Create or update one status comment back to the originating issue or PR | No |
 | `spec.when.githubWebhook.reporting.checks.name` | Creates a GitHub Check Run for tasks spawned by PR-related webhook events, enabling branch protection and merge queue integration. Sets the Check Run name (defaults to `"Kelos: <taskspawner-name>"`, max 100 chars). The token used by the workspace must have `checks:write` permission. Requires `events` to include at least one of `pull_request`, `pull_request_review`, `pull_request_review_comment`, or `pull_request_target` (enforced by CEL validation). | No |
 | `spec.when.linearWebhook.types` | Linear resource types to listen for (e.g., `"Issue"`, `"Comment"`) | Yes (when using linearWebhook) |
 | `spec.when.linearWebhook.filters[].type` | Scope filter to a specific resource type | No |

--- a/internal/reporting/github.go
+++ b/internal/reporting/github.go
@@ -8,9 +8,14 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
-const defaultBaseURL = "https://api.github.com"
+const (
+	defaultBaseURL            = "https://api.github.com"
+	githubStatusCommentHeader = "🤖 **Kelos Task Status**"
+	commentsPageSize          = 100
+)
 
 // GitHubReporter posts and updates issue/PR comments on GitHub.
 // TokenFunc, when set, is called on every API request to resolve the current
@@ -45,7 +50,8 @@ type createCommentRequest struct {
 }
 
 type commentResponse struct {
-	ID int64 `json:"id"`
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
 }
 
 // CreateComment creates a comment on a GitHub issue or pull request and returns
@@ -112,6 +118,67 @@ func (r *GitHubReporter) UpdateComment(ctx context.Context, commentID int64, bod
 	return nil
 }
 
+// FindTaskStatusComment returns the latest Kelos status comment for a task on
+// the given issue or pull request.
+func (r *GitHubReporter) FindTaskStatusComment(ctx context.Context, number int, taskName string) (int64, bool, error) {
+	var matchedID int64
+
+	for page := 1; ; page++ {
+		comments, err := r.listCommentsPage(ctx, number, page)
+		if err != nil {
+			return 0, false, err
+		}
+
+		for _, comment := range comments {
+			if isTaskStatusComment(comment.Body, taskName) {
+				matchedID = comment.ID
+			}
+		}
+
+		if len(comments) < commentsPageSize {
+			break
+		}
+	}
+
+	if matchedID == 0 {
+		return 0, false, nil
+	}
+	return matchedID, true, nil
+}
+
+func (r *GitHubReporter) listCommentsPage(ctx context.Context, number, page int) ([]commentResponse, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=%d&page=%d", r.baseURL(), r.Owner, r.Repo, number, commentsPageSize, page)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	r.setHeaders(req)
+
+	resp, err := r.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("listing comments: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	var comments []commentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+		return nil, fmt.Errorf("decoding comments response: %w", err)
+	}
+
+	return comments, nil
+}
+
+func isTaskStatusComment(body, taskName string) bool {
+	return strings.Contains(body, githubStatusCommentHeader) &&
+		strings.Contains(body, fmt.Sprintf("Task `%s` ", taskName))
+}
+
 // resolveToken returns the current GitHub token. When TokenFunc is set it
 // is called to resolve the token dynamically. Falls back to the static
 // Token field.
@@ -132,15 +199,15 @@ func (r *GitHubReporter) setHeaders(req *http.Request) {
 
 // FormatAcceptedComment returns the comment body for an accepted task.
 func FormatAcceptedComment(taskName string) string {
-	return fmt.Sprintf("🤖 **Kelos Task Status**\n\nTask `%s` has been **accepted** and is being processed.", taskName)
+	return fmt.Sprintf("%s\n\nTask `%s` has been **accepted** and is being processed.", githubStatusCommentHeader, taskName)
 }
 
 // FormatSucceededComment returns the comment body for a succeeded task.
 func FormatSucceededComment(taskName string) string {
-	return fmt.Sprintf("🤖 **Kelos Task Status**\n\nTask `%s` has **succeeded**. ✅", taskName)
+	return fmt.Sprintf("%s\n\nTask `%s` has **succeeded**. ✅", githubStatusCommentHeader, taskName)
 }
 
 // FormatFailedComment returns the comment body for a failed task.
 func FormatFailedComment(taskName string) string {
-	return fmt.Sprintf("🤖 **Kelos Task Status**\n\nTask `%s` has **failed**. ❌", taskName)
+	return fmt.Sprintf("%s\n\nTask `%s` has **failed**. ❌", githubStatusCommentHeader, taskName)
 }

--- a/internal/reporting/github_test.go
+++ b/internal/reporting/github_test.go
@@ -153,6 +153,93 @@ func TestUpdateCommentError(t *testing.T) {
 	}
 }
 
+func TestFindTaskStatusComment(t *testing.T) {
+	var (
+		gotMethod  string
+		gotPath    string
+		gotPage    string
+		gotPerPage string
+		gotAuth    string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotPage = r.URL.Query().Get("page")
+		gotPerPage = r.URL.Query().Get("per_page")
+		gotAuth = r.Header.Get("Authorization")
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]commentResponse{
+			{ID: 111, Body: "Unrelated comment"},
+			{ID: 222, Body: FormatAcceptedComment("test-task")},
+			{ID: 333, Body: FormatSucceededComment("test-task")},
+		})
+	}))
+	defer server.Close()
+
+	reporter := &GitHubReporter{
+		Owner:   "owner",
+		Repo:    "repo",
+		Token:   "token",
+		BaseURL: server.URL,
+	}
+
+	commentID, found, err := reporter.FindTaskStatusComment(context.Background(), 42, "test-task")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("Expected status comment to be found")
+	}
+	if commentID != 333 {
+		t.Errorf("Expected latest comment ID 333, got %d", commentID)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("Expected GET, got %s", gotMethod)
+	}
+	if gotPath != "/repos/owner/repo/issues/42/comments" {
+		t.Errorf("Unexpected path: %s", gotPath)
+	}
+	if gotPage != "1" {
+		t.Errorf("Expected page 1, got %q", gotPage)
+	}
+	if gotPerPage != "100" {
+		t.Errorf("Expected per_page 100, got %q", gotPerPage)
+	}
+	if gotAuth != "token token" {
+		t.Errorf("Expected auth %q, got %q", "token token", gotAuth)
+	}
+}
+
+func TestFindTaskStatusCommentNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]commentResponse{
+			{ID: 111, Body: FormatAcceptedComment("other-task")},
+		})
+	}))
+	defer server.Close()
+
+	reporter := &GitHubReporter{
+		Owner:   "owner",
+		Repo:    "repo",
+		Token:   "token",
+		BaseURL: server.URL,
+	}
+
+	commentID, found, err := reporter.FindTaskStatusComment(context.Background(), 42, "test-task")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if found {
+		t.Fatal("Expected no status comment to be found")
+	}
+	if commentID != 0 {
+		t.Errorf("Expected comment ID 0, got %d", commentID)
+	}
+}
+
 func TestCreateCommentNoToken(t *testing.T) {
 	var gotAuth string
 

--- a/internal/reporting/watcher.go
+++ b/internal/reporting/watcher.go
@@ -269,6 +269,16 @@ func (tr *TaskReporter) reportViaComment(ctx context.Context, task *kelos.Task) 
 	}
 
 	if commentID == 0 {
+		foundID, found, err := tr.Reporter.FindTaskStatusComment(ctx, number, task.Name)
+		if err != nil {
+			return fmt.Errorf("finding GitHub status comment for task %s: %w", task.Name, err)
+		}
+		if found {
+			commentID = foundID
+		}
+	}
+
+	if commentID == 0 {
 		log.Info("Creating GitHub status comment", "task", task.Name, "number", number, "phase", desiredPhase)
 		newID, err := tr.Reporter.CreateComment(ctx, number, body)
 		if err != nil {

--- a/internal/reporting/watcher_test.go
+++ b/internal/reporting/watcher_test.go
@@ -97,6 +97,9 @@ func newTestServer(t *testing.T) (*httptest.Server, *[]commentRecord) {
 		json.NewDecoder(r.Body).Decode(&body)
 
 		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]commentResponse{})
 		case http.MethodPost:
 			nextID++
 			records = append(records, commentRecord{
@@ -443,11 +446,10 @@ func TestReportTaskStatus_RunningMapsToAccepted(t *testing.T) {
 	}
 }
 
-func TestReportTaskStatus_CreatesNewCommentWhenNoCommentID(t *testing.T) {
+func TestReportTaskStatus_CreatesCommentWhenNoExistingStatusComment(t *testing.T) {
 	server, records := newTestServer(t)
 	defer server.Close()
 
-	// Task with succeeded phase but no comment ID (e.g. short-lived task)
 	task := newTaskWithAnnotations("test-task", "default", kelos.TaskPhaseSucceeded, map[string]string{
 		AnnotationGitHubReporting: "enabled",
 		AnnotationSourceNumber:    "42",
@@ -478,9 +480,8 @@ func TestReportTaskStatus_CreatesNewCommentWhenNoCommentID(t *testing.T) {
 	if len(*records) != 1 {
 		t.Fatalf("Expected 1 API call, got %d", len(*records))
 	}
-	// Should create, not update, since no comment ID exists
 	if (*records)[0].method != "create" {
-		t.Errorf("Expected create for task with no comment ID, got %s", (*records)[0].method)
+		t.Errorf("Expected create for task with no existing status comment, got %s", (*records)[0].method)
 	}
 
 	var updated kelos.Task
@@ -490,6 +491,97 @@ func TestReportTaskStatus_CreatesNewCommentWhenNoCommentID(t *testing.T) {
 	commentID, err := strconv.ParseInt(updated.Annotations[AnnotationGitHubCommentID], 10, 64)
 	if err != nil || commentID == 0 {
 		t.Errorf("Expected valid comment ID, got %q", updated.Annotations[AnnotationGitHubCommentID])
+	}
+}
+
+func TestReportTaskStatus_UpdatesExistingStatusCommentWhenCommentIDMissing(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		records []commentRecord
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]commentResponse{
+				{ID: 1111, Body: "Unrelated comment"},
+				{ID: 2222, Body: FormatAcceptedComment("test-task")},
+			})
+		case http.MethodPatch:
+			var body createCommentRequest
+			json.NewDecoder(r.Body).Decode(&body)
+			id, _ := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
+			records = append(records, commentRecord{
+				method: "update",
+				id:     id,
+				body:   body.Body,
+			})
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(commentResponse{ID: id})
+		case http.MethodPost:
+			var body createCommentRequest
+			json.NewDecoder(r.Body).Decode(&body)
+			records = append(records, commentRecord{
+				method: "create",
+				body:   body.Body,
+			})
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(commentResponse{ID: 3333})
+		}
+	}))
+	defer server.Close()
+
+	task := newTaskWithAnnotations("test-task", "default", kelos.TaskPhaseSucceeded, map[string]string{
+		AnnotationGitHubReporting: "enabled",
+		AnnotationSourceNumber:    "42",
+		AnnotationSourceKind:      "issue",
+	})
+
+	cl := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(task).
+		Build()
+
+	tr := &TaskReporter{
+		Client: cl,
+		Reporter: &GitHubReporter{
+			Owner:   "owner",
+			Repo:    "repo",
+			Token:   "token",
+			BaseURL: server.URL,
+		},
+	}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("Expected 1 API call, got %d", len(records))
+	}
+	if records[0].method != "update" {
+		t.Errorf("Expected update, got %s", records[0].method)
+	}
+	if records[0].id != 2222 {
+		t.Errorf("Expected comment ID 2222, got %d", records[0].id)
+	}
+	if records[0].body != FormatSucceededComment("test-task") {
+		t.Errorf("Expected succeeded comment body, got %q", records[0].body)
+	}
+
+	var updated kelos.Task
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(task), &updated); err != nil {
+		t.Fatalf("Getting updated task: %v", err)
+	}
+	if updated.Annotations[AnnotationGitHubCommentID] != "2222" {
+		t.Errorf("Expected persisted comment ID 2222, got %q", updated.Annotations[AnnotationGitHubCommentID])
+	}
+	if updated.Annotations[AnnotationGitHubReportPhase] != "succeeded" {
+		t.Errorf("Expected report phase 'succeeded', got %q", updated.Annotations[AnnotationGitHubReportPhase])
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates GitHub task status reporting to reuse an existing Kelos status comment for the same task instead of posting another comment when the stored comment ID annotation is missing. The reporter now searches existing issue/PR comments for the Kelos task-status marker, patches the latest matching comment, and only creates a comment when no match exists.

This keeps GitHub issue and PR timelines compact while preserving the existing initial-comment behavior for tasks that have not reported before.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with:
- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
GitHub task status reporting now updates an existing Kelos status comment for the task instead of creating additional lifecycle comments when possible.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates GitHub status reporting to reuse a single Kelos status comment per task. When the stored comment ID is missing, we find the existing status comment and update it instead of creating duplicates.

- **Bug Fixes**
  - Added `FindTaskStatusComment` to scan issue/PR comments (paged) and find the latest Kelos status by header and task name; updates it when found, creates only if none exist.
  - Updated watcher to call this lookup when `AnnotationGitHubCommentID` is absent and persist the found ID for future runs.
  - Adjusted tests to cover GET→PATCH/POST flows and added coverage for not-found cases.
  - Clarified docs to say we maintain one status comment per task.

<sup>Written for commit 266997b8903c584a609f1539b6fa0f2d08759299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

