### PR TITLE
Add YAML mode and PVC options to Session server

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -231,10 +231,12 @@ the workspace uses `emptyDir`, so conversation history and workspace changes do
 not survive Pod replacement.
 
 The shared web server is restricted to its configured
-`sessionServer.defaultNamespace`. Its creation API accepts provider,
-credentials, model, effort, Workspace, and AgentConfig references; image and Pod
-overrides and `volumeClaimTemplate` require direct Kubernetes API access governed
-by Kubernetes RBAC.
+`sessionServer.defaultNamespace`. Its creation form accepts provider,
+credentials, model, Workspace, AgentConfig references, and an optional persistent
+volume claim. YAML mode server-side applies one `kelos.dev/v1alpha2` Session
+manifest with the same worker fields and namespace restriction as the form. The
+manifest may also include labels, annotations, and an optional persistent volume
+claim.
 
 ## WorkerPool
 

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -208,6 +208,7 @@ func TestRender_SessionServer(t *testing.T) {
 		"secretName: session-auth",
 		"resources:\n      - pods/exec",
 		"resources:\n      - agentconfigs\n      - workspaces\n    verbs:\n      - list",
+		"resources:\n      - sessions\n    verbs:\n      - create\n      - delete\n      - get\n      - list\n      - patch\n      - watch",
 		"--token-file=/var/run/secrets/kelos-session/token",
 		"--default-namespace=team-a",
 		"kind: Role\nmetadata:\n  name: kelos-session-server-role\n  namespace: team-a",

--- a/internal/manifests/charts/kelos/README.md
+++ b/internal/manifests/charts/kelos/README.md
@@ -213,9 +213,11 @@ kubectl port-forward -n kelos-system service/kelos-session-server 8080:80
 Then open `http://localhost:8080` and enter the token. The token represents one
 shared user that can create, list, delete, and connect to Sessions only in
 `sessionServer.defaultNamespace` (`default` unless overridden). That namespace
-must already exist. The web API accepts provider, credentials, model, effort,
-Workspace, and AgentConfig references; Pod and image overrides remain available
-only through the Kubernetes API and its RBAC.
+must already exist. The creation form accepts provider, credentials, model,
+Workspace, AgentConfig references, and an optional persistent volume claim. YAML
+mode server-side applies one `kelos.dev/v1alpha2` Session manifest with the same
+worker fields as the form in the configured namespace. The manifest may also
+include labels, annotations, and an optional persistent volume claim.
 
 ## Uninstall
 

--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -254,6 +254,7 @@ rules:
       - delete
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - kelos.dev

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -2,6 +2,7 @@ package sessionserver
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -22,11 +23,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
@@ -34,6 +39,8 @@ import (
 const (
 	authCookieName       = "kelos_session_auth"
 	sessionRuntimeClient = "/kelos/bin/kelos-session-runtime"
+	sessionApplyManager  = "kelos-session-server"
+	requestBodyLimit     = 1024 * 1024
 )
 
 //go:embed web/*
@@ -101,9 +108,10 @@ type credentialOption struct {
 }
 
 type createSessionRequest struct {
-	Name      string              `json:"name"`
-	Namespace string              `json:"namespace"`
-	Worker    createSessionWorker `json:"worker"`
+	Name                string                            `json:"name"`
+	Namespace           string                            `json:"namespace"`
+	Worker              createSessionWorker               `json:"worker"`
+	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
 }
 
 type createSessionWorker struct {
@@ -112,6 +120,25 @@ type createSessionWorker struct {
 	Model           string                       `json:"model,omitempty"`
 	WorkspaceRef    *kelos.WorkspaceReference    `json:"workspaceRef,omitempty"`
 	AgentConfigRefs []kelos.AgentConfigReference `json:"agentConfigRefs,omitempty"`
+}
+
+type sessionManifest struct {
+	APIVersion string                  `json:"apiVersion"`
+	Kind       string                  `json:"kind"`
+	Metadata   sessionManifestMetadata `json:"metadata"`
+	Spec       sessionManifestSpec     `json:"spec"`
+}
+
+type sessionManifestMetadata struct {
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type sessionManifestSpec struct {
+	Worker              createSessionWorker               `json:"worker"`
+	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
 }
 
 func (w createSessionWorker) workerSpec() kelos.WorkerSpec {
@@ -270,6 +297,10 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 		}
 		return
 	}
+	if path == "sessions/apply" && request.Method == http.MethodPost {
+		s.applySession(writer, request)
+		return
+	}
 
 	parts := strings.Split(strings.Trim(path, "/"), "/")
 	if len(parts) < 3 || parts[0] != "sessions" {
@@ -401,7 +432,10 @@ func (s *Server) createSession(writer http.ResponseWriter, request *http.Request
 			Name:      payload.Name,
 			Namespace: payload.Namespace,
 		},
-		Spec: kelos.SessionSpec{Worker: payload.Worker.workerSpec()},
+		Spec: kelos.SessionSpec{
+			Worker:              payload.Worker.workerSpec(),
+			VolumeClaimTemplate: payload.VolumeClaimTemplate,
+		},
 	}
 	if err := s.client.Create(request.Context(), session); err != nil {
 		status := http.StatusInternalServerError
@@ -412,6 +446,64 @@ func (s *Server) createSession(writer http.ResponseWriter, request *http.Request
 		return
 	}
 	writeJSON(writer, http.StatusCreated, summarize(session))
+}
+
+func (s *Server) applySession(writer http.ResponseWriter, request *http.Request) {
+	session, err := decodeSessionYAML(request.Body)
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err.Error())
+		return
+	}
+	if session.APIVersion != kelos.GroupVersion.String() || session.Kind != "Session" {
+		writeError(writer, http.StatusBadRequest, fmt.Sprintf("manifest must be a %s Session", kelos.GroupVersion.String()))
+		return
+	}
+	session.Name = strings.TrimSpace(session.Name)
+	session.Namespace = strings.TrimSpace(session.Namespace)
+	if session.Namespace == "" {
+		session.Namespace = s.defaultNamespace
+	}
+	if session.Name == "" {
+		writeError(writer, http.StatusBadRequest, "Session metadata.name is required")
+		return
+	}
+	if session.Namespace != s.defaultNamespace {
+		writeError(writer, http.StatusForbidden, fmt.Sprintf("namespace %q is not served", session.Namespace))
+		return
+	}
+
+	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(session)
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, fmt.Sprintf("converting Session manifest: %v", err))
+		return
+	}
+	delete(object, "status")
+	manifest := &unstructured.Unstructured{Object: object}
+	if err := s.client.Apply(
+		request.Context(),
+		client.ApplyConfigurationFromUnstructured(manifest),
+		client.FieldOwner(sessionApplyManager),
+		client.ForceOwnership,
+	); err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case apierrors.IsInvalid(err):
+			status = http.StatusBadRequest
+		case apierrors.IsForbidden(err):
+			status = http.StatusForbidden
+		case apierrors.IsConflict(err):
+			status = http.StatusConflict
+		}
+		writeError(writer, status, fmt.Sprintf("applying Session %q: %v", session.Name, err))
+		return
+	}
+
+	var applied kelos.Session
+	if err := s.client.Get(request.Context(), client.ObjectKeyFromObject(session), &applied); err != nil {
+		writeKubernetesError(writer, fmt.Sprintf("getting applied Session %q", session.Name), err)
+		return
+	}
+	writeJSON(writer, http.StatusOK, summarize(&applied))
 }
 
 func (s *Server) deleteSession(writer http.ResponseWriter, request *http.Request, namespace, name string) {
@@ -563,12 +655,67 @@ func sameOrigin(request *http.Request) bool {
 }
 
 func decodeJSON(reader io.Reader, target any) error {
-	decoder := json.NewDecoder(io.LimitReader(reader, 1024*1024))
+	decoder := json.NewDecoder(io.LimitReader(reader, requestBodyLimit))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
 		return fmt.Errorf("invalid JSON request: %w", err)
 	}
 	return nil
+}
+
+func decodeSessionYAML(reader io.Reader) (*kelos.Session, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, requestBodyLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading Session manifest: %w", err)
+	}
+	if len(data) > requestBodyLimit {
+		return nil, fmt.Errorf("Session manifest exceeds %d bytes", requestBodyLimit)
+	}
+
+	documents := yamlutil.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	var session *kelos.Session
+	for {
+		document, err := documents.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading Session manifest: %w", err)
+		}
+		if len(bytes.TrimSpace(document)) == 0 {
+			continue
+		}
+		if session != nil {
+			return nil, errors.New("Session manifest must contain exactly one YAML document")
+		}
+		jsonData, err := yaml.YAMLToJSONStrict(document)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Session YAML: %w", err)
+		}
+		decoded := &sessionManifest{}
+		decoder := json.NewDecoder(bytes.NewReader(jsonData))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(decoded); err != nil {
+			return nil, fmt.Errorf("invalid Session manifest: %w", err)
+		}
+		session = &kelos.Session{
+			TypeMeta: metav1.TypeMeta{APIVersion: decoded.APIVersion, Kind: decoded.Kind},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        decoded.Metadata.Name,
+				Namespace:   decoded.Metadata.Namespace,
+				Labels:      decoded.Metadata.Labels,
+				Annotations: decoded.Metadata.Annotations,
+			},
+			Spec: kelos.SessionSpec{
+				Worker:              decoded.Spec.Worker.workerSpec(),
+				VolumeClaimTemplate: decoded.Spec.VolumeClaimTemplate,
+			},
+		}
+	}
+	if session == nil {
+		return nil, errors.New("Session manifest is empty")
+	}
+	return session, nil
 }
 
 func writeJSON(writer http.ResponseWriter, status int, value any) {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -13,10 +13,12 @@ import (
 
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
@@ -82,11 +84,168 @@ func TestSessionFormUsesResourceSelectors(t *testing.T) {
 		`id="workspace-select"`,
 		`id="agent-config-select"`,
 		`id="selected-agent-configs"`,
+		`id="session-mode-yaml"`,
+		`id="session-yaml"`,
+		`id="volume-claim-enabled"`,
 		`<option value="opencode">OpenCode</option>`,
 	} {
 		if !strings.Contains(response.Body.String(), expected) {
 			t.Errorf("new Session form does not contain %s", expected)
 		}
+	}
+}
+
+func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
+	server := testServer(t)
+	payload := `{
+		"name":"persistent-chat",
+		"namespace":"default",
+		"worker":{"type":"codex","credentials":{"type":"none"}},
+		"volumeClaimTemplate":{
+			"accessModes":["ReadWriteOnce"],
+			"storageClassName":"fast",
+			"resources":{"requests":{"storage":"20Gi"}}
+		}
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "persistent-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	claim := session.Spec.VolumeClaimTemplate
+	if claim == nil {
+		t.Fatal("volumeClaimTemplate is nil")
+	}
+	if len(claim.AccessModes) != 1 || claim.AccessModes[0] != corev1.ReadWriteOnce {
+		t.Fatalf("accessModes = %v", claim.AccessModes)
+	}
+	if claim.StorageClassName == nil || *claim.StorageClassName != "fast" {
+		t.Fatalf("storageClassName = %v", claim.StorageClassName)
+	}
+	wantStorage := resource.MustParse("20Gi")
+	if storage := claim.Resources.Requests[corev1.ResourceStorage]; storage.Cmp(wantStorage) != 0 {
+		t.Fatalf("storage request = %s, want %s", storage.String(), wantStorage.String())
+	}
+}
+
+func TestSessionYAMLApplyAPI(t *testing.T) {
+	server := testServer(t)
+	manifest := `apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: yaml-chat
+  labels:
+    source: web
+spec:
+  volumeClaimTemplate:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+  worker:
+    type: codex
+    credentials:
+      type: none
+    model: gpt-5
+`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(manifest))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	request.Header.Set("Content-Type", "application/yaml")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("apply status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "yaml-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.Labels["source"] != "web" {
+		t.Fatalf("Session labels = %v", session.Labels)
+	}
+	if session.Spec.Worker.Model != "gpt-5" {
+		t.Fatalf("worker model = %q, want %q", session.Spec.Worker.Model, "gpt-5")
+	}
+	if session.Spec.VolumeClaimTemplate == nil {
+		t.Fatal("volumeClaimTemplate is nil")
+	}
+	wantStorage := resource.MustParse("5Gi")
+	if storage := session.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage]; storage.Cmp(wantStorage) != 0 {
+		t.Fatalf("storage request = %s, want %s", storage.String(), wantStorage.String())
+	}
+
+	updated := strings.Replace(manifest, "source: web", "source: yaml", 1)
+	request = httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(updated))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("reapply status = %d body = %s", response.Code, response.Body.String())
+	}
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "yaml-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.Labels["source"] != "yaml" {
+		t.Fatalf("Session labels after reapply = %v", session.Labels)
+	}
+}
+
+func TestSessionYAMLApplyAPIRejectsInvalidManifests(t *testing.T) {
+	server := testServer(t)
+	for _, test := range []struct {
+		name       string
+		manifest   string
+		wantStatus int
+	}{
+		{
+			name:       "wrong kind",
+			manifest:   "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: config\n",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "other namespace",
+			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\n  namespace: team-a\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "unknown field",
+			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\nspec:\n  unknown: value\n  worker:\n    type: codex\n    credentials:\n      type: none\n",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "custom image",
+			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n    image: example.invalid/unsafe:latest\n",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "pod overrides",
+			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n    podOverrides:\n      serviceAccountName: kelos-controller\n",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "multiple documents",
+			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: one\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n---\napiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: two\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n",
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(test.manifest))
+			request.Header.Set("Authorization", "Bearer secret-token")
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -21,6 +21,14 @@ const elements = {
   agentConfig: document.querySelector('#agent-config-select'),
   addAgentConfig: document.querySelector('#add-agent-config'),
   selectedAgentConfigs: document.querySelector('#selected-agent-configs'),
+  formFields: document.querySelector('#session-form-fields'),
+  formMode: document.querySelector('#session-mode-form'),
+  yamlMode: document.querySelector('#session-mode-yaml'),
+  yamlPanel: document.querySelector('#session-yaml-panel'),
+  yaml: document.querySelector('#session-yaml'),
+  persistentVolume: document.querySelector('#volume-claim-enabled'),
+  volumeClaimFields: document.querySelector('#volume-claim-fields'),
+  createButton: document.querySelector('#create-session'),
   stopButton: document.querySelector('#stop-session'),
   deleteButton: document.querySelector('#delete-session'),
   sidebar: document.querySelector('#sidebar'),
@@ -44,6 +52,7 @@ const state = {
   defaultNamespace: 'default',
   options: {credentials: [], workspaces: [], agentConfigs: []},
   selectedAgentConfigs: [],
+  creationMode: 'form',
 };
 
 const customOption = '__custom__';
@@ -143,6 +152,43 @@ async function loadConfig() {
   const config = await api('/api/config');
   state.defaultNamespace = config.defaultNamespace;
   elements.form.elements.namespace.value = state.defaultNamespace;
+}
+
+function defaultSessionYAML() {
+  return `apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: my-session
+  namespace: ${state.defaultNamespace}
+spec:
+  worker:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials
+`;
+}
+
+function setCreationMode(mode) {
+  const yaml = mode === 'yaml';
+  state.creationMode = yaml ? 'yaml' : 'form';
+  elements.formFields.hidden = yaml;
+  elements.formFields.disabled = yaml;
+  elements.yamlPanel.hidden = !yaml;
+  elements.yaml.disabled = !yaml;
+  elements.yaml.required = yaml;
+  elements.formMode.setAttribute('aria-selected', String(!yaml));
+  elements.yamlMode.setAttribute('aria-selected', String(yaml));
+  elements.createButton.textContent = yaml ? 'Apply YAML' : 'Create session';
+  if (yaml && !elements.yaml.value.trim()) elements.yaml.value = defaultSessionYAML();
+}
+
+function updateVolumeClaimFields() {
+  const enabled = elements.persistentVolume.checked;
+  elements.volumeClaimFields.hidden = !enabled;
+  elements.form.elements.storageRequest.required = enabled;
+  elements.form.elements.accessMode.required = enabled;
 }
 
 async function loadOptions() {
@@ -726,11 +772,18 @@ function resizeComposer() {
   elements.input.style.height = `${Math.min(elements.input.scrollHeight, 160)}px`;
 }
 
-function openDialog() {
+async function openDialog() {
+  try {
+    await configReady;
+  } catch (error) {
+    showToast(error.message);
+    return;
+  }
   elements.dialogError.textContent = '';
+  setCreationMode(state.creationMode);
   elements.dialog.showModal();
   loadOptions().catch(error => { elements.dialogError.textContent = error.message; });
-  window.setTimeout(() => elements.form.elements.name.focus(), 0);
+  window.setTimeout(() => (state.creationMode === 'yaml' ? elements.yaml : elements.form.elements.name).focus(), 0);
 }
 
 document.querySelector('#new-session').addEventListener('click', openDialog);
@@ -760,42 +813,68 @@ elements.addAgentConfig.addEventListener('click', () => {
   state.selectedAgentConfigs.push(name);
   renderAgentConfigOptions();
 });
+elements.formMode.addEventListener('click', () => setCreationMode('form'));
+elements.yamlMode.addEventListener('click', () => setCreationMode('yaml'));
+elements.persistentVolume.addEventListener('change', updateVolumeClaimFields);
 renderCredentialOptions();
 renderWorkspaceOptions();
 renderAgentConfigOptions();
+updateVolumeClaimFields();
+setCreationMode('form');
 
 elements.form.addEventListener('submit', async event => {
   event.preventDefault();
   if (!elements.form.reportValidity()) return;
   elements.dialogError.textContent = '';
-  const submit = document.querySelector('#create-session');
+  const submit = elements.createButton;
   submit.disabled = true;
-  const values = new FormData(elements.form);
-  const credentialType = values.get('credentialType');
-  const worker = {
-    type: values.get('provider'),
-    credentials: {type: credentialType},
-  };
-  if (credentialType !== 'none') worker.credentials.secretRef = {name: selectedCredentialName()};
-  const workspace = selectedWorkspaceName();
-  if (workspace) worker.workspaceRef = {name: workspace};
-  if (values.get('model').trim()) worker.model = values.get('model').trim();
-  if (state.selectedAgentConfigs.length) {
-    worker.agentConfigRefs = state.selectedAgentConfigs.map(name => ({name}));
-  }
   try {
-    const created = await api('/api/sessions', {
-      method: 'POST',
-      body: JSON.stringify({
+    let created;
+    if (state.creationMode === 'yaml') {
+      created = await api('/api/sessions/apply', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/yaml'},
+        body: elements.yaml.value,
+      });
+    } else {
+      const values = new FormData(elements.form);
+      const credentialType = values.get('credentialType');
+      const worker = {
+        type: values.get('provider'),
+        credentials: {type: credentialType},
+      };
+      if (credentialType !== 'none') worker.credentials.secretRef = {name: selectedCredentialName()};
+      const workspace = selectedWorkspaceName();
+      if (workspace) worker.workspaceRef = {name: workspace};
+      if (values.get('model').trim()) worker.model = values.get('model').trim();
+      if (state.selectedAgentConfigs.length) {
+        worker.agentConfigRefs = state.selectedAgentConfigs.map(name => ({name}));
+      }
+      const payload = {
         name: values.get('name').trim(),
         namespace: values.get('namespace').trim(),
         worker,
-      }),
-    });
+      };
+      if (values.get('persistentVolume')) {
+        payload.volumeClaimTemplate = {
+          accessModes: [values.get('accessMode')],
+          resources: {requests: {storage: values.get('storageRequest').trim()}},
+        };
+        const storageClassName = values.get('storageClassName').trim();
+        if (storageClassName) payload.volumeClaimTemplate.storageClassName = storageClassName;
+      }
+      created = await api('/api/sessions', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    }
     elements.dialog.close();
     elements.form.reset();
     state.selectedAgentConfigs = [];
     elements.form.elements.namespace.value = state.defaultNamespace;
+    elements.yaml.value = '';
+    updateVolumeClaimFields();
+    setCreationMode('form');
     renderCredentialOptions();
     renderWorkspaceOptions();
     renderAgentConfigOptions();
@@ -837,7 +916,8 @@ document.querySelector('#logout').addEventListener('click', async () => {
 document.querySelector('#open-sidebar').addEventListener('click', () => elements.sidebar.classList.add('open'));
 document.querySelector('#close-sidebar').addEventListener('click', () => elements.sidebar.classList.remove('open'));
 
-Promise.all([loadConfig(), loadOptions()]).then(() => loadSessions()).then(() => {
+const configReady = loadConfig();
+Promise.all([configReady, loadOptions()]).then(() => loadSessions()).then(() => {
   if (state.sessions.length) selectSession(state.sessions[0]);
 }).catch(error => showToast(error.message));
 window.setInterval(() => loadSessions({quiet: true}), 5000);

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -71,7 +71,12 @@
         </div>
         <button class="icon-button close-dialog" type="button" aria-label="Close">×</button>
       </div>
-      <div class="form-grid">
+      <div class="mode-switch" role="tablist" aria-label="Session creation mode">
+        <button type="button" id="session-mode-form" role="tab" aria-selected="true">Form</button>
+        <button type="button" id="session-mode-yaml" role="tab" aria-selected="false">YAML</button>
+      </div>
+      <fieldset class="mode-panel" id="session-form-fields">
+        <div class="form-grid">
         <label>
           <span>Name</span>
           <input name="name" required pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?" placeholder="feature-review" autocomplete="off">
@@ -128,6 +133,40 @@
           <div class="selected-options" id="selected-agent-configs" aria-live="polite"></div>
           <small>Select one at a time. The displayed order is the application order.</small>
         </div>
+          <div class="form-wide form-section">
+            <label class="checkbox-field">
+              <input type="checkbox" name="persistentVolume" id="volume-claim-enabled">
+              <span>
+                <strong>Persistent volume</strong>
+                <small>Keep the workspace and conversation history when the Session Pod is replaced.</small>
+              </span>
+            </label>
+            <div class="nested-grid" id="volume-claim-fields" hidden>
+              <label>
+                <span>Storage request</span>
+                <input name="storageRequest" value="10Gi" placeholder="10Gi" autocomplete="off">
+              </label>
+              <label>
+                <span>Access mode</span>
+                <select name="accessMode">
+                  <option value="ReadWriteOnce">ReadWriteOnce</option>
+                  <option value="ReadWriteOncePod">ReadWriteOncePod</option>
+                  <option value="ReadWriteMany">ReadWriteMany</option>
+                  <option value="ReadOnlyMany">ReadOnlyMany</option>
+                </select>
+              </label>
+              <label class="form-wide">
+                <span>StorageClass <em>optional</em></span>
+                <input name="storageClassName" placeholder="Cluster default" autocomplete="off">
+              </label>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+      <div class="mode-panel yaml-panel" id="session-yaml-panel" hidden>
+        <label for="session-yaml">Session manifest</label>
+        <textarea id="session-yaml" name="sessionYAML" rows="19" spellcheck="false" aria-describedby="session-yaml-help"></textarea>
+        <small id="session-yaml-help">Apply one <code>kelos.dev/v1alpha2</code> Session in the configured namespace.</small>
       </div>
       <div class="dialog-error" id="dialog-error" role="alert"></div>
       <div class="dialog-actions">

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -126,6 +126,11 @@ button { color: inherit; }
 .dialog-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; }
 .dialog-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
 .dialog-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; }
+.mode-switch { width: fit-content; display: flex; margin-top: 20px; padding: 3px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
+.mode-switch button { padding: 6px 13px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 700; cursor: pointer; }
+.mode-switch button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 2px 7px rgba(31,46,38,.08); }
+.mode-panel { min-width: 0; margin: 0; padding: 0; border: 0; }
+.mode-panel[hidden], .nested-grid[hidden] { display: none; }
 .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-top: 23px; }
 .form-wide { grid-column: 1 / -1; }
 .form-grid label > span, .form-label { display: block; margin: 0 0 7px; font-size: 11px; font-weight: 700; }
@@ -142,6 +147,18 @@ button { color: inherit; }
 .selected-option-order { width: 18px; height: 18px; display: grid; place-items: center; border-radius: 50%; background: var(--accent-soft); color: var(--accent-2); font-size: 9px; font-weight: 800; }
 .selected-option button { width: 18px; height: 18px; padding: 0; border: 0; border-radius: 50%; background: transparent; color: var(--muted); font-size: 14px; line-height: 1; cursor: pointer; }
 .selected-option button:hover { background: var(--line-soft); color: var(--ink); }
+.form-section { padding-top: 15px; border-top: 1px solid var(--line-soft); }
+.form-grid .checkbox-field { display: flex; align-items: flex-start; gap: 10px; cursor: pointer; }
+.form-grid .checkbox-field > input { width: auto; margin: 2px 0 0; accent-color: var(--accent); }
+.form-grid .checkbox-field > span { margin: 0; }
+.checkbox-field strong { display: block; font-size: 11px; }
+.checkbox-field small { margin-top: 4px; }
+.nested-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 14px; padding: 14px; border: 1px solid var(--line-soft); border-radius: 11px; background: var(--panel); }
+.yaml-panel { margin-top: 18px; }
+.yaml-panel > label { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 700; }
+.yaml-panel textarea { width: 100%; min-height: 360px; resize: vertical; padding: 13px; border: 1px solid #d4d9d5; border-radius: 10px; outline: none; background: var(--card); color: var(--ink); font: 11.5px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; tab-size: 2; }
+.yaml-panel textarea:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.yaml-panel small { display: block; margin-top: 6px; color: var(--faint); font-size: 9.5px; }
 .dialog-error { min-height: 19px; padding-top: 10px; color: var(--danger); font-size: 11px; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 7px; }
 .toast { position: fixed; z-index: 20; right: 22px; bottom: 22px; max-width: min(390px, calc(100vw - 44px)); padding: 11px 14px; border: 1px solid var(--line); border-radius: 11px; background: var(--card); box-shadow: var(--shadow); color: var(--ink); font-size: 12px; opacity: 0; pointer-events: none; transform: translateY(8px); transition: .2s; }
@@ -162,6 +179,7 @@ button { color: inherit; }
   .message-bubble { max-width: 90%; }
   .form-grid { grid-template-columns: 1fr; }
   .form-wide { grid-column: auto; }
+  .nested-grid { grid-template-columns: 1fr; }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -2,6 +2,9 @@ package integration
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,9 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/sessionserver"
 )
 
 var _ = Describe("Session", func() {
@@ -22,6 +27,58 @@ var _ = Describe("Session", func() {
 	BeforeEach(func() {
 		namespace = fmt.Sprintf("session-%d", time.Now().UnixNano())
 		Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).To(Succeed())
+	})
+
+	It("applies a persistent Session through the web YAML API", func() {
+		clientset, err := kubernetes.NewForConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		server, err := sessionserver.New(sessionserver.Config{
+			Token:            "secret-token",
+			Client:           k8sClient,
+			Clientset:        clientset,
+			RESTConfig:       cfg,
+			DefaultNamespace: namespace,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		manifest := fmt.Sprintf(`apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: yaml-chat
+  namespace: %s
+  labels:
+    source: web
+spec:
+  volumeClaimTemplate:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  worker:
+    type: codex
+    credentials:
+      type: none
+`, namespace)
+
+		request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(manifest))
+		request.Header.Set("Authorization", "Bearer secret-token")
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		Expect(response.Code).To(Equal(http.StatusOK), response.Body.String())
+
+		var session kelos.Session
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "yaml-chat"}, &session)).To(Succeed())
+		Expect(session.Spec.VolumeClaimTemplate).NotTo(BeNil())
+		storage := session.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage]
+		Expect(storage.Cmp(resource.MustParse("2Gi"))).To(Equal(0))
+
+		request = httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(strings.Replace(manifest, "source: web", "source: yaml", 1)))
+		request.Header.Set("Authorization", "Bearer secret-token")
+		response = httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		Expect(response.Code).To(Equal(http.StatusOK), response.Body.String())
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "yaml-chat"}, &session)).To(Succeed())
+		Expect(session.Labels).To(HaveKeyWithValue("source", "yaml"))
 	})
 
 	It("creates a one-replica StatefulSet and becomes ready with its Pod", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds Form and YAML modes to the Session server creation dialog.

The regular form can now configure a persistent workspace with a storage request, access mode, and optional StorageClass. YAML mode accepts one strict `kelos.dev/v1alpha2` Session manifest and applies it with Kubernetes server-side apply. It supports metadata labels and annotations, the same worker fields as the form, and an optional persistent volume claim while preserving the configured namespace restriction.

The Session server Role now includes the `patch` permission required for server-side apply. Documentation and unit, chart-rendering, and integration coverage are updated for both creation paths.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- YAML mode rejects unknown fields, multiple YAML documents, other kinds/API versions, and namespaces outside `sessionServer.defaultNamespace`.
- Reapplying a manifest can update mutable labels and annotations, but the existing immutable Session spec validation still prevents spec changes after creation.
- Validation completed with `make test`, `make verify`, and `make test-integration` (124 main integration specs and 12 install integration specs). `node --check internal/sessionserver/web/app.js` and `git diff --check` also passed.

#### Does this PR introduce a user-facing change?

```release-note
Add YAML mode and persistent volume claim options to the Session server creation dialog.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds YAML mode and persistent volume options to Session creation in the web UI. Users can apply a strict `kelos.dev/v1alpha2` Session manifest via `/api/sessions/apply` or create a persistent workspace from the form.

- **New Features**
  - Added Form/YAML toggle; YAML uses server‑side apply with field owner `kelos-session-server`.
  - YAML mode: one-document, strict `Session` in `kelos.dev/v1alpha2` (1 MiB limit) in `defaultNamespace`; supports labels/annotations and optional `volumeClaimTemplate`.
  - Form: persistent workspaces via `volumeClaimTemplate` (storage request, access mode, optional `storageClassName`). RBAC adds `patch` on Sessions; docs and unit/integration/helm tests updated.

<sup>Written for commit a66e0f1b3b486748555bd82fa0476dead9412889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

