### PR TITLE
Enable OpenCode auto permissions

### DIFF
--- a/internal/controller/entrypoint_test.go
+++ b/internal/controller/entrypoint_test.go
@@ -70,6 +70,18 @@ func TestAgentEntrypointsHandleKelosEffort(t *testing.T) {
 	}
 }
 
+func TestOpenCodeEntrypointUsesAutoPermissions(t *testing.T) {
+	section := extractEntrypointSection(
+		t,
+		"../..//opencode/kelos_entrypoint.sh",
+		"ARGS=(",
+		"if [ -n \"${KELOS_EFFORT:-}\" ]; then",
+	)
+	if !strings.Contains(section, "\"--auto\"") {
+		t.Fatalf("expected OpenCode entrypoint args to include --auto, got:\n%s", section)
+	}
+}
+
 func TestOpenCodeEntrypointMapsZAIProviderKey(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/opencode/kelos_entrypoint.sh
+++ b/opencode/kelos_entrypoint.sh
@@ -42,6 +42,7 @@ fi
 ARGS=(
   "run"
   "--format" "json"
+  "--auto"
   "$PROMPT"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

OpenCode agent tasks now pass `--auto` to `opencode run` so noninteractive Kelos jobs auto-approve OpenCode permission prompts that are not explicitly denied. This prevents review tasks from failing when OpenCode asks for approval during autonomous execution inside the ephemeral agent pod.

A focused controller test asserts that the OpenCode entrypoint keeps the `--auto` flag in its run arguments.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The failing task showed OpenCode auto-rejecting an `external_directory (/tmp/*)` permission request. Using `--auto` aligns OpenCode with the other noninteractive Kelos agent images, where the pod boundary and injected credentials define the runtime safety boundary.

Validation: `make test`

#### Does this PR introduce a user-facing change?

```release-note
OpenCode agent tasks now run with automatic permission approval for noninteractive Kelos jobs.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable automatic permission approval for OpenCode in noninteractive Kelos agent runs. The entrypoint now calls `opencode run` with `--auto`, preventing tasks from failing on permission prompts.

- **Bug Fixes**
  - Pass `--auto` to `opencode run` in the Kelos entrypoint to auto-approve safe prompts.
  - Add a test to ensure the entrypoint keeps the `--auto` flag.

<sup>Written for commit 423b58b17206dbfaffb5ae5219881e3a71db54d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

