### PR TITLE
Enable live Session namespace switching

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -230,13 +230,17 @@ afterward follows the StorageClass reclaim policy. When the field is omitted,
 the workspace uses `emptyDir`, so conversation history and workspace changes do
 not survive Pod replacement.
 
-The shared web server is restricted to its configured
-`sessionServer.defaultNamespace`. Its creation form accepts provider,
-credentials, model, Workspace, AgentConfig references, and an optional persistent
-volume claim. YAML mode server-side applies one `kelos.dev/v1alpha2` Session
-manifest with the same worker fields and namespace restriction as the form. The
-manifest may also include labels, annotations, and an optional persistent volume
-claim.
+The shared web server can create, list, delete, and connect to Sessions across
+namespaces while the web application operates on one active namespace at a
+time. Users can switch the active namespace live from the sidebar.
+`sessionServer.defaultNamespace` sets its initial value, and Session, Workspace,
+AgentConfig, and credential options are loaded only from the active namespace.
+The creation form accepts provider, credentials, model, Workspace, AgentConfig
+references, and an optional persistent volume claim. YAML mode server-side
+applies one `kelos.dev/v1alpha2` Session manifest in the active namespace with
+the same worker fields as the form. The manifest may also include labels,
+annotations, and an optional persistent volume claim. Image and Pod overrides
+require direct Kubernetes API access governed by Kubernetes RBAC.
 
 ## WorkerPool
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -57,11 +57,15 @@ var kelosConversionCRDNames = []string{
 }
 
 var (
-	crdGVR            = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
-	endpointSlicesGVR = discoveryv1.SchemeGroupVersion.WithResource("endpointslices")
-	roleGVR           = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
-	roleBindingGVR    = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
-	secretGVR         = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	crdGVR                = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+	endpointSlicesGVR     = discoveryv1.SchemeGroupVersion.WithResource("endpointslices")
+	clusterRoleGVR        = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	clusterRoleBindingGVR = schema.GroupVersionResource{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings",
+	}
+	roleGVR        = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+	roleBindingGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	secretGVR      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 )
 
 type helmValuesOptions struct {
@@ -876,12 +880,15 @@ func newUninstallCommand(cfg *ClientConfig) *cobra.Command {
 
 func deleteSessionServerRBAC(ctx context.Context, dyn dynamic.Interface) error {
 	resources := []struct {
-		gvr  schema.GroupVersionResource
-		name string
-		kind string
+		gvr        schema.GroupVersionResource
+		name       string
+		kind       string
+		namespaced bool
 	}{
-		{gvr: roleBindingGVR, name: "kelos-session-server-rolebinding", kind: "RoleBinding"},
-		{gvr: roleGVR, name: "kelos-session-server-role", kind: "Role"},
+		{gvr: clusterRoleBindingGVR, name: "kelos-session-server-rolebinding", kind: "ClusterRoleBinding"},
+		{gvr: clusterRoleGVR, name: "kelos-session-server-role", kind: "ClusterRole"},
+		{gvr: roleBindingGVR, name: "kelos-session-server-rolebinding", kind: "RoleBinding", namespaced: true},
+		{gvr: roleGVR, name: "kelos-session-server-role", kind: "Role", namespaced: true},
 	}
 	for _, resource := range resources {
 		list, err := dyn.Resource(resource.gvr).List(ctx, metav1.ListOptions{})
@@ -896,8 +903,14 @@ func deleteSessionServerRBAC(ctx context.Context, dyn dynamic.Interface) error {
 			if item.GetName() != resource.name {
 				continue
 			}
-			if err := dyn.Resource(resource.gvr).Namespace(item.GetNamespace()).Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("deleting Session server %s %s/%s: %w", resource.kind, item.GetNamespace(), item.GetName(), err)
+			var err error
+			if resource.namespaced {
+				err = dyn.Resource(resource.gvr).Namespace(item.GetNamespace()).Delete(ctx, item.GetName(), metav1.DeleteOptions{})
+			} else {
+				err = dyn.Resource(resource.gvr).Delete(ctx, item.GetName(), metav1.DeleteOptions{})
+			}
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("deleting Session server %s %s: %w", resource.kind, item.GetName(), err)
 			}
 		}
 	}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1112,31 +1112,52 @@ func TestDeleteAllCustomResources_DeletesExistingResources(t *testing.T) {
 
 func TestDeleteSessionServerRBACAcrossNamespaces(t *testing.T) {
 	scheme := runtime.NewScheme()
-	objects := []*unstructured.Unstructured{
+	objects := []runtime.Object{
+		rbacObject("ClusterRole", "kelos-session-server-role", ""),
+		rbacObject("ClusterRoleBinding", "kelos-session-server-rolebinding", ""),
 		rbacObject("Role", "kelos-session-server-role", "team-a"),
 		rbacObject("RoleBinding", "kelos-session-server-rolebinding", "team-a"),
+		rbacObject("ClusterRole", "unrelated-cluster-role", ""),
+		rbacObject("ClusterRoleBinding", "unrelated-cluster-rolebinding", ""),
 		rbacObject("Role", "unrelated-role", "team-a"),
 		rbacObject("RoleBinding", "unrelated-rolebinding", "team-a"),
 	}
 	listKinds := map[schema.GroupVersionResource]string{
-		roleGVR:        "RoleList",
-		roleBindingGVR: "RoleBindingList",
+		clusterRoleGVR:        "ClusterRoleList",
+		clusterRoleBindingGVR: "ClusterRoleBindingList",
+		roleGVR:               "RoleList",
+		roleBindingGVR:        "RoleBindingList",
 	}
-	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects[0], objects[1], objects[2], objects[3])
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
 	if err := deleteSessionServerRBAC(context.Background(), client); err != nil {
 		t.Fatalf("deleteSessionServerRBAC() error = %v", err)
 	}
 
 	for _, resource := range []struct {
-		gvr  schema.GroupVersionResource
-		name string
+		gvr       schema.GroupVersionResource
+		name      string
+		namespace string
 	}{
-		{gvr: roleGVR, name: "kelos-session-server-role"},
-		{gvr: roleBindingGVR, name: "kelos-session-server-rolebinding"},
+		{gvr: clusterRoleGVR, name: "kelos-session-server-role"},
+		{gvr: clusterRoleBindingGVR, name: "kelos-session-server-rolebinding"},
+		{gvr: roleGVR, name: "kelos-session-server-role", namespace: "team-a"},
+		{gvr: roleBindingGVR, name: "kelos-session-server-rolebinding", namespace: "team-a"},
 	} {
-		if _, err := client.Resource(resource.gvr).Namespace("team-a").Get(context.Background(), resource.name, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		var err error
+		if resource.namespace == "" {
+			_, err = client.Resource(resource.gvr).Get(context.Background(), resource.name, metav1.GetOptions{})
+		} else {
+			_, err = client.Resource(resource.gvr).Namespace(resource.namespace).Get(context.Background(), resource.name, metav1.GetOptions{})
+		}
+		if !apierrors.IsNotFound(err) {
 			t.Fatalf("%s still exists: %v", resource.name, err)
 		}
+	}
+	if _, err := client.Resource(clusterRoleGVR).Get(context.Background(), "unrelated-cluster-role", metav1.GetOptions{}); err != nil {
+		t.Fatalf("unrelated ClusterRole was removed: %v", err)
+	}
+	if _, err := client.Resource(clusterRoleBindingGVR).Get(context.Background(), "unrelated-cluster-rolebinding", metav1.GetOptions{}); err != nil {
+		t.Fatalf("unrelated ClusterRoleBinding was removed: %v", err)
 	}
 	if _, err := client.Resource(roleGVR).Namespace("team-a").Get(context.Background(), "unrelated-role", metav1.GetOptions{}); err != nil {
 		t.Fatalf("unrelated Role was removed: %v", err)

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -211,8 +211,9 @@ func TestRender_SessionServer(t *testing.T) {
 		"resources:\n      - sessions\n    verbs:\n      - create\n      - delete\n      - get\n      - list\n      - patch\n      - watch",
 		"--token-file=/var/run/secrets/kelos-session/token",
 		"--default-namespace=team-a",
-		"kind: Role\nmetadata:\n  name: kelos-session-server-role\n  namespace: team-a",
-		"kind: RoleBinding\nmetadata:\n  name: kelos-session-server-rolebinding\n  namespace: team-a",
+		"kind: ClusterRole\nmetadata:\n  name: kelos-session-server-role",
+		"kind: ClusterRoleBinding\nmetadata:\n  name: kelos-session-server-rolebinding",
+		"roleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: kelos-session-server-role",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Errorf("expected Session server render to contain %q", expected)

--- a/internal/manifests/charts/kelos/README.md
+++ b/internal/manifests/charts/kelos/README.md
@@ -211,13 +211,18 @@ kubectl port-forward -n kelos-system service/kelos-session-server 8080:80
 ```
 
 Then open `http://localhost:8080` and enter the token. The token represents one
-shared user that can create, list, delete, and connect to Sessions only in
-`sessionServer.defaultNamespace` (`default` unless overridden). That namespace
-must already exist. The creation form accepts provider, credentials, model,
-Workspace, AgentConfig references, and an optional persistent volume claim. YAML
-mode server-side applies one `kelos.dev/v1alpha2` Session manifest with the same
-worker fields as the form in the configured namespace. The manifest may also
-include labels, annotations, and an optional persistent volume claim.
+shared user that can create, list, delete, and connect to Sessions in any
+namespace. The web application operates on one active namespace at a time and
+can switch it live from the sidebar. `sessionServer.defaultNamespace` (`default`
+unless overridden) sets the initial active namespace. The selected namespace
+must already exist. Session, Workspace, AgentConfig, and previously used
+credential options are loaded only from the active namespace. The creation form
+accepts provider, credentials, model, Workspace, AgentConfig references, and an
+optional persistent volume claim. YAML mode server-side applies one
+`kelos.dev/v1alpha2` Session manifest in the active namespace with the same
+worker fields as the form. The manifest may also include labels, annotations,
+and an optional persistent volume claim. Pod and image overrides remain
+available only through the Kubernetes API and its RBAC.
 
 ## Uninstall
 

--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -240,10 +240,9 @@ subjects:
 {{- if .Values.sessionServer.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: kelos-session-server-role
-  namespace: {{ .Values.sessionServer.defaultNamespace }}
 rules:
   - apiGroups:
       - kelos.dev
@@ -277,13 +276,12 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: kelos-session-server-rolebinding
-  namespace: {{ .Values.sessionServer.defaultNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: kelos-session-server-role
 subjects:
   - kind: ServiceAccount

--- a/internal/manifests/charts/kelos/values.yaml
+++ b/internal/manifests/charts/kelos/values.yaml
@@ -44,6 +44,7 @@ sessionServer:
   replicas: 1
   secretName: ""
   tokenKey: token
+  # Initial active namespace in the Session web application.
   defaultNamespace: default
   secureCookie: false
   service:

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -308,10 +308,6 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	namespace, name := parts[1], parts[2]
-	if namespace != s.defaultNamespace {
-		writeError(writer, http.StatusForbidden, fmt.Sprintf("namespace %q is not served", namespace))
-		return
-	}
 	if len(parts) == 4 && parts[3] == "connect" && request.Method == http.MethodGet {
 		s.connectSession(writer, request, namespace, name)
 		return
@@ -330,7 +326,7 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 
 func (s *Server) listSessions(writer http.ResponseWriter, request *http.Request) {
 	var list kelos.SessionList
-	if err := s.client.List(request.Context(), &list, client.InNamespace(s.defaultNamespace)); err != nil {
+	if err := s.client.List(request.Context(), &list, client.InNamespace(s.requestNamespace(request))); err != nil {
 		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("listing Sessions: %v", err))
 		return
 	}
@@ -345,18 +341,19 @@ func (s *Server) listSessions(writer http.ResponseWriter, request *http.Request)
 }
 
 func (s *Server) listSessionOptions(writer http.ResponseWriter, request *http.Request) {
+	namespace := s.requestNamespace(request)
 	var sessions kelos.SessionList
-	if err := s.client.List(request.Context(), &sessions, client.InNamespace(s.defaultNamespace)); err != nil {
+	if err := s.client.List(request.Context(), &sessions, client.InNamespace(namespace)); err != nil {
 		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("listing Sessions for form options: %v", err))
 		return
 	}
 	var workspaces kelos.WorkspaceList
-	if err := s.client.List(request.Context(), &workspaces, client.InNamespace(s.defaultNamespace)); err != nil {
+	if err := s.client.List(request.Context(), &workspaces, client.InNamespace(namespace)); err != nil {
 		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("listing Workspaces for form options: %v", err))
 		return
 	}
 	var agentConfigs kelos.AgentConfigList
-	if err := s.client.List(request.Context(), &agentConfigs, client.InNamespace(s.defaultNamespace)); err != nil {
+	if err := s.client.List(request.Context(), &agentConfigs, client.InNamespace(namespace)); err != nil {
 		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("listing AgentConfigs for form options: %v", err))
 		return
 	}
@@ -367,6 +364,14 @@ func (s *Server) listSessionOptions(writer http.ResponseWriter, request *http.Re
 		AgentConfigs: objectNames(agentConfigs.Items, func(item kelos.AgentConfig) string { return item.Name }),
 	}
 	writeJSON(writer, http.StatusOK, options)
+}
+
+func (s *Server) requestNamespace(request *http.Request) string {
+	namespace := strings.TrimSpace(request.URL.Query().Get("namespace"))
+	if namespace == "" {
+		return s.defaultNamespace
+	}
+	return namespace
 }
 
 func credentialOptions(sessions []kelos.Session) []credentialOption {
@@ -422,10 +427,6 @@ func (s *Server) createSession(writer http.ResponseWriter, request *http.Request
 		writeError(writer, http.StatusBadRequest, "name and namespace are required")
 		return
 	}
-	if payload.Namespace != s.defaultNamespace {
-		writeError(writer, http.StatusForbidden, fmt.Sprintf("namespace %q is not served", payload.Namespace))
-		return
-	}
 	session := &kelos.Session{
 		TypeMeta: metav1.TypeMeta{APIVersion: kelos.GroupVersion.String(), Kind: "Session"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -460,15 +461,16 @@ func (s *Server) applySession(writer http.ResponseWriter, request *http.Request)
 	}
 	session.Name = strings.TrimSpace(session.Name)
 	session.Namespace = strings.TrimSpace(session.Namespace)
+	namespace := s.requestNamespace(request)
 	if session.Namespace == "" {
-		session.Namespace = s.defaultNamespace
+		session.Namespace = namespace
 	}
 	if session.Name == "" {
 		writeError(writer, http.StatusBadRequest, "Session metadata.name is required")
 		return
 	}
-	if session.Namespace != s.defaultNamespace {
-		writeError(writer, http.StatusForbidden, fmt.Sprintf("namespace %q is not served", session.Namespace))
+	if session.Namespace != namespace {
+		writeError(writer, http.StatusForbidden, fmt.Sprintf("namespace %q is not active", session.Namespace))
 		return
 	}
 

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -80,6 +80,9 @@ func TestSessionFormUsesResourceSelectors(t *testing.T) {
 		t.Fatalf("GET / status = %d body = %s", response.Code, response.Body.String())
 	}
 	for _, expected := range []string{
+		`id="namespace-form"`,
+		`id="active-namespace"`,
+		`name="namespace" required value="default" autocomplete="off" readonly>`,
 		`id="credential-secret"`,
 		`id="workspace-select"`,
 		`id="agent-config-select"`,
@@ -156,7 +159,7 @@ spec:
       type: none
     model: gpt-5
 `
-	request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(manifest))
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply?namespace=team-a", strings.NewReader(manifest))
 	request.Header.Set("Authorization", "Bearer secret-token")
 	request.Header.Set("Content-Type", "application/yaml")
 	response := httptest.NewRecorder()
@@ -166,7 +169,7 @@ spec:
 	}
 
 	var session kelos.Session
-	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "yaml-chat"}, &session); err != nil {
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "team-a", Name: "yaml-chat"}, &session); err != nil {
 		t.Fatal(err)
 	}
 	if session.Labels["source"] != "web" {
@@ -184,14 +187,14 @@ spec:
 	}
 
 	updated := strings.Replace(manifest, "source: web", "source: yaml", 1)
-	request = httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(updated))
+	request = httptest.NewRequest(http.MethodPost, "/api/sessions/apply?namespace=team-a", strings.NewReader(updated))
 	request.Header.Set("Authorization", "Bearer secret-token")
 	response = httptest.NewRecorder()
 	server.ServeHTTP(response, request)
 	if response.Code != http.StatusOK {
 		t.Fatalf("reapply status = %d body = %s", response.Code, response.Body.String())
 	}
-	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "yaml-chat"}, &session); err != nil {
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "team-a", Name: "yaml-chat"}, &session); err != nil {
 		t.Fatal(err)
 	}
 	if session.Labels["source"] != "yaml" {
@@ -261,7 +264,7 @@ func TestSessionAPIHappyPath(t *testing.T) {
 
 	payload := map[string]any{
 		"name":      "chat",
-		"namespace": "default",
+		"namespace": "team-a",
 		"worker": map[string]any{
 			"type":        "codex",
 			"credentials": map[string]string{"type": "none"},
@@ -276,7 +279,7 @@ func TestSessionAPIHappyPath(t *testing.T) {
 		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
 	}
 
-	request = httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	request = httptest.NewRequest(http.MethodGet, "/api/sessions?namespace=team-a", nil)
 	request.Header.Set("Authorization", "Bearer secret-token")
 	response = httptest.NewRecorder()
 	server.ServeHTTP(response, request)
@@ -287,11 +290,11 @@ func TestSessionAPIHappyPath(t *testing.T) {
 	if err := json.Unmarshal(response.Body.Bytes(), &sessions); err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].Name != "chat" || sessions[0].Provider != "codex" {
+	if len(sessions) != 1 || sessions[0].Name != "chat" || sessions[0].Namespace != "team-a" || sessions[0].Provider != "codex" {
 		t.Fatalf("listed Sessions = %#v", sessions)
 	}
 
-	request = httptest.NewRequest(http.MethodDelete, "/api/sessions/default/chat", nil)
+	request = httptest.NewRequest(http.MethodDelete, "/api/sessions/team-a/chat", nil)
 	request.Header.Set("Authorization", "Bearer secret-token")
 	response = httptest.NewRecorder()
 	server.ServeHTTP(response, request)
@@ -300,18 +303,13 @@ func TestSessionAPIHappyPath(t *testing.T) {
 	}
 }
 
-func TestSessionAPIRejectsOtherNamespacesAndUnsafeWorkerFields(t *testing.T) {
+func TestSessionAPIRejectsUnsafeWorkerFields(t *testing.T) {
 	server := testServer(t)
 	for _, test := range []struct {
 		name       string
 		payload    string
 		wantStatus int
 	}{
-		{
-			name:       "other namespace",
-			payload:    `{"name":"chat","namespace":"team-a","worker":{"type":"codex","credentials":{"type":"none"}}}`,
-			wantStatus: http.StatusForbidden,
-		},
 		{
 			name:       "custom image",
 			payload:    `{"name":"chat","namespace":"default","worker":{"type":"codex","credentials":{"type":"none"},"image":"example.invalid/unsafe:latest"}}`,
@@ -333,17 +331,9 @@ func TestSessionAPIRejectsOtherNamespacesAndUnsafeWorkerFields(t *testing.T) {
 			}
 		})
 	}
-
-	request := httptest.NewRequest(http.MethodGet, "/api/sessions/team-a/chat", nil)
-	request.Header.Set("Authorization", "Bearer secret-token")
-	response := httptest.NewRecorder()
-	server.ServeHTTP(response, request)
-	if response.Code != http.StatusForbidden {
-		t.Fatalf("cross-namespace get status = %d, want %d", response.Code, http.StatusForbidden)
-	}
 }
 
-func TestSessionAPIListsOnlyConfiguredNamespace(t *testing.T) {
+func TestSessionAPIListsRequestedNamespace(t *testing.T) {
 	server := testServer(t)
 	for _, namespace := range []string{"default", "team-a"} {
 		session := &kelos.Session{
@@ -357,19 +347,30 @@ func TestSessionAPIListsOnlyConfiguredNamespace(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	request := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
-	request.Header.Set("Authorization", "Bearer secret-token")
-	response := httptest.NewRecorder()
-	server.ServeHTTP(response, request)
-	if response.Code != http.StatusOK {
-		t.Fatalf("list status = %d body = %s", response.Code, response.Body.String())
-	}
-	var sessions []sessionSummary
-	if err := json.Unmarshal(response.Body.Bytes(), &sessions); err != nil {
-		t.Fatal(err)
-	}
-	if len(sessions) != 1 || sessions[0].Namespace != "default" {
-		t.Fatalf("listed Sessions = %#v", sessions)
+	for _, test := range []struct {
+		name          string
+		path          string
+		wantNamespace string
+	}{
+		{name: "default namespace", path: "/api/sessions", wantNamespace: "default"},
+		{name: "requested namespace", path: "/api/sessions?namespace=team-a", wantNamespace: "team-a"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			request.Header.Set("Authorization", "Bearer secret-token")
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, request)
+			if response.Code != http.StatusOK {
+				t.Fatalf("list status = %d body = %s", response.Code, response.Body.String())
+			}
+			var sessions []sessionSummary
+			if err := json.Unmarshal(response.Body.Bytes(), &sessions); err != nil {
+				t.Fatal(err)
+			}
+			if len(sessions) != 1 || sessions[0].Namespace != test.wantNamespace {
+				t.Fatalf("listed Sessions = %#v", sessions)
+			}
+		})
 	}
 }
 
@@ -476,6 +477,26 @@ func TestSessionOptionsAPI(t *testing.T) {
 	if got := strings.Join(options.AgentConfigs, ","); got != "defaults,tools" {
 		t.Errorf("AgentConfig options = %q, want %q", got, "defaults,tools")
 	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/options?namespace=team-a", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("team-a options status = %d body = %s", response.Code, response.Body.String())
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &options); err != nil {
+		t.Fatal(err)
+	}
+	if len(options.Credentials) != 1 || options.Credentials[0].Name != "other-credentials" {
+		t.Errorf("team-a credential options = %#v", options.Credentials)
+	}
+	if got := strings.Join(options.Workspaces, ","); got != "other" {
+		t.Errorf("team-a workspace options = %q, want %q", got, "other")
+	}
+	if got := strings.Join(options.AgentConfigs, ","); got != "other" {
+		t.Errorf("team-a AgentConfig options = %q, want %q", got, "other")
+	}
 }
 
 func TestNewRejectsEmptyToken(t *testing.T) {
@@ -497,7 +518,7 @@ func TestNewRejectsEmptyDefaultNamespace(t *testing.T) {
 func TestConnectSessionBridgesReadySession(t *testing.T) {
 	server := testServer(t)
 	session := &kelos.Session{
-		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "team-a"},
 		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
 			Type:        "codex",
 			Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
@@ -510,8 +531,8 @@ func TestConnectSessionBridgesReadySession(t *testing.T) {
 	bridged := make(chan struct{})
 	server.bridge = func(_ context.Context, connection *sessionSocket, namespace, podName string) error {
 		defer close(bridged)
-		if namespace != "default" || podName != "chat-pod" {
-			t.Errorf("bridge target = %s/%s, want default/chat-pod", namespace, podName)
+		if namespace != "team-a" || podName != "chat-pod" {
+			t.Errorf("bridge target = %s/%s, want team-a/chat-pod", namespace, podName)
 		}
 		var request map[string]any
 		if err := connection.ReadJSON(&request); err != nil {
@@ -526,7 +547,7 @@ func TestConnectSessionBridgesReadySession(t *testing.T) {
 	httpServer := httptest.NewServer(server)
 	defer httpServer.Close()
 	header := http.Header{"Authorization": []string{"Bearer secret-token"}}
-	connection, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpServer.URL, "http")+"/api/sessions/default/chat/connect", header)
+	connection, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpServer.URL, "http")+"/api/sessions/team-a/chat/connect", header)
 	if err != nil {
 		if response != nil {
 			t.Fatalf("connecting WebSocket: %v (status %d)", err, response.StatusCode)

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -11,6 +11,9 @@ const elements = {
   dialog: document.querySelector('#session-dialog'),
   form: document.querySelector('#session-form'),
   dialogError: document.querySelector('#dialog-error'),
+  namespaceForm: document.querySelector('#namespace-form'),
+  activeNamespace: document.querySelector('#active-namespace'),
+  namespace: document.querySelector('[name="namespace"]'),
   provider: document.querySelector('[name="provider"]'),
   credentialType: document.querySelector('#credential-type'),
   secretField: document.querySelector('#secret-field'),
@@ -50,6 +53,8 @@ const state = {
   activeTurn: false,
   interrupting: false,
   defaultNamespace: 'default',
+  namespace: 'default',
+  namespaceGeneration: 0,
   options: {credentials: [], workspaces: [], agentConfigs: []},
   selectedAgentConfigs: [],
   creationMode: 'form',
@@ -98,7 +103,7 @@ function renderSessions() {
   if (!state.sessions.length) {
     const empty = document.createElement('div');
     empty.className = 'sidebar-empty';
-    empty.textContent = 'No Sessions are visible yet.';
+    empty.textContent = `No Sessions in ${state.namespace}.`;
     elements.list.append(empty);
     return;
   }
@@ -128,8 +133,11 @@ function renderSessions() {
 }
 
 async function loadSessions({quiet = false} = {}) {
+  const namespace = state.namespace;
+  const generation = state.namespaceGeneration;
   try {
-    const sessions = await api('/api/sessions');
+    const sessions = await api(`/api/sessions?namespace=${encodeURIComponent(namespace)}`);
+    if (generation !== state.namespaceGeneration) return;
     state.sessions = sessions;
     if (state.selected) {
       const current = sessions.find(item => sessionKey(item) === sessionKey(state.selected));
@@ -144,14 +152,16 @@ async function loadSessions({quiet = false} = {}) {
     }
     renderSessions();
   } catch (error) {
-    if (!quiet) showToast(error.message);
+    if (!quiet && generation === state.namespaceGeneration) showToast(error.message);
   }
 }
 
 async function loadConfig() {
   const config = await api('/api/config');
   state.defaultNamespace = config.defaultNamespace;
-  elements.form.elements.namespace.value = state.defaultNamespace;
+  state.namespace = window.localStorage.getItem('kelos-session-namespace') || state.defaultNamespace;
+  elements.activeNamespace.value = state.namespace;
+  elements.namespace.value = state.namespace;
 }
 
 function defaultSessionYAML() {
@@ -159,7 +169,7 @@ function defaultSessionYAML() {
 kind: Session
 metadata:
   name: my-session
-  namespace: ${state.defaultNamespace}
+  namespace: ${state.namespace}
 spec:
   worker:
     type: claude-code
@@ -192,10 +202,47 @@ function updateVolumeClaimFields() {
 }
 
 async function loadOptions() {
-  state.options = await api('/api/options');
+  const namespace = state.namespace;
+  const generation = state.namespaceGeneration;
+  let options;
+  try {
+    options = await api(`/api/options?namespace=${encodeURIComponent(namespace)}`);
+  } catch (error) {
+    if (generation !== state.namespaceGeneration) return;
+    throw error;
+  }
+  if (generation !== state.namespaceGeneration) return;
+  state.options = options;
   renderCredentialOptions();
   renderWorkspaceOptions();
   renderAgentConfigOptions();
+}
+
+function resetNamespaceReferences() {
+  state.selectedAgentConfigs = [];
+  elements.credentialSecret.value = '';
+  elements.credentialSecretCustom.value = '';
+  elements.workspace.value = '';
+  elements.workspaceCustom.value = '';
+}
+
+async function switchNamespace(namespace) {
+  namespace = namespace.trim();
+  if (!namespace || namespace === state.namespace) return;
+  state.namespace = namespace;
+  state.namespaceGeneration += 1;
+  state.sessions = [];
+  state.options = {credentials: [], workspaces: [], agentConfigs: []};
+  window.localStorage.setItem('kelos-session-namespace', namespace);
+  elements.activeNamespace.value = namespace;
+  elements.namespace.value = namespace;
+  resetNamespaceReferences();
+  elements.yaml.value = '';
+  renderCredentialOptions();
+  renderWorkspaceOptions();
+  renderAgentConfigOptions();
+  selectSession(null);
+  await Promise.all([loadSessions(), loadOptions()]);
 }
 
 function addOption(select, value, label) {
@@ -847,6 +894,14 @@ async function openDialog() {
 document.querySelector('#new-session').addEventListener('click', openDialog);
 document.querySelector('#welcome-new').addEventListener('click', openDialog);
 document.querySelectorAll('.close-dialog').forEach(button => button.addEventListener('click', () => elements.dialog.close()));
+elements.namespaceForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  try {
+    await switchNamespace(elements.activeNamespace.value);
+  } catch (error) {
+    showToast(error.message);
+  }
+});
 elements.credentialType.addEventListener('change', () => {
   const option = elements.credentialSecret.selectedOptions[0];
   if (option?.dataset.type && option.dataset.type !== elements.credentialType.value) {
@@ -889,7 +944,7 @@ elements.form.addEventListener('submit', async event => {
   try {
     let created;
     if (state.creationMode === 'yaml') {
-      created = await api('/api/sessions/apply', {
+      created = await api(`/api/sessions/apply?namespace=${encodeURIComponent(state.namespace)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/yaml'},
         body: elements.yaml.value,
@@ -929,7 +984,7 @@ elements.form.addEventListener('submit', async event => {
     elements.dialog.close();
     elements.form.reset();
     state.selectedAgentConfigs = [];
-    elements.form.elements.namespace.value = state.defaultNamespace;
+    elements.namespace.value = state.namespace;
     elements.yaml.value = '';
     updateVolumeClaimFields();
     setCreationMode('form');
@@ -975,7 +1030,7 @@ document.querySelector('#open-sidebar').addEventListener('click', () => elements
 document.querySelector('#close-sidebar').addEventListener('click', () => elements.sidebar.classList.remove('open'));
 
 const configReady = loadConfig();
-Promise.all([configReady, loadOptions()]).then(() => loadSessions()).then(() => {
+configReady.then(() => Promise.all([loadOptions(), loadSessions()])).then(() => {
   if (state.sessions.length) selectSession(state.sessions[0]);
 }).catch(error => showToast(error.message));
 window.setInterval(() => loadSessions({quiet: true}), 5000);

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -21,6 +21,13 @@
       <button class="new-session-button" id="new-session">
         <span aria-hidden="true">＋</span> New session
       </button>
+      <form class="namespace-form" id="namespace-form">
+        <label for="active-namespace">Namespace</label>
+        <div>
+          <input id="active-namespace" required autocomplete="off" aria-label="Active namespace">
+          <button type="submit">Switch</button>
+        </div>
+      </form>
       <div class="sidebar-label">Conversations</div>
       <div class="session-list" id="session-list" aria-live="polite"></div>
       <div class="sidebar-footer">
@@ -166,7 +173,7 @@
       <div class="mode-panel yaml-panel" id="session-yaml-panel" hidden>
         <label for="session-yaml">Session manifest</label>
         <textarea id="session-yaml" name="sessionYAML" rows="19" spellcheck="false" aria-describedby="session-yaml-help"></textarea>
-        <small id="session-yaml-help">Apply one <code>kelos.dev/v1alpha2</code> Session in the configured namespace.</small>
+        <small id="session-yaml-help">Apply one <code>kelos.dev/v1alpha2</code> Session in the active namespace.</small>
       </div>
       <div class="dialog-error" id="dialog-error" role="alert"></div>
       <div class="dialog-actions">

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -28,8 +28,14 @@ button { color: inherit; }
 .brand-mark { width: 37px; height: 37px; display: grid; place-items: center; border-radius: 12px; background: var(--accent); color: #fff; font: 700 17px/1 ui-monospace, SFMono-Regular, Menlo, monospace; box-shadow: 0 7px 16px rgba(29, 81, 59, .2); }
 .brand { font: 600 17px/1.05 Georgia, "Times New Roman", serif; letter-spacing: -.015em; }
 .brand-subtitle { margin-top: 4px; color: var(--muted); font-size: 11px; font-weight: 650; letter-spacing: .11em; text-transform: uppercase; }
-.new-session-button { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; margin: 25px 0 24px; padding: 11px 14px; border: 1px solid #cbd4cd; border-radius: 12px; background: rgba(255,255,255,.7); font-size: 13px; font-weight: 700; cursor: pointer; transition: background .15s, transform .15s, box-shadow .15s; }
+.new-session-button { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; margin: 25px 0 15px; padding: 11px 14px; border: 1px solid #cbd4cd; border-radius: 12px; background: rgba(255,255,255,.7); font-size: 13px; font-weight: 700; cursor: pointer; transition: background .15s, transform .15s, box-shadow .15s; }
 .new-session-button:hover { background: #fff; transform: translateY(-1px); box-shadow: 0 7px 18px rgba(32,51,41,.08); }
+.namespace-form { margin: 0 0 22px; padding: 0 5px; }
+.namespace-form label { display: block; margin: 0 5px 6px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
+.namespace-form div { display: grid; grid-template-columns: minmax(0, 1fr) auto; }
+.namespace-form input { min-width: 0; padding: 8px 9px; border: 1px solid #cbd4cd; border-right: 0; border-radius: 9px 0 0 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 11px; }
+.namespace-form input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.namespace-form button { padding: 8px 9px; border: 1px solid #cbd4cd; border-radius: 0 9px 9px 0; background: var(--accent); color: white; font-size: 10px; font-weight: 700; cursor: pointer; }
 .sidebar-label { padding: 0 10px 9px; color: var(--faint); font-size: 10px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
 .session-list { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin; }
 .session-item { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 9px; padding: 11px 10px; border: 0; border-radius: 11px; background: transparent; text-align: left; cursor: pointer; transition: background .15s; }

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -31,10 +31,7 @@ import (
 	"github.com/kelos-dev/kelos/test/e2e/framework"
 )
 
-const (
-	sessionWebNamespace = "default"
-	sessionWebTokenEnv  = "E2E_SESSION_WEB_TOKEN"
-)
+const sessionWebTokenEnv = "E2E_SESSION_WEB_TOKEN"
 
 //go:embed fixtures/fake-claude.js
 var fakeClaude string
@@ -56,17 +53,17 @@ var _ = Describe("Session remote control", func() {
 		sessionName := strings.TrimPrefix(f.Namespace, "e2e-")
 		configMapName := sessionName + "-provider"
 		mode := int32(0555)
-		_, err := f.Clientset.CoreV1().ConfigMaps(sessionWebNamespace).Create(context.TODO(), &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: sessionWebNamespace},
+		_, err := f.Clientset.CoreV1().ConfigMaps(f.Namespace).Create(context.TODO(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: f.Namespace},
 			Data:       map[string]string{"claude": fakeClaude},
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
-			_ = f.Clientset.CoreV1().ConfigMaps(sessionWebNamespace).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
+			_ = f.Clientset.CoreV1().ConfigMaps(f.Namespace).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
 		})
 
 		created := createSession(f, &kelos.Session{
-			ObjectMeta: metav1.ObjectMeta{Name: sessionName, Namespace: sessionWebNamespace},
+			ObjectMeta: metav1.ObjectMeta{Name: sessionName, Namespace: f.Namespace},
 			Spec: kelos.SessionSpec{
 				Worker: kelos.WorkerSpec{
 					Type:        "claude-code",
@@ -99,35 +96,35 @@ var _ = Describe("Session remote control", func() {
 			},
 		})
 		DeferCleanup(func() {
-			_ = f.KelosClientset.ApiV1alpha2().Sessions(sessionWebNamespace).Delete(context.TODO(), sessionName, metav1.DeleteOptions{})
+			_ = f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Delete(context.TODO(), sessionName, metav1.DeleteOptions{})
 		})
 		DeferCleanup(func() {
 			if CurrentSpecReport().Failed() {
-				collectSessionDebugInfo(f, sessionWebNamespace, sessionName)
+				collectSessionDebugInfo(f, f.Namespace, sessionName)
 			}
 		})
 
-		current := waitForSessionPhase(f, sessionWebNamespace, sessionName, kelos.SessionPhaseReady)
-		pod, err := f.Clientset.CoreV1().Pods(sessionWebNamespace).Get(context.TODO(), current.Status.PodName, metav1.GetOptions{})
+		current := waitForSessionPhase(f, f.Namespace, sessionName, kelos.SessionPhaseReady)
+		pod, err := f.Clientset.CoreV1().Pods(f.Namespace).Get(context.TODO(), current.Status.PodName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(current.Status.PodUID).To(Equal(pod.UID))
 		controllerRef := metav1.GetControllerOf(pod)
 		Expect(controllerRef).NotTo(BeNil())
-		statefulSet, err := f.Clientset.AppsV1().StatefulSets(sessionWebNamespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{})
+		statefulSet, err := f.Clientset.AppsV1().StatefulSets(f.Namespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(metav1.IsControlledBy(statefulSet, created)).To(BeTrue())
 		Expect(metav1.IsControlledBy(pod, statefulSet)).To(BeTrue())
 		Expect(statefulSet.Spec.Replicas).NotTo(BeNil())
 		Expect(*statefulSet.Spec.Replicas).To(Equal(int32(1)))
-		pods, err := f.Clientset.CoreV1().Pods(sessionWebNamespace).List(context.TODO(), metav1.ListOptions{
+		pods, err := f.Clientset.CoreV1().Pods(f.Namespace).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "kelos.dev/session=" + sessionName,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pods.Items).To(HaveLen(1))
 
 		By("completing turns through separate terminal connections")
-		runTerminalTurn(sessionWebNamespace, sessionName, "terminal-one", "agent › turn 1: terminal-one")
-		runTerminalTurn(sessionWebNamespace, sessionName, "terminal-two", "agent › turn 2: terminal-two")
+		runTerminalTurn(f.Namespace, sessionName, "terminal-one", "agent › turn 1: terminal-one")
+		runTerminalTurn(f.Namespace, sessionName, "terminal-two", "agent › turn 2: terminal-two")
 
 		By("authenticating to the shared Session web server")
 		baseURL := startSessionServerPortForward()
@@ -139,10 +136,10 @@ var _ = Describe("Session remote control", func() {
 
 		webClient := loginSessionWeb(baseURL, token)
 		Eventually(func() []string {
-			return listWebSessions(webClient, baseURL)
+			return listWebSessions(webClient, baseURL, f.Namespace)
 		}, 30*time.Second, 200*time.Millisecond).Should(ContainElement(sessionName))
 
-		connection := connectSessionWebSocket(webClient, baseURL, sessionName)
+		connection := connectSessionWebSocket(webClient, baseURL, f.Namespace, sessionName)
 		DeferCleanup(func() { _ = connection.Close() })
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "subscribe"})
 		seenFirstTurn := false
@@ -198,7 +195,7 @@ var _ = Describe("Session remote control", func() {
 			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 6: after"
 		})
 		waitForTurnCompletion(connection, "completed")
-		Expect(waitForSessionPhase(f, sessionWebNamespace, sessionName, kelos.SessionPhaseReady).Status.PodUID).To(Equal(pod.UID))
+		Expect(waitForSessionPhase(f, f.Namespace, sessionName, kelos.SessionPhaseReady).Status.PodUID).To(Equal(pod.UID))
 
 		By("recovering conversation and workspace state after the Pod is deleted")
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "message", Text: "write-state"})
@@ -213,16 +210,16 @@ var _ = Describe("Session remote control", func() {
 		oldPodUID := pod.UID
 		oldClaimName := sessionWorkspaceClaimName(pod)
 		Expect(oldClaimName).NotTo(BeEmpty())
-		Expect(f.Clientset.CoreV1().Pods(sessionWebNamespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
+		Expect(f.Clientset.CoreV1().Pods(f.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
 		_ = connection.Close()
 
-		recovered := waitForSessionPodReplacement(f, sessionWebNamespace, sessionName, oldPodUID)
-		replacement, err := f.Clientset.CoreV1().Pods(sessionWebNamespace).Get(context.TODO(), recovered.Status.PodName, metav1.GetOptions{})
+		recovered := waitForSessionPodReplacement(f, f.Namespace, sessionName, oldPodUID)
+		replacement, err := f.Clientset.CoreV1().Pods(f.Namespace).Get(context.TODO(), recovered.Status.PodName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(replacement.UID).NotTo(Equal(oldPodUID))
 		Expect(sessionWorkspaceClaimName(replacement)).To(Equal(oldClaimName))
 
-		connection = connectSessionWebSocket(webClient, baseURL, sessionName)
+		connection = connectSessionWebSocket(webClient, baseURL, f.Namespace, sessionName)
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "subscribe"})
 		seenRecovery := false
 		seenInterruptedTurn := false
@@ -243,9 +240,9 @@ var _ = Describe("Session remote control", func() {
 		waitForTurnCompletion(connection, "completed")
 
 		By("deleting the Session and its StatefulSet-backed Pod")
-		Expect(f.KelosClientset.ApiV1alpha2().Sessions(sessionWebNamespace).Delete(context.TODO(), sessionName, metav1.DeleteOptions{})).To(Succeed())
-		waitForPodDeletion(f, sessionWebNamespace, pod.Name)
-		waitForPVCDeletion(f, sessionWebNamespace, oldClaimName)
+		Expect(f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Delete(context.TODO(), sessionName, metav1.DeleteOptions{})).To(Succeed())
+		waitForPodDeletion(f, f.Namespace, pod.Name)
+		waitForPVCDeletion(f, f.Namespace, oldClaimName)
 	})
 
 	It("runs an OpenCode conversation through terminal chat", func() {
@@ -507,8 +504,8 @@ func loginSessionWeb(baseURL, token string) *http.Client {
 	return client
 }
 
-func listWebSessions(client *http.Client, baseURL string) []string {
-	response, err := client.Get(baseURL + "/api/sessions")
+func listWebSessions(client *http.Client, baseURL, namespace string) []string {
+	response, err := client.Get(baseURL + "/api/sessions?namespace=" + url.QueryEscape(namespace))
 	if err != nil {
 		return nil
 	}
@@ -529,14 +526,14 @@ func listWebSessions(client *http.Client, baseURL string) []string {
 	return names
 }
 
-func connectSessionWebSocket(client *http.Client, baseURL, sessionName string) *websocket.Conn {
+func connectSessionWebSocket(client *http.Client, baseURL, namespace, sessionName string) *websocket.Conn {
 	parsed, err := url.Parse(baseURL)
 	Expect(err).NotTo(HaveOccurred())
 	header := http.Header{}
 	for _, cookie := range client.Jar.Cookies(parsed) {
 		header.Add("Cookie", cookie.String())
 	}
-	webSocketURL := "ws://" + parsed.Host + "/api/sessions/" + sessionWebNamespace + "/" + sessionName + "/connect"
+	webSocketURL := "ws://" + parsed.Host + "/api/sessions/" + namespace + "/" + sessionName + "/connect"
 	connection, response, err := websocket.DefaultDialer.Dial(webSocketURL, header)
 	if response != nil && response.Body != nil {
 		response.Body.Close()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The Session web application now operates on one active namespace at a time and lets users switch that namespace live from the sidebar. Session lists and form options are scoped to the active namespace, and new Sessions inherit it.

The Session server uses cluster-wide RBAC because live switching requires access to each namespace selected by the user. `sessionServer.defaultNamespace` remains the initial UI namespace rather than an authorization boundary.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The existing Session end-to-end test now runs in its generated test namespace instead of relying on `default`.
- Verified with `make test`, `make verify`, JavaScript syntax checking, and a live kind deployment with Ready Sessions in two namespaces.
- The shared Session server token can operate on Sessions across namespaces; the UI displays only the active namespace.

#### Does this PR introduce a user-facing change?

```release-note
The Session web UI can switch its active Kubernetes namespace without restarting the Session server.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables live namespace switching in the Session web UI so users can browse, create, and connect to Sessions across namespaces without restarting. The server now scopes lists, options, and YAML apply by `?namespace=` and the Helm chart uses cluster-scoped RBAC.

- **New Features**
  - Sidebar namespace switcher with `localStorage` persistence; lists and options load from the active namespace. Switching clears cross-namespace selections.
  - API accepts `?namespace=` on `/api/sessions`, `/api/options`, and `/api/sessions/apply` (falls back to `defaultNamespace`). Create uses the request `namespace`; delete and WebSocket connect work across namespaces. YAML apply runs in the active namespace and requires the manifest namespace to match it.

- **Migration**
  - Helm chart moves from `Role`/`RoleBinding` to `ClusterRole`/`ClusterRoleBinding` for the Session server. Upgrade the chart and ensure target namespaces exist.
  - Uninstall removes the cluster-scoped RBAC and also cleans up legacy namespaced `Role`/`RoleBinding` with the same names.

<sup>Written for commit f14a6e8db93cbfb09bf3a5b26dada0d1e9ba27fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

