### PR TITLE
Make session message URLs clickable

### DIFF
--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -415,6 +415,60 @@ function ensureConversation() {
   if (elements.messages.querySelector('.welcome')) elements.messages.replaceChildren();
 }
 
+function trimURLSuffix(value) {
+  const openingBrackets = '([{';
+  const closingBrackets = ')]}';
+  const bracketBalance = [0, 0, 0];
+  for (const character of value) {
+    const openingIndex = openingBrackets.indexOf(character);
+    if (openingIndex >= 0) bracketBalance[openingIndex]++;
+    const closingIndex = closingBrackets.indexOf(character);
+    if (closingIndex >= 0) bracketBalance[closingIndex]--;
+  }
+
+  let end = value.length;
+  while (end > 0) {
+    const character = value[end - 1];
+    if ('.,;:!?'.includes(character)) {
+      end--;
+      continue;
+    }
+    const closingIndex = closingBrackets.indexOf(character);
+    if (closingIndex < 0 || bracketBalance[closingIndex] >= 0) break;
+    bracketBalance[closingIndex]++;
+    end--;
+  }
+  return value.slice(0, end);
+}
+
+function renderMessageText(element, text) {
+  const value = text || '';
+  const pattern = /https?:\/\/[^\s<>"']+/gi;
+  const fragment = document.createDocumentFragment();
+  let textEnd = 0;
+
+  for (const match of value.matchAll(pattern)) {
+    const linkText = trimURLSuffix(match[0]);
+    try {
+      new URL(linkText);
+    } catch {
+      continue;
+    }
+
+    fragment.append(document.createTextNode(value.slice(textEnd, match.index)));
+    const link = document.createElement('a');
+    link.href = linkText;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = linkText;
+    fragment.append(link);
+    textEnd = match.index + linkText.length;
+  }
+
+  fragment.append(document.createTextNode(value.slice(textEnd)));
+  element.replaceChildren(fragment);
+}
+
 function handleEvent(event) {
   if (event.id) state.lastEventID = Math.max(state.lastEventID, event.id);
   switch (event.type) {
@@ -479,7 +533,7 @@ function renderUser(event) {
   row.className = 'event-row user';
   const bubble = document.createElement('div');
   bubble.className = 'message-bubble';
-  bubble.textContent = event.text;
+  renderMessageText(bubble, event.text);
   row.append(bubble);
   elements.messages.append(row);
   scrollToBottom();
@@ -504,7 +558,10 @@ function assistantBubble(turnID) {
 }
 
 function endAssistantSegment(turnID) {
-  state.assistantSegmentByTurn.delete(turnID || 'current');
+  const key = turnID || 'current';
+  const bubble = state.assistantSegmentByTurn.get(key);
+  if (bubble) renderMessageText(bubble, bubble.textContent);
+  state.assistantSegmentByTurn.delete(key);
 }
 
 function renderAssistantDelta(event) {
@@ -516,6 +573,7 @@ function renderAssistantDelta(event) {
 function renderAssistantMessage(event) {
   const bubble = assistantBubble(event.turnId);
   if (!bubble.textContent && event.text) bubble.textContent = event.text;
+  renderMessageText(bubble, bubble.textContent);
   scrollToBottom();
 }
 

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -74,6 +74,7 @@ button { color: inherit; }
 @keyframes event-in { from { opacity: 0; transform: translateY(4px); } }
 .event-row.user { justify-content: flex-end; }
 .message-bubble { max-width: min(78%, 700px); padding: 13px 16px; border-radius: 18px; font-size: 14px; line-height: 1.62; white-space: pre-wrap; overflow-wrap: anywhere; }
+.message-bubble a { color: var(--accent-2); text-decoration: underline; text-underline-offset: 2px; }
 .user .message-bubble { border-bottom-right-radius: 5px; background: #dfe9e2; }
 .assistant { gap: 11px; align-items: flex-start; }
 .agent-avatar { flex: 0 0 auto; width: 29px; height: 29px; display: grid; place-items: center; margin-top: 2px; border-radius: 9px; background: var(--accent); color: white; font: 700 11px/1 ui-monospace, monospace; }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Session messages currently render all content as plain text, so HTTP and HTTPS URLs cannot be clicked. This PR safely converts URLs in user and assistant messages into links, including streamed assistant messages, without rendering arbitrary HTML.

Links open in a new tab, and trailing prose punctuation remains outside the link.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The linkifier creates DOM nodes directly and accepts only valid HTTP and HTTPS URLs.

#### Does this PR introduce a user-facing change?

```release-note
Session messages now render HTTP and HTTPS URLs as clickable links.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make HTTP/HTTPS URLs in session messages clickable, including streamed assistant output. Adds safe linkification with linear-time suffix trimming.

- **Bug Fixes**
  - Converts URLs to <a> elements during render; no arbitrary HTML.
  - Trims trailing punctuation and unmatched closing brackets in a single linear pass.
  - Linkifies user messages immediately and assistant messages on segment completion and final render.
  - Only accepts `http`/`https` via `new URL()`, sets `target="_blank" rel="noopener noreferrer"`, and styles links in `.message-bubble a`.

<sup>Written for commit 8e8b90c45c4d609db15abfd017a0eecf5aacb827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

