### PR TITLE
Reduce cert-manager resource requests

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -58,7 +58,13 @@ jobs:
             --namespace cert-manager \
             --create-namespace \
             --set crds.enabled=true \
-            --set global.leaderElection.namespace=cert-manager
+            --set global.leaderElection.namespace=cert-manager \
+            --set resources.requests.cpu=50m \
+            --set resources.requests.memory=64Mi \
+            --set webhook.resources.requests.cpu=50m \
+            --set webhook.resources.requests.memory=64Mi \
+            --set cainjector.resources.requests.cpu=50m \
+            --set cainjector.resources.requests.memory=64Mi
           kubectl rollout status deployment/cert-manager -n cert-manager --timeout=300s
           kubectl rollout status deployment/cert-manager-webhook -n cert-manager --timeout=300s
           kubectl rollout status deployment/cert-manager-cainjector -n cert-manager --timeout=300s


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Configures explicit CPU and memory requests for the cert-manager controller, webhook, and cainjector in the dev deployment workflow.

GKE applies default requests of 500m CPU and 2Gi memory to each component when the chart leaves them unspecified. Requesting 50m CPU and 64Mi memory for each component avoids overprovisioning this low-traffic development workload and reduces its Google Cloud resource cost.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The pinned cert-manager chart was rendered locally to confirm all three deployments receive the intended requests.

Validation:

- `make verify`
- `helm template` with cert-manager chart v1.20.2

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set explicit CPU and memory requests for `cert-manager` in the dev deploy workflow to avoid GKE’s high defaults and reduce cost. The controller, webhook, and cainjector now each request 50m CPU and 64Mi memory.

<sup>Written for commit 15a2ed0c62cc10a86e693d5a2caa663a10fc7f69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

