### PR TITLE
Support GitHub App secrets for persistent WorkerPools

### DIFF
--- a/cmd/kelos-controller/main.go
+++ b/cmd/kelos-controller/main.go
@@ -276,6 +276,7 @@ func main() {
 		Scheme:                      mgr.GetScheme(),
 		Recorder:                    mgr.GetEventRecorderFor("kelos-controller"),
 		Clientset:                   clientset,
+		TokenClient:                 githubapp.NewTokenClient(),
 		WorkerRunnerImage:           workerRunnerImage,
 		WorkerRunnerImagePullPolicy: corev1.PullPolicy(workerRunnerImagePullPolicy),
 		ClaudeCodeImage:             claudeCodeImage,

--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -124,15 +124,18 @@ failures when tailing pod logs.
 ### 8. GitHub token freshness
 
 For GitHub App-backed workspaces, the installation token has a ~1h TTL but
-the controller re-mints it in place while the Job is running. The
+the controller re-mints it in place while the workload is running. This
+applies to both per-Task Jobs and long-lived WorkerPool StatefulSets. The
 `GITHUB_TOKEN`, `GH_TOKEN`, and `GH_ENTERPRISE_TOKEN` env vars are still
 set for compatibility, but their values are frozen at pod start and will
-expire mid-run for long-running tasks.
+expire mid-run for long-running tasks and for pooled workers.
 
 **Custom agent images should read `$KELOS_GITHUB_TOKEN_FILE` on each
 GitHub call** instead of capturing the env var once. The file is mounted
-from the per-task token Secret; the kubelet auto-syncs its contents
-(~60s latency) so each read returns the current token.
+from the derived token Secret — `<task-name>-github-token` for per-Task
+Jobs and `<pool-name>-github-token` for WorkerPools — and the kubelet
+auto-syncs its contents (~60s latency) so each read returns the current
+token.
 
 Two concrete recommendations:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -191,6 +191,8 @@ For each labeled Secret with a non-empty `CODEX_AUTH_JSON` key, the controller m
 
 A WorkerPool manages a fleet of persistent worker pods backed by a StatefulSet. Tasks reference a WorkerPool via `spec.workerPoolRef` to execute on pre-warmed infrastructure instead of creating per-task Jobs.
 
+A WorkerPool's Workspace may use either a PAT-style or a GitHub App secret. For App secrets the controller mints a short-lived installation token into a `<pool-name>-github-token` Secret and re-mints it before expiry (see [Workspace authentication](#workspace-authentication)), so long-lived worker pods keep a valid token without restarts.
+
 | Field | Description | Required |
 |-------|-------------|----------|
 | `spec.worker.type` | Agent type | Yes |
@@ -278,7 +280,7 @@ kubectl create secret generic github-app-creds \
 
 GitHub Apps are preferred over PATs for production use because they offer fine-grained permissions, higher rate limits, no dependency on a specific user account, and automatically expiring tokens.
 
-The installation token is minted to a per-task Secret (`<task-name>-github-token`) at admission and is mounted into the agent pod as a file at `/kelos/github-token/GITHUB_TOKEN`. While the task is running, the controller re-mints the token before it expires and updates the Secret in place. The kubelet syncs the file contents automatically, and the agent image's git credential helper and `gh` wrapper read the file on each invocation, so tasks that run longer than the ~1h installation-token TTL keep working without a pod restart.
+The installation token is minted to a derived Secret and mounted into the agent pod as a file at `/kelos/github-token/GITHUB_TOKEN`. For per-Task Jobs the Secret is `<task-name>-github-token` (minted at admission); for WorkerPools it is `<pool-name>-github-token` (minted on first reconcile). In both cases the controller re-mints the token before it expires and updates the Secret in place. The kubelet syncs the file contents automatically, and the agent image's git credential helper and `gh` wrapper read the file on each invocation, so runs that last longer than the ~1h installation-token TTL keep working without a pod restart. This makes GitHub App secrets usable for persistent WorkerPools, not just ephemeral Task pods.
 
 ## AgentConfig
 

--- a/internal/controller/github_token_secret.go
+++ b/internal/controller/github_token_secret.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 Kelos contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/kelos-dev/kelos/internal/githubapp"
+)
+
+// githubTokenSecretName returns the name of the derived Secret that holds the
+// short-lived GitHub App installation token minted for the resource named
+// ownerName (a Task or a WorkerPool).
+func githubTokenSecretName(ownerName string) string {
+	return ownerName + "-github-token"
+}
+
+// tokenClientForRepo returns a per-call TokenClient targeting the GitHub API
+// host derived from repoURL, falling back to base's BaseURL. A per-call client
+// avoids racing on the shared client's BaseURL across concurrent reconciles
+// that resolve to different GitHub Enterprise hosts.
+func tokenClientForRepo(base *githubapp.TokenClient, repoURL string) *githubapp.TokenClient {
+	tc := &githubapp.TokenClient{
+		BaseURL: base.BaseURL,
+		Client:  base.Client,
+	}
+	if repoURL != "" {
+		host, _, _ := parseGitHubRepo(repoURL)
+		if apiBaseURL := gitHubAPIBaseURL(host); apiBaseURL != "" {
+			tc.BaseURL = apiBaseURL
+		}
+	}
+	return tc
+}
+
+// mintGitHubAppTokenSecret generates a new installation token from the given
+// GitHub App credentials and writes it into a derived Secret named
+// tokenSecretName, owner-referenced to owner so it is garbage-collected with
+// it. The derived Secret carries annotations recording the source App Secret
+// name (marking it refreshable) and the token expiry so the refresh path can
+// re-mint it. repoURL resolves the GitHub API host. It returns the token
+// expiry.
+func mintGitHubAppTokenSecret(ctx context.Context, cl client.Client, scheme *runtime.Scheme, tokenClient *githubapp.TokenClient, owner client.Object, tokenSecretName, appSecretName, repoURL string, creds *githubapp.Credentials) (time.Time, error) {
+	tc := tokenClientForRepo(tokenClient, repoURL)
+	tokenResp, err := tc.GenerateInstallationToken(ctx, creds)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("generating installation token: %w", err)
+	}
+
+	annotations := map[string]string{
+		githubAppSecretAnnotation: appSecretName,
+		tokenExpiresAtAnnotation:  tokenResp.ExpiresAt.UTC().Format(time.RFC3339),
+	}
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        tokenSecretName,
+			Namespace:   owner.GetNamespace(),
+			Annotations: annotations,
+		},
+		StringData: map[string]string{
+			GitHubTokenSecretKey: tokenResp.Token,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(owner, tokenSecret, scheme); err != nil {
+		return time.Time{}, fmt.Errorf("setting owner reference on token secret: %w", err)
+	}
+
+	if err := cl.Create(ctx, tokenSecret); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return time.Time{}, fmt.Errorf("creating token secret: %w", err)
+		}
+		// Update the existing secret in place. Only adopt a Secret this owner
+		// already controls: a Task and a WorkerPool can share a name in a
+		// namespace and both derive <name>-github-token, so overwriting a
+		// Secret owned by a different resource would leak the wrong token into
+		// it and tie garbage collection to the wrong owner. Re-assert the
+		// controller reference and retry on conflict like the other update
+		// paths in this package.
+		updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existing := &corev1.Secret{}
+			if err := cl.Get(ctx, client.ObjectKey{Name: tokenSecretName, Namespace: owner.GetNamespace()}, existing); err != nil {
+				return err
+			}
+			if !metav1.IsControlledBy(existing, owner) {
+				return fmt.Errorf("token secret %q already exists and is not controlled by %q", tokenSecretName, owner.GetName())
+			}
+			existing.StringData = tokenSecret.StringData
+			if existing.Annotations == nil {
+				existing.Annotations = map[string]string{}
+			}
+			for k, v := range annotations {
+				existing.Annotations[k] = v
+			}
+			if err := controllerutil.SetControllerReference(owner, existing, scheme); err != nil {
+				return err
+			}
+			return cl.Update(ctx, existing)
+		})
+		if updateErr != nil {
+			return time.Time{}, fmt.Errorf("updating token secret: %w", updateErr)
+		}
+	}
+
+	return tokenResp.ExpiresAt, nil
+}
+
+// refreshGitHubAppTokenSecret re-mints the installation token held in the
+// derived Secret named tokenSecretName when it is within tokenRefreshMargin of
+// expiry, updating the Secret in place. repoURL resolves the GitHub API host.
+//
+// It returns the duration until the next refresh should be scheduled, the new
+// token expiry, and whether a refresh was actually performed (so callers can
+// emit an event). A return of (0, zero, false, nil) means the token Secret is
+// absent or is not App-derived, i.e. no refresh is applicable.
+func refreshGitHubAppTokenSecret(ctx context.Context, cl client.Client, tokenClient *githubapp.TokenClient, namespace, tokenSecretName, repoURL string) (time.Duration, time.Time, bool, error) {
+	var tokenSecret corev1.Secret
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: tokenSecretName}, &tokenSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return 0, time.Time{}, false, nil
+		}
+		return 0, time.Time{}, false, fmt.Errorf("fetching token secret %q: %w", tokenSecretName, err)
+	}
+
+	appSecretName := tokenSecret.Annotations[githubAppSecretAnnotation]
+	if appSecretName == "" {
+		return 0, time.Time{}, false, nil
+	}
+
+	retryAfter := tokenRefreshRetryInterval
+	expiresAtStr := tokenSecret.Annotations[tokenExpiresAtAnnotation]
+	if expiresAtStr != "" {
+		expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+		if err == nil {
+			retryAfter = tokenRefreshFailureRetryAfter(expiresAt)
+			refreshAt := expiresAt.Add(-tokenRefreshMargin)
+			if time.Now().Before(refreshAt) {
+				return time.Until(refreshAt), time.Time{}, false, nil
+			}
+		}
+	}
+
+	if tokenClient == nil {
+		return retryAfter, time.Time{}, false, fmt.Errorf("GitHub App token refresh requested but TokenClient is not configured")
+	}
+
+	var appSecret corev1.Secret
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: appSecretName}, &appSecret); err != nil {
+		return retryAfter, time.Time{}, false, fmt.Errorf("fetching GitHub App secret %q: %w", appSecretName, err)
+	}
+	if !githubapp.IsGitHubApp(appSecret.Data) {
+		return 0, time.Time{}, false, nil
+	}
+
+	creds, err := githubapp.ParseCredentials(appSecret.Data)
+	if err != nil {
+		return retryAfter, time.Time{}, false, fmt.Errorf("parsing GitHub App credentials: %w", err)
+	}
+
+	tc := tokenClientForRepo(tokenClient, repoURL)
+	tokenResp, err := tc.GenerateInstallationToken(ctx, creds)
+	if err != nil {
+		return retryAfter, time.Time{}, false, fmt.Errorf("generating refreshed installation token: %w", err)
+	}
+
+	// StringData wins over Data on the apiserver, so writing through
+	// StringData is the idiomatic way to update a Secret in place and
+	// matches the initial-mint path.
+	tokenSecret.StringData = map[string]string{
+		GitHubTokenSecretKey: tokenResp.Token,
+	}
+	if tokenSecret.Annotations == nil {
+		tokenSecret.Annotations = map[string]string{}
+	}
+	tokenSecret.Annotations[tokenExpiresAtAnnotation] = tokenResp.ExpiresAt.UTC().Format(time.RFC3339)
+	if err := cl.Update(ctx, &tokenSecret); err != nil {
+		return retryAfter, time.Time{}, false, fmt.Errorf("updating token secret with refreshed token: %w", err)
+	}
+
+	next := time.Until(tokenResp.ExpiresAt.Add(-tokenRefreshMargin))
+	if next < 0 {
+		next = 0
+	}
+	return next, tokenResp.ExpiresAt, true, nil
+}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -558,64 +558,9 @@ func (r *TaskReconciler) resolveGitHubAppToken(ctx context.Context, task *kelos.
 		return nil, fmt.Errorf("parsing GitHub App credentials: %w", err)
 	}
 
-	// Use a per-call TokenClient so that concurrent reconciles with different
-	// hosts do not race on the shared r.TokenClient.BaseURL.
-	tc := &githubapp.TokenClient{
-		BaseURL: r.TokenClient.BaseURL,
-		Client:  r.TokenClient.Client,
-	}
-	if workspace.Repo != "" {
-		host, _, _ := parseGitHubRepo(workspace.Repo)
-		if apiBaseURL := gitHubAPIBaseURL(host); apiBaseURL != "" {
-			tc.BaseURL = apiBaseURL
-		}
-	}
-
-	tokenResp, err := tc.GenerateInstallationToken(ctx, creds)
-	if err != nil {
-		return nil, fmt.Errorf("generating installation token: %w", err)
-	}
-
-	// Create a new secret with the generated token, owned by the Task
-	tokenSecretName := task.Name + "-github-token"
-	tokenAnnotations := map[string]string{
-		githubAppSecretAnnotation: workspace.SecretRef.Name,
-		tokenExpiresAtAnnotation:  tokenResp.ExpiresAt.UTC().Format(time.RFC3339),
-	}
-	tokenSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        tokenSecretName,
-			Namespace:   task.Namespace,
-			Annotations: tokenAnnotations,
-		},
-		StringData: map[string]string{
-			"GITHUB_TOKEN": tokenResp.Token,
-		},
-	}
-
-	if err := controllerutil.SetControllerReference(task, tokenSecret, r.Scheme); err != nil {
-		return nil, fmt.Errorf("setting owner reference on token secret: %w", err)
-	}
-
-	if err := r.Create(ctx, tokenSecret); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("creating token secret: %w", err)
-		}
-		// Update existing secret
-		existing := &corev1.Secret{}
-		if err := r.Get(ctx, client.ObjectKey{Name: tokenSecretName, Namespace: task.Namespace}, existing); err != nil {
-			return nil, fmt.Errorf("fetching existing token secret: %w", err)
-		}
-		existing.StringData = tokenSecret.StringData
-		if existing.Annotations == nil {
-			existing.Annotations = map[string]string{}
-		}
-		for k, v := range tokenAnnotations {
-			existing.Annotations[k] = v
-		}
-		if err := r.Update(ctx, existing); err != nil {
-			return nil, fmt.Errorf("updating token secret: %w", err)
-		}
+	tokenSecretName := githubTokenSecretName(task.Name)
+	if _, err := mintGitHubAppTokenSecret(ctx, r.Client, r.Scheme, r.TokenClient, task, tokenSecretName, workspace.SecretRef.Name, workspace.Repo, creds); err != nil {
+		return nil, err
 	}
 
 	// Return a modified workspace spec that points to the generated token secret
@@ -683,96 +628,29 @@ func (r *TaskReconciler) ensurePluginConfigMap(ctx context.Context, task *kelos.
 func (r *TaskReconciler) refreshGitHubAppTokenIfNeeded(ctx context.Context, task *kelos.Task) (time.Duration, error) {
 	logger := log.FromContext(ctx)
 
-	tokenSecretName := task.Name + "-github-token"
-	var tokenSecret corev1.Secret
-	if err := r.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: tokenSecretName}, &tokenSecret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return 0, nil
-		}
-		return 0, fmt.Errorf("fetching token secret %q: %w", tokenSecretName, err)
-	}
+	tokenSecretName := githubTokenSecretName(task.Name)
 
-	appSecretName := tokenSecret.Annotations[githubAppSecretAnnotation]
-	if appSecretName == "" {
-		return 0, nil
-	}
-
-	retryAfter := tokenRefreshRetryInterval
-	expiresAtStr := tokenSecret.Annotations[tokenExpiresAtAnnotation]
-	if expiresAtStr != "" {
-		expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
-		if err == nil {
-			retryAfter = tokenRefreshFailureRetryAfter(expiresAt)
-			refreshAt := expiresAt.Add(-tokenRefreshMargin)
-			if time.Now().Before(refreshAt) {
-				return time.Until(refreshAt), nil
-			}
-		}
-	}
-
-	if r.TokenClient == nil {
-		return retryAfter, fmt.Errorf("GitHub App token refresh requested but TokenClient is not configured")
-	}
-
-	var appSecret corev1.Secret
-	if err := r.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: appSecretName}, &appSecret); err != nil {
-		return retryAfter, fmt.Errorf("fetching GitHub App secret %q: %w", appSecretName, err)
-	}
-	if !githubapp.IsGitHubApp(appSecret.Data) {
-		return 0, nil
-	}
-
-	creds, err := githubapp.ParseCredentials(appSecret.Data)
-	if err != nil {
-		return retryAfter, fmt.Errorf("parsing GitHub App credentials: %w", err)
-	}
-
-	tc := &githubapp.TokenClient{
-		BaseURL: r.TokenClient.BaseURL,
-		Client:  r.TokenClient.Client,
-	}
-	if resolveTaskWorkspaceRef(task) != nil {
+	// Resolve the workspace repo so refreshed tokens are minted against the
+	// correct GitHub API host for GitHub Enterprise workspaces.
+	repoURL := ""
+	if ref := resolveTaskWorkspaceRef(task); ref != nil {
 		var ws kelos.Workspace
-		if err := r.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: resolveTaskWorkspaceRef(task).Name}, &ws); err != nil {
+		if err := r.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: ref.Name}, &ws); err != nil {
 			// Fall back to the controller-wide BaseURL. Log at V(1) so
 			// operators can correlate a later 401 against the wrong
 			// API host with the lookup that failed here.
-			logger.V(1).Info("Unable to fetch workspace for token refresh, using default API base URL", "workspace", resolveTaskWorkspaceRef(task).Name, "error", err)
-		} else if ws.Spec.Repo != "" {
-			host, _, _ := parseGitHubRepo(ws.Spec.Repo)
-			if apiBaseURL := gitHubAPIBaseURL(host); apiBaseURL != "" {
-				tc.BaseURL = apiBaseURL
-			}
+			logger.V(1).Info("Unable to fetch workspace for token refresh, using default API base URL", "workspace", ref.Name, "error", err)
+		} else {
+			repoURL = ws.Spec.Repo
 		}
 	}
 
-	tokenResp, err := tc.GenerateInstallationToken(ctx, creds)
-	if err != nil {
-		return retryAfter, fmt.Errorf("generating refreshed installation token: %w", err)
+	next, expiresAt, refreshed, err := refreshGitHubAppTokenSecret(ctx, r.Client, r.TokenClient, task.Namespace, tokenSecretName, repoURL)
+	if refreshed {
+		logger.Info("Refreshed GitHub App installation token", "task", task.Name, "expiresAt", expiresAt)
+		r.recordEvent(task, corev1.EventTypeNormal, "GitHubTokenRefreshed", "Refreshed GitHub App installation token (expires at %s)", expiresAt.UTC().Format(time.RFC3339))
 	}
-
-	// StringData wins over Data on the apiserver, so writing through
-	// StringData is the idiomatic way to update a Secret in place and
-	// matches resolveGitHubAppToken on the initial-mint path.
-	tokenSecret.StringData = map[string]string{
-		"GITHUB_TOKEN": tokenResp.Token,
-	}
-	if tokenSecret.Annotations == nil {
-		tokenSecret.Annotations = map[string]string{}
-	}
-	tokenSecret.Annotations[tokenExpiresAtAnnotation] = tokenResp.ExpiresAt.UTC().Format(time.RFC3339)
-	if err := r.Update(ctx, &tokenSecret); err != nil {
-		return retryAfter, fmt.Errorf("updating token secret with refreshed token: %w", err)
-	}
-
-	logger.Info("Refreshed GitHub App installation token", "task", task.Name, "expiresAt", tokenResp.ExpiresAt)
-	r.recordEvent(task, corev1.EventTypeNormal, "GitHubTokenRefreshed", "Refreshed GitHub App installation token (expires at %s)", tokenResp.ExpiresAt.UTC().Format(time.RFC3339))
-
-	next := time.Until(tokenResp.ExpiresAt.Add(-tokenRefreshMargin))
-	if next < 0 {
-		next = 0
-	}
-	return next, nil
+	return next, err
 }
 
 func tokenRefreshFailureRetryAfter(expiresAt time.Time) time.Duration {

--- a/internal/controller/workerpool_controller.go
+++ b/internal/controller/workerpool_controller.go
@@ -89,6 +89,11 @@ type WorkerPoolReconciler struct {
 	CursorImage                 string
 	CursorImagePullPolicy       corev1.PullPolicy
 
+	// TokenClient mints GitHub App installation tokens for workspaces backed
+	// by a GitHub App secret. Required for App-backed pools; PAT-style
+	// workspaces do not use it.
+	TokenClient *githubapp.TokenClient
+
 	// NowFunc returns the current time. Defaults to time.Now.
 	// Overridable in tests for deterministic behavior.
 	NowFunc func() time.Time
@@ -120,7 +125,7 @@ func (r *WorkerPoolReconciler) budget() *budgetEnforcer {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
 
 // Reconcile handles both WorkerPool infrastructure and Task assignment.
 func (r *WorkerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -191,18 +196,19 @@ func (r *WorkerPoolReconciler) reconcilePool(ctx context.Context, pool *kelos.Wo
 	}
 	workspace = &ws.Spec
 
-	// Validate that the workspace secret is not a GitHub App secret.
-	// WorkerPool pods are long-lived, so short-lived GitHub App installation
-	// tokens cannot be refreshed per task. Only PAT-style secrets are supported.
+	// Resolve GitHub App-backed workspace secrets into a derived Secret
+	// holding a short-lived installation token, minting it on first use and
+	// re-minting it before expiry. PAT-style secrets are used as-is.
+	var refreshAfter time.Duration
 	if workspace.SecretRef != nil {
-		var wsSecret corev1.Secret
-		if err := r.Get(ctx, types.NamespacedName{Namespace: pool.Namespace, Name: workspace.SecretRef.Name}, &wsSecret); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("workerpool %s: fetching workspace secret %q: %w", pool.Name, workspace.SecretRef.Name, err)
-			}
-		} else if githubapp.IsGitHubApp(wsSecret.Data) {
-			return ctrl.Result{}, fmt.Errorf("workerpool %s: workspace %q uses a GitHub App secret which is not supported for persistent worker pools (use a PAT-style secret instead)", pool.Name, pool.Spec.Worker.WorkspaceRef.Name)
+		resolvedWorkspace, next, err := r.ensureGitHubAppToken(ctx, pool, workspace)
+		if err != nil {
+			logger.Error(err, "Unable to ensure GitHub App installation token", "workerpool", pool.Name)
+			r.recordEvent(pool, corev1.EventTypeWarning, "GitHubTokenFailed", "Failed to ensure GitHub App installation token: %v", err)
+			return ctrl.Result{}, err
 		}
+		workspace = resolvedWorkspace
+		refreshAfter = next
 	}
 
 	// Resolve AgentConfig
@@ -256,7 +262,104 @@ func (r *WorkerPoolReconciler) reconcilePool(ctx context.Context, pool *kelos.Wo
 		return ctrl.Result{}, err
 	}
 
+	// Schedule the next GitHub App token refresh alongside any StatefulSet
+	// requeue so the derived token Secret is re-minted before it expires.
+	if refreshAfter > 0 {
+		result = mergeReconcileResults(result, ctrl.Result{RequeueAfter: refreshAfter})
+	}
+
 	return result, nil
+}
+
+// ensureGitHubAppToken resolves a workspace secret that holds GitHub App
+// credentials into a derived Secret containing a short-lived installation
+// token, minting it on first use and re-minting it before expiry. It returns a
+// workspace spec pointing at the derived token Secret (or the original
+// workspace when the secret is a plain PAT or is not present yet), and the
+// duration until the next token refresh should be scheduled (0 when no refresh
+// is applicable).
+func (r *WorkerPoolReconciler) ensureGitHubAppToken(ctx context.Context, pool *kelos.WorkerPool, workspace *kelos.WorkspaceSpec) (*kelos.WorkspaceSpec, time.Duration, error) {
+	logger := log.FromContext(ctx)
+
+	var appSecret corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{Namespace: pool.Namespace, Name: workspace.SecretRef.Name}, &appSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Secret not present yet; leave the workspace untouched and let a
+			// later reconcile (triggered by the secret watch) resolve it.
+			return workspace, 0, nil
+		}
+		return nil, 0, fmt.Errorf("workerpool %s: fetching workspace secret %q: %w", pool.Name, workspace.SecretRef.Name, err)
+	}
+
+	if !githubapp.IsGitHubApp(appSecret.Data) {
+		return workspace, 0, nil
+	}
+
+	if r.TokenClient == nil {
+		return nil, 0, fmt.Errorf("workerpool %s: workspace %q uses a GitHub App secret but TokenClient is not configured", pool.Name, workspace.SecretRef.Name)
+	}
+
+	tokenSecretName := githubTokenSecretName(pool.Name)
+
+	// Mint the derived token Secret if it does not exist yet. When it already
+	// exists, the refresh below re-mints it only when close to expiry, so we
+	// avoid a GitHub API call on every reconcile.
+	var derived corev1.Secret
+	switch err := r.Get(ctx, types.NamespacedName{Namespace: pool.Namespace, Name: tokenSecretName}, &derived); {
+	case err != nil && !apierrors.IsNotFound(err):
+		return nil, 0, fmt.Errorf("workerpool %s: fetching token secret %q: %w", pool.Name, tokenSecretName, err)
+	case apierrors.IsNotFound(err):
+		logger.Info("Detected GitHub App secret, generating installation token", "workerpool", pool.Name, "secret", workspace.SecretRef.Name)
+		creds, err := githubapp.ParseCredentials(appSecret.Data)
+		if err != nil {
+			return nil, 0, fmt.Errorf("workerpool %s: parsing GitHub App credentials: %w", pool.Name, err)
+		}
+		if _, err := mintGitHubAppTokenSecret(ctx, r.Client, r.Scheme, r.TokenClient, pool, tokenSecretName, workspace.SecretRef.Name, workspace.Repo, creds); err != nil {
+			return nil, 0, fmt.Errorf("workerpool %s: %w", pool.Name, err)
+		}
+	case !metav1.IsControlledBy(&derived, pool):
+		// A Task and a WorkerPool can share a name in a namespace and both
+		// derive <name>-github-token. Refuse to refresh or mount a token
+		// Secret owned by another resource: doing so would mint into and point
+		// the pool's pods at a Secret garbage-collected with a different owner.
+		return nil, 0, fmt.Errorf("workerpool %s: token secret %q already exists and is not controlled by this WorkerPool", pool.Name, tokenSecretName)
+	case derived.Annotations[githubAppSecretAnnotation] != workspace.SecretRef.Name:
+		// The Workspace now points at a different App Secret than the one the
+		// derived Secret was minted from. The refresh path keys off the derived
+		// Secret's kelos.dev/github-app-secret annotation, so without re-minting
+		// here it would keep reading the stale source Secret and never adopt the
+		// new credential. Re-mint from the current workspace.SecretRef.Name,
+		// which rewrites the annotation and the token in place.
+		logger.Info("Workspace GitHub App secret changed, re-minting installation token",
+			"workerpool", pool.Name,
+			"previousSecret", derived.Annotations[githubAppSecretAnnotation],
+			"secret", workspace.SecretRef.Name)
+		creds, err := githubapp.ParseCredentials(appSecret.Data)
+		if err != nil {
+			return nil, 0, fmt.Errorf("workerpool %s: parsing GitHub App credentials: %w", pool.Name, err)
+		}
+		if _, err := mintGitHubAppTokenSecret(ctx, r.Client, r.Scheme, r.TokenClient, pool, tokenSecretName, workspace.SecretRef.Name, workspace.Repo, creds); err != nil {
+			return nil, 0, fmt.Errorf("workerpool %s: %w", pool.Name, err)
+		}
+	}
+
+	next, expiresAt, refreshed, refreshErr := refreshGitHubAppTokenSecret(ctx, r.Client, r.TokenClient, pool.Namespace, tokenSecretName, workspace.Repo)
+	if refreshErr != nil {
+		// Non-fatal: the token Secret exists and may still be valid. Log,
+		// emit an event, and requeue to retry before expiry.
+		logger.Error(refreshErr, "Unable to refresh GitHub App installation token", "workerpool", pool.Name)
+		r.recordEvent(pool, corev1.EventTypeWarning, "GitHubTokenRefreshFailed", "Failed to refresh GitHub App installation token: %v", refreshErr)
+		if next == 0 {
+			next = tokenRefreshRetryInterval
+		}
+	} else if refreshed {
+		logger.Info("Refreshed GitHub App installation token", "workerpool", pool.Name, "expiresAt", expiresAt)
+		r.recordEvent(pool, corev1.EventTypeNormal, "GitHubTokenRefreshed", "Refreshed GitHub App installation token (expires at %s)", expiresAt.UTC().Format(time.RFC3339))
+	}
+
+	resolved := *workspace
+	resolved.SecretRef = &kelos.SecretReference{Name: tokenSecretName}
+	return &resolved, next, nil
 }
 
 func (r *WorkerPoolReconciler) reconcileService(ctx context.Context, pool *kelos.WorkerPool, svcName string) error {
@@ -531,10 +634,16 @@ func (r *WorkerPoolReconciler) buildStatefulSet(pool *kelos.WorkerPool, stsName,
 			Value: GHConfigDir,
 		})
 
-		// Token refresh support: worker runner reads this secret name
+		// Expose the mounted token file path so the worker runner can re-read
+		// the token on every task, picking up controller-side refreshes without
+		// a pod restart. The secret-backed GITHUB_TOKEN / GH_TOKEN env vars
+		// above are frozen at pod start, so the file is the source of truth for
+		// long-lived pools. Only the main container runs the worker runner; the
+		// init-container credential helper hardcodes the mount path via
+		// gitCredentialHelper(), so it does not need this env var.
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "KELOS_TOKEN_SECRET",
-			Value: workspace.SecretRef.Name,
+			Name:  "KELOS_GITHUB_TOKEN_FILE",
+			Value: GitHubTokenMountPath + "/" + GitHubTokenSecretKey,
 		})
 	}
 
@@ -574,11 +683,46 @@ func (r *WorkerPoolReconciler) buildStatefulSet(pool *kelos.WorkerPool, stsName,
 		},
 	}
 
+	// Mount the workspace token Secret as a file so the git credential helper
+	// and worker runner read the current token on each use. kubelet syncs
+	// secret-volume updates into the running pod, so a controller-side token
+	// refresh propagates without a pod restart.
+	if workspace != nil && workspace.SecretRef != nil {
+		volumes = append(volumes, corev1.Volume{
+			Name: GitHubTokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: workspace.SecretRef.Name,
+					Items: []corev1.KeyToPath{
+						{Key: GitHubTokenSecretKey, Path: GitHubTokenSecretKey},
+					},
+					Optional: ptr.To(true),
+				},
+			},
+		})
+		mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, corev1.VolumeMount{
+			Name:      GitHubTokenVolumeName,
+			MountPath: GitHubTokenMountPath,
+			ReadOnly:  true,
+		})
+	}
+
 	// Build workspace init containers (git-clone, remote-setup, workspace-files)
 	if workspace != nil {
 		volumeMount := corev1.VolumeMount{
 			Name:      WorkspaceVolumeName,
 			MountPath: WorkspaceMountPath,
+		}
+
+		// Containers that need the cloned repo plus, when a token Secret is
+		// configured, the auto-syncing token file used by the credential helper.
+		workspaceVolumeMounts := []corev1.VolumeMount{volumeMount}
+		if workspace.SecretRef != nil {
+			workspaceVolumeMounts = append(workspaceVolumeMounts, corev1.VolumeMount{
+				Name:      GitHubTokenVolumeName,
+				MountPath: GitHubTokenMountPath,
+				ReadOnly:  true,
+			})
 		}
 
 		targetPath := WorkspaceMountPath + "/repo"
@@ -596,7 +740,7 @@ func (r *WorkerPoolReconciler) buildStatefulSet(pool *kelos.WorkerPool, stsName,
 			Image:        GitCloneImage,
 			Args:         cloneArgs,
 			Env:          workspaceEnvVars,
-			VolumeMounts: []corev1.VolumeMount{volumeMount},
+			VolumeMounts: append([]corev1.VolumeMount(nil), workspaceVolumeMounts...),
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: &agentUID,
 			},

--- a/internal/controller/workerpool_controller_test.go
+++ b/internal/controller/workerpool_controller_test.go
@@ -2,9 +2,17 @@ package controller
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/githubapp"
 )
 
 func newWorkerPoolTestScheme() *runtime.Scheme {
@@ -1038,7 +1047,27 @@ func TestPodTemplateSpecEqual_IgnoresAPIDefaults(t *testing.T) {
 	assert.False(t, podTemplateSpecEqual(desired, *changed))
 }
 
-func TestWorkerPoolReconciler_RejectsGitHubAppSecret(t *testing.T) {
+func TestWorkerPoolReconciler_MintsGitHubAppTokenSecret(t *testing.T) {
+	// A GitHub App-backed workspace is now supported: the reconciler mints a
+	// derived <pool>-github-token Secret and points the StatefulSet at it,
+	// mounting the token as a file so refreshes propagate into running pods.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	expiresAt := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      "ghs_minted_token",
+			"expires_at": expiresAt.Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
 	scheme := newWorkerPoolTestScheme()
 	pool := newTestWorkerPool("my-pool", "default", 1)
 
@@ -1056,7 +1085,6 @@ func TestWorkerPoolReconciler_RejectsGitHubAppSecret(t *testing.T) {
 		},
 	}
 
-	// GitHub App secret has appID, installationID, privateKey
 	appSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "github-app-secret",
@@ -1065,7 +1093,7 @@ func TestWorkerPoolReconciler_RejectsGitHubAppSecret(t *testing.T) {
 		Data: map[string][]byte{
 			"appID":          []byte("12345"),
 			"installationID": []byte("67890"),
-			"privateKey":     []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"),
+			"privateKey":     keyPEM,
 		},
 	}
 
@@ -1076,12 +1104,228 @@ func TestWorkerPoolReconciler_RejectsGitHubAppSecret(t *testing.T) {
 		Build()
 
 	r := newWorkerPoolReconciler(cl, scheme)
+	r.TokenClient = &githubapp.TokenClient{BaseURL: server.URL, Client: server.Client()}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-pool", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// A derived token Secret was minted, owned by the pool, with the token
+	// and refresh annotations.
+	var tokenSecret corev1.Secret
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: "my-pool-github-token", Namespace: "default"}, &tokenSecret))
+	assert.Equal(t, "ghs_minted_token", tokenSecret.StringData["GITHUB_TOKEN"])
+	assert.Equal(t, "github-app-secret", tokenSecret.Annotations["kelos.dev/github-app-secret"])
+	assert.Equal(t, expiresAt.Format(time.RFC3339), tokenSecret.Annotations["kelos.dev/token-expires-at"])
+	require.Len(t, tokenSecret.OwnerReferences, 1)
+	assert.Equal(t, "my-pool", tokenSecret.OwnerReferences[0].Name)
+
+	// The StatefulSet points at the derived Secret via the token-file volume
+	// and exposes KELOS_GITHUB_TOKEN_FILE.
+	var sts appsv1.StatefulSet
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: workerPoolStatefulSetName("my-pool"), Namespace: "default"}, &sts))
+
+	var tokenVolume *corev1.Volume
+	for i := range sts.Spec.Template.Spec.Volumes {
+		if sts.Spec.Template.Spec.Volumes[i].Name == GitHubTokenVolumeName {
+			tokenVolume = &sts.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, tokenVolume, "expected token-file volume %q", GitHubTokenVolumeName)
+	require.NotNil(t, tokenVolume.Secret)
+	assert.Equal(t, "my-pool-github-token", tokenVolume.Secret.SecretName)
+
+	main := sts.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, envValue(main.Env, "KELOS_GITHUB_TOKEN_FILE"), GitHubTokenMountPath)
+	assert.True(t, hasVolumeMount(main.VolumeMounts, GitHubTokenVolumeName, GitHubTokenMountPath),
+		"main container should mount the token file volume")
+}
+
+func TestWorkerPoolReconciler_RefusesForeignOwnedTokenSecret(t *testing.T) {
+	// A Task and a WorkerPool can share a name in a namespace and both derive
+	// <name>-github-token. If a derived token Secret named <pool>-github-token
+	// already exists but is controlled by another resource, the reconciler must
+	// refuse to refresh or mount it rather than clobber the other owner's token
+	// and mis-tie garbage collection.
+	scheme := newWorkerPoolTestScheme()
+	pool := newTestWorkerPool("my-pool", "default", 1)
+	pool.UID = "pool-uid"
+
+	ws := &kelos.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+		Spec: kelos.WorkspaceSpec{
+			Repo:      "https://github.com/example/repo.git",
+			Ref:       "main",
+			SecretRef: &kelos.SecretReference{Name: "github-app-secret"},
+		},
+	}
+
+	appSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-app-secret", Namespace: "default"},
+		Data: map[string][]byte{
+			"appID":          []byte("12345"),
+			"installationID": []byte("67890"),
+			"privateKey":     []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"),
+		},
+	}
+
+	// A pre-existing token Secret controlled by a Task of the same name.
+	controller := true
+	foreignToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pool-github-token",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kelos.dev/github-app-secret": "github-app-secret",
+				"kelos.dev/token-expires-at":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kelos.GroupVersion.String(),
+				Kind:       "Task",
+				Name:       "my-pool",
+				UID:        "task-uid",
+				Controller: &controller,
+			}},
+		},
+		StringData: map[string]string{"GITHUB_TOKEN": "ghs_task_token"},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kelos.Task{}, &kelos.WorkerPool{}).
+		WithObjects(pool, ws, appSecret, foreignToken).
+		Build()
+
+	r := newWorkerPoolReconciler(cl, scheme)
+	r.TokenClient = &githubapp.TokenClient{}
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "my-pool", Namespace: "default"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "GitHub App secret which is not supported for persistent worker pools")
+	assert.Contains(t, err.Error(), "not controlled by this WorkerPool")
+
+	// The other owner's token was left untouched.
+	var after corev1.Secret
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: "my-pool-github-token", Namespace: "default"}, &after))
+	require.Len(t, after.OwnerReferences, 1)
+	assert.Equal(t, "task-uid", string(after.OwnerReferences[0].UID))
+}
+
+func TestWorkerPoolReconciler_ReMintsTokenOnWorkspaceSecretChange(t *testing.T) {
+	// When an existing pool's Workspace switches from GitHub App Secret A to
+	// Secret B, the derived <pool>-github-token Secret already exists, so the
+	// mint path is skipped. The refresh path keys off the derived Secret's
+	// kelos.dev/github-app-secret annotation, so without re-minting the pool
+	// would keep serving the stale Secret A credential. The reconciler must
+	// detect the annotation mismatch and re-mint from the current SecretRef.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	expiresAt := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      "ghs_token_from_secret_b",
+			"expires_at": expiresAt.Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	scheme := newWorkerPoolTestScheme()
+	pool := newTestWorkerPool("my-pool", "default", 1)
+	pool.UID = "pool-uid"
+
+	// The Workspace now points at Secret B.
+	ws := &kelos.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+		Spec: kelos.WorkspaceSpec{
+			Repo:      "https://github.com/example/repo.git",
+			Ref:       "main",
+			SecretRef: &kelos.SecretReference{Name: "github-app-secret-b"},
+		},
+	}
+
+	appSecretB := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "github-app-secret-b", Namespace: "default"},
+		Data: map[string][]byte{
+			"appID":          []byte("12345"),
+			"installationID": []byte("67890"),
+			"privateKey":     keyPEM,
+		},
+	}
+
+	// A pre-existing derived token Secret, controlled by the pool, minted from
+	// the old Secret A and still far from expiry (so the refresh path alone
+	// would not re-mint it).
+	controller := true
+	derived := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pool-github-token",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kelos.dev/github-app-secret": "github-app-secret-a",
+				"kelos.dev/token-expires-at":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kelos.GroupVersion.String(),
+				Kind:       "WorkerPool",
+				Name:       "my-pool",
+				UID:        "pool-uid",
+				Controller: &controller,
+			}},
+		},
+		StringData: map[string]string{"GITHUB_TOKEN": "ghs_token_from_secret_a"},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kelos.Task{}, &kelos.WorkerPool{}).
+		WithObjects(pool, ws, appSecretB, derived).
+		Build()
+
+	r := newWorkerPoolReconciler(cl, scheme)
+	r.TokenClient = &githubapp.TokenClient{BaseURL: server.URL, Client: server.Client()}
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-pool", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// The derived Secret was re-minted from Secret B: the token and the source
+	// annotation both track the current workspace credential.
+	var after corev1.Secret
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: "my-pool-github-token", Namespace: "default"}, &after))
+	assert.Equal(t, "ghs_token_from_secret_b", after.StringData["GITHUB_TOKEN"])
+	assert.Equal(t, "github-app-secret-b", after.Annotations["kelos.dev/github-app-secret"])
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for _, e := range env {
+		if e.Name == name {
+			return e.Value
+		}
+	}
+	return ""
+}
+
+func hasVolumeMount(mounts []corev1.VolumeMount, name, path string) bool {
+	for _, m := range mounts {
+		if m.Name == name && m.MountPath == path {
+			return true
+		}
+	}
+	return false
 }
 
 func int32Ptr(v int32) *int32 { return &v }

--- a/internal/workerrunner/runner.go
+++ b/internal/workerrunner/runner.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -284,6 +285,21 @@ func (r *Runner) runAgent(ctx context.Context, task *kelos.Task) error {
 
 func taskAgentEnv(base []string, task *kelos.Task) []string {
 	env := append([]string{}, base...)
+
+	// Refresh the GitHub token env vars from the mounted token file so
+	// env-reading tools pick up controller-side token refreshes. The token
+	// env vars in os.Environ() are captured at pod start and never update,
+	// so for long-lived worker pods they go stale once the installation token
+	// is re-minted. The git credential helper already re-reads the file per
+	// git call; this covers tools that read GITHUB_TOKEN/GH_TOKEN directly.
+	// Only env vars already present are overridden, matching whichever the
+	// pod set (GH_TOKEN for github.com, GH_ENTERPRISE_TOKEN for GHE).
+	if token := currentGitHubToken(); token != "" {
+		env = overrideEnvIfPresent(env, "GITHUB_TOKEN", token)
+		env = overrideEnvIfPresent(env, "GH_TOKEN", token)
+		env = overrideEnvIfPresent(env, "GH_ENTERPRISE_TOKEN", token)
+	}
+
 	env = append(env, "KELOS_PROMPT="+task.Spec.Prompt)
 	if task.Spec.Model != "" {
 		env = append(env, "KELOS_MODEL="+task.Spec.Model)
@@ -293,6 +309,36 @@ func taskAgentEnv(base []string, task *kelos.Task) []string {
 	}
 	if task.Spec.UpstreamRepo != "" {
 		env = append(env, "KELOS_UPSTREAM_REPO="+task.Spec.UpstreamRepo)
+	}
+	return env
+}
+
+// currentGitHubToken reads the current GitHub token from the file named by
+// KELOS_GITHUB_TOKEN_FILE, returning "" when the env var is unset or the file
+// is missing/unreadable/empty. The file is a kubelet-synced secret volume, so
+// it reflects controller-side token refreshes within the kubelet sync period.
+func currentGitHubToken() string {
+	tokenFile := os.Getenv("KELOS_GITHUB_TOKEN_FILE")
+	if tokenFile == "" {
+		return ""
+	}
+	data, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// overrideEnvIfPresent replaces the value of key in env when it is already
+// present, leaving env unchanged otherwise. It edits in place so the agent
+// subprocess sees a single, up-to-date value rather than a duplicate key.
+func overrideEnvIfPresent(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			env[i] = prefix + value
+			return env
+		}
 	}
 	return env
 }

--- a/internal/workerrunner/runner_test.go
+++ b/internal/workerrunner/runner_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -181,6 +183,44 @@ func TestTaskAgentEnvIncludesPerTaskModelAndEffort(t *testing.T) {
 	}
 	if got := lastEnvValue(env, "KELOS_UPSTREAM_REPO"); got != "upstream/repo" {
 		t.Errorf("KELOS_UPSTREAM_REPO = %q, want task upstream repo", got)
+	}
+}
+
+func TestTaskAgentEnvRefreshesGitHubTokenFromFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("ghs_fresh_token\n"), 0o600); err != nil {
+		t.Fatalf("writing token file: %v", err)
+	}
+	t.Setenv("KELOS_GITHUB_TOKEN_FILE", tokenFile)
+
+	task := &kelos.Task{Spec: kelos.TaskSpec{Prompt: "Fix the bug"}}
+
+	// The pod-start (frozen) token env vars should be overridden by the
+	// current file contents; GH_ENTERPRISE_TOKEN is absent so it stays unset.
+	base := []string{"GITHUB_TOKEN=stale", "GH_TOKEN=stale", "OTHER=value"}
+	env := taskAgentEnv(base, task)
+
+	if got := lastEnvValue(env, "GITHUB_TOKEN"); got != "ghs_fresh_token" {
+		t.Errorf("GITHUB_TOKEN = %q, want refreshed token", got)
+	}
+	if got := lastEnvValue(env, "GH_TOKEN"); got != "ghs_fresh_token" {
+		t.Errorf("GH_TOKEN = %q, want refreshed token", got)
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GH_ENTERPRISE_TOKEN=") {
+			t.Errorf("GH_ENTERPRISE_TOKEN unexpectedly set: %q", kv)
+		}
+	}
+}
+
+func TestTaskAgentEnvNoTokenFileLeavesEnvUnchanged(t *testing.T) {
+	t.Setenv("KELOS_GITHUB_TOKEN_FILE", "")
+
+	task := &kelos.Task{Spec: kelos.TaskSpec{Prompt: "Fix the bug"}}
+	env := taskAgentEnv([]string{"GITHUB_TOKEN=pat-value"}, task)
+
+	if got := lastEnvValue(env, "GITHUB_TOKEN"); got != "pat-value" {
+		t.Errorf("GITHUB_TOKEN = %q, want original PAT value", got)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds GitHub App–backed workspace support to persistent WorkerPools, which
previously hard-rejected App secrets with an error and required a PAT-style
secret instead.

The blocker was that a GitHub App installation token expires (~1h) while a
WorkerPool pod lives for hours or days, and the pod consumed the token as a
frozen, secret-backed env var captured at pod start. This PR fixes both halves:

- **Keep a valid token in a Secret.** The WorkerPool reconciler now resolves an
  App-backed workspace secret into a derived `<pool-name>-github-token` Secret
  holding a short-lived installation token, minting it on first reconcile and
  re-minting it before expiry. The minting/refresh logic is extracted from the
  Task reconciler into a shared `github_token_secret.go` helper so both
  reconcilers share one implementation.
- **Make the pod consume the current token.** The derived Secret is mounted as a
  file (`/kelos/github-token/GITHUB_TOKEN`), which the kubelet keeps in sync. The
  git credential helper already re-reads that file per git call; the worker
  runner now also refreshes `GITHUB_TOKEN` / `GH_TOKEN` / `GH_ENTERPRISE_TOKEN`
  from the file for each task's agent subprocess, so env-reading tools pick up
  refreshes without a pod restart.

The next token refresh is scheduled alongside the StatefulSet requeue, and the
WorkerPool reconciler's RBAC is widened to `create;update` on secrets.

#### Which issue(s) this PR is related to:

Fixes #1433

#### Special notes for your reviewer:

- The token-minting/refresh code paths for Tasks and WorkerPools are now unified
  in `internal/controller/github_token_secret.go`; the Task reconciler behavior
  is unchanged by the refactor.
- PAT-style workspaces are unaffected: they skip minting entirely and continue
  to use the secret as-is.

#### Does this PR introduce a user-facing change?

```release-note
WorkerPools now support GitHub App–backed workspaces. The controller mints a short-lived installation token into a `<pool-name>-github-token` Secret and re-mints it before expiry, mounting it as a file so long-lived worker pods keep a valid token without restarts.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable GitHub App–backed workspaces for persistent WorkerPools by minting and auto-refreshing a short‑lived installation token and mounting it as a kubelet-synced file. Long‑lived worker pods keep a valid token without restarts; PAT workspaces are unchanged.

- New Features
  - WorkerPools now support GitHub App secrets via a derived `'<pool-name>-github-token'` Secret that is minted on first reconcile and refreshed before expiry; if a preexisting token Secret isn’t controlled by the pool we refuse to use/overwrite it, and we re‑mint if the workspace’s App secret changes.
  - Token is mounted as a file at `/kelos/github-token/GITHUB_TOKEN`; kubelet keeps it in sync, and the StatefulSet exposes `KELOS_GITHUB_TOKEN_FILE` so the worker runner re-reads it.
  - Worker runner reads `KELOS_GITHUB_TOKEN_FILE` per task and refreshes `GITHUB_TOKEN`/`GH_TOKEN`/`GH_ENTERPRISE_TOKEN` for env-reading tools.
  - Controller RBAC widened to `create;update` on Secrets; `TokenClient` injected to mint installation tokens; docs updated.

- **Refactors**
  - Unified token mint/refresh logic into `internal/controller/github_token_secret.go` and switched Task and WorkerPool reconcilers to use it (Task behavior unchanged); per-call `TokenClient` selection avoids races across different GitHub/GHE hosts.

<sup>Written for commit 9a2a9d35b8833dc8471f7809436b1d96ed52f687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

