### PR TITLE
Use WorkerSpec in self-development manifests

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -363,10 +364,38 @@ func TestDevelopmentTaskSpawnersSetExpectedEffort(t *testing.T) {
 			t.Parallel()
 
 			ts := readTaskSpawnerFromDir(t, tt.dir, tt.file)
-			if ts.Spec.TaskTemplate.Effort != tt.effort {
-				t.Fatalf("TaskTemplate.Effort = %q, want %q", ts.Spec.TaskTemplate.Effort, tt.effort)
+			if ts.Spec.TaskTemplate.Worker == nil {
+				t.Fatal("TaskTemplate.Worker is nil")
+			}
+			if ts.Spec.TaskTemplate.Worker.Effort != tt.effort {
+				t.Fatalf("TaskTemplate.Worker.Effort = %q, want %q", ts.Spec.TaskTemplate.Worker.Effort, tt.effort)
 			}
 		})
+	}
+}
+
+func TestSelfDevelopmentUsesWorkerSpec(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "..", "self-development")
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		t.Run(rel, func(t *testing.T) {
+			assertSelfDevelopmentYAMLUsesWorkerSpec(t, path)
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("walking self-development YAML files: %v", err)
 	}
 }
 
@@ -430,6 +459,168 @@ func readSelfDevelopmentTaskSpawner(t *testing.T, file string) *kelos.TaskSpawne
 	t.Helper()
 
 	return readTaskSpawnerFromDir(t, "self-development", file)
+}
+
+func assertSelfDevelopmentYAMLUsesWorkerSpec(t *testing.T, path string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	reader := yamlutil.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	for {
+		doc, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading YAML document from %s: %v", path, err)
+		}
+
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		var meta struct {
+			APIVersion string `yaml:"apiVersion"`
+			Kind       string `yaml:"kind"`
+		}
+		if err := sigyaml.Unmarshal(doc, &meta); err != nil {
+			t.Fatalf("decoding document metadata from %s: %v", path, err)
+		}
+		if strings.HasPrefix(meta.APIVersion, "kelos.dev/") && meta.APIVersion != "kelos.dev/v1alpha2" {
+			t.Fatalf("%s uses %s, want kelos.dev/v1alpha2", meta.Kind, meta.APIVersion)
+		}
+
+		var raw map[string]any
+		if err := sigyaml.Unmarshal(doc, &raw); err != nil {
+			t.Fatalf("decoding raw YAML document from %s: %v", path, err)
+		}
+
+		switch meta.Kind {
+		case "TaskSpawner":
+			var ts kelos.TaskSpawner
+			if err := sigyaml.Unmarshal(doc, &ts); err != nil {
+				t.Fatalf("decoding TaskSpawner from %s: %v", path, err)
+			}
+			assertNoLegacyAgentConfigRef(t, path, raw, "spec", "taskTemplate")
+			assertTaskTemplateUsesWorkerSpec(t, path, ts.Spec.TaskTemplate)
+		case "Task":
+			var task kelos.Task
+			if err := sigyaml.Unmarshal(doc, &task); err != nil {
+				t.Fatalf("decoding Task from %s: %v", path, err)
+			}
+			assertNoLegacyAgentConfigRef(t, path, raw, "spec")
+			assertTaskUsesWorkerSpec(t, path, task.Spec)
+		}
+	}
+}
+
+func assertNoLegacyAgentConfigRef(t *testing.T, path string, raw map[string]any, keys ...string) {
+	t.Helper()
+
+	current := any(raw)
+	for _, key := range keys {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			return
+		}
+		current, ok = mapping[key]
+		if !ok {
+			return
+		}
+	}
+	mapping, ok := current.(map[string]any)
+	if !ok {
+		return
+	}
+	if _, ok := mapping["agentConfigRef"]; ok {
+		t.Fatalf("%s %s.agentConfigRef is deprecated; use %s.worker.agentConfigRefs", path, strings.Join(keys, "."), strings.Join(keys, "."))
+	}
+}
+
+func assertTaskTemplateUsesWorkerSpec(t *testing.T, path string, template kelos.TaskTemplate) {
+	t.Helper()
+
+	if template.Worker == nil && template.WorkerPoolRef == nil {
+		t.Fatalf("%s taskTemplate must set worker or workerPoolRef", path)
+	}
+	if template.Worker != nil {
+		assertWorkerSpecComplete(t, path, *template.Worker)
+	}
+	if template.Type != "" {
+		t.Fatalf("%s taskTemplate.type is deprecated; use taskTemplate.worker.type", path)
+	}
+	if template.Credentials != nil {
+		t.Fatalf("%s taskTemplate.credentials is deprecated; use taskTemplate.worker.credentials", path)
+	}
+	if template.Model != "" {
+		t.Fatalf("%s taskTemplate.model is deprecated; use taskTemplate.worker.model", path)
+	}
+	if template.Effort != "" {
+		t.Fatalf("%s taskTemplate.effort is deprecated; use taskTemplate.worker.effort", path)
+	}
+	if template.Image != "" {
+		t.Fatalf("%s taskTemplate.image is deprecated; use taskTemplate.worker.image", path)
+	}
+	if template.WorkspaceRef != nil {
+		t.Fatalf("%s taskTemplate.workspaceRef is deprecated; use taskTemplate.worker.workspaceRef", path)
+	}
+	if len(template.AgentConfigRefs) != 0 {
+		t.Fatalf("%s taskTemplate.agentConfigRefs is deprecated; use taskTemplate.worker.agentConfigRefs", path)
+	}
+	if template.PodOverrides != nil {
+		t.Fatalf("%s taskTemplate.podOverrides is deprecated; use taskTemplate.worker.podOverrides", path)
+	}
+}
+
+func assertTaskUsesWorkerSpec(t *testing.T, path string, spec kelos.TaskSpec) {
+	t.Helper()
+
+	if spec.Worker == nil && spec.WorkerPoolRef == nil {
+		t.Fatalf("%s spec must set worker or workerPoolRef", path)
+	}
+	if spec.Worker != nil {
+		assertWorkerSpecComplete(t, path, *spec.Worker)
+	}
+	if spec.Type != "" {
+		t.Fatalf("%s spec.type is deprecated; use spec.worker.type", path)
+	}
+	if spec.Credentials != nil {
+		t.Fatalf("%s spec.credentials is deprecated; use spec.worker.credentials", path)
+	}
+	if spec.Model != "" {
+		t.Fatalf("%s spec.model is deprecated; use spec.worker.model", path)
+	}
+	if spec.Effort != "" {
+		t.Fatalf("%s spec.effort is deprecated; use spec.worker.effort", path)
+	}
+	if spec.Image != "" {
+		t.Fatalf("%s spec.image is deprecated; use spec.worker.image", path)
+	}
+	if spec.WorkspaceRef != nil {
+		t.Fatalf("%s spec.workspaceRef is deprecated; use spec.worker.workspaceRef", path)
+	}
+	if len(spec.AgentConfigRefs) != 0 {
+		t.Fatalf("%s spec.agentConfigRefs is deprecated; use spec.worker.agentConfigRefs", path)
+	}
+	if spec.PodOverrides != nil {
+		t.Fatalf("%s spec.podOverrides is deprecated; use spec.worker.podOverrides", path)
+	}
+}
+
+func assertWorkerSpecComplete(t *testing.T, path string, worker kelos.WorkerSpec) {
+	t.Helper()
+
+	if worker.Type == "" {
+		t.Fatalf("%s worker.type is empty", path)
+	}
+	if worker.Credentials == nil {
+		t.Fatalf("%s worker.credentials is nil", path)
+	}
 }
 
 func readTaskSpawnerFromDir(t *testing.T, dir, file string) *kelos.TaskSpawner {

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -427,7 +427,7 @@ kubectl create secret generic kelos-credentials \
 To adapt these examples for your own repository:
 
 1. **Update the Workspace reference:**
-   - Change `spec.taskTemplate.workspaceRef.name` to match your Workspace resource
+   - Change `spec.taskTemplate.worker.workspaceRef.name` to match your Workspace resource
    - Or update the Workspace to point to your repository
 
 2. **Update the webhook repository and filters:**
@@ -495,8 +495,9 @@ To adapt these examples for your own repository:
    ```yaml
    spec:
      taskTemplate:
-       model: gpt-5.5
-       effort: xhigh
+       worker:
+         model: gpt-5.5
+         effort: xhigh
    ```
 
    The checked-in spawners use `gpt-5.5` for the tasks that previously used

--- a/self-development/agora/agora-config-update.yaml
+++ b/self-development/agora/agora-config-update.yaml
@@ -8,14 +8,38 @@ spec:
       schedule: "0 18 * * *"
   maxConcurrency: 1
   taskTemplate:
-    # self-development/agora/ lives in the kelos-dev/kelos repository, so this agent
-    # operates on the kelos repo (kelos-agent) to edit the config files, while
-    # learning from the kelos-dev/agora repository's recent activity.
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      # self-development/agora/ lives in the kelos-dev/kelos repository, so this agent
+      # operates on the kelos repo (kelos-agent) to edit the config files, while
+      # learning from the kelos-dev/agora repository's recent activity.
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -27,30 +51,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
     branch: "agora-config-update-latest"
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a configuration improvement agent for the Agora coding agents.
       Your goal is to review recent pull requests on the Agora repository

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -38,11 +38,26 @@ spec:
       schedule: "0 */12 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: agora-fake-strategist-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -54,20 +69,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: agora-fake-strategist-agent
     promptTemplate: |
       You are a strategic product thinker for Agora — a local coordination server for humans and coding agents.
       Your goal is to find new and better ways to use Agora — expanding its reach, improving its workflows, and identifying opportunities for growth.

--- a/self-development/agora/agora-fake-user.yaml
+++ b/self-development/agora/agora-fake-user.yaml
@@ -38,11 +38,26 @@ spec:
       schedule: "0 9 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: agora-fake-user-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -54,20 +69,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: agora-fake-user-agent
     promptTemplate: |
       You are a developer experience tester for Agora — a local coordination server for humans and coding agents.
       Your goal is to improve Agora so that more developers adopt it. Act as a new user trying out the project for the first time.

--- a/self-development/agora/agora-planner.yaml
+++ b/self-development/agora/agora-planner.yaml
@@ -43,11 +43,26 @@ spec:
         enabled: true
   maxConcurrency: 2
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: agora-planner-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -59,20 +74,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: agora-planner-agent
     promptTemplate: |
       You are an implementation planner for the Agora project (github.com/kelos-dev/agora),
       a local coordination server for humans and coding agents. Your job is to investigate

--- a/self-development/agora/agora-pr-responder.yaml
+++ b/self-development/agora/agora-pr-responder.yaml
@@ -29,11 +29,35 @@ spec:
         checks: {}
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: agora-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -45,30 +69,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: "{{.Branch}}"
-    agentConfigRefs:
-      - name: agora-dev-agent
     promptTemplate: |
       You are a coding agent updating an existing PR in response to review feedback.
 

--- a/self-development/agora/agora-reviewer.yaml
+++ b/self-development/agora/agora-reviewer.yaml
@@ -65,11 +65,26 @@ spec:
         checks: {}
   maxConcurrency: 3
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+      agentConfigRefs:
+        - name: agora-reviewer-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -81,21 +96,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: agora-reviewer-agent
     promptTemplate: |
       You are a code review agent for the Agora project (github.com/kelos-dev/agora),
       a local coordination server for humans and coding agents. Your job is to

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -8,14 +8,29 @@ spec:
       schedule: "0 6 * * *"
   maxConcurrency: 1
   taskTemplate:
-    # self-development/agora/ lives in the kelos-dev/kelos repository, so this agent
-    # operates on the kelos repo (kelos-agent) to review and reason about these
-    # workflow files, while learning from the kelos-dev/agora repository's activity.
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      # self-development/agora/ lives in the kelos-dev/kelos repository, so this agent
+      # operates on the kelos repo (kelos-agent) to review and reason about these
+      # workflow files, while learning from the kelos-dev/agora repository's activity.
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -27,20 +42,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a self-improvement agent for the Agora development workflow.
       Your goal is to review and propose improvements to the workflow files that

--- a/self-development/agora/agora-squash-commits.yaml
+++ b/self-development/agora/agora-squash-commits.yaml
@@ -26,11 +26,35 @@ spec:
         checks: {}
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: agora-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -42,30 +66,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: agora-dev-agent
     promptTemplate: |
       You are a coding agent. Your only task is to rebase and squash commits on a PR branch.
 

--- a/self-development/agora/agora-triage.yaml
+++ b/self-development/agora/agora-triage.yaml
@@ -25,11 +25,26 @@ spec:
         enabled: true
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.5
-    effort: high
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.5
+      effort: high
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: agora-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -41,20 +56,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: agora-dev-agent
     promptTemplate: |
       You are a triage agent for the Agora project (github.com/kelos-dev/agora),
       a local coordination server for humans and coding agents. Your job is to

--- a/self-development/agora/agora-workers.yaml
+++ b/self-development/agora/agora-workers.yaml
@@ -55,11 +55,35 @@ spec:
         enabled: true
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: agora-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: agora-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: agora-workers-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -71,30 +95,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: "agora-task-{{.Number}}"
-    agentConfigRefs:
-      - name: agora-workers-agent
     promptTemplate: |
       You are a coding agent. You either
       - create a PR to fix the issue

--- a/self-development/kanon/kanon-config-update.yaml
+++ b/self-development/kanon/kanon-config-update.yaml
@@ -8,14 +8,38 @@ spec:
       schedule: "0 18 * * *"
   maxConcurrency: 1
   taskTemplate:
-    # self-development/kanon/ lives in the kelos-dev/kelos repository, so this agent
-    # operates on the kelos repo (kelos-agent) to edit the config files, while
-    # learning from the kelos-dev/kanon repository's recent activity.
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      # self-development/kanon/ lives in the kelos-dev/kelos repository, so this agent
+      # operates on the kelos repo (kelos-agent) to edit the config files, while
+      # learning from the kelos-dev/kanon repository's recent activity.
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -27,30 +51,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
     branch: "kanon-config-update-latest"
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a configuration improvement agent for the Kanon coding agents.
       Your goal is to review recent pull requests on the Kanon repository

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -36,11 +36,26 @@ spec:
       schedule: "0 */12 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kanon-fake-strategist-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -52,20 +67,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kanon-fake-strategist-agent
     promptTemplate: |
       You are a strategic product thinker for Kanon — a Go CLI that manages coding-agent settings (instructions, skills, MCP servers, hooks, permissions) across multiple machines.
       Your goal is to find new and better ways to use Kanon — expanding its reach, improving its workflows, and identifying opportunities for growth.

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -36,11 +36,26 @@ spec:
       schedule: "0 9 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kanon-fake-user-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -52,20 +67,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kanon-fake-user-agent
     promptTemplate: |
       You are a developer experience tester for Kanon — a Go CLI that manages coding-agent settings (instructions, skills, MCP servers, hooks, permissions) across multiple machines.
       Your goal is to improve Kanon so that more developers adopt it. Act as a new user trying out the project for the first time.

--- a/self-development/kanon/kanon-planner.yaml
+++ b/self-development/kanon/kanon-planner.yaml
@@ -42,11 +42,26 @@ spec:
         enabled: true
   maxConcurrency: 2
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kanon-planner-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -58,20 +73,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kanon-planner-agent
     promptTemplate: |
       You are an implementation planner for the Kanon project (github.com/kelos-dev/kanon),
       a Go CLI that manages coding-agent settings (instructions, skills, MCP servers,

--- a/self-development/kanon/kanon-pr-responder.yaml
+++ b/self-development/kanon/kanon-pr-responder.yaml
@@ -29,11 +29,35 @@ spec:
         checks: {}
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kanon-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -45,30 +69,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: "{{.Branch}}"
-    agentConfigRefs:
-      - name: kanon-dev-agent
     promptTemplate: |
       You are a coding agent updating an existing PR in response to review feedback.
 

--- a/self-development/kanon/kanon-reviewer.yaml
+++ b/self-development/kanon/kanon-reviewer.yaml
@@ -59,11 +59,26 @@ spec:
         checks: {}
   maxConcurrency: 3
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+      agentConfigRefs:
+        - name: kanon-reviewer-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -75,21 +90,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: kanon-reviewer-agent
     promptTemplate: |
       You are a code review agent for the Kanon project (github.com/kelos-dev/kanon),
       a Go CLI that manages coding-agent settings (instructions, skills, MCP servers,

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -8,14 +8,29 @@ spec:
       schedule: "0 6 * * *"
   maxConcurrency: 1
   taskTemplate:
-    # self-development/kanon/ lives in the kelos-dev/kelos repository, so this agent
-    # operates on the kelos repo (kelos-agent) to review and reason about the
-    # config files, while learning from the kelos-dev/kanon repository's activity.
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      # self-development/kanon/ lives in the kelos-dev/kelos repository, so this agent
+      # operates on the kelos repo (kelos-agent) to review and reason about the
+      # config files, while learning from the kelos-dev/kanon repository's activity.
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -27,20 +42,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a self-improvement agent for the Kanon development workflow.
       Your goal is to review and propose improvements to the workflow files that

--- a/self-development/kanon/kanon-squash-commits.yaml
+++ b/self-development/kanon/kanon-squash-commits.yaml
@@ -26,11 +26,35 @@ spec:
         checks: {}
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kanon-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -42,30 +66,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: kanon-dev-agent
     promptTemplate: |
       You are a coding agent. Your only task is to rebase and squash commits on a PR branch.
 

--- a/self-development/kanon/kanon-triage.yaml
+++ b/self-development/kanon/kanon-triage.yaml
@@ -25,11 +25,26 @@ spec:
         enabled: true
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.5
-    effort: high
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.5
+      effort: high
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kanon-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -41,20 +56,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kanon-dev-agent
     promptTemplate: |
       You are a triage agent for the Kanon project (github.com/kelos-dev/kanon),
       a Go CLI that manages coding-agent settings (instructions, skills, MCP servers,

--- a/self-development/kanon/kanon-workers.yaml
+++ b/self-development/kanon/kanon-workers.yaml
@@ -53,11 +53,35 @@ spec:
         enabled: true
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: kanon-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kanon-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kanon-workers-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -69,30 +93,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: "kanon-task-{{.Number}}"
-    agentConfigRefs:
-      - name: kanon-workers-agent
     promptTemplate: |
       You are a coding agent. You either
       - create a PR to fix the issue

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -67,11 +67,26 @@ spec:
         checks: {}
   maxConcurrency: 3
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+      agentConfigRefs:
+        - name: kelos-api-reviewer-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -83,21 +98,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: kelos-api-reviewer-agent
     promptTemplate: |
       You are a Kubernetes API design reviewer for the Kelos project (github.com/kelos-dev/kelos).
       Your job is to review API design, compatibility, and adherence to Kubernetes API

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -8,11 +8,35 @@ spec:
       schedule: "0 18 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -24,30 +48,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
     branch: "kelos-config-update-latest"
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a configuration improvement agent for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       Your goal is to review recent PRs and their review comments, then update agent configuration to reflect lessons learned.

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -40,11 +40,26 @@ spec:
       schedule: "0 */12 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-fake-strategist-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -56,20 +71,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-fake-strategist-agent
     promptTemplate: |
       You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       Your goal is to find new and better ways to use Kelos — expanding its reach, improving its workflows, and identifying opportunities for growth.

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -40,11 +40,26 @@ spec:
       schedule: "0 9 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-fake-user-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -56,20 +71,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-fake-user-agent
     promptTemplate: |
       You are a developer experience tester for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       Your goal is to improve Kelos so that more developers adopt it. Act as a new user trying out the project for the first time.

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -29,11 +29,35 @@ spec:
       schedule: "0 3 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-image-update-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -45,29 +69,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
-    agentConfigRefs:
-      - name: kelos-image-update-agent
     promptTemplate: |
       You are an image update agent for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       Your goal is to check whether any coding agent images have newer versions available and create PRs to update them.

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -42,11 +42,26 @@ spec:
         enabled: true
   maxConcurrency: 2
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-planner-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -58,20 +73,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-planner-agent
     promptTemplate: |
       You are an implementation planner for the Kelos project (github.com/kelos-dev/kelos).
       Your job is to investigate an issue, inspect the codebase, and post a structured

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -29,11 +29,35 @@ spec:
         checks: {}
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -45,30 +69,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: "{{.Branch}}"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a coding agent updating an existing PR in response to review feedback.
 

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -68,11 +68,26 @@ spec:
         checks: {}
   maxConcurrency: 3
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+      agentConfigRefs:
+        - name: kelos-reviewer-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -84,21 +99,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: kelos-reviewer-agent
     promptTemplate: |
       You are a code review agent for the Kelos project (github.com/kelos-dev/kelos).
       Your job is to thoroughly review a pull request and submit a structured review

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -40,11 +40,26 @@ spec:
       schedule: "0 6 * * *"
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-self-update-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -56,20 +71,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-self-update-agent
     promptTemplate: |
       You are a self-improvement agent for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
       Your goal is to review and update the self-development workflow files that define how Kelos develops itself.

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -26,11 +26,35 @@ spec:
         checks: {}
   maxConcurrency: 1
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.4-mini
-    effort: medium
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -42,30 +66,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a coding agent. Your only task is to rebase and squash commits on a PR branch.
 

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -25,11 +25,26 @@ spec:
         enabled: true
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: high
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: high
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "2Gi"
+          limits:
+            ephemeral-storage: "2Gi"
+      agentConfigRefs:
+        - name: kelos-dev-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -41,20 +56,6 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "2Gi"
-        limits:
-          ephemeral-storage: "2Gi"
-    agentConfigRefs:
-      - name: kelos-dev-agent
     promptTemplate: |
       You are a triage agent for the Kelos project (github.com/kelos-dev/kelos).
       Your job is to fully triage the following issue: classify it, check validity,

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -72,11 +72,35 @@ spec:
         enabled: true
   maxConcurrency: 8
   taskTemplate:
-    workspaceRef:
-      name: kelos-agent
-    model: gpt-5.5
-    effort: xhigh
-    type: codex
+    worker:
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.5
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "4Gi"
+          limits:
+            ephemeral-storage: "4Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: kelos-workers-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -88,30 +112,7 @@ spec:
           onExitCodes:
             operator: NotIn
             values: [0]
-    credentials:
-      type: oauth
-      secretRef:
-        name: kelos-credentials
-    podOverrides:
-      resources:
-        requests:
-          cpu: "250m"
-          memory: "512Mi"
-          ephemeral-storage: "4Gi"
-        limits:
-          ephemeral-storage: "4Gi"
-      env:
-        - name: GIT_AUTHOR_NAME
-          value: "Gunju Kim"
-        - name: GIT_AUTHOR_EMAIL
-          value: "gjkim042@gmail.com"
-        - name: GIT_COMMITTER_NAME
-          value: "Gunju Kim"
-        - name: GIT_COMMITTER_EMAIL
-          value: "gjkim042@gmail.com"
     branch: "kelos-task-{{.Number}}"
-    agentConfigRefs:
-      - name: kelos-workers-agent
     promptTemplate: |
       You are a coding agent. You either
       - create a PR to fix the issue

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -5,11 +5,26 @@ metadata:
   labels:
     kelos.dev/type: fake-strategist-manual
 spec:
-  workspaceRef:
-    name: kelos-agent
-  model: gpt-5.5
-  effort: xhigh
-  type: codex
+  worker:
+    workspaceRef:
+      name: kelos-agent
+    model: gpt-5.5
+    effort: xhigh
+    type: codex
+    credentials:
+      type: oauth
+      secretRef:
+        name: kelos-credentials
+    agentConfigRefs:
+      - name: kelos-fake-strategist-agent
+    podOverrides:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "2Gi"
+        limits:
+          ephemeral-storage: "2Gi"
   ttlSecondsAfterFinished: 864000
   podFailurePolicy:
     rules:
@@ -21,20 +36,6 @@ spec:
         onExitCodes:
           operator: NotIn
           values: [0]
-  credentials:
-    type: oauth
-    secretRef:
-      name: kelos-credentials
-  agentConfigRefs:
-    - name: kelos-fake-strategist-agent
-  podOverrides:
-    resources:
-      requests:
-        cpu: "250m"
-        memory: "512Mi"
-        ephemeral-storage: "2Gi"
-      limits:
-        ephemeral-storage: "2Gi"
   prompt: |
     You are a strategic product thinker for the Kelos framework — a Kubernetes-native controller that runs autonomous AI coding agents.
     Your goal is to find new and better ways to use Kelos — expanding its reach, improving its workflows, and identifying opportunities for growth.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates self-development Task and TaskSpawner manifests to use `worker` for execution configuration instead of deprecated top-level execution fields. Also updates the self-development README example and adds tests to prevent these manifests from drifting back to deprecated fields.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:
- `make test`
- `git diff --check`
- `rg -n "apiVersion: kelos.dev/v1alpha1|agentConfigRef:" self-development` returned no matches

`make verify` currently fails on unrelated pre-existing/untracked shell-format inputs: `get_helm.sh` and `.git/logs/refs/heads/support-skills.sh`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates all self-development `Task` and `TaskSpawner` manifests to `WorkerSpec` via `worker`, removing deprecated top‑level execution fields. Updates the README and adds tests that scan all self-development YAML to enforce `kelos.dev/v1alpha2` and block regressions.

- **Refactors**
  - Moved execution settings under `worker.*` in all self-development YAML (type, model, effort, credentials, agentConfigRefs, workspaceRef, podOverrides).
  - Standardized API version to `kelos.dev/v1alpha2`.
  - Added tests that walk all YAML to require `worker` or `workerPoolRef`, forbid legacy fields at `spec`/`taskTemplate` top level, and ensure `worker.type` and `worker.credentials` are set.

- **Migration**
  - For any custom self-development manifests, move execution config under `spec.worker` or `spec.taskTemplate.worker` and use `kelos.dev/v1alpha2` (e.g., `model` -> `worker.model`, `effort` -> `worker.effort`, `credentials` -> `worker.credentials`, `agentConfigRefs` -> `worker.agentConfigRefs`, `workspaceRef` -> `worker.workspaceRef`, `podOverrides` -> `worker.podOverrides`).

<sup>Written for commit dd9fabfc305b658fd89b9564a7ea4782e8a8a839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

