### PR TITLE
Use gpt-5.6-sol for self-development agents

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -552,11 +552,11 @@ To adapt these examples for your own repository:
    spec:
      taskTemplate:
        worker:
-         model: gpt-5.5
+         model: gpt-5.6-sol
          effort: xhigh
    ```
 
-   The checked-in spawners use `gpt-5.5` for the tasks that previously used
+   The checked-in spawners use `gpt-5.6-sol` for the tasks that previously used
    Opus, and `gpt-5.4-mini` for the tasks that previously used Sonnet.
    They set `effort` by role: `xhigh` for complex planning, coding, strategy,
    review, PR update, and configuration update workflows; `high` for triage;

--- a/self-development/agora/agora-config-update.yaml
+++ b/self-development/agora/agora-config-update.yaml
@@ -14,7 +14,7 @@ spec:
       # learning from the kelos-dev/agora repository's recent activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -41,7 +41,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-planner.yaml
+++ b/self-development/agora/agora-planner.yaml
@@ -46,7 +46,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-pr-responder.yaml
+++ b/self-development/agora/agora-pr-responder.yaml
@@ -32,7 +32,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-reviewer.yaml
+++ b/self-development/agora/agora-reviewer.yaml
@@ -65,7 +65,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -14,7 +14,7 @@ spec:
       # workflow files, while learning from the kelos-dev/agora repository's activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-triage.yaml
+++ b/self-development/agora/agora-triage.yaml
@@ -28,7 +28,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: high
       type: codex
       credentials:

--- a/self-development/agora/agora-workers.yaml
+++ b/self-development/agora/agora-workers.yaml
@@ -58,7 +58,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-config-update.yaml
+++ b/self-development/kanon/kanon-config-update.yaml
@@ -14,7 +14,7 @@ spec:
       # learning from the kelos-dev/kanon repository's recent activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -39,7 +39,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-planner.yaml
+++ b/self-development/kanon/kanon-planner.yaml
@@ -45,7 +45,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-pr-responder.yaml
+++ b/self-development/kanon/kanon-pr-responder.yaml
@@ -32,7 +32,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-reviewer.yaml
+++ b/self-development/kanon/kanon-reviewer.yaml
@@ -65,7 +65,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -14,7 +14,7 @@ spec:
       # config files, while learning from the kelos-dev/kanon repository's activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-triage.yaml
+++ b/self-development/kanon/kanon-triage.yaml
@@ -28,7 +28,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: high
       type: codex
       credentials:

--- a/self-development/kanon/kanon-workers.yaml
+++ b/self-development/kanon/kanon-workers.yaml
@@ -56,7 +56,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -67,7 +67,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -11,7 +11,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -43,7 +43,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -45,7 +45,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -32,7 +32,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -68,7 +68,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -43,7 +43,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -28,7 +28,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: high
       type: codex
       credentials:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -75,7 +75,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.5
+      model: gpt-5.6-sol
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -8,7 +8,7 @@ spec:
   worker:
     workspaceRef:
       name: kelos-agent
-    model: gpt-5.5
+    model: gpt-5.6-sol
     effort: xhigh
     type: codex
     credentials:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the higher-capability Codex model used by the Kelos, Agora, and Kanon self-development agents from `gpt-5.5` to `gpt-5.6-sol`.

The self-development documentation and example task are updated to match. Existing `gpt-5.4-mini` and GLM model selections remain unchanged.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`git diff --check` passes, and no tracked `gpt-5.5` references remain under `self-development/`.

Local `make verify` reached and passed YAML formatting, but the repository-wide shell formatting check found unrelated untracked `get_helm.sh` content and a `.git` log path in the working tree.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches all self-development agents (Kelos, Agora, Kanon) from `gpt-5.5` to `gpt-5.6-sol` to improve planning, coding, review, and config update quality. Updated README and the fake strategist task; `gpt-5.4-mini` stays the same.

- **Migration**
  - Update any local overrides or custom spawners still using `gpt-5.5` to `gpt-5.6-sol`.
  - No workflow changes; effort levels, credentials, and `type: codex` are unchanged.

<sup>Written for commit 847bd33a38cc97c38585760630e9f4a310416770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

