### PR TITLE
Fix sticky issue slot lookup

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -439,22 +439,23 @@ func TestAgoraIssueCreatorsUseTriageAcceptedLabel(t *testing.T) {
 	}
 }
 
-func TestStickyIssueSlotCommandsUseTriageAcceptedLabel(t *testing.T) {
+func TestStickyIssueSlotCommands(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		dir  string
-		file string
+		dir    string
+		file   string
+		marker string
 	}{
-		{dir: "self-development", file: "kelos-fake-strategist.yaml"},
-		{dir: "self-development", file: "kelos-fake-user.yaml"},
-		{dir: "self-development", file: "kelos-self-update.yaml"},
-		{dir: "self-development/agora", file: "agora-fake-strategist.yaml"},
-		{dir: "self-development/agora", file: "agora-fake-user.yaml"},
-		{dir: "self-development/agora", file: "agora-self-update.yaml"},
-		{dir: "self-development/kanon", file: "kanon-fake-strategist.yaml"},
-		{dir: "self-development/kanon", file: "kanon-fake-user.yaml"},
-		{dir: "self-development/kanon", file: "kanon-self-update.yaml"},
+		{dir: "self-development", file: "kelos-fake-strategist.yaml", marker: "kelos-fake-strategist"},
+		{dir: "self-development", file: "kelos-fake-user.yaml", marker: "kelos-fake-user"},
+		{dir: "self-development", file: "kelos-self-update.yaml", marker: "kelos-self-update"},
+		{dir: "self-development/agora", file: "agora-fake-strategist.yaml", marker: "agora-fake-strategist"},
+		{dir: "self-development/agora", file: "agora-fake-user.yaml", marker: "agora-fake-user"},
+		{dir: "self-development/agora", file: "agora-self-update.yaml", marker: "agora-self-update"},
+		{dir: "self-development/kanon", file: "kanon-fake-strategist.yaml", marker: "kanon-fake-strategist"},
+		{dir: "self-development/kanon", file: "kanon-fake-user.yaml", marker: "kanon-fake-user"},
+		{dir: "self-development/kanon", file: "kanon-self-update.yaml", marker: "kanon-self-update"},
 	}
 
 	for _, tt := range tests {
@@ -464,11 +465,12 @@ func TestStickyIssueSlotCommandsUseTriageAcceptedLabel(t *testing.T) {
 
 			ts := readTaskSpawnerFromDir(t, tt.dir, tt.file)
 			assertStickyIssueCommandsUseTriageAccepted(t, tt.dir+"/"+tt.file, ts.Spec.TaskTemplate.PromptTemplate)
+			assertStickyIssueLookupUsesExactMarker(t, tt.dir+"/"+tt.file, ts.Spec.TaskTemplate.PromptTemplate, tt.marker)
 		})
 	}
 }
 
-func TestManualFakeStrategistTaskUsesTriageAcceptedLabel(t *testing.T) {
+func TestManualFakeStrategistTaskStickyIssueCommands(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join("..", "..", "self-development", "tasks", "fake-strategist-task.yaml")
@@ -478,6 +480,7 @@ func TestManualFakeStrategistTaskUsesTriageAcceptedLabel(t *testing.T) {
 	}
 
 	assertStickyIssueCommandsUseTriageAccepted(t, path, string(data))
+	assertStickyIssueLookupUsesExactMarker(t, path, string(data), "kelos-fake-strategist")
 }
 
 func TestAgoraPlannerOnlyTriggersForIssues(t *testing.T) {
@@ -955,6 +958,15 @@ func assertStickyIssueCommandsUseTriageAccepted(t *testing.T, name, prompt strin
 	}
 	if !strings.Contains(prompt, wantCreate) {
 		t.Fatalf("%s prompt does not add triage-accepted when creating a sticky issue slot", name)
+	}
+}
+
+func assertStickyIssueLookupUsesExactMarker(t *testing.T, name, prompt, marker string) {
+	t.Helper()
+
+	want := `gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=` + marker + ` -->")))'`
+	if !strings.Contains(prompt, want) {
+		t.Fatalf("%s prompt does not filter sticky issue slots by the exact marker", name)
 	}
 }
 

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -101,7 +101,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=agora-fake-strategist in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=agora-fake-strategist -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/agora/agora-fake-user.yaml
+++ b/self-development/agora/agora-fake-user.yaml
@@ -99,7 +99,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=agora-fake-user in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=agora-fake-user -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -86,7 +86,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=agora-self-update in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=agora-self-update -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -99,7 +99,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kanon-fake-strategist in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kanon-fake-strategist -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -97,7 +97,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kanon-fake-user in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kanon-fake-user -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -86,7 +86,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kanon-self-update in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kanon-self-update -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -103,7 +103,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-fake-strategist in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kelos-fake-strategist -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -100,7 +100,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-fake-user in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kelos-fake-user -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -113,7 +113,7 @@ spec:
       - Publish the candidate through this TaskSpawner's single issue slot.
         Find the current open issue slot with:
         ```
-        gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-self-update in:body" --json number,title,body,assignees
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kelos-self-update -->")))'
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -73,7 +73,7 @@ spec:
       actionability, and confidence.
     - Publish the candidate through the kelos-fake-strategist issue slot.
       Find the current open issue slot with:
-      gh issue list --state open --label generated-by-kelos --search "kelos-taskspawner=kelos-fake-strategist in:body" --json number,title,body,assignees
+      gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kelos-fake-strategist -->")))'
       - If an open slot exists and has assignees, treat it as ongoing. Do not
         edit it, do not update related PRs, and do not create another issue.
       - If an open unassigned slot exists, compare your candidate with the


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

GitHub issue search tokenizes the sticky slot marker instead of matching it exactly. As a result, the self-development agents could treat unrelated generated issues as their slot, skip creating a missing slot, or update the wrong unassigned issue.

This PR replaces the fuzzy body searches with local filtering against the complete HTML marker for all sticky issue slot owners, including the manual fake-strategist task. It also extends the self-development manifest tests to require the exact lookup command for each marker.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`make test` passes. The exact command was also validated against GitHub for both an existing slot and a missing slot.

`make verify` remains blocked by pre-existing shell-format findings in the untracked `get_helm.sh` file and `.git/logs/refs/heads/support-skills.sh`; neither file is part of this PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sticky issue slot lookup by matching the full HTML marker in issue bodies instead of using tokenized GitHub search. Prevents agents from claiming the wrong issue or skipping a missing slot.

- **Bug Fixes**
  - Switched `gh issue list` commands to local `--jq` filtering for the exact `<!-- kelos-taskspawner=... -->` marker across all self-development TaskSpawners and the manual fake strategist task.
  - Added tests to require the exact lookup command for each marker and to keep triage label checks.

<sup>Written for commit 1b78bbb027a66641edb0ca60bca66b426bebb880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

