### PR TITLE
Mark sticky issues triage accepted

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -278,6 +278,47 @@ func TestAgoraIssueCreatorsUseTriageAcceptedLabel(t *testing.T) {
 	}
 }
 
+func TestStickyIssueSlotCommandsUseTriageAcceptedLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dir  string
+		file string
+	}{
+		{dir: "self-development", file: "kelos-fake-strategist.yaml"},
+		{dir: "self-development", file: "kelos-fake-user.yaml"},
+		{dir: "self-development", file: "kelos-self-update.yaml"},
+		{dir: "self-development/agora", file: "agora-fake-strategist.yaml"},
+		{dir: "self-development/agora", file: "agora-fake-user.yaml"},
+		{dir: "self-development/agora", file: "agora-self-update.yaml"},
+		{dir: "self-development/kanon", file: "kanon-fake-strategist.yaml"},
+		{dir: "self-development/kanon", file: "kanon-fake-user.yaml"},
+		{dir: "self-development/kanon", file: "kanon-self-update.yaml"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.dir+"/"+tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			ts := readTaskSpawnerFromDir(t, tt.dir, tt.file)
+			assertStickyIssueCommandsUseTriageAccepted(t, tt.dir+"/"+tt.file, ts.Spec.TaskTemplate.PromptTemplate)
+		})
+	}
+}
+
+func TestManualFakeStrategistTaskUsesTriageAcceptedLabel(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "self-development", "tasks", "fake-strategist-task.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	assertStickyIssueCommandsUseTriageAccepted(t, path, string(data))
+}
+
 func TestAgoraPlannerOnlyTriggersForIssues(t *testing.T) {
 	t.Parallel()
 
@@ -475,6 +516,19 @@ func readTaskSpawnerFromDir(t *testing.T, dir, file string) *kelos.TaskSpawner {
 
 	t.Fatalf("no TaskSpawner found in %s", path)
 	return nil
+}
+
+func assertStickyIssueCommandsUseTriageAccepted(t *testing.T, name, prompt string) {
+	t.Helper()
+
+	wantUpdate := `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+	wantCreate := `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
+	if !strings.Contains(prompt, wantUpdate) {
+		t.Fatalf("%s prompt does not add triage-accepted when updating a sticky issue slot", name)
+	}
+	if !strings.Contains(prompt, wantCreate) {
+		t.Fatalf("%s prompt does not add triage-accepted when creating a sticky issue slot", name)
+	}
 }
 
 func developmentWebhookPayload(t *testing.T, repository string, filter kelos.GitHubWebhookFilter, body string) []byte {

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -110,8 +110,8 @@ spec:
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kanon-fake-strategist -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
         to create the first slot.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -108,8 +108,8 @@ spec:
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kanon-fake-user -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
         to create the first slot.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -97,8 +97,8 @@ spec:
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kanon-self-update -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
         to create the first slot.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -114,8 +114,8 @@ spec:
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kelos-fake-strategist -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
         to create the first slot.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -111,8 +111,8 @@ spec:
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kelos-fake-user -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
         to create the first slot.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -124,8 +124,8 @@ spec:
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kelos-self-update -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
         to create the first slot.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -83,8 +83,8 @@ spec:
     - Every issue body you create or update MUST include this marker on its
       own line:
       <!-- kelos-taskspawner=kelos-fake-strategist -->
-    - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
-      to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos`
+    - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
+      to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
       to create the first slot.
     - Do NOT create PRs. Only create or update this issue slot
     - Prefer well-researched issues with clear proposals over broad, vague suggestions


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Sticky generated issue slots can be updated after they are created. This updates the Kelos and Kanon sticky issue creator prompts so the first created slot is immediately labeled `triage-accepted`, matching the existing Agora behavior, and preserves that label when unassigned slots are updated.

It also adds manifest tests that assert sticky issue create and update commands include `triage-accepted`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with `make test` and `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sticky issue slots automatically get and keep the `triage-accepted` label for Kelos and Kanon, matching existing Agora behavior. Adds tests to enforce the label on create and update commands.

- **Bug Fixes**
  - Updated Kelos and Kanon prompts to use `--add-label triage-accepted` on edit and `--label triage-accepted` on create in: `kelos-fake-strategist.yaml`, `kelos-fake-user.yaml`, `kelos-self-update.yaml`, `kanon-fake-strategist.yaml`, `kanon-fake-user.yaml`, `kanon-self-update.yaml`, and `tasks/fake-strategist-task.yaml`.
  - Added tests in `internal/examples/self_development_test.go` to assert sticky issue create/update commands include `triage-accepted` for Kelos, Kanon, and Agora.

<sup>Written for commit 6544043a0bdb62deb30180bd303557f648ecdec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

