### PR TITLE
Add Session support to Kelos skill

### DIFF
--- a/skills/kelos/SKILL.md
+++ b/skills/kelos/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: kelos
 description: >-
-  Use only for Kelos Kubernetes resource work: authoring/debugging Task,
-  Workspace, AgentConfig, or TaskSpawner manifests/CRDs, examples, generated
-  CRDs, self-development manifests, or live kelos/kubectl operations. Do not use
-  for ordinary Kelos repo code edits, tests, reviews, build/CI, or git tasks
-  unless they involve those resources.
-compatibility: Requires kubectl and cluster access only for live operations
+  Author, debug, and operate Kelos resources (Task, Session, Workspace,
+  AgentConfig, TaskSpawner) on Kubernetes. Use for Kelos CRDs, resource
+  manifests, the kelos CLI, or live cluster operations. Do not use for ordinary
+  Kelos repo code edits, tests, reviews, build/CI, or git tasks unless they
+  involve those resources.
 ---
 
 # Kelos Skill
@@ -19,7 +18,7 @@ user's request.
 
 Use this skill for:
 
-- Authoring or editing Kelos manifests for `Task`, `Workspace`, `AgentConfig`, or `TaskSpawner`.
+- Authoring or editing Kelos manifests for `Task`, `Session`, `Workspace`, `AgentConfig`, or `TaskSpawner`.
 - Debugging live Kelos resources on Kubernetes with `kelos` or `kubectl`.
 - Operating Kelos installs, task runs, logs, suspension, deletion, or cluster resources.
 - Editing Kelos CRD/API examples, generated CRDs, self-development manifests, or docs that describe resource fields.
@@ -45,17 +44,20 @@ Kelos resources use `apiVersion: kelos.dev/v1alpha2`.
 | Resource | Purpose | Key fields |
 | --- | --- | --- |
 | `Task` | Single agent run | `spec.type`, `spec.prompt`, `spec.credentials`, `spec.workspaceRef`, `spec.agentConfigRefs[]`, `spec.branch`, `spec.dependsOn`, `spec.model`, `spec.effort`, `spec.podOverrides`, `spec.ttlSecondsAfterFinished` |
+| `Session` | Persistent interactive agent conversation | `spec.worker`, `spec.volumeClaimTemplate` |
 | `Workspace` | Git repository for the agent | `spec.repo`, `spec.ref`, `spec.secretRef`, `spec.remotes`, `spec.files` |
 | `AgentConfig` | Reusable instructions and tools | `spec.agentsMD`, `spec.plugins`, `spec.skills`, `spec.mcpServers` |
 | `TaskSpawner` | Creates Tasks from external sources | `spec.when.githubIssues`, `spec.when.githubPullRequests`, `spec.when.cron`, `spec.when.jira`, per-source `pollInterval`, `spec.taskTemplate`, `spec.maxConcurrency`, `spec.maxTotalTasks`, `spec.suspend` |
 
 Task phases are `Pending`, `Waiting`, `Running`, `Succeeded`, and `Failed`.
+Session phases are `Pending`, `Ready`, and `Failed`.
 
 ## References
 
 | Need | Read |
 | --- | --- |
 | Task examples, credentials, dependencies, branch locks, pod overrides, TTL | `references/task.yaml` |
+| Session examples, worker configuration, ephemeral or persistent storage | `references/session.yaml` |
 | Workspace examples, repository auth, remotes, injected files | `references/workspace.yaml` |
 | AgentConfig examples, plugins, skills, agents, MCP servers | `references/agentconfig.yaml` |
 | TaskSpawner examples, GitHub/Jira/cron sources, comment policy, concurrency | `references/taskspawner.yaml` |
@@ -81,13 +83,17 @@ kelos create workspace my-ws --repo https://github.com/org/repo.git --ref main -
 kelos create agentconfig my-ac --skill review=@review.md --dry-run
 
 kelos get tasks
+kelos get sessions
 kelos get task my-task -d
 kelos get task my-task -o yaml
+kelos get session my-session -d
+kelos session connect my-session
 kelos logs my-task -f
 
 kelos suspend taskspawner my-spawner
 kelos resume taskspawner my-spawner
 kelos delete task my-task
+kelos delete session my-session
 ```
 
 ## Operational Workflow

--- a/skills/kelos/references/cli.md
+++ b/skills/kelos/references/cli.md
@@ -72,16 +72,20 @@ current UTC time and configured schedule by default.
 
 ```bash
 kelos get tasks
+kelos get sessions
 kelos get taskspawners
 kelos get workspaces
 
 kelos get task my-task -d
 kelos get task my-task -o yaml
+kelos get session my-session -d
+kelos session connect my-session
 kelos logs my-task -f
 
 kelos suspend taskspawner my-spawner
 kelos resume taskspawner my-spawner
 kelos delete task my-task
+kelos delete session my-session
 ```
 
 ## Supported Agent Types

--- a/skills/kelos/references/session.yaml
+++ b/skills/kelos/references/session.yaml
@@ -1,0 +1,46 @@
+# Session with an ephemeral workspace
+apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: interactive-review
+spec:
+  worker:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials
+---
+# Session with a persistent workspace, repository, and agent configuration
+apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: persistent-review
+spec:
+  worker:
+    type: codex
+    credentials:
+      type: oauth
+      secretRef:
+        name: codex-credentials
+    workspaceRef:
+      name: my-workspace
+    agentConfigRefs:
+      - name: code-reviewer
+  volumeClaimTemplate:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+---
+# OpenCode Session without built-in credential injection
+apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: opencode-chat
+spec:
+  worker:
+    type: opencode
+    credentials:
+      type: none

--- a/skills/kelos/references/troubleshooting.md
+++ b/skills/kelos/references/troubleshooting.md
@@ -22,6 +22,16 @@ failure state.
 - Review pod logs with `kelos logs <task-name>` or
   `kubectl logs -l job-name=<job-name>`.
 
+## Session Stuck In Pending Or Failed
+
+- Inspect the Session status with `kelos get session <name> -d` or
+  `kubectl get session <name> -o yaml`.
+- Check whether the credentials Secret, Workspace, and AgentConfig resources
+  referenced by `spec.worker` exist.
+- Check controller logs: `kubectl logs deployment/kelos-controller-manager -n kelos-system`.
+- Inspect the Session Pod only after checking the status reason and referenced
+  resources. Do not print Secret values.
+
 ## TaskSpawner Not Creating Tasks
 
 - Check spawner status: `kubectl get taskspawner <name> -o yaml`.


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Updates the Kelos skill from the current personal skill while preserving the repository's progressive-disclosure structure.

The skill now covers Session resources, including worker and storage configuration, CLI operations, troubleshooting guidance, and reusable YAML examples.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The shared Task, Workspace, AgentConfig, and TaskSpawner YAML references already matched the source skill, so this PR keeps them unchanged.

Validation:

- `quick_validate.py skills/kelos`
- `git diff --check`
- `make verify` *(fails because pre-existing untracked `get_helm.sh` and `.git/logs/refs/heads/support-skills.sh` are included by the shell-format check)*

#### Does this PR introduce a user-facing change?

```release-note
The Kelos skill now supports authoring, operating, and troubleshooting Session resources.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Session support to the Kelos skill so users can author, operate, and troubleshoot `Session` resources with clear examples and CLI guidance. Improves discoverability with concise docs and reusable YAML.

- **New Features**
  - Added `Session` docs to SKILL.md, including phases and reference to `references/session.yaml`.
  - Introduced `references/session.yaml` with ephemeral and persistent workspace examples, worker credentials, and PVC config.
  - Updated CLI and troubleshooting refs with `kelos get sessions`, `kelos get session`, `kelos session connect`, and delete commands, plus guidance for Sessions stuck in Pending/Failed.

<sup>Written for commit 2a348c5fc35d6c5300c5249731bbb3741b80c8b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

