### PR TITLE
Add self-development session helper

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -9,6 +9,10 @@ repository while keeping the configuration in this repo.
 The nested [`kanon/`](kanon/README.md) directory does the same for the sibling
 [`kelos-dev/kanon`](https://github.com/kelos-dev/kanon) repository.
 
+[`cs`](cs) creates persistent interactive Codex environments for developing
+Kelos with the same Workspace, credentials, model, effort, and Git identity as
+the `kelos-workers` TaskSpawner.
+
 ## How It Works
 
 <img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/10719599-426e-4c3d-87a0-cde43e1b3113" />
@@ -389,6 +393,29 @@ Rebases and squashes PR branch commits into a single clean commit when a maintai
 ```bash
 kubectl apply -f self-development/kelos-squash-commits.yaml
 ```
+
+## Interactive Development Session
+
+`cs NAME` creates a persistent Codex Session with the same Workspace,
+credentials, model, effort, and Git identity as `kelos-workers`. It does not use
+the worker's resource settings or AgentConfig, allowing namespace resource
+defaults to apply without the instructions for an ephemeral autonomous GitHub
+bot.
+
+The Session requires the `kelos-agent` Workspace and `kelos-credentials` Secret
+described below. Its `10Gi` workspace persists across Pod replacement and is
+deleted with the Session.
+
+Add this directory to your `PATH` and run the script from any directory:
+
+```bash
+export PATH="$PWD/self-development:$PATH"
+cs my-session
+```
+
+`cs` embeds the Session manifest and uses the current kubectl context and
+namespace. It fails if that name already exists and prints the `kelos session
+connect` command after creation.
 
 ## Prerequisites
 

--- a/self-development/cs
+++ b/self-development/cs
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+  echo "Usage: cs NAME" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+name=$1
+if [[ ${#name} -gt 253 || ! $name =~ ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$ ]]; then
+  echo "Session name must be a lowercase Kubernetes DNS name" >&2
+  exit 2
+fi
+
+kubectl create -f - <<EOF
+apiVersion: kelos.dev/v1alpha2
+kind: Session
+metadata:
+  name: ${name}
+spec:
+  volumeClaimTemplate:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  worker:
+    workspaceRef:
+      name: kelos-agent
+    model: gpt-5.6-sol
+    effort: xhigh
+    type: codex
+    credentials:
+      type: oauth
+      secretRef:
+        name: kelos-credentials
+    podOverrides:
+      env:
+        - name: GIT_AUTHOR_NAME
+          value: "Gunju Kim"
+        - name: GIT_AUTHOR_EMAIL
+          value: "gjkim042@gmail.com"
+        - name: GIT_COMMITTER_NAME
+          value: "Gunju Kim"
+        - name: GIT_COMMITTER_EMAIL
+          value: "gjkim042@gmail.com"
+EOF
+
+echo "Connect with: kelos session connect $name"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds an executable `self-development/cs` helper that creates a named,
persistent Codex Session from an embedded manifest. The Session mirrors the
Workspace, credentials, model, effort, and Git identity used by
`kelos-workers`, while allowing namespace resource defaults to apply.

This provides a concise `cs NAME` workflow for starting personal interactive
Kelos development environments without maintaining or editing a separate
Session manifest.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The helper uses the current kubectl context and namespace, validates the
Session name before interpolation, and uses `kubectl create` so an existing
Session is not modified.

Validation:

- `make verify`
- Server-side dry run of the embedded Session manifest against a kind cluster

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `self-development/cs`, a helper to create a named, persistent Codex Session for personal Kelos development with the same Workspace, credentials, model, effort, and Git identity as `kelos-workers`. Enables a simple `cs NAME` workflow without maintaining a separate manifest.

- **New Features**
  - Embedded manifest creates a Session with a 10Gi persistent workspace.
  - Uses current kubectl context/namespace; validates DNS-safe name; uses `kubectl create` to avoid modifying existing Sessions.
  - Prints the `kelos session connect NAME` command after creation.
  - Adds README usage and prerequisites.

<sup>Written for commit 8982b80a531b2915223ce9ae1c2e50dc22a972c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

