### PR TITLE
Run TaskSpawner templates manually with kelos run

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ See the [`self-development/` README](self-development/README.md) for the full pi
 | `kelos uninstall` | Uninstall Kelos from the cluster |
 | `kelos init` | Initialize `~/.kelos/config.yaml` |
 | `kelos run` | Create and run a new Task |
+| `kelos run --from taskspawner/<name> [-f values.yaml]` | Run a standalone Task from a TaskSpawner template |
 | `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
 | `kelos delete <resource> [name]` | Delete a resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`); supports `--all` to delete every resource of that type in the namespace |
 | `kelos logs <task-name> [-f]` | View or stream logs from a task |

--- a/cmd/kelos-spawner/main.go
+++ b/cmd/kelos-spawner/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -753,46 +752,7 @@ func deriveUpstreamRepo(ts *kelos.TaskSpawner) string {
 	} else if ts.Spec.When.GitHubPullRequests != nil && ts.Spec.When.GitHubPullRequests.Repo != "" {
 		repoOverride = ts.Spec.When.GitHubPullRequests.Repo
 	}
-	if repoOverride == "" {
-		return ""
-	}
-	// Detect shorthand "owner/repo" format by checking that the first
-	// segment has no ":" (rules out SSH "git@host:owner/repo") and no "."
-	// (rules out "https://host/..."). Anything else is treated as a URL.
-	parts := strings.SplitN(repoOverride, "/", 2)
-	if len(parts) == 2 && !strings.Contains(parts[0], ":") && !strings.Contains(parts[0], ".") {
-		return repoOverride
-	}
-	// Parse full URL to extract owner/repo.
-	owner, repo := parseOwnerRepo(repoOverride)
-	if owner != "" && repo != "" {
-		return owner + "/" + repo
-	}
-	return ""
-}
-
-// parseOwnerRepo extracts owner and repo from a GitHub repository URL.
-// Supports HTTPS (https://host/owner/repo) and SSH (git@host:owner/repo).
-func parseOwnerRepo(repoURL string) (string, string) {
-	repoURL = strings.TrimSuffix(repoURL, ".git")
-	repoURL = strings.TrimSuffix(repoURL, "/")
-
-	// Handle SSH format: git@host:owner/repo
-	// SSH URLs have no "//" after the colon, unlike "https://".
-	if idx := strings.Index(repoURL, ":"); idx > 0 && !strings.HasPrefix(repoURL, "http") {
-		path := repoURL[idx+1:]
-		parts := strings.SplitN(path, "/", 2)
-		if len(parts) == 2 {
-			return parts[0], parts[1]
-		}
-	}
-
-	// Handle HTTPS format: https://host/owner/repo
-	parts := strings.Split(repoURL, "/")
-	if len(parts) >= 2 {
-		return parts[len(parts)-2], parts[len(parts)-1]
-	}
-	return "", ""
+	return source.GitHubRepositoryName(repoOverride)
 }
 
 func parsePollInterval(s string) time.Duration {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -407,6 +407,45 @@ The installation token is minted to a per-task Secret (`<task-name>-github-token
 | `spec.maxConcurrency` | Limit max concurrent running tasks (important for cost control) | No |
 | `spec.maxTotalTasks` | Lifetime limit on total tasks created by this spawner | No |
 | `spec.suspend` | Pause the spawner without deleting it; resume with `spec.suspend: false` (default: `false`) | No |
+
+### Manual Task Creation
+
+Run a standalone Task from any TaskSpawner's `taskTemplate`:
+
+```bash
+kelos run --from taskspawner/daily-audit
+kelos run --from taskspawner/issue-worker -f values.yaml
+```
+
+The values file is a YAML or JSON object whose top-level keys are exposed
+directly to the Go template. Use `-f -` to read it from stdin. For example:
+
+```yaml
+ID: "42"
+Number: 42
+Title: Fix the login timeout
+Body: Reproduce and fix the timeout under load.
+Kind: Issue
+```
+
+Kelos supplies `TriggerType: manual` and the current UTC time as
+`TriggerTime`. Cron TaskSpawners also receive the current UTC time as `Time`
+and their configured expression as `Schedule`; these cron values cannot be
+overridden by `-f`. A static template or a cron template that only uses the
+supplied defaults does not require a values file. Rendering fails if a template
+uses a key that is not supplied.
+
+Manual creation bypasses source filters and creates a standalone Task. It does
+not apply `spec.suspend`, `spec.maxConcurrency`, or `spec.maxTotalTasks`, does
+not enable source reporting, and does not update TaskSpawner status. The Task
+has no TaskSpawner owner reference or `kelos.dev/taskspawner` label. Instead,
+Kelos records its origin with `kelos.dev/created-from-taskspawner`,
+`kelos.dev/trigger-type`, and `kelos.dev/trigger-time` annotations.
+
+Configured `contextSources` are fetched after the values are resolved, matching
+automatic Task creation. `--dry-run` still connects to the cluster to read the
+TaskSpawner and any Secrets referenced by context sources.
+
 <a id="prompttemplate-variables"></a>
 
 ### promptTemplate Variables
@@ -723,6 +762,7 @@ The `kelos` CLI lets you manage the full lifecycle without writing YAML.
 | Command | Description |
 |---------|-------------|
 | `kelos run` | Create and run a new Task |
+| `kelos run --from taskspawner/<name>` | Run a standalone Task from a TaskSpawner template |
 | `kelos create workspace` | Create a Workspace resource |
 | `kelos create agentconfig` | Create an AgentConfig resource |
 | `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
@@ -755,8 +795,10 @@ When the same key is set multiple ways, precedence is: chart defaults, then `--v
 
 ### `kelos run` Flags
 
-- `--prompt, -p`: Task prompt (required unless `--prompt-file` is set)
+- `--prompt, -p`: Task prompt (required unless `--prompt-file` or `--from` is set)
 - `--prompt-file`: Read task prompt from a file path; use `-` to read from stdin (mutually exclusive with `--prompt`)
+- `--from`: Run the Task template from a `taskspawner/name` reference
+- `--values, -f`: Read top-level template values from a YAML or JSON file; use `-` to read from stdin (requires `--from`)
 - `--type, -t`: Agent type (default: `claude-code`)
 - `--model`: Model override
 - `--effort`: Agent reasoning effort
@@ -771,6 +813,7 @@ When the same key is set multiple ways, precedence is: chart defaults, then `--v
 - `--watch, -w`: Watch task status after creation
 - `--secret`: Pre-created secret name
 - `--credential-type`: Credential type when using `--secret` (default: `api-key`)
+- `--dry-run`: Render the Task without creating it; with `--from`, the TaskSpawner and any context-source Secrets are still read
 
 ### `kelos get` Flags
 

--- a/examples/04-taskspawner-cron/README.md
+++ b/examples/04-taskspawner-cron/README.md
@@ -43,7 +43,17 @@ kubectl get taskspawners -w
 kubectl get tasks -w
 ```
 
-7. **Cleanup:**
+7. **Create a standalone Task without waiting for the schedule:**
+
+```bash
+kelos run --from taskspawner/weekly-dependency-update
+```
+
+The command always uses the current UTC time for `{{.Time}}`, so no values file
+is needed. It instantiates the Task template directly; it does not update the
+TaskSpawner's status or apply its concurrency and lifetime limits.
+
+8. **Cleanup:**
 
 ```bash
 kubectl delete -f examples/04-taskspawner-cron/

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -53,12 +53,52 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		agentConfigRefs []string
 		dependsOn       []string
 		branch          string
+		from            string
+		valuesFile      string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Create and run a new Task",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if from != "" {
+				if err := validateTaskSpawnerRunFlags(cmd); err != nil {
+					return err
+				}
+				spawnerName, err := parseTaskSpawnerReference(from)
+				if err != nil {
+					return err
+				}
+				values, err := readTaskTemplateValues(valuesFile, cmd.Flags().Changed("values"), cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				cl, ns, err := cfg.NewClient()
+				if err != nil {
+					return err
+				}
+				options := runFromTaskSpawnerOptions{Name: name, Values: values, ErrorWriter: os.Stderr}
+				if dryRun {
+					task, err := buildTaskFromTaskSpawner(cmd.Context(), cl, ns, spawnerName, options)
+					if err != nil {
+						return err
+					}
+					return printYAML(os.Stdout, task)
+				}
+				task, err := createTaskFromTaskSpawner(cmd.Context(), cl, ns, spawnerName, options)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(os.Stdout, "task/%s created\n", task.Name)
+				if watch {
+					return watchTask(cmd.Context(), cl, task.Name, ns, os.Stdout, os.Stderr)
+				}
+				return nil
+			}
+			if cmd.Flags().Changed("values") {
+				return fmt.Errorf("--values requires --from")
+			}
+
 			if c := cfg.Config; c != nil {
 				if !cmd.Flags().Changed("secret") && c.Secret != "" {
 					secret = c.Secret
@@ -357,7 +397,7 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "task prompt (required unless --prompt-file is set)")
+	cmd.Flags().StringVarP(&prompt, "prompt", "p", "", "task prompt (required unless --prompt-file or --from is set)")
 	cmd.Flags().StringVar(&promptFile, "prompt-file", "", "read task prompt from a file (use - for stdin)")
 	cmd.Flags().StringVarP(&agentType, "type", "t", "claude-code", "agent type (claude-code, codex, gemini, opencode, cursor)")
 	cmd.Flags().StringVar(&secret, "secret", "", "secret name with credentials (overrides oauthToken/apiKey in config)")
@@ -375,6 +415,8 @@ func newRunCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.Flags().StringArrayVar(&agentConfigRefs, "agent-config", nil, "name of AgentConfig resource(s) to use (repeatable)")
 	cmd.Flags().StringArrayVar(&dependsOn, "depends-on", nil, "Task names this task depends on (repeatable)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Git branch to work on")
+	cmd.Flags().StringVar(&from, "from", "", "TaskSpawner reference in taskspawner/name form")
+	cmd.Flags().StringVarP(&valuesFile, "values", "f", "", "template values file in YAML or JSON format (use - for stdin)")
 
 	cmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
 

--- a/internal/cli/run_from_taskspawner.go
+++ b/internal/cli/run_from_taskspawner.go
@@ -1,0 +1,235 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/spf13/cobra"
+	json "k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/contextfetch"
+	"github.com/kelos-dev/kelos/internal/source"
+	"github.com/kelos-dev/kelos/internal/taskbuilder"
+)
+
+const (
+	annotationCreatedFromTaskSpawner = "kelos.dev/created-from-taskspawner"
+	annotationManualTrigger          = "kelos.dev/trigger-type"
+	annotationManualTriggerTime      = "kelos.dev/trigger-time"
+)
+
+type runFromTaskSpawnerOptions struct {
+	Name        string
+	Values      map[string]interface{}
+	Now         time.Time
+	HTTPClient  *http.Client
+	ErrorWriter io.Writer
+}
+
+func validateTaskSpawnerRunFlags(cmd *cobra.Command) error {
+	incompatible := []string{
+		"prompt",
+		"prompt-file",
+		"type",
+		"secret",
+		"credential-type",
+		"model",
+		"effort",
+		"image",
+		"workspace",
+		"yes",
+		"timeout",
+		"env",
+		"agent-config",
+		"depends-on",
+		"branch",
+	}
+	for _, flag := range incompatible {
+		if cmd.Flags().Changed(flag) {
+			return fmt.Errorf("--%s cannot be used with --from", flag)
+		}
+	}
+	return nil
+}
+
+func parseTaskSpawnerReference(ref string) (string, error) {
+	parts := strings.Split(ref, "/")
+	if len(parts) != 2 || parts[1] == "" {
+		return "", fmt.Errorf("invalid TaskSpawner reference %q: expected taskspawner/name", ref)
+	}
+	switch parts[0] {
+	case "taskspawner", "taskspawners", "ts":
+		return parts[1], nil
+	default:
+		return "", fmt.Errorf("invalid TaskSpawner reference %q: expected taskspawner/name", ref)
+	}
+}
+
+func readTaskTemplateValues(path string, provided bool, stdin io.Reader) (map[string]interface{}, error) {
+	if !provided {
+		return nil, nil
+	}
+	if path == "" {
+		return nil, fmt.Errorf("--values must name a file or - for stdin")
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading --values from stdin: %w", err)
+		}
+	} else {
+		expanded, expandErr := expandHome(path)
+		if expandErr != nil {
+			return nil, fmt.Errorf("expanding --values path %s: %w", path, expandErr)
+		}
+		data, err = os.ReadFile(expanded)
+		if err != nil {
+			return nil, fmt.Errorf("reading --values file %s: %w", path, err)
+		}
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, fmt.Errorf("--values file must not be empty")
+	}
+
+	jsonData, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing --values file: %w", err)
+	}
+	var values map[string]interface{}
+	if err := json.Unmarshal(jsonData, &values); err != nil {
+		return nil, fmt.Errorf("parsing --values file: expected a top-level object: %w", err)
+	}
+	if values == nil {
+		return nil, fmt.Errorf("parsing --values file: expected a top-level object")
+	}
+	return values, nil
+}
+
+func createTaskFromTaskSpawner(ctx context.Context, cl client.Client, namespace, spawnerName string, opts runFromTaskSpawnerOptions) (*kelos.Task, error) {
+	task, err := buildTaskFromTaskSpawner(ctx, cl, namespace, spawnerName, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := cl.Create(ctx, task); err != nil {
+		return nil, fmt.Errorf("creating task %s from TaskSpawner %s: %w", task.Name, spawnerName, err)
+	}
+	return task, nil
+}
+
+func buildTaskFromTaskSpawner(ctx context.Context, cl client.Client, namespace, spawnerName string, opts runFromTaskSpawnerOptions) (*kelos.Task, error) {
+	var spawner kelos.TaskSpawner
+	if err := cl.Get(ctx, client.ObjectKey{Name: spawnerName, Namespace: namespace}, &spawner); err != nil {
+		return nil, fmt.Errorf("getting TaskSpawner %s: %w", spawnerName, err)
+	}
+
+	now := opts.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	manualID := "manual-" + rand.String(5)
+	vars := map[string]interface{}{
+		"ID":          manualID,
+		"Title":       "Manual run of TaskSpawner " + spawner.Name,
+		"Kind":        "Manual",
+		"TriggerType": "manual",
+		"TriggerTime": now.Format(time.RFC3339),
+	}
+	for key, value := range opts.Values {
+		vars[key] = value
+	}
+	if spawner.Spec.When.Cron != nil {
+		vars["Time"] = now.Format(time.RFC3339)
+		vars["Schedule"] = spawner.Spec.When.Cron.Schedule
+	}
+
+	httpClient := taskSpawnerHTTPClient(opts.HTTPClient)
+	if len(spawner.Spec.TaskTemplate.ContextSources) > 0 {
+		errorWriter := opts.ErrorWriter
+		if errorWriter == nil {
+			errorWriter = os.Stderr
+		}
+		warningLog := log.New(errorWriter, "Warning: ", 0)
+		logger := funcr.New(func(prefix, args string) {
+			warningLog.Print(strings.TrimSpace(prefix + " " + args))
+		}, funcr.Options{})
+		fetcher := &contextfetch.Fetcher{
+			Client:     cl,
+			HTTPClient: httpClient,
+			Namespace:  namespace,
+			Logger:     logger,
+		}
+		contextData, err := fetcher.FetchAll(ctx, spawner.Spec.TaskTemplate.ContextSources, vars)
+		if err != nil {
+			return nil, fmt.Errorf("fetching context sources for TaskSpawner %s: %w", spawner.Name, err)
+		}
+		vars["Context"] = contextData
+	}
+
+	taskName := opts.Name
+	if taskName == "" {
+		taskName = manualTaskName(spawner.Name, strings.TrimPrefix(manualID, "manual-"))
+	}
+	builder, err := taskbuilder.NewTaskBuilder(cl)
+	if err != nil {
+		return nil, fmt.Errorf("creating Task builder for TaskSpawner %s: %w", spawner.Name, err)
+	}
+	task, err := builder.BuildTask(taskName, namespace, &spawner.Spec.TaskTemplate, vars, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building task %s from TaskSpawner %s: %w", taskName, spawner.Name, err)
+	}
+	if task.Spec.UpstreamRepo == "" {
+		task.Spec.UpstreamRepo = taskSpawnerUpstreamRepo(&spawner)
+	}
+	delete(task.Labels, "kelos.dev/taskspawner")
+	if task.Annotations == nil {
+		task.Annotations = make(map[string]string)
+	}
+	task.Annotations[annotationCreatedFromTaskSpawner] = spawner.Name
+	task.Annotations[annotationManualTrigger] = "manual"
+	task.Annotations[annotationManualTriggerTime] = now.Format(time.RFC3339)
+	task.SetGroupVersionKind(kelos.GroupVersion.WithKind("Task"))
+	return task, nil
+}
+
+func taskSpawnerHTTPClient(configured *http.Client) *http.Client {
+	if configured != nil {
+		return configured
+	}
+	return http.DefaultClient
+}
+
+func taskSpawnerUpstreamRepo(spawner *kelos.TaskSpawner) string {
+	var repo string
+	if spawner.Spec.When.GitHubIssues != nil {
+		repo = spawner.Spec.When.GitHubIssues.Repo
+	} else if spawner.Spec.When.GitHubPullRequests != nil {
+		repo = spawner.Spec.When.GitHubPullRequests.Repo
+	}
+	return source.GitHubRepositoryName(repo)
+}
+
+func manualTaskName(spawnerName, suffix string) string {
+	const separator = "-manual-"
+	maxPrefix := 63 - len(separator) - len(suffix)
+	prefix := spawnerName
+	if len(prefix) > maxPrefix {
+		prefix = strings.TrimRight(prefix[:maxPrefix], "-.")
+	}
+	return prefix + separator + suffix
+}

--- a/internal/cli/run_from_taskspawner_test.go
+++ b/internal/cli/run_from_taskspawner_test.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+)
+
+func TestBuildTaskFromCronTaskSpawner(t *testing.T) {
+	spawner := testManualTaskSpawner("cron-spawner")
+	spawner.Spec.When.Cron = &kelos.Cron{Schedule: "0 9 * * 1"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Run for {{.Time}} on {{.Schedule}}: {{.Reason}} ({{.TriggerType}})"
+	spawner.Spec.TaskTemplate.Metadata = &kelos.TaskTemplateMetadata{
+		Labels: map[string]string{"kelos.dev/taskspawner": "automatic-owner"},
+		Annotations: map[string]string{
+			annotationCreatedFromTaskSpawner: "template-value",
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+
+	task, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name: "manual-task",
+		Values: map[string]interface{}{
+			"Reason":      "operator request",
+			"Time":        "2026-07-06T00:00:00Z",
+			"TriggerType": "replay",
+		},
+		Now: time.Date(2026, 7, 10, 1, 2, 3, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("buildTaskFromTaskSpawner: %v", err)
+	}
+
+	wantPrompt := "Run for 2026-07-10T01:02:03Z on 0 9 * * 1: operator request (replay)"
+	if task.Spec.Prompt != wantPrompt {
+		t.Errorf("Prompt = %q, want %q", task.Spec.Prompt, wantPrompt)
+	}
+	if _, ok := task.Labels["kelos.dev/taskspawner"]; ok {
+		t.Error("standalone manual Task has kelos.dev/taskspawner label")
+	}
+	if len(task.OwnerReferences) != 0 {
+		t.Errorf("OwnerReferences = %#v, want none", task.OwnerReferences)
+	}
+	if got := task.Annotations[annotationCreatedFromTaskSpawner]; got != spawner.Name {
+		t.Errorf("created-from annotation = %q, want %q", got, spawner.Name)
+	}
+	if got := task.Annotations[annotationManualTrigger]; got != "manual" {
+		t.Errorf("trigger-type annotation = %q, want manual", got)
+	}
+	if got := task.Annotations[annotationManualTriggerTime]; got != "2026-07-10T01:02:03Z" {
+		t.Errorf("trigger-time annotation = %q", got)
+	}
+}
+
+func TestBuildTaskFromNonCronTaskSpawnerWithValues(t *testing.T) {
+	spawner := testManualTaskSpawner("webhook-spawner")
+	spawner.Spec.When.GenericWebhook = &kelos.GenericWebhook{Source: "alerts"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Investigate {{.Title}} with severity {{.Severity}}"
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+
+	task, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name: "manual-webhook-task",
+		Values: map[string]interface{}{
+			"Title":    "API latency",
+			"Severity": "critical",
+		},
+		Now: time.Date(2026, 7, 10, 1, 2, 3, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("buildTaskFromTaskSpawner: %v", err)
+	}
+	if task.Spec.Prompt != "Investigate API latency with severity critical" {
+		t.Errorf("Prompt = %q", task.Spec.Prompt)
+	}
+}
+
+func TestCreateTaskFromTaskSpawnerCreatesTask(t *testing.T) {
+	spawner := testManualTaskSpawner("cron-spawner")
+	spawner.Spec.When.Cron = &kelos.Cron{Schedule: "0 9 * * 1"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Run at {{.Time}}"
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+
+	task, err := createTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name: "manual-task",
+		Now:  time.Date(2026, 7, 10, 1, 2, 3, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("createTaskFromTaskSpawner: %v", err)
+	}
+
+	var created kelos.Task
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: task.Name, Namespace: "default"}, &created); err != nil {
+		t.Fatalf("getting created Task: %v", err)
+	}
+	if created.Spec.Prompt != "Run at 2026-07-10T01:02:03Z" {
+		t.Errorf("Prompt = %q", created.Spec.Prompt)
+	}
+}
+
+func TestBuildTaskFromTaskSpawnerMissingTemplateValue(t *testing.T) {
+	spawner := testManualTaskSpawner("issue-spawner")
+	spawner.Spec.When.GitHubIssues = &kelos.GitHubIssues{Repo: "owner/repo"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Issue {{.Number}}"
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+
+	_, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{Name: "manual-task"})
+	if err == nil {
+		t.Fatal("expected missing template value error")
+	}
+	if !strings.Contains(err.Error(), "Number") {
+		t.Fatalf("error = %v, want missing key context", err)
+	}
+}
+
+func TestBuildTaskFromTaskSpawnerPreservesIntegerValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(path, []byte("Number: 42\n"), 0o600); err != nil {
+		t.Fatalf("writing values file: %v", err)
+	}
+	values, err := readTaskTemplateValues(path, true, nil)
+	if err != nil {
+		t.Fatalf("readTaskTemplateValues: %v", err)
+	}
+
+	spawner := testManualTaskSpawner("issue-spawner")
+	spawner.Spec.When.GitHubIssues = &kelos.GitHubIssues{Repo: "owner/repo"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "{{if eq .Number 42}}matched{{else}}not matched{{end}}"
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+	task, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name:   "manual-task",
+		Values: values,
+	})
+	if err != nil {
+		t.Fatalf("buildTaskFromTaskSpawner: %v", err)
+	}
+	if task.Spec.Prompt != "matched" {
+		t.Errorf("Prompt = %q, want matched", task.Spec.Prompt)
+	}
+}
+
+func TestBuildTaskFromTaskSpawnerDerivesUpstreamRepo(t *testing.T) {
+	spawner := testManualTaskSpawner("issue-spawner")
+	spawner.Spec.When.GitHubIssues = &kelos.GitHubIssues{Repo: "https://github.com/upstream/repository.git"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Issue {{.Number}}"
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+
+	task, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name:   "manual-task",
+		Values: map[string]interface{}{"Number": int64(42)},
+	})
+	if err != nil {
+		t.Fatalf("buildTaskFromTaskSpawner: %v", err)
+	}
+	if task.Spec.UpstreamRepo != "upstream/repository" {
+		t.Errorf("UpstreamRepo = %q, want upstream/repository", task.Spec.UpstreamRepo)
+	}
+}
+
+func TestBuildTaskFromTaskSpawnerWarnsWhenContextFailureIsIgnored(t *testing.T) {
+	spawner := testManualTaskSpawner("context-spawner")
+	spawner.Spec.When.Cron = &kelos.Cron{Schedule: "0 9 * * 1"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Context: {{.Context.unavailable}}"
+	spawner.Spec.TaskTemplate.ContextSources = []kelos.ContextSource{{
+		Name: "unavailable",
+		HTTP: &kelos.HTTPContextSource{
+			URL: "http://example.com",
+		},
+		FailurePolicy: kelos.ContextSourceFailurePolicyIgnore,
+	}}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+	var warnings bytes.Buffer
+
+	task, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name:        "manual-task",
+		ErrorWriter: &warnings,
+	})
+	if err != nil {
+		t.Fatalf("buildTaskFromTaskSpawner: %v", err)
+	}
+	if task.Spec.Prompt != "Context: " {
+		t.Errorf("Prompt = %q, want empty ignored context", task.Spec.Prompt)
+	}
+	if got := warnings.String(); !strings.Contains(got, "Context source fetch failed") || !strings.Contains(got, `"source"="unavailable"`) {
+		t.Errorf("warning = %q, want ignored context failure details", got)
+	}
+}
+
+func TestTaskSpawnerHTTPClientUsesContextSourceTimeout(t *testing.T) {
+	if got := taskSpawnerHTTPClient(nil); got != http.DefaultClient {
+		t.Fatalf("taskSpawnerHTTPClient(nil) = %p, want http.DefaultClient", got)
+	}
+	if http.DefaultClient.Timeout != 0 {
+		t.Fatalf("http.DefaultClient.Timeout = %s, want no client-level timeout", http.DefaultClient.Timeout)
+	}
+}
+
+func TestParseTaskSpawnerReference(t *testing.T) {
+	for _, ref := range []string{"taskspawner/example", "taskspawners/example", "ts/example"} {
+		name, err := parseTaskSpawnerReference(ref)
+		if err != nil {
+			t.Fatalf("parseTaskSpawnerReference(%q): %v", ref, err)
+		}
+		if name != "example" {
+			t.Errorf("parseTaskSpawnerReference(%q) = %q", ref, name)
+		}
+	}
+	if _, err := parseTaskSpawnerReference("workspace/example"); err == nil {
+		t.Fatal("expected invalid resource type error")
+	}
+}
+
+func TestReadTaskTemplateValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(path, []byte("Title: manual\nCount: 2\nNested:\n  Enabled: true\n"), 0o600); err != nil {
+		t.Fatalf("writing values file: %v", err)
+	}
+	values, err := readTaskTemplateValues(path, true, nil)
+	if err != nil {
+		t.Fatalf("readTaskTemplateValues: %v", err)
+	}
+	if values["Title"] != "manual" || values["Count"] != int64(2) {
+		t.Errorf("values = %#v", values)
+	}
+
+	stdinValues, err := readTaskTemplateValues("-", true, strings.NewReader(`{"Title":"stdin"}`))
+	if err != nil {
+		t.Fatalf("readTaskTemplateValues from stdin: %v", err)
+	}
+	if stdinValues["Title"] != "stdin" {
+		t.Errorf("stdin values = %#v", stdinValues)
+	}
+
+	if _, err := readTaskTemplateValues("-", true, strings.NewReader("- one\n- two\n")); err == nil {
+		t.Fatal("expected top-level array error")
+	}
+}
+
+func TestRunFromTaskSpawnerRejectsTaskDefinitionFlags(t *testing.T) {
+	cmd := newRunCommand(&ClientConfig{})
+	cmd.SetArgs([]string{"--from", "taskspawner/example", "--prompt", "override"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--prompt cannot be used with --from") {
+		t.Fatalf("error = %v, want incompatible flag error", err)
+	}
+}
+
+func TestRunValuesRequiresFrom(t *testing.T) {
+	cmd := newRunCommand(&ClientConfig{})
+	cmd.SetArgs([]string{"-f", "values.yaml"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--values requires --from") {
+		t.Fatalf("error = %v, want --values requirement", err)
+	}
+}
+
+func TestManualTaskNameFitsDNSLabel(t *testing.T) {
+	name := manualTaskName(strings.Repeat("a", 63), "abcde")
+	if len(name) > 63 {
+		t.Fatalf("name length = %d, want at most 63", len(name))
+	}
+	if !strings.HasSuffix(name, "-manual-abcde") {
+		t.Errorf("name = %q, want manual suffix", name)
+	}
+}
+
+func testManualTaskSpawner(name string) *kelos.TaskSpawner {
+	return &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: kelos.TaskSpawnerSpec{
+			TaskTemplate: kelos.TaskTemplate{
+				Type: "claude-code",
+				Credentials: &kelos.Credentials{
+					Type: kelos.CredentialTypeNone,
+				},
+			},
+		},
+	}
+}

--- a/internal/source/repository.go
+++ b/internal/source/repository.go
@@ -1,0 +1,25 @@
+package source
+
+import "strings"
+
+// GitHubRepositoryName returns a repository reference in owner/repo form.
+func GitHubRepositoryName(repoRef string) string {
+	repoRef = strings.TrimSuffix(repoRef, "/")
+	repoRef = strings.TrimSuffix(repoRef, ".git")
+	if repoRef == "" {
+		return ""
+	}
+
+	parts := strings.SplitN(repoRef, "/", 2)
+	if len(parts) == 2 && !strings.Contains(parts[0], ":") && !strings.Contains(parts[0], ".") {
+		return repoRef
+	}
+	if idx := strings.Index(repoRef, ":"); idx > 0 && !strings.HasPrefix(repoRef, "http") {
+		repoRef = repoRef[idx+1:]
+	}
+	parts = strings.Split(repoRef, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+}

--- a/internal/source/repository_test.go
+++ b/internal/source/repository_test.go
@@ -1,0 +1,18 @@
+package source
+
+import "testing"
+
+func TestGitHubRepositoryName(t *testing.T) {
+	tests := map[string]string{
+		"owner/repo":                            "owner/repo",
+		"https://github.com/owner/repo.git":     "owner/repo",
+		"https://github.example.com/owner/repo": "owner/repo",
+		"git@github.com:owner/repo.git":         "owner/repo",
+		"":                                      "",
+	}
+	for repoRef, want := range tests {
+		if got := GitHubRepositoryName(repoRef); got != want {
+			t.Errorf("GitHubRepositoryName(%q) = %q, want %q", repoRef, got, want)
+		}
+	}
+}

--- a/skills/kelos/SKILL.md
+++ b/skills/kelos/SKILL.md
@@ -74,6 +74,9 @@ kelos run -p "Add tests" --workspace my-ws --agent-config my-ac
 kelos run -p "Refactor auth" --model opus --effort high --branch feature/auth
 kelos run -p "Fix bug" -w
 
+kelos run --from taskspawner/daily-audit
+kelos run --from taskspawner/issue-worker -f values.yaml
+
 kelos create workspace my-ws --repo https://github.com/org/repo.git --ref main --secret github-token
 kelos create agentconfig my-ac --skill review=@review.md --dry-run
 

--- a/skills/kelos/references/cli.md
+++ b/skills/kelos/references/cli.md
@@ -40,6 +40,9 @@ kelos run -p "Fix bug" -w
 ## Creating Resources
 
 ```bash
+kelos run --from taskspawner/daily-audit
+kelos run --from taskspawner/issue-worker -f values.yaml
+
 kelos create workspace my-ws \
   --repo https://github.com/org/repo.git \
   --ref main \
@@ -57,6 +60,13 @@ kelos create agentconfig my-ac \
 
 kelos create agentconfig my-ac --skill review=@review.md --dry-run
 ```
+
+`kelos run --from taskspawner/NAME` creates a standalone Task from the
+spawner's template. Use `-f values.yaml` to expose the file's top-level YAML or
+JSON keys as template values, or `-f -` to read them from stdin. Manual Tasks
+bypass source filters and TaskSpawner suspension and limits; they do not update
+TaskSpawner status or enable source reporting. Cron templates receive the
+current UTC time and configured schedule by default.
 
 ## Managing Resources
 

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -189,6 +190,23 @@ var _ = Describe("Cron TaskSpawner", func() {
 		Eventually(func() string {
 			return f.GetTaskSpawnerPhase("cron-spawner")
 		}, 3*time.Minute, 10*time.Second).Should(Equal("Running"))
+
+		By("creating a standalone Task from the cron TaskSpawner")
+		output := framework.KelosOutput(
+			"run",
+			"--from", "taskspawner/cron-spawner",
+			"--name", "cron-manual-task",
+			"-n", f.Namespace,
+		)
+		Expect(output).To(Equal("task/cron-manual-task created"))
+
+		By("verifying the standalone Task uses the current cron context")
+		manualTask, err := f.KelosClientset.ApiV1alpha2().Tasks(f.Namespace).Get(context.TODO(), "cron-manual-task", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manualTask.Spec.Prompt).To(ContainSubstring("Cron triggered at "))
+		Expect(manualTask.Spec.Prompt).To(ContainSubstring("(schedule: * * * * *)"))
+		Expect(manualTask.Labels).NotTo(HaveKey("kelos.dev/taskspawner"))
+		Expect(manualTask.Annotations).To(HaveKeyWithValue("kelos.dev/created-from-taskspawner", "cron-spawner"))
 
 		By("verifying at least one Task was created")
 		Eventually(func() []string {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `kelos run --from taskspawner/<name>` for running a standalone Task from any TaskSpawner template without waiting for its configured source.

Operators can pass `-f values.yaml` (or `-f -` for stdin) when a template requires caller-supplied values; the YAML or JSON object's top-level keys are exposed directly to the template. Cron TaskSpawners need no values file for their source values: `Time` is always the current UTC time and `Schedule` is always the configured cron expression. This keeps the interface source-neutral, so the same command works for cron, polling, webhook, and Slack TaskSpawners without source-specific lookup or event flags.

Manual Tasks retain the TaskSpawner template and context-source behavior, but deliberately do not receive TaskSpawner ownership, automatic reporting, suspension, concurrency, lifetime-limit, or status-accounting behavior. Provenance is recorded through `kelos.dev/created-from-taskspawner`, `kelos.dev/trigger-type`, and `kelos.dev/trigger-time` annotations.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`make test`, `make verify`, and `make build WHAT=cmd/kelos` pass locally. The cron manual-run e2e scenario was added but was not run locally, per the repository guidance for e2e tests.

#### Does this PR introduce a user-facing change?

```release-note
Add `kelos run --from taskspawner/<name> [-f values.yaml]` to run standalone Tasks from TaskSpawner templates with optional template values.
```
