### PR TITLE
Update local kind deployment

### DIFF
--- a/local-run.sh
+++ b/local-run.sh
@@ -7,6 +7,7 @@ set -o pipefail
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 REGISTRY="${REGISTRY:-ghcr.io/kelos-dev}"
 LOCAL_IMAGE_TAG="${LOCAL_IMAGE_TAG:-local-dev}"
+KELOS_SESSION_TOKEN="${KELOS_SESSION_TOKEN:-local-dev}"
 if ! command -v kind >/dev/null 2>&1; then
   echo "Kind CLI not found in PATH" >&2
   exit 1
@@ -22,18 +23,57 @@ make image REGISTRY="${REGISTRY}" VERSION="${LOCAL_IMAGE_TAG}"
 images=(
   "${REGISTRY}/kelos-controller:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/kelos-spawner:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-worker-runner:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-session-runtime:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-session-server:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/ghproxy:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-webhook-server:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/claude-code:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/codex:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/gemini:${LOCAL_IMAGE_TAG}"
   "${REGISTRY}/opencode:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/cursor:${LOCAL_IMAGE_TAG}"
+  "${REGISTRY}/kelos-slack-server:${LOCAL_IMAGE_TAG}"
 )
 
 for image in "${images[@]}"; do
   kind load docker-image --name "${KIND_CLUSTER_NAME}" "${image}"
 done
 
-go install github.com/kelos-dev/kelos/cmd/kelos
+make build WHAT=cmd/kelos
 
-kelos install --version "${LOCAL_IMAGE_TAG}" --image-pull-policy IfNotPresent
+kubectl create namespace kelos-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic kelos-session-server-auth \
+  --namespace kelos-system \
+  --from-file=token=<(printf '%s' "${KELOS_SESSION_TOKEN}") \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+bin/kelos install --version "${LOCAL_IMAGE_TAG}" --image-pull-policy Never --values - <<EOF
+controllerImage: "${REGISTRY}/kelos-controller"
+ghproxy:
+  image: "${REGISTRY}/ghproxy"
+claudeCodeImage: "${REGISTRY}/claude-code"
+codexImage: "${REGISTRY}/codex"
+geminiImage: "${REGISTRY}/gemini"
+opencodeImage: "${REGISTRY}/opencode"
+cursorImage: "${REGISTRY}/cursor"
+spawner:
+  image: "${REGISTRY}/kelos-spawner"
+workerRunner:
+  image: "${REGISTRY}/kelos-worker-runner"
+sessionRuntime:
+  image: "${REGISTRY}/kelos-session-runtime"
+sessionServer:
+  enabled: true
+  image: "${REGISTRY}/kelos-session-server"
+  secretName: kelos-session-server-auth
+webhookServer:
+  image: "${REGISTRY}/kelos-webhook-server"
+slackServer:
+  image: "${REGISTRY}/kelos-slack-server"
+EOF
+
 kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
+kubectl rollout restart deployment/kelos-session-server -n kelos-system
 kubectl rollout status deployment/kelos-controller-manager -n kelos-system
+kubectl rollout status deployment/kelos-session-server -n kelos-system


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates `local-run.sh` so a local kind deployment uses all images built from the current checkout, including the worker, Session, webhook, Cursor, ghproxy, and Slack images. The script now builds the Kelos CLI through the Makefile, installs with `imagePullPolicy: Never`, and embeds Helm values that enable `kelos-session-server` with an idempotently managed local authentication Secret.

The image list and install path had fallen behind the current codebase, so local clusters could use incomplete or stale components instead of the code being tested.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `KELOS_SESSION_TOKEN` defaults to `local-dev` and can be overridden for the local cluster.
- The Session server remains a cluster-internal Service and can be accessed with `kubectl port-forward -n kelos-system service/kelos-session-server 8080:80`.
- Validated with `make test`, shell syntax and formatting checks, a complete `./local-run.sh` deployment to kind, and an HTTP readiness probe through the Session Service.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `local-run.sh` to build/load all images from the current checkout, wire Helm values so every component uses local images, and enable the Session server with a local auth Secret for reliable kind deployments. Builds `kelos` via Make and installs with `imagePullPolicy: Never`.

- **Refactors**
  - Builds and loads: `kelos-worker-runner`, `kelos-session-runtime`, `kelos-session-server`, `kelos-webhook-server`, `ghproxy`, `cursor`, and `kelos-slack-server`.
  - Uses `make build WHAT=cmd/kelos` and installs via `bin/kelos` with `--image-pull-policy Never`, setting image values for controller, spawner, runner, session runtime/server, webhook, `ghproxy`, `cursor`, Slack, and model images.
  - Creates `kelos-system` and `kelos-session-server-auth` (token from `KELOS_SESSION_TOKEN`, defaults to `local-dev`).
  - Restarts and waits for `kelos-controller-manager` and `kelos-session-server`.

<sup>Written for commit 402756285d170b7aec7fb27c2eefb13b04a23aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

