### PR TITLE
Make GLM reviewers use sticky comments

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -224,6 +224,20 @@ func TestReviewersUseStickyPRComments(t *testing.T) {
 			templatePrefix: "Format the PR comment body as:",
 		},
 		{
+			dir:            "self-development",
+			file:           "kelos-glm-reviewer.yaml",
+			repository:     "kelos-dev/kelos",
+			marker:         "<!-- kelos-glm-reviewer:sticky-review -->",
+			templatePrefix: "Format the PR comment body as:",
+		},
+		{
+			dir:            "self-development",
+			file:           "kelos-glm-api-reviewer.yaml",
+			repository:     "kelos-dev/kelos",
+			marker:         "<!-- kelos-glm-api-reviewer:sticky-review -->",
+			templatePrefix: "Format the PR comment body as:",
+		},
+		{
 			dir:            "self-development/kanon",
 			file:           "kanon-reviewer.yaml",
 			repository:     "kelos-dev/kanon",
@@ -289,17 +303,38 @@ func TestReviewersUseStickyPRComments(t *testing.T) {
 	}
 }
 
-func TestKelosAPIReviewerUsesConcreteIssueCommentBodyFile(t *testing.T) {
+func TestKelosAPIReviewersUseConcreteIssueCommentBodyFile(t *testing.T) {
 	t.Parallel()
 
-	ts := readSelfDevelopmentTaskSpawner(t, "kelos-api-reviewer.yaml")
-	prompt := ts.Spec.TaskTemplate.PromptTemplate
-	want := `gh issue comment {{.Number}} --body-file /tmp/kelos-api-reviewer-comment.md`
-	if !strings.Contains(prompt, want) {
-		t.Fatalf("kelos-api-reviewer.yaml prompt does not contain concrete issue comment command %q", want)
+	tests := []struct {
+		file string
+		path string
+	}{
+		{
+			file: "kelos-api-reviewer.yaml",
+			path: "/tmp/kelos-api-reviewer-comment.md",
+		},
+		{
+			file: "kelos-glm-api-reviewer.yaml",
+			path: "/tmp/kelos-glm-api-reviewer-comment.md",
+		},
 	}
-	if strings.Contains(prompt, `--body-file <file>`) {
-		t.Fatal("kelos-api-reviewer.yaml prompt contains placeholder issue comment body file")
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			ts := readSelfDevelopmentTaskSpawner(t, tt.file)
+			prompt := ts.Spec.TaskTemplate.PromptTemplate
+			want := `gh issue comment {{.Number}} --body-file ` + tt.path
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("%s prompt does not contain concrete issue comment command %q", tt.file, want)
+			}
+			if strings.Contains(prompt, `--body-file <file>`) {
+				t.Fatalf("%s prompt contains placeholder issue comment body file", tt.file)
+			}
+		})
 	}
 }
 

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -31,9 +31,9 @@ while a worker or PR responder is handling an explicitly requested issue or PR.
 | **kelos-workers** | Webhook: issue comment `/kelos pick-up` | Codex | Picks up issues, creates or updates PRs, self-reviews, and ensures CI passes |
 | **kelos-planner** | Webhook: issue comment `/kelos plan` | Codex | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
 | **kelos-reviewer** | Webhook: PR comment `/kelos review` | Codex | Reviews PRs on demand — analyzes code, checks conventions, and updates a sticky review comment |
-| **kelos-glm-reviewer** | Webhook: PR comment `/kelos glm-review` | GLM-5.2 | Runs a second code review path with Z.AI GLM-5.2 through OpenCode |
+| **kelos-glm-reviewer** | Webhook: PR comment `/kelos glm-review` | GLM-5.2 | Runs a second code review path with Z.AI GLM-5.2 through OpenCode and updates a sticky review comment |
 | **kelos-api-reviewer** | Webhook: issue/PR comment `/kelos api-review` | Codex | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
-| **kelos-glm-api-reviewer** | Webhook: issue/PR comment `/kelos glm-api-review` | GLM-5.2 | Runs a second Kubernetes API design review path with Z.AI GLM-5.2 through OpenCode |
+| **kelos-glm-api-reviewer** | Webhook: issue/PR comment `/kelos glm-api-review` | GLM-5.2 | Runs a second Kubernetes API design review path with Z.AI GLM-5.2 through OpenCode and updates sticky PR comments |
 | **kelos-pr-responder** | Webhook: PR review/comment on `generated-by-kelos` PRs | Codex | Re-engages on PR review feedback and updates the existing branch incrementally |
 | **kelos-triage** | Webhook: issue opened/labeled/reopened (`needs-actor`) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
 | **kelos-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user and maintains one unassigned issue slot for the highest-impact problem found |
@@ -133,7 +133,8 @@ Z.AI GLM-5.2 through the OpenCode runner. It uses a separate trigger from
 | **Concurrency** | 3 |
 
 **Key features:**
-- Uses the same code review checklist and structured `gh pr review` output as `kelos-reviewer`
+- Uses the same code review checklist and structured sticky comment output as `kelos-reviewer`
+- Creates or updates a single GLM-specific sticky PR comment with the structured review result
 - Provides an independent model-family review without replacing the Codex reviewer
 - Read-only agent — does not push code or modify files
 
@@ -188,6 +189,8 @@ uses a separate trigger from `kelos-api-reviewer`, which continues to handle
 **Key features:**
 - Uses the same Kubernetes API design checklist and structured output as `kelos-api-reviewer`
 - Works on both issues (API design proposals) and pull requests (API implementation review)
+- For PRs: creates or updates a single GLM-specific sticky PR comment with structured API review feedback
+- For issues: posts a structured comment with API design guidance
 - Provides an independent model-family review without replacing the Codex API reviewer
 - Read-only agent — does not push code or modify files
 

--- a/self-development/kelos-glm-api-reviewer.yaml
+++ b/self-development/kelos-glm-api-reviewer.yaml
@@ -247,29 +247,39 @@ spec:
       - Are defaults set via kubebuilder markers or webhook defaulting?
       - If this is a multi-version API, are conversion functions updated?
 
-      ### 5. Submit the review
+      ### 5. Publish the review
 
-      **For pull requests**, submit a review using `gh pr review {{.Number}}`:
+      **For pull requests**, publish exactly one sticky PR comment. Update your
+      existing sticky comment when it exists; otherwise create it. Do NOT submit
+      a GitHub PR review and do NOT create inline review comments.
 
-      - If the API design looks good with no or only minor nits:
-        `gh pr review {{.Number}} --approve --body "..."`
-      - If the API design needs changes:
-        `gh pr review {{.Number}} --request-changes --body "..."`
-      - If you are unsure about something and need maintainer input:
-        `gh pr review {{.Number}} --comment --body "..."`
-
-      For inline comments on specific lines, use:
-        `gh api repos/:owner/:repo/pulls/{{.Number}}/reviews \
-          -f body="..." \
-          -f event="<APPROVE|REQUEST_CHANGES|COMMENT>" \
-          -f 'comments=[{"path":"file.go","line":42,"body":"comment"}]'`
-      The `event` value MUST match your chosen verdict (APPROVE, REQUEST_CHANGES, or COMMENT).
-
-      **For issues**, post a comment using `gh issue comment {{.Number}} --body "..."`.
-
-      Format the review body (for both PRs and issues) as:
+      Write the full comment body to `/tmp/kelos-glm-api-reviewer-comment.md`, then run:
 
       ```
+      comment_author=$(gh api user --jq .login)
+      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/kelos/issues/{{.Number}}/comments?per_page=100" \
+        --paginate \
+        --slurp \
+        --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- kelos-glm-api-reviewer:sticky-review -->")))) | last | .id // empty')
+
+      if [ -n "$comment_id" ]; then
+        gh api --method PATCH "repos/kelos-dev/kelos/issues/comments/$comment_id" \
+          -F body=@/tmp/kelos-glm-api-reviewer-comment.md
+      else
+        gh api "repos/kelos-dev/kelos/issues/{{.Number}}/comments" \
+          -F body=@/tmp/kelos-glm-api-reviewer-comment.md
+      fi
+      ```
+
+      **For issues**, post a comment using `gh issue comment {{.Number}} --body-file /tmp/kelos-glm-api-reviewer-comment.md`.
+
+      Format the PR comment body as:
+
+      ```
+      🤖 **Kelos GLM API Reviewer Agent** @gjkim42
+
+      <!-- kelos-glm-api-reviewer:sticky-review -->
+
       ## API Design Review
 
       **Verdict**: APPROVE / REQUEST CHANGES / COMMENT
@@ -288,12 +298,15 @@ spec:
       /kelos needs-input
       ```
 
+      Format the issue review body the same way, but omit the sticky marker.
+
       ## Rules
 
       - Do NOT push code, create commits, or modify any files
       - Do NOT merge or close the PR or issue
       - Do NOT change labels
-      - Submit exactly one review or comment per run
+      - Publish exactly one sticky PR comment or one issue comment per run
+      - Do NOT use `gh pr comment --edit-last`; only update PR comments with the sticky marker
       - The review body MUST end with a standalone `/kelos needs-input` line
       - Focus on API design — leave general code correctness to the regular reviewer
       - Be specific: reference file paths and line numbers

--- a/self-development/kelos-glm-reviewer.yaml
+++ b/self-development/kelos-glm-reviewer.yaml
@@ -102,8 +102,8 @@ spec:
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
       You are a GLM 5.2 code review agent for the Kelos project (github.com/kelos-dev/kelos).
-      Your job is to thoroughly review a pull request and submit a structured review
-      using `gh pr review`. You do NOT write code, push changes, or modify any files.
+      Your job is to thoroughly review a pull request and publish a structured
+      sticky PR comment. You do NOT write code, push changes, or modify any files.
 
       ---
       Webhook:
@@ -260,21 +260,16 @@ spec:
       Output every qualifying finding. If none qualify, output no findings — do
       not manufacture issues to fill the review.
 
-      **How to write each comment.**
-      - One comment per distinct issue; use a multi-line range only when needed.
+      **How to write each finding.**
+      - One finding per distinct issue.
       - Keep the body to a single paragraph that explains *why* it is a bug and
         names the inputs, environments, or scenarios under which it arises.
       - Communicate severity accurately — do not inflate it.
       - Matter-of-fact tone, not accusatory or flattering; avoid filler like
         "Great job" or "Thanks for".
-      - Code in comments: inline `code` or fenced blocks; no chunks over 3 lines.
-      - Use ` ```suggestion ` blocks only for concrete replacement code.
-        Preserve the exact leading whitespace (spaces vs tabs, count) and do
-        not change outer indentation levels unless that is the fix.
-      - Keep inline line ranges tight (≤ 5–10 lines); pick the tightest
-        subrange that pinpoints the problem.
+      - Code in findings: inline `code` or fenced blocks; no chunks over 3 lines.
 
-      **Priority.** Tag every finding and inline comment with a P0–P3 label:
+      **Priority.** Tag every finding with a P0–P3 label:
       - **[P0]** — Drop everything to fix. Blocks release, operations, or major
               usage. Reserve for universal issues that do not depend on any
               assumptions about inputs.
@@ -282,8 +277,8 @@ spec:
       - **[P2]** — Normal. To be fixed eventually.
       - **[P3]** — Low. Nice to have.
 
-      Blocking verdicts (`REQUEST_CHANGES`) are reserved for P0/P1 findings.
-      P2/P3 findings are raised on an `APPROVE` or `COMMENT` review.
+      Blocking verdicts (`REQUEST CHANGES`) are reserved for P0/P1 findings.
+      P2/P3 findings are raised on an `APPROVE` or `COMMENT` result.
 
       **Overall correctness.** Decide whether the patch is "correct" or
       "incorrect." A patch is **correct** if it is free of P0/P1 bugs and will
@@ -292,26 +287,25 @@ spec:
 
       The two verdicts must stay consistent:
       - `APPROVE` requires overall correctness = "patch is correct".
-      - Overall correctness = "patch is incorrect" requires `REQUEST_CHANGES`
+      - Overall correctness = "patch is incorrect" requires `REQUEST CHANGES`
         (or `COMMENT` if you need maintainer input before blocking).
       - `COMMENT` is valid with either correctness value.
 
-      ### 6. Submit the review
-      Submit a review using `gh pr review {{.Number}}`:
+      ### 6. Publish the sticky review comment
+      Publish exactly one PR comment. Update your existing sticky comment when
+      it exists; otherwise create it. Do NOT submit a GitHub PR review and do
+      NOT create inline review comments.
 
-      - If the PR looks good with no or only minor nits:
-        `gh pr review {{.Number}} --approve --body "..."`
-      - If the PR needs changes:
-        `gh pr review {{.Number}} --request-changes --body "..."`
-      - If you are unsure about something and need maintainer input:
-        `gh pr review {{.Number}} --comment --body "..."`
-
-      Format the review body as:
+      Format the PR comment body as:
 
       ```
+      🤖 **Kelos GLM Reviewer Agent** @gjkim42
+
+      <!-- kelos-glm-reviewer:sticky-review -->
+
       ## Review Summary
 
-      **Verdict**: APPROVE / REQUEST CHANGES / COMMENT
+      **Verdict**: APPROVE / REQUEST CHANGES / COMMENT (sticky comment only)
       **Overall correctness**: patch is correct / patch is incorrect
       **Scope**: <one-line summary of what the PR does>
 
@@ -343,20 +337,23 @@ spec:
       - <1–3 bullets highlighting the most important points from the review>
       ```
 
-      For inline comments on specific lines, use:
-        `gh api repos/{owner}/{repo}/pulls/{{.Number}}/reviews \
-          -f body="..." \
-          -f event="<APPROVE|REQUEST_CHANGES|COMMENT>" \
-          -f 'comments=[{"path":"file.go","line":42,"body":"[P1] comment"}]'`
-      Use the same review summary body in `-f body="..."` when submitting inline comments.
+      Write the full comment body to `/tmp/kelos-glm-reviewer-comment.md`, then run:
 
-      Choose ONE submission command per run:
-      - Use `gh pr review --body "..."` when there are no inline comments.
-      - Use the `gh api .../reviews` form when inline comments are needed.
-      Do NOT call both — each call creates a separate review on the PR.
+      ```
+      comment_author=$(gh api user --jq .login)
+      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/kelos/issues/{{.Number}}/comments?per_page=100" \
+        --paginate \
+        --slurp \
+        --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- kelos-glm-reviewer:sticky-review -->")))) | last | .id // empty')
 
-      The `event` value MUST match your chosen verdict (APPROVE, REQUEST_CHANGES, or COMMENT).
-      Prefix each inline comment body with its priority tag (e.g., `[P1]`).
+      if [ -n "$comment_id" ]; then
+        gh api --method PATCH "repos/kelos-dev/kelos/issues/comments/$comment_id" \
+          -F body=@/tmp/kelos-glm-reviewer-comment.md
+      else
+        gh api "repos/kelos-dev/kelos/issues/{{.Number}}/comments" \
+          -F body=@/tmp/kelos-glm-reviewer-comment.md
+      fi
+      ```
 
       ## Rules
 
@@ -364,8 +361,9 @@ spec:
       - Do NOT run local validation commands or wait for CI status as part of the review
       - Do NOT merge or close the PR
       - Do NOT change labels
-      - Submit exactly one review per run
-      - The single review body must contain the review summary and priority table; do NOT post a separate PR comment
+      - Publish exactly one sticky PR comment per run
+      - Do NOT use `gh pr comment --edit-last`; only update the comment with the sticky marker
+      - The sticky comment body must contain the review summary and priority table
       - Be specific: reference file paths and line numbers
       - Be constructive: explain why something is a problem and suggest a fix
       - Distinguish between blocking issues (request changes) and optional nits (approve with comments)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the GLM reviewer and GLM API reviewer prompts to follow the same sticky PR comment flow as the main reviewer prompts.

The GLM reviewer now creates or updates a GLM-specific sticky PR comment instead of submitting a GitHub PR review. The GLM API reviewer now creates or updates a GLM-specific sticky PR comment for pull requests while keeping normal issue comments for issue reviews.

This also updates the self-development README and extends prompt tests so the GLM reviewers keep their sticky markers, comment update flow, and concrete issue comment body file path.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with `make test`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GLM reviewers to sticky PR comments to align with the main reviewer flow and avoid creating GitHub PR reviews. GLM API reviewer now uses sticky PR comments on PRs and keeps regular issue comments for issues.

- **Refactors**
  - `kelos-glm-reviewer.yaml`: publish one sticky PR comment (`<!-- kelos-glm-reviewer:sticky-review -->`) via `gh api`, writing the body to `/tmp/kelos-glm-reviewer-comment.md`; no PR reviews or inline comments.
  - `kelos-glm-api-reviewer.yaml`: for PRs, publish one sticky comment (`<!-- kelos-glm-api-reviewer:sticky-review -->`) via `gh api` with body at `/tmp/kelos-glm-api-reviewer-comment.md`; for issues, use `gh issue comment` with the same body file.
  - README updated to note sticky behavior; tests extended to verify sticky markers and concrete `--body-file` paths for both GLM reviewers.

<sup>Written for commit c16f243686a9b56359bdd64cc5b10f6790edd29c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

