### PR TITLE
Fall back to legacy /rest/api/2/search when Jira Data Center 404s on /search/jql

### DIFF
--- a/internal/source/jira.go
+++ b/internal/source/jira.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,6 +37,22 @@ type jiraSearchResponse struct {
 	Issues        []jiraIssue `json:"issues"`
 	NextPageToken string      `json:"nextPageToken"`
 	IsLast        bool        `json:"isLast"`
+
+	// StartAt and Total are only populated by the legacy /rest/api/2/search
+	// endpoint, which paginates by offset instead of NextPageToken.
+	StartAt int `json:"startAt"`
+	Total   int `json:"total"`
+}
+
+// jiraAPIError carries the HTTP status code returned by the Jira API so
+// callers can distinguish a missing endpoint (404) from other failures.
+type jiraAPIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *jiraAPIError) Error() string {
+	return fmt.Sprintf("Jira API returned status %d: %s", e.StatusCode, e.Body)
 }
 
 type jiraIssue struct {
@@ -109,13 +126,36 @@ func (s *JiraSource) Discover(ctx context.Context) ([]WorkItem, error) {
 func (s *JiraSource) fetchAllIssues(ctx context.Context) ([]jiraIssue, error) {
 	var allIssues []jiraIssue
 	var nextPageToken string
+	startAt := 0
+
+	// legacy tracks whether we've fallen back to the offset-paginated
+	// /rest/api/2/search endpoint. The token-paginated /rest/api/2/search/jql
+	// endpoint used below is Jira Cloud-only; Jira Data Center/Server
+	// instances 404 on it and only expose the classic endpoint, so on a 404
+	// we switch to it for the remainder of this discovery run.
+	legacy := false
 
 	for page := 0; page < maxJiraPages; page++ {
-		result, err := s.fetchIssuesPage(ctx, nextPageToken)
+		result, err := s.fetchIssuesPage(ctx, nextPageToken, startAt, legacy)
 		if err != nil {
-			return nil, err
+			if !legacy && isJiraNotFound(err) {
+				legacy = true
+				startAt = len(allIssues)
+				result, err = s.fetchIssuesPage(ctx, nextPageToken, startAt, legacy)
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 		allIssues = append(allIssues, result.Issues...)
+
+		if legacy {
+			startAt += len(result.Issues)
+			if len(result.Issues) == 0 || startAt >= result.Total {
+				break
+			}
+			continue
+		}
 
 		if result.IsLast || result.NextPageToken == "" {
 			break
@@ -124,6 +164,12 @@ func (s *JiraSource) fetchAllIssues(ctx context.Context) ([]jiraIssue, error) {
 	}
 
 	return allIssues, nil
+}
+
+// isJiraNotFound reports whether err is a Jira API 404 response.
+func isJiraNotFound(err error) bool {
+	var apiErr *jiraAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }
 
 func (s *JiraSource) buildJQL() string {
@@ -149,8 +195,12 @@ func splitJQLOrderBy(jql string) (filter, orderBy string) {
 	return strings.TrimSpace(jql[:idx]), strings.TrimSpace(jql[idx:])
 }
 
-func (s *JiraSource) fetchIssuesPage(ctx context.Context, nextPageToken string) (*jiraSearchResponse, error) {
-	u, err := url.Parse(strings.TrimRight(s.BaseURL, "/") + "/rest/api/2/search/jql")
+func (s *JiraSource) fetchIssuesPage(ctx context.Context, nextPageToken string, startAt int, legacy bool) (*jiraSearchResponse, error) {
+	path := "/rest/api/2/search/jql"
+	if legacy {
+		path = "/rest/api/2/search"
+	}
+	u, err := url.Parse(strings.TrimRight(s.BaseURL, "/") + path)
 	if err != nil {
 		return nil, fmt.Errorf("parsing base URL: %w", err)
 	}
@@ -158,7 +208,9 @@ func (s *JiraSource) fetchIssuesPage(ctx context.Context, nextPageToken string) 
 	params := url.Values{}
 	params.Set("jql", s.buildJQL())
 	params.Set("maxResults", strconv.Itoa(maxJiraResults))
-	if nextPageToken != "" {
+	if legacy {
+		params.Set("startAt", strconv.Itoa(startAt))
+	} else if nextPageToken != "" {
 		params.Set("nextPageToken", nextPageToken)
 	}
 	params.Set("fields", "summary,status,labels,comment,issuetype")
@@ -188,7 +240,7 @@ func (s *JiraSource) fetchIssuesPage(ctx context.Context, nextPageToken string) 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("Jira API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, &jiraAPIError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
 	var result jiraSearchResponse

--- a/internal/source/jira_test.go
+++ b/internal/source/jira_test.go
@@ -501,3 +501,149 @@ func TestExtractIssueNumber(t *testing.T) {
 		})
 	}
 }
+
+// TestJiraDiscoverLegacySearchFallback verifies that when the Cloud-only
+// token-paginated /rest/api/2/search/jql endpoint returns 404 (as on Jira
+// Data Center/Server), the source falls back to the classic offset-paginated
+// /rest/api/2/search endpoint and still returns all discovered issues.
+func TestJiraDiscoverLegacySearchFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/2/search/jql":
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message":"HTTP 404 Not Found","status-code":404,"sub-code":-1}`))
+		case "/rest/api/2/search":
+			startAt := r.URL.Query().Get("startAt")
+			if startAt == "" || startAt == "0" {
+				json.NewEncoder(w).Encode(jiraSearchResponse{
+					StartAt: 0,
+					Total:   2,
+					Issues: []jiraIssue{
+						{Key: "PROJ-1", Fields: jiraIssueFields{Summary: "Issue 1"}},
+					},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(jiraSearchResponse{
+				StartAt: 1,
+				Total:   2,
+				Issues: []jiraIssue{
+					{Key: "PROJ-2", Fields: jiraIssueFields{Summary: "Issue 2"}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	s := &JiraSource{
+		BaseURL: server.URL,
+		Project: "PROJ",
+		Token:   "test-pat",
+	}
+
+	items, err := s.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].ID != "PROJ-1" || items[1].ID != "PROJ-2" {
+		t.Errorf("unexpected items: %+v", items)
+	}
+}
+
+// TestJiraDiscoverNonNotFoundErrorNotRetried verifies that non-404 errors
+// from the Cloud endpoint are returned directly, without attempting the
+// legacy fallback (avoiding masking real failures like auth errors).
+func TestJiraDiscoverNonNotFoundErrorNotRetried(t *testing.T) {
+	var legacyHit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/2/search/jql":
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"message":"unauthorized"}`))
+		case "/rest/api/2/search":
+			legacyHit = true
+			json.NewEncoder(w).Encode(jiraSearchResponse{IsLast: true})
+		}
+	}))
+	defer server.Close()
+
+	s := &JiraSource{
+		BaseURL: server.URL,
+		Project: "PROJ",
+		Token:   "test-pat",
+	}
+
+	_, err := s.Discover(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to mention status 401, got: %v", err)
+	}
+	if legacyHit {
+		t.Error("legacy endpoint should not be hit for non-404 errors")
+	}
+}
+
+// TestJiraDiscoverLegacyFallbackAfterCloudPageMidRun verifies that when the
+// Cloud endpoint succeeds for one or more pages before 404ing on a later
+// page (e.g. a flaky proxy or an endpoint that disappears mid-run), the
+// legacy fallback resumes pagination from the issues already collected
+// instead of restarting at offset 0 and duplicating them.
+func TestJiraDiscoverLegacyFallbackAfterCloudPageMidRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/2/search/jql":
+			if r.URL.Query().Get("nextPageToken") == "" {
+				json.NewEncoder(w).Encode(jiraSearchResponse{
+					NextPageToken: "tok1",
+					Issues: []jiraIssue{
+						{Key: "PROJ-1", Fields: jiraIssueFields{Summary: "Issue 1"}},
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message":"HTTP 404 Not Found","status-code":404,"sub-code":-1}`))
+		case "/rest/api/2/search":
+			startAt := r.URL.Query().Get("startAt")
+			if startAt != "1" {
+				t.Errorf("expected legacy fallback to resume at startAt=1, got %q", startAt)
+			}
+			json.NewEncoder(w).Encode(jiraSearchResponse{
+				StartAt: 1,
+				Total:   2,
+				Issues: []jiraIssue{
+					{Key: "PROJ-2", Fields: jiraIssueFields{Summary: "Issue 2"}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	s := &JiraSource{
+		BaseURL: server.URL,
+		Project: "PROJ",
+		Token:   "test-pat",
+	}
+
+	items, err := s.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d: %+v", len(items), items)
+	}
+	if items[0].ID != "PROJ-1" || items[1].ID != "PROJ-2" {
+		t.Errorf("unexpected items: %+v", items)
+	}
+}


### PR DESCRIPTION
/kind bug

Fixes #1439

## Summary
- The Jira source only called `/rest/api/2/search/jql`, which is a
  Cloud-only endpoint. Jira Data Center/Server (self-hosted) 404s on it,
  so discovery never returns any issues against those instances even
  though the `Jira` CRD type's doc comment explicitly documents PAT/Bearer
  auth for "Jira Data Center/Server".
- On a 404 from that endpoint, the source now falls back to the classic
  offset-paginated `/rest/api/2/search` endpoint for the remainder of the
  discovery run. Non-404 errors (auth failures, etc.) are returned as-is
  without attempting the fallback, so real failures aren't masked as a
  compatibility issue.

## Verification
- Reproduced against a real Jira Data Center instance: `/search/jql` →
  404, classic `/search` → 200 with real issues. Confirmed the fix
  resolves discovery there.
- Added two tests: one exercising the fallback across an offset-paginated
  two-page response, one confirming a non-404 error (401) is returned
  directly without hitting the legacy endpoint.
- `go build ./...` and `go test ./internal/source/...` pass; existing
  Jira tests (which only mock `/search/jql`) are unaffected since the
  fallback only triggers on 404.

## Test plan
- [x] `go test ./internal/source/...`
- [x] `go build ./...`
- [x] Manually verified against a live Jira Data Center/Server instance

```release-note
Fixed Jira issue discovery against Data Center/Server instances, which previously returned no issues because the source only called the Jira Cloud-only `/rest/api/2/search/jql` endpoint.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Jira issue discovery on Jira Data Center/Server by falling back to `/rest/api/2/search` when the Cloud-only `/rest/api/2/search/jql` returns 404. Resume from the current offset to avoid duplicates; non-404 errors are returned as-is.

- **Bug Fixes**
  - Detect 404 on `/search/jql` and switch to legacy `/search` for the rest of the run; resume with `startAt` based on already-fetched issues.
  - Support legacy pagination via `startAt` and `total`; keep token pagination for Cloud.
  - Add `jiraAPIError` and `isJiraNotFound` to expose status codes and drive fallback.
  - Add tests for two-page legacy fallback, mid-run resume, and non-404 pass-through; use t.Errorf in HTTP handler goroutines.

<sup>Written for commit c8c73392c6bd6221f65ed15043b5a7d77f990060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

