### PR TITLE
Add Session resource support to Kelos CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,8 +525,8 @@ See the [`self-development/` README](self-development/README.md) for the full pi
 | `kelos run` | Create and run a new Task |
 | `kelos run --from taskspawner/<name> [-f values.yaml]` | Run a standalone Task from a TaskSpawner template |
 | `kelos session connect NAME` | Continue a Session through terminal chat |
-| `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
-| `kelos delete <resource> [name]` | Delete a resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`); supports `--all` to delete every resource of that type in the namespace |
+| `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `sessions`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
+| `kelos delete <resource> [name]` | Delete a resource (`tasks`, `sessions`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`); supports `--all` to delete every resource of that type in the namespace |
 | `kelos logs <task-name> [-f]` | View or stream logs from a task |
 | `kelos suspend taskspawner <name>` | Pause a TaskSpawner |
 | `kelos resume taskspawner <name>` | Resume a paused TaskSpawner |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -817,8 +817,8 @@ The `kelos` CLI lets you manage the full lifecycle without writing YAML.
 | `kelos session connect NAME` | Continue a ready Session through terminal chat |
 | `kelos create workspace` | Create a Workspace resource |
 | `kelos create agentconfig` | Create an AgentConfig resource |
-| `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
-| `kelos delete <resource> [name]` | Delete a resource (`tasks`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
+| `kelos get <resource> [name]` | List resources or view a specific resource (`tasks`, `sessions`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
+| `kelos delete <resource> [name]` | Delete a resource (`tasks`, `sessions`, `taskspawners`, `workspaces`, `agentconfigs`, `workerpools`) |
 | `kelos logs <task-name> [-f]` | View or stream logs from a task |
 | `kelos suspend taskspawner <name>` | Pause a TaskSpawner (stops polling, running tasks continue) |
 | `kelos resume taskspawner <name>` | Resume a paused TaskSpawner |
@@ -876,7 +876,7 @@ When the same key is set multiple ways, precedence is: chart defaults, then `--v
 
 ### `kelos delete` Flags
 
-- `--all`: Delete every resource of the given type in the namespace; mutually exclusive with a resource name. Supported by `task`, `workspace`, `taskspawner`, `agentconfig`, and `workerpool` subcommands
+- `--all`: Delete every resource of the given type in the namespace; mutually exclusive with a resource name. Supported by `task`, `session`, `workspace`, `taskspawner`, `agentconfig`, and `workerpool` subcommands
 
 ### Common Flags
 
@@ -914,17 +914,20 @@ In addition to subcommands and flags, the following arguments complete dynamical
 |---------|-----------|
 | `kelos logs <TAB>` | task names |
 | `kelos get task <TAB>` | task names |
+| `kelos get session <TAB>` | session names |
 | `kelos get taskspawner <TAB>` | taskspawner names |
 | `kelos get workspace <TAB>` | workspace names |
 | `kelos get agentconfig <TAB>` | agentconfig names |
 | `kelos get workerpool <TAB>` | workerpool names |
 | `kelos delete task <TAB>` | task names |
+| `kelos delete session <TAB>` | session names |
 | `kelos delete taskspawner <TAB>` | taskspawner names |
 | `kelos delete workspace <TAB>` | workspace names |
 | `kelos delete agentconfig <TAB>` | agentconfig names |
 | `kelos delete workerpool <TAB>` | workerpool names |
 | `kelos suspend taskspawner <TAB>` | taskspawner names |
 | `kelos resume taskspawner <TAB>` | taskspawner names |
+| `kelos session connect <TAB>` | session names |
 
 Enum-valued flags — `kelos run --type`, `kelos run --credential-type`, `kelos get --output`, and `kelos get task --phase` — complete from their fixed value set without contacting the cluster.
 

--- a/examples/16-session/README.md
+++ b/examples/16-session/README.md
@@ -5,7 +5,7 @@ StatefulSet. Replace the API key placeholder, then apply both files:
 
 ```bash
 kubectl apply -f examples/16-session/
-kubectl get session interactive-review -w
+kelos get session interactive-review
 ```
 
 When the Session is `Ready`, connect from a terminal:
@@ -27,7 +27,7 @@ StatefulSet, Pod, governing Service, and persistent workspace and ends the
 conversation:
 
 ```bash
-kubectl delete session interactive-review
+kelos delete session interactive-review
 ```
 
 To use another supported provider, set `spec.worker.type` to `codex` or

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -18,10 +18,12 @@ func TestValidArgsFunctionWired(t *testing.T) {
 		{"get taskspawner", []string{"get", "taskspawner"}},
 		{"get workspace", []string{"get", "workspace"}},
 		{"get workerpool", []string{"get", "workerpool"}},
+		{"get session", []string{"get", "session"}},
 		{"delete task", []string{"delete", "task"}},
 		{"delete workspace", []string{"delete", "workspace"}},
 		{"delete taskspawner", []string{"delete", "taskspawner"}},
 		{"delete workerpool", []string{"delete", "workerpool"}},
+		{"delete session", []string{"delete", "session"}},
 		{"logs", []string{"logs"}},
 		{"session connect", []string{"session", "connect"}},
 	}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -27,6 +27,7 @@ func newDeleteCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.AddCommand(newDeleteTaskSpawnerCommand(cfg))
 	cmd.AddCommand(newDeleteAgentConfigCommand(cfg))
 	cmd.AddCommand(newDeleteWorkerPoolCommand(cfg))
+	cmd.AddCommand(newDeleteSessionCommand(cfg))
 
 	return cmd
 }

--- a/internal/cli/delete_session.go
+++ b/internal/cli/delete_session.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+)
+
+func newDeleteSessionCommand(cfg *ClientConfig) *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:     "session [name]",
+		Aliases: []string{"sessions", "sess"},
+		Short:   "Delete a session",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if all && len(args) > 0 {
+				return fmt.Errorf("cannot specify session name with --all")
+			}
+			if !all {
+				if len(args) == 0 {
+					return fmt.Errorf("session name is required (or use --all)\nUsage: %s", cmd.Use)
+				}
+				if len(args) > 1 {
+					return fmt.Errorf("too many arguments: expected 1 session name, got %d\nUsage: %s", len(args), cmd.Use)
+				}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cl, namespace, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+			return runDeleteSession(cmd.Context(), cl, namespace, args, all, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Delete all sessions in the namespace")
+	cmd.ValidArgsFunction = completeSessionNames(cfg)
+
+	return cmd
+}
+
+func runDeleteSession(ctx context.Context, cl client.Client, namespace string, args []string, all bool, out io.Writer) error {
+	if all {
+		sessionList := &kelos.SessionList{}
+		if err := cl.List(ctx, sessionList, client.InNamespace(namespace)); err != nil {
+			return fmt.Errorf("listing sessions: %w", err)
+		}
+		if len(sessionList.Items) == 0 {
+			fmt.Fprintln(out, "No sessions found")
+			return nil
+		}
+		for i := range sessionList.Items {
+			if err := cl.Delete(ctx, &sessionList.Items[i]); err != nil {
+				return fmt.Errorf("deleting session %s: %w", sessionList.Items[i].Name, err)
+			}
+			fmt.Fprintf(out, "session/%s deleted\n", sessionList.Items[i].Name)
+		}
+		return nil
+	}
+
+	name := args[0]
+	session := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if err := cl.Delete(ctx, session); err != nil {
+		return fmt.Errorf("deleting session %s: %w", name, err)
+	}
+	fmt.Fprintf(out, "session/%s deleted\n", name)
+	return nil
+}

--- a/internal/cli/delete_session_test.go
+++ b/internal/cli/delete_session_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+)
+
+func TestRunDeleteSessionDeletesNamedSession(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testSession("chat", "default")).Build()
+
+	var out strings.Builder
+	if err := runDeleteSession(ctx, cl, "default", []string{"chat"}, false, &out); err != nil {
+		t.Fatalf("runDeleteSession: %v", err)
+	}
+
+	err := cl.Get(ctx, client.ObjectKey{Name: "chat", Namespace: "default"}, &kelos.Session{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected session to be deleted, got error %v", err)
+	}
+	if out.String() != "session/chat deleted\n" {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestRunDeleteSessionAllDeletesSessionsInNamespace(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		testSession("chat-a", "default"),
+		testSession("chat-b", "default"),
+		testSession("chat-c", "other"),
+	).Build()
+
+	var out strings.Builder
+	if err := runDeleteSession(ctx, cl, "default", nil, true, &out); err != nil {
+		t.Fatalf("runDeleteSession: %v", err)
+	}
+
+	for _, name := range []string{"chat-a", "chat-b"} {
+		err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &kelos.Session{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected session %s to be deleted, got error %v", name, err)
+		}
+	}
+	if err := cl.Get(ctx, client.ObjectKey{Name: "chat-c", Namespace: "other"}, &kelos.Session{}); err != nil {
+		t.Fatalf("expected session in other namespace to remain: %v", err)
+	}
+
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	slices.Sort(gotLines)
+	wantLines := []string{"session/chat-a deleted", "session/chat-b deleted"}
+	if !slices.Equal(gotLines, wantLines) {
+		t.Fatalf("unexpected output lines: got %v, want %v", gotLines, wantLines)
+	}
+}
+
+func TestRunDeleteSessionAllNoSessions(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	var out strings.Builder
+	if err := runDeleteSession(context.Background(), cl, "default", nil, true, &out); err != nil {
+		t.Fatalf("runDeleteSession: %v", err)
+	}
+	if out.String() != "No sessions found\n" {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -30,6 +30,7 @@ func newGetCommand(cfg *ClientConfig) *cobra.Command {
 	cmd.AddCommand(newGetWorkspaceCommand(cfg, &allNamespaces))
 	cmd.AddCommand(newGetAgentConfigCommand(cfg, &allNamespaces))
 	cmd.AddCommand(newGetWorkerPoolCommand(cfg, &allNamespaces))
+	cmd.AddCommand(newGetSessionCommand(cfg, &allNamespaces))
 
 	return cmd
 }

--- a/internal/cli/get_session.go
+++ b/internal/cli/get_session.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+)
+
+func newGetSessionCommand(cfg *ClientConfig, allNamespaces *bool) *cobra.Command {
+	var output string
+	var detail bool
+
+	cmd := &cobra.Command{
+		Use:     "session [name]",
+		Aliases: []string{"sessions", "sess"},
+		Short:   "List sessions or get a specific session",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if output != "" && output != "yaml" && output != "json" {
+				return fmt.Errorf("unknown output format %q: must be one of yaml, json", output)
+			}
+			if *allNamespaces && len(args) == 1 {
+				return fmt.Errorf("a resource cannot be retrieved by name across all namespaces")
+			}
+
+			cl, namespace, err := cfg.NewClient()
+			if err != nil {
+				return err
+			}
+			return runGetSession(cmd.Context(), cl, namespace, args, *allNamespaces, output, detail, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format (yaml or json)")
+	cmd.Flags().BoolVarP(&detail, "detail", "d", false, "Show detailed information for a specific session")
+	cmd.ValidArgsFunction = completeSessionNames(cfg)
+	_ = cmd.RegisterFlagCompletionFunc("output", cobra.FixedCompletions([]string{"yaml", "json"}, cobra.ShellCompDirectiveNoFileComp))
+
+	return cmd
+}
+
+func runGetSession(
+	ctx context.Context,
+	cl client.Client,
+	namespace string,
+	args []string,
+	allNamespaces bool,
+	output string,
+	detail bool,
+	out io.Writer,
+) error {
+	if len(args) == 1 {
+		name := args[0]
+		session := &kelos.Session{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, session); err != nil {
+			return fmt.Errorf("getting session %s: %w", name, err)
+		}
+
+		session.SetGroupVersionKind(kelos.GroupVersion.WithKind("Session"))
+		switch output {
+		case "yaml":
+			return printYAML(out, session)
+		case "json":
+			return printJSON(out, session)
+		default:
+			if detail {
+				printSessionDetail(out, session)
+			} else {
+				printSessionTable(out, []kelos.Session{*session}, false)
+			}
+			return nil
+		}
+	}
+
+	sessionList := &kelos.SessionList{}
+	var listOptions []client.ListOption
+	if !allNamespaces {
+		listOptions = append(listOptions, client.InNamespace(namespace))
+	}
+	if err := cl.List(ctx, sessionList, listOptions...); err != nil {
+		return fmt.Errorf("listing sessions: %w", err)
+	}
+
+	sessionList.SetGroupVersionKind(kelos.GroupVersion.WithKind("SessionList"))
+	switch output {
+	case "yaml":
+		return printYAML(out, sessionList)
+	case "json":
+		return printJSON(out, sessionList)
+	default:
+		printSessionTable(out, sessionList.Items, allNamespaces)
+		return nil
+	}
+}

--- a/internal/cli/get_session_test.go
+++ b/internal/cli/get_session_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+)
+
+func TestRunGetSessionGetsNamedSession(t *testing.T) {
+	ctx := context.Background()
+	session := testSession("chat", "default")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(session).Build()
+
+	var out strings.Builder
+	if err := runGetSession(ctx, cl, "default", []string{"chat"}, false, "", false, &out); err != nil {
+		t.Fatalf("runGetSession: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("unexpected output lines: %q", out.String())
+	}
+	if fields := strings.Fields(lines[0]); !slices.Equal(fields, []string{"NAME", "TYPE", "PHASE", "POD", "AGE"}) {
+		t.Fatalf("unexpected header fields: %v", fields)
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) < 5 || !slices.Equal(fields[:4], []string{"chat", "codex", "Ready", "chat-0"}) {
+		t.Fatalf("unexpected session fields: %v", fields)
+	}
+}
+
+func TestRunGetSessionListsAllNamespaces(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		testSession("chat-a", "team-a"),
+		testSession("chat-b", "team-b"),
+	).Build()
+
+	var out strings.Builder
+	if err := runGetSession(ctx, cl, "default", nil, true, "", false, &out); err != nil {
+		t.Fatalf("runGetSession: %v", err)
+	}
+
+	output := out.String()
+	for _, pattern := range []string{
+		`(?m)^NAMESPACE\s+NAME\s+TYPE\s+PHASE\s+POD\s+AGE$`,
+		`(?m)^team-a\s+chat-a\s+codex\s+Ready\s+chat-a-0\s+\S+$`,
+		`(?m)^team-b\s+chat-b\s+codex\s+Ready\s+chat-b-0\s+\S+$`,
+	} {
+		if !regexp.MustCompile(pattern).MatchString(output) {
+			t.Errorf("output did not match %q:\n%s", pattern, output)
+		}
+	}
+}
+
+func TestRunGetSessionPrintsYAML(t *testing.T) {
+	ctx := context.Background()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(testSession("chat", "default")).Build()
+
+	var out strings.Builder
+	if err := runGetSession(ctx, cl, "default", []string{"chat"}, false, "yaml", false, &out); err != nil {
+		t.Fatalf("runGetSession: %v", err)
+	}
+
+	for _, expected := range []string{"apiVersion: kelos.dev/v1alpha2", "kind: Session", "name: chat"} {
+		if !strings.Contains(out.String(), expected) {
+			t.Errorf("expected %q in YAML output:\n%s", expected, out.String())
+		}
+	}
+}
+
+func TestRunGetSessionPrintsDetail(t *testing.T) {
+	ctx := context.Background()
+	session := testSession("chat", "default")
+	storageClass := "fast"
+	session.Spec.Worker.WorkspaceRef = &kelos.WorkspaceReference{Name: "repo"}
+	session.Spec.Worker.AgentConfigRefs = []kelos.AgentConfigReference{{Name: "reviewer"}}
+	session.Spec.VolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{
+		StorageClassName: &storageClass,
+		Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse("10Gi"),
+		}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(session).Build()
+
+	var out strings.Builder
+	if err := runGetSession(ctx, cl, "default", []string{"chat"}, false, "", true, &out); err != nil {
+		t.Fatalf("runGetSession: %v", err)
+	}
+
+	for _, pattern := range []string{
+		`(?m)^Name:\s+chat$`,
+		`(?m)^Workspace:\s+repo$`,
+		`(?m)^Agent Config:\s+reviewer$`,
+		`(?m)^Storage:\s+10Gi$`,
+		`(?m)^Storage Class:\s+fast$`,
+		`(?m)^Pod:\s+chat-0$`,
+	} {
+		if !regexp.MustCompile(pattern).MatchString(out.String()) {
+			t.Errorf("detail output did not match %q:\n%s", pattern, out.String())
+		}
+	}
+}
+
+func testSession(name, namespace string) *kelos.Session {
+	return &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+		},
+		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
+			Type: "codex",
+			Credentials: &kelos.Credentials{
+				Type:      kelos.CredentialTypeAPIKey,
+				SecretRef: &kelos.SecretReference{Name: "codex-credentials"},
+			},
+		}},
+		Status: kelos.SessionStatus{
+			Phase:   kelos.SessionPhaseReady,
+			PodName: name + "-0",
+		},
+	}
+}

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -18,6 +18,7 @@ func TestDetailFlagRegistered(t *testing.T) {
 		{"get workspace", []string{"get", "workspace"}},
 		{"get agentconfig", []string{"get", "agentconfig"}},
 		{"get workerpool", []string{"get", "workerpool"}},
+		{"get session", []string{"get", "session"}},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/printer.go
+++ b/internal/cli/printer.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
@@ -386,6 +387,71 @@ func printWorkerPoolDetail(w io.Writer, wp *kelos.WorkerPool) {
 	}
 	if wp.Status.Message != "" {
 		printField(w, "Message", wp.Status.Message)
+	}
+}
+
+func printSessionTable(w io.Writer, sessions []kelos.Session, allNamespaces bool) {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	if allNamespaces {
+		fmt.Fprintln(tw, "NAMESPACE\tNAME\tTYPE\tPHASE\tPOD\tAGE")
+	} else {
+		fmt.Fprintln(tw, "NAME\tTYPE\tPHASE\tPOD\tAGE")
+	}
+	for _, session := range sessions {
+		age := duration.HumanDuration(time.Since(session.CreationTimestamp.Time))
+		if allNamespaces {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				session.Namespace, session.Name, session.Spec.Worker.Type, session.Status.Phase, session.Status.PodName, age)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				session.Name, session.Spec.Worker.Type, session.Status.Phase, session.Status.PodName, age)
+		}
+	}
+	tw.Flush()
+}
+
+func printSessionDetail(w io.Writer, session *kelos.Session) {
+	printField(w, "Name", session.Name)
+	printField(w, "Namespace", session.Namespace)
+	printField(w, "Type", session.Spec.Worker.Type)
+	printField(w, "Phase", string(session.Status.Phase))
+	if credentials := session.Spec.Worker.Credentials; credentials != nil {
+		printField(w, "Credential Type", string(credentials.Type))
+		if credentials.SecretRef != nil {
+			printField(w, "Secret", credentials.SecretRef.Name)
+		}
+	}
+	if session.Spec.Worker.Model != "" {
+		printField(w, "Model", session.Spec.Worker.Model)
+	}
+	if session.Spec.Worker.Effort != "" {
+		printField(w, "Effort", session.Spec.Worker.Effort)
+	}
+	if session.Spec.Worker.Image != "" {
+		printField(w, "Image", session.Spec.Worker.Image)
+	}
+	if session.Spec.Worker.WorkspaceRef != nil {
+		printField(w, "Workspace", session.Spec.Worker.WorkspaceRef.Name)
+	}
+	if len(session.Spec.Worker.AgentConfigRefs) > 0 {
+		printField(w, "Agent Config", strings.Join(agentConfigRefNames(session.Spec.Worker.AgentConfigRefs), ","))
+	}
+	if claim := session.Spec.VolumeClaimTemplate; claim != nil {
+		if storage, ok := claim.Resources.Requests[corev1.ResourceStorage]; ok {
+			printField(w, "Storage", storage.String())
+		}
+		if claim.StorageClassName != nil {
+			printField(w, "Storage Class", *claim.StorageClassName)
+		}
+	}
+	if session.Status.PodName != "" {
+		printField(w, "Pod", session.Status.PodName)
+	}
+	if session.Status.PodUID != "" {
+		printField(w, "Pod UID", string(session.Status.PodUID))
+	}
+	if session.Status.Message != "" {
+		printField(w, "Message", session.Status.Message)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds Session support to the Kelos CLI resource commands so operators can list, inspect, and delete Sessions without switching to kubectl.

- Adds `kelos get session` with table, detail, YAML, JSON, and all-namespace output.
- Adds `kelos delete session` with named and `--all` deletion.
- Reuses Session name completion for both commands.
- Documents the new commands and updates the interactive Session example.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Session creation remains manifest- or web-driven. The existing `kelos session connect` command is unchanged.

Validation:

- `make test`
- `make verify`
- `make build WHAT=cmd/kelos`

#### Does this PR introduce a user-facing change?

```release-note
Add Session listing, detail output, deletion, and shell completion to the Kelos CLI.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Session resource support to the Kelos CLI so you can list, inspect, and delete Sessions without switching to kubectl. Also adds shell completion and updates docs and examples.

- **New Features**
  - `kelos get session [name]`: table view by default, `-d/--detail` for detailed info, `-o yaml|json`, and `--all-namespaces` support.
  - `kelos delete session [name]`: delete a specific Session or use `--all` to delete all in the namespace.
  - Shell completion for `get session`, `delete session`, and `session connect`; updated docs and the interactive Session example.

<sup>Written for commit c01105f8eb37b69c9e21273e35b97ac09e551f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

