### PR TITLE
Improve Session UI for active turns

### DIFF
--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -249,6 +249,27 @@ func TestSessionYAMLApplyAPIRejectsInvalidManifests(t *testing.T) {
 	}
 }
 
+func TestSessionComposerUsesOneSendAndInterruptAction(t *testing.T) {
+	server := testServer(t)
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d body = %s", response.Code, response.Body.String())
+	}
+	body := response.Body.String()
+	if !strings.Contains(body, `id="send-message" type="submit" aria-label="Send message" data-action="send"`) {
+		t.Error("Session composer does not contain the send action")
+	}
+	if !strings.Contains(body, `id="queued-prompts"`) {
+		t.Error("Session composer does not contain the queued prompts region")
+	}
+	if strings.Contains(body, `id="stop-session"`) {
+		t.Error("Session header contains a separate interrupt action")
+	}
+}
+
 func TestSessionAPIHappyPath(t *testing.T) {
 	server := testServer(t)
 	request := httptest.NewRequest(http.MethodGet, "/api/config", nil)

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -7,6 +7,8 @@ const elements = {
   composer: document.querySelector('#composer'),
   input: document.querySelector('#message-input'),
   send: document.querySelector('#send-message'),
+  composerHint: document.querySelector('#composer-hint'),
+  queue: document.querySelector('#queued-prompts'),
   connection: document.querySelector('#connection-pill'),
   dialog: document.querySelector('#session-dialog'),
   form: document.querySelector('#session-form'),
@@ -29,7 +31,6 @@ const elements = {
   persistentVolume: document.querySelector('#volume-claim-enabled'),
   volumeClaimFields: document.querySelector('#volume-claim-fields'),
   createButton: document.querySelector('#create-session'),
-  stopButton: document.querySelector('#stop-session'),
   deleteButton: document.querySelector('#delete-session'),
   sidebar: document.querySelector('#sidebar'),
   toast: document.querySelector('#toast'),
@@ -47,6 +48,7 @@ const state = {
   tools: new Map(),
   inputs: new Map(),
   diffs: new Map(),
+  queuedMessages: new Map(),
   activeTurn: false,
   interrupting: false,
   defaultNamespace: 'default',
@@ -338,6 +340,9 @@ function selectSession(session) {
   state.tools.clear();
   state.inputs.clear();
   state.diffs.clear();
+  state.queuedMessages.clear();
+  elements.queue.replaceChildren();
+  elements.queue.hidden = true;
   state.activeTurn = false;
   state.interrupting = false;
   elements.messages.replaceChildren();
@@ -373,7 +378,7 @@ function createWelcome() {
 function renderHeader() {
   const session = state.selected;
   elements.deleteButton.disabled = !session;
-  updateStopButton();
+  updateComposerAction();
   if (!session) {
     elements.title.textContent = 'Choose a session';
     elements.meta.textContent = 'Select an existing conversation or create one.';
@@ -396,13 +401,21 @@ function setConnection(status, label) {
 
 function setComposer(enabled) {
   elements.input.disabled = !enabled;
-  elements.send.disabled = !enabled;
   elements.input.placeholder = enabled ? 'Message the agent…' : 'Choose a ready session to start chatting';
+  updateComposerAction();
 }
 
-function updateStopButton() {
+function updateComposerAction() {
   const connected = state.socket && state.socket.readyState === WebSocket.OPEN;
-  elements.stopButton.disabled = !connected || !state.activeTurn || state.interrupting;
+  const interrupt = state.activeTurn && !elements.input.value.trim();
+  elements.send.dataset.action = interrupt ? 'interrupt' : 'send';
+  elements.send.textContent = interrupt ? '■' : '↑';
+  elements.send.setAttribute('aria-label', interrupt ? 'Interrupt active work' : 'Send message');
+  elements.send.title = interrupt ? 'Interrupt active work' : 'Send message';
+  elements.send.disabled = !connected || elements.input.disabled || (interrupt && state.interrupting);
+  elements.composerHint.textContent = state.activeTurn
+    ? 'Enter to queue · Shift+Enter for a new line'
+    : 'Enter to send · Shift+Enter for a new line';
 }
 
 function closeSocket() {
@@ -415,7 +428,7 @@ function closeSocket() {
     state.socket = null;
   }
   setComposer(false);
-  updateStopButton();
+  updateComposerAction();
 }
 
 function connectSocket() {
@@ -434,7 +447,7 @@ function connectSocket() {
     socket.send(JSON.stringify({type: 'subscribe', since: state.lastEventID}));
     setConnection('connected', 'Connected');
     setComposer(true);
-    updateStopButton();
+    updateComposerAction();
     elements.input.focus();
   });
   socket.addEventListener('message', event => {
@@ -450,7 +463,7 @@ function connectSocket() {
     state.socket = null;
     setConnection('error', 'Reconnecting');
     setComposer(false);
-    updateStopButton();
+    updateComposerAction();
     state.reconnectTimer = window.setTimeout(connectSocket, state.reconnectDelay);
     state.reconnectDelay = Math.min(state.reconnectDelay * 1.8, 10000);
   });
@@ -531,11 +544,12 @@ function handleEvent(event) {
       endAssistantSegment(event.turnId);
       state.activeTurn = true;
       state.interrupting = false;
-      updateStopButton();
+      acceptQueuedMessage(event.turnId);
+      updateComposerAction();
       break;
     case 'turn.interrupting':
       state.interrupting = true;
-      updateStopButton();
+      updateComposerAction();
       break;
     case 'assistant.delta':
       renderAssistantDelta(event);
@@ -574,15 +588,51 @@ function handleEvent(event) {
 }
 
 function renderUser(event) {
+  if (event.turnId) {
+    renderQueuedUser(event);
+    return;
+  }
+  renderAcceptedUser(event);
+}
+
+function renderAcceptedUser(event) {
   ensureConversation();
   const row = document.createElement('div');
   row.className = 'event-row user';
+  const message = document.createElement('div');
+  message.className = 'user-message';
   const bubble = document.createElement('div');
   bubble.className = 'message-bubble';
   renderMessageText(bubble, event.text);
-  row.append(bubble);
+  message.append(bubble);
+  row.append(message);
   elements.messages.append(row);
   scrollToBottom();
+}
+
+function renderQueuedUser(event) {
+  if (state.queuedMessages.has(event.turnId)) return;
+  const item = document.createElement('div');
+  item.className = 'queued-prompt';
+  const text = document.createElement('div');
+  text.className = 'queued-prompt-text';
+  text.textContent = event.text;
+  const status = document.createElement('span');
+  status.className = 'queued-prompt-status';
+  status.textContent = 'Queued';
+  item.append(text, status);
+  elements.queue.append(item);
+  elements.queue.hidden = false;
+  state.queuedMessages.set(event.turnId, {event, item});
+}
+
+function acceptQueuedMessage(turnID) {
+  const queued = state.queuedMessages.get(turnID);
+  if (!queued) return;
+  queued.item.remove();
+  state.queuedMessages.delete(turnID);
+  elements.queue.hidden = state.queuedMessages.size === 0;
+  renderAcceptedUser(queued.event);
 }
 
 function assistantBubble(turnID) {
@@ -771,7 +821,7 @@ function renderDiff(event) {
 function renderError(event) {
   if (event.status === 'rejected') {
     state.interrupting = false;
-    updateStopButton();
+    updateComposerAction();
   }
   ensureConversation();
   const card = document.createElement('div');
@@ -793,7 +843,8 @@ function renderRecovery(event) {
 function renderTurnEnd(event) {
   state.activeTurn = false;
   state.interrupting = false;
-  updateStopButton();
+  acceptQueuedMessage(event.turnId);
+  updateComposerAction();
   if (event.status === 'interrupted') showToast('Active work interrupted');
   const divider = document.createElement('div');
   divider.className = 'turn-divider';
@@ -811,10 +862,15 @@ function scrollToBottom(smooth = true) {
 elements.composer.addEventListener('submit', event => {
   event.preventDefault();
   const text = elements.input.value.trim();
-  if (!text || !state.socket || state.socket.readyState !== WebSocket.OPEN) return;
-  state.socket.send(JSON.stringify({type: 'message', text}));
-  elements.input.value = '';
-  resizeComposer();
+  if (!state.socket || state.socket.readyState !== WebSocket.OPEN) return;
+  if (text) {
+    state.socket.send(JSON.stringify({type: 'message', text}));
+    elements.input.value = '';
+    resizeComposer();
+    updateComposerAction();
+  } else if (state.activeTurn) {
+    interruptActiveTurn();
+  }
 });
 
 elements.input.addEventListener('keydown', event => {
@@ -823,7 +879,10 @@ elements.input.addEventListener('keydown', event => {
     elements.composer.requestSubmit();
   }
 });
-elements.input.addEventListener('input', resizeComposer);
+elements.input.addEventListener('input', () => {
+  resizeComposer();
+  updateComposerAction();
+});
 
 function resizeComposer() {
   elements.input.style.height = 'auto';
@@ -959,12 +1018,12 @@ elements.deleteButton.addEventListener('click', async () => {
   }
 });
 
-elements.stopButton.addEventListener('click', () => {
-  if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn) return;
+function interruptActiveTurn() {
+  if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn || state.interrupting) return;
   state.interrupting = true;
-  updateStopButton();
+  updateComposerAction();
   state.socket.send(JSON.stringify({type: 'interrupt'}));
-});
+}
 
 document.querySelector('#refresh-sessions').addEventListener('click', () => loadSessions());
 document.querySelector('#logout').addEventListener('click', async () => {

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -38,7 +38,6 @@
         </div>
         <div class="header-actions">
           <span class="connection-pill" id="connection-pill" data-state="idle"><span></span>Not connected</span>
-          <button class="icon-button stop" id="stop-session" aria-label="Interrupt active work" title="Interrupt active work" disabled>■</button>
           <button class="icon-button danger" id="delete-session" aria-label="Delete session" title="Delete session" disabled>⌫</button>
         </div>
       </header>
@@ -53,11 +52,12 @@
       </section>
 
       <footer class="composer-wrap">
+        <div class="queued-prompts" id="queued-prompts" aria-label="Queued prompts" aria-live="polite" hidden></div>
         <form class="composer" id="composer">
           <textarea id="message-input" rows="1" placeholder="Choose a ready session to start chatting" aria-label="Message" disabled></textarea>
-          <button class="send-button" id="send-message" type="submit" aria-label="Send message" disabled>↑</button>
+          <button class="send-button" id="send-message" type="submit" aria-label="Send message" data-action="send" disabled>↑</button>
         </form>
-        <div class="composer-hint">Enter to send · Shift+Enter for a new line</div>
+        <div class="composer-hint" id="composer-hint">Enter to send · Shift+Enter for a new line</div>
       </footer>
     </main>
   </div>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -60,8 +60,6 @@ button { color: inherit; }
 .icon-button { width: 35px; height: 35px; display: grid; place-items: center; border: 1px solid var(--line); border-radius: 10px; background: var(--card); cursor: pointer; }
 .icon-button:hover { border-color: #c5ccc6; }
 .icon-button:disabled { opacity: .38; cursor: default; }
-.icon-button.stop:not(:disabled) { color: var(--warning); }
-.icon-button.stop:not(:disabled):hover { border-color: rgba(161,105,34,.35); background: #fffaf1; }
 .icon-button.danger:not(:disabled):hover { color: var(--danger); border-color: rgba(167,63,63,.3); background: #fff6f6; }
 .messages { min-height: 0; overflow-y: auto; padding: 35px max(24px, calc((100% - 850px) / 2)); scroll-behavior: smooth; }
 .welcome { height: 100%; min-height: 410px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
@@ -73,6 +71,8 @@ button { color: inherit; }
 .event-row { width: 100%; display: flex; margin: 0 0 22px; animation: event-in .2s ease-out; }
 @keyframes event-in { from { opacity: 0; transform: translateY(4px); } }
 .event-row.user { justify-content: flex-end; }
+.user-message { max-width: min(78%, 700px); display: flex; flex-direction: column; align-items: flex-end; gap: 5px; }
+.user-message .message-bubble { max-width: 100%; }
 .message-bubble { max-width: min(78%, 700px); padding: 13px 16px; border-radius: 18px; font-size: 14px; line-height: 1.62; white-space: pre-wrap; overflow-wrap: anywhere; }
 .message-bubble a { color: var(--accent-2); text-decoration: underline; text-underline-offset: 2px; }
 .user .message-bubble { border-bottom-right-radius: 5px; background: #dfe9e2; }
@@ -109,11 +109,17 @@ button { color: inherit; }
 .recovery-card { padding: 12px 14px; border-color: rgba(197,138,62,.3); background: #fff9ef; color: #8a5b1f; font-size: 12px; line-height: 1.5; }
 .turn-divider { height: 1px; margin: 2px 0 22px 40px; background: linear-gradient(90deg,var(--line),transparent); }
 .composer-wrap { padding: 12px max(24px, calc((100% - 850px) / 2)) 19px; background: linear-gradient(transparent, var(--canvas) 20%); }
+.queued-prompts { max-height: 150px; display: grid; gap: 6px; margin-bottom: 8px; overflow-y: auto; }
+.queued-prompts[hidden] { display: none; }
+.queued-prompt { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 9px 12px; border: 1px solid var(--line); border-radius: 11px; background: var(--accent-soft); }
+.queued-prompt-text { overflow: hidden; color: var(--ink); font-size: 11.5px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
+.queued-prompt-status { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
 .composer { display: flex; align-items: flex-end; gap: 10px; padding: 9px 9px 9px 16px; border: 1px solid #d1d8d2; border-radius: 17px; background: var(--card); box-shadow: 0 12px 38px rgba(28,45,36,.08); transition: border .15s, box-shadow .15s; }
 .composer:focus-within { border-color: #85a493; box-shadow: 0 12px 38px rgba(28,45,36,.1), 0 0 0 3px rgba(57,112,84,.08); }
 .composer textarea { flex: 1; max-height: 160px; resize: none; border: 0; outline: 0; padding: 8px 0 6px; background: transparent; color: var(--ink); font-size: 14px; line-height: 1.45; }
 .composer textarea::placeholder { color: #99a19c; }
 .send-button { flex: 0 0 auto; width: 36px; height: 36px; border: 0; border-radius: 11px; background: var(--accent); color: white; font-size: 20px; font-weight: 500; cursor: pointer; }
+.send-button[data-action="interrupt"] { background: var(--warning); font-size: 11px; }
 .send-button:disabled { background: #c8ceca; cursor: default; }
 .composer-hint { padding-top: 7px; text-align: center; color: var(--faint); font-size: 9.5px; }
 .primary-button, .secondary-button { padding: 10px 15px; border-radius: 10px; font-size: 12px; font-weight: 750; cursor: pointer; }
@@ -177,7 +183,7 @@ button { color: inherit; }
   .connection-pill { max-width: 35px; overflow: hidden; padding: 8px; color: transparent; gap: 0; }
   .messages { padding: 27px 16px; }
   .composer-wrap { padding: 10px 13px 15px; }
-  .message-bubble { max-width: 90%; }
+  .message-bubble, .user-message { max-width: 90%; }
   .form-grid { grid-template-columns: 1fr; }
   .form-wide { grid-column: auto; }
   .nested-grid { grid-template-columns: 1fr; }
@@ -192,7 +198,6 @@ button { color: inherit; }
   .error-card { background: #2d1e1e; }
   .recovery-card { background: #2d281e; color: #e7bd78; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
-  .icon-button.stop:not(:disabled):hover { background: #2c281e; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
   .form-grid input, .form-grid select { border-color: #3a4740; }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates the Session web composer for active agent turns:

- turns the send button into an interrupt button when the agent is working and the draft is empty
- keeps non-empty follow-up messages sendable while the agent is working
- shows accepted prompts in an ordered queue above the composer until their matching turn starts
- moves each queued prompt into the transcript when the agent accepts it
- prevents duplicate interrupt requests while an interruption is pending
- removes the separate interrupt button from the Session header

The Session runtime already queues turns. This change makes that behavior visible, preserves prompt order for fast and shared-client submissions, and keeps send and interrupt actions in the composer where the current draft determines the intended action.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with `make test` and `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
The Session web UI now shows ordered follow-up prompts until the agent accepts them and uses the composer button to interrupt active work when the draft is empty.
```
