### PR TITLE
Clarify TaskSpawner reference placeholder

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -797,7 +797,7 @@ When the same key is set multiple ways, precedence is: chart defaults, then `--v
 
 - `--prompt, -p`: Task prompt (required unless `--prompt-file` or `--from` is set)
 - `--prompt-file`: Read task prompt from a file path; use `-` to read from stdin (mutually exclusive with `--prompt`)
-- `--from`: Run the Task template from a `taskspawner/name` reference
+- `--from`: Run the Task template from a `taskspawner/<name>` reference
 - `--values, -f`: Read top-level template values from a YAML or JSON file; use `-` to read from stdin (requires `--from`)
 - `--type, -t`: Agent type (default: `claude-code`)
 - `--model`: Model override


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Clarifies that the `--from` TaskSpawner reference uses a replaceable name by documenting it as `taskspawner/<name>` consistently with the CLI command table.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Follow-up to #1442 addressing its valid documentation review comment. `make verify` passes locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `--from` flag docs to show `taskspawner/<name>` as a replaceable reference. Aligns wording with the CLI table to reduce confusion about the expected format.

<sup>Written for commit e98683e523ddd350b5bb2cd2ccf84fdafd8914ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

