### PR TITLE
Add Session file changes views

### DIFF
--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -98,6 +98,66 @@ func TestSessionFormUsesResourceSelectors(t *testing.T) {
 	}
 }
 
+func TestApplicationIncludesFileChangesView(t *testing.T) {
+	server := testServer(t)
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	for _, expected := range []string{
+		`id="conversation-tab" type="button" role="tab" aria-selected="true" aria-controls="messages" tabindex="0"`,
+		`id="changes-tab" type="button" role="tab" aria-selected="false" aria-controls="changes-view" tabindex="-1"`,
+		`id="changes-count"`,
+		`id="changes-view"`,
+		`id="changes-list"`,
+		`No file changes yet.`,
+	} {
+		if !strings.Contains(response.Body.String(), expected) {
+			t.Errorf("Session application does not contain %s", expected)
+		}
+	}
+
+	javascript, err := webFiles.ReadFile("web/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		`state.fileChanges.set(file.name, file.diff)`,
+		`state.diffs.set(key, block)`,
+		`renderFileChangeList(block.list, block.files, openFiles)`,
+		`const path = normalizeDiffPath(header.slice(prefix.length))`,
+		`const rawPath = value.split('\t', 1)[0]`,
+		`return new TextDecoder().decode(new Uint8Array(bytes))`,
+		`!line.startsWith('+++ ')`,
+		`!line.startsWith('--- ')`,
+		`elements.viewTabs.addEventListener('keydown', handleViewTabKeydown)`,
+	} {
+		if !strings.Contains(string(javascript), expected) {
+			t.Errorf("file changes JavaScript does not contain %q", expected)
+		}
+	}
+
+	styles, err := webFiles.ReadFile("web/styles.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		`.diff-card .file-change`,
+		`.diff-line.added`,
+		`.diff-line.removed`,
+		`--diff-added-bg:#173424`,
+		`--diff-removed-bg:#3a2020`,
+	} {
+		if !strings.Contains(string(styles), expected) {
+			t.Errorf("file changes styles do not contain %q", expected)
+		}
+	}
+}
+
 func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
 	server := testServer(t)
 	payload := `{

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -3,7 +3,15 @@ const elements = {
   title: document.querySelector('#session-title'),
   meta: document.querySelector('#session-meta'),
   messages: document.querySelector('#messages'),
+  changes: document.querySelector('#changes-view'),
+  changesList: document.querySelector('#changes-list'),
+  changesSummary: document.querySelector('#changes-summary'),
+  changesCount: document.querySelector('#changes-count'),
+  viewTabs: document.querySelector('.view-tabs'),
+  conversationTab: document.querySelector('#conversation-tab'),
+  changesTab: document.querySelector('#changes-tab'),
   welcome: document.querySelector('#welcome'),
+  composerWrap: document.querySelector('.composer-wrap'),
   composer: document.querySelector('#composer'),
   input: document.querySelector('#message-input'),
   send: document.querySelector('#send-message'),
@@ -51,6 +59,7 @@ const state = {
   tools: new Map(),
   inputs: new Map(),
   diffs: new Map(),
+  fileChanges: new Map(),
   queuedMessages: new Map(),
   activeTurn: false,
   interrupting: false,
@@ -387,11 +396,14 @@ function selectSession(session) {
   state.tools.clear();
   state.inputs.clear();
   state.diffs.clear();
+  state.fileChanges.clear();
   state.queuedMessages.clear();
   elements.queue.replaceChildren();
   elements.queue.hidden = true;
   state.activeTurn = false;
   state.interrupting = false;
+  setActiveView('conversation');
+  renderFileChanges();
   elements.messages.replaceChildren();
   renderSessions();
   renderHeader();
@@ -425,6 +437,8 @@ function createWelcome() {
 function renderHeader() {
   const session = state.selected;
   elements.deleteButton.disabled = !session;
+  elements.conversationTab.disabled = !session;
+  elements.changesTab.disabled = !session;
   updateComposerAction();
   if (!session) {
     elements.title.textContent = 'Choose a session';
@@ -846,23 +860,231 @@ function resolveInputCard(event) {
 
 function renderDiff(event) {
   if (!event.diff) return;
+  const files = parseFileDiffs(event.diff);
+  updateFileChanges(files);
   const key = event.turnId || `diff-${event.id || 'current'}`;
-  const existing = state.diffs.get(key);
-  if (existing) {
-    existing.textContent = event.diff;
+  let block = state.diffs.get(key);
+  const created = !block;
+  if (!block) {
+    ensureConversation();
+    const card = document.createElement('section');
+    card.className = 'diff-card';
+    card.setAttribute('aria-label', 'File changes');
+    const header = document.createElement('div');
+    header.className = 'diff-card-header';
+    const title = document.createElement('strong');
+    title.textContent = 'File changes';
+    const count = document.createElement('span');
+    const list = document.createElement('div');
+    list.className = 'changes-list';
+    header.append(title, count);
+    card.append(header, list);
+    elements.messages.append(card);
+    block = {count, list, files: new Map()};
+    state.diffs.set(key, block);
+  }
+  for (const file of files) block.files.set(file.name, file.diff);
+  renderDiffBlock(block, created);
+  if (created) scrollToBottom();
+}
+
+function updateFileChanges(files) {
+  for (const file of files) state.fileChanges.set(file.name, file.diff);
+  renderFileChanges();
+}
+
+function parseFileDiffs(diff) {
+  const lines = diff.split('\n');
+  const starts = [];
+  lines.forEach((line, index) => {
+    if (line.startsWith('diff --git ') || /^\*\*\* (?:Add|Delete|Update) File: /.test(line)) starts.push(index);
+  });
+  if (!starts.length) starts.push(0);
+
+  return starts.map((start, index) => {
+    const segment = lines.slice(start, starts[index + 1] ?? lines.length);
+    return {name: diffFileName(segment) || 'File changes', diff: segment.join('\n')};
+  });
+}
+
+function diffFileName(lines) {
+  const patchHeader = lines.find(line => /^\*\*\* (?:Add|Delete|Update) File: /.test(line));
+  if (patchHeader) return patchHeader.replace(/^\*\*\* (?:Add|Delete|Update) File: /, '');
+
+  for (const prefix of ['+++ ', '--- ']) {
+    const header = lines.find(line => line.startsWith(prefix));
+    if (!header) continue;
+    const path = normalizeDiffPath(header.slice(prefix.length));
+    if (path !== '/dev/null') return path;
+  }
+
+  const header = lines.find(line => line.startsWith('diff --git '));
+  if (!header) return '';
+  const quotedPath = header.match(/ ("(?:\\.|[^"\\])*")$/)?.[1];
+  if (quotedPath) return normalizeDiffPath(quotedPath);
+  const separator = header.lastIndexOf(' b/');
+  return normalizeDiffPath(separator < 0 ? header.slice('diff --git '.length) : header.slice(separator + 1));
+}
+
+function normalizeDiffPath(value) {
+  const rawPath = value.split('\t', 1)[0];
+  const path = rawPath.startsWith('"') && rawPath.endsWith('"')
+    ? decodeGitQuotedPath(rawPath.slice(1, -1))
+    : rawPath;
+  return path.replace(/^[ab]\//, '');
+}
+
+function decodeGitQuotedPath(value) {
+  const bytes = [];
+  const encoder = new TextEncoder();
+  const escapedBytes = {a: 7, b: 8, t: 9, n: 10, v: 11, f: 12, r: 13, '\\': 92, '"': 34};
+  const append = text => bytes.push(...encoder.encode(text));
+
+  for (let index = 0; index < value.length;) {
+    if (value[index] !== '\\') {
+      const character = String.fromCodePoint(value.codePointAt(index));
+      append(character);
+      index += character.length;
+      continue;
+    }
+
+    index++;
+    if (index === value.length) {
+      append('\\');
+      break;
+    }
+    const octal = value.slice(index).match(/^[0-7]{1,3}/)?.[0];
+    if (octal) {
+      bytes.push(Number.parseInt(octal, 8));
+      index += octal.length;
+      continue;
+    }
+    const escaped = value[index];
+    if (Object.prototype.hasOwnProperty.call(escapedBytes, escaped)) bytes.push(escapedBytes[escaped]);
+    else append(escaped);
+    index++;
+  }
+
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+function renderFileChanges() {
+  const openFiles = new Set(
+    [...elements.changesList.querySelectorAll('.file-change[open]')].map(item => item.dataset.path),
+  );
+  const count = state.fileChanges.size;
+  elements.changesCount.textContent = String(count);
+  elements.changesSummary.textContent = count === 1 ? '1 changed file' : `${count} changed files`;
+
+  if (!count) {
+    elements.changesList.replaceChildren();
+    const empty = document.createElement('div');
+    empty.className = 'changes-empty';
+    empty.textContent = state.selected ? 'No file changes yet.' : 'Choose a Session to inspect its file changes.';
+    elements.changesList.append(empty);
     return;
   }
-  ensureConversation();
-  const details = document.createElement('details');
-  details.className = 'diff-card';
-  const summary = document.createElement('summary');
-  summary.textContent = 'File changes';
-  const pre = document.createElement('pre');
-  pre.textContent = event.diff;
-  details.append(summary, pre);
-  elements.messages.append(details);
-  state.diffs.set(key, pre);
-  scrollToBottom();
+
+  renderFileChangeList(elements.changesList, state.fileChanges, openFiles);
+}
+
+function renderDiffBlock(block, created) {
+  const openFiles = new Set(
+    [...block.list.querySelectorAll('.file-change[open]')].map(item => item.dataset.path),
+  );
+  if (created && block.files.size === 1) openFiles.add(block.files.keys().next().value);
+  const count = block.files.size;
+  block.count.textContent = count === 1 ? '1 file' : `${count} files`;
+  renderFileChangeList(block.list, block.files, openFiles);
+}
+
+function renderFileChangeList(list, files, openFiles) {
+  list.replaceChildren();
+  for (const [path, diff] of files) {
+    const details = document.createElement('details');
+    details.className = 'file-change';
+    details.dataset.path = path;
+    details.open = openFiles.has(path);
+    const summary = document.createElement('summary');
+    const name = document.createElement('span');
+    name.className = 'file-change-name';
+    name.textContent = path;
+    const stats = diffStats(diff);
+    const stat = document.createElement('span');
+    stat.className = 'file-change-stat';
+    stat.setAttribute('aria-label', `${stats.added} additions and ${stats.removed} deletions`);
+    const added = document.createElement('span');
+    added.className = 'file-change-added';
+    added.textContent = `+${stats.added}`;
+    const removed = document.createElement('span');
+    removed.className = 'file-change-removed';
+    removed.textContent = `−${stats.removed}`;
+    stat.append(added, removed);
+    summary.append(name, stat);
+    details.append(summary, renderDiffLines(diff));
+    list.append(details);
+  }
+}
+
+function diffStats(diff) {
+  let added = 0;
+  let removed = 0;
+  for (const line of diff.split('\n')) {
+    const kind = diffChangeKind(line);
+    if (kind === 'added') added++;
+    if (kind === 'removed') removed++;
+  }
+  return {added, removed};
+}
+
+function diffChangeKind(line) {
+  if (line.startsWith('+') && !line.startsWith('+++ ')) return 'added';
+  if (line.startsWith('-') && !line.startsWith('--- ')) return 'removed';
+  return '';
+}
+
+function renderDiffLines(diff) {
+  const lines = document.createElement('div');
+  lines.className = 'diff-lines';
+  for (const text of diff.split('\n')) {
+    const line = document.createElement('div');
+    line.className = 'diff-line';
+    const kind = diffChangeKind(text);
+    if (kind) line.classList.add(kind);
+    if (text.startsWith('@@')) line.classList.add('hunk');
+    if (/^(diff --git |index |--- |\+\+\+ )/.test(text)) line.classList.add('metadata');
+    line.textContent = text || ' ';
+    lines.append(line);
+  }
+  return lines;
+}
+
+function setActiveView(view) {
+  const changesActive = view === 'changes';
+  elements.messages.hidden = changesActive;
+  elements.composerWrap.hidden = changesActive;
+  elements.changes.hidden = !changesActive;
+  elements.conversationTab.setAttribute('aria-selected', String(!changesActive));
+  elements.changesTab.setAttribute('aria-selected', String(changesActive));
+  elements.conversationTab.tabIndex = changesActive ? -1 : 0;
+  elements.changesTab.tabIndex = changesActive ? 0 : -1;
+}
+
+function handleViewTabKeydown(event) {
+  const tabs = [elements.conversationTab, elements.changesTab].filter(tab => !tab.disabled);
+  const current = tabs.indexOf(event.target);
+  if (current < 0) return;
+
+  let target;
+  if (event.key === 'ArrowLeft') target = tabs[(current - 1 + tabs.length) % tabs.length];
+  if (event.key === 'ArrowRight') target = tabs[(current + 1) % tabs.length];
+  if (event.key === 'Home') target = tabs[0];
+  if (event.key === 'End') target = tabs[tabs.length - 1];
+  if (!target) return;
+
+  event.preventDefault();
+  target.click();
+  target.focus();
 }
 
 function renderError(event) {
@@ -1072,6 +1294,9 @@ elements.deleteButton.addEventListener('click', async () => {
     showToast(error.message);
   }
 });
+elements.conversationTab.addEventListener('click', () => setActiveView('conversation'));
+elements.changesTab.addEventListener('click', () => setActiveView('changes'));
+elements.viewTabs.addEventListener('keydown', handleViewTabKeydown);
 
 function interruptActiveTurn() {
   if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn || state.interrupting) return;

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -44,17 +44,33 @@
           <div class="session-meta" id="session-meta">Select an existing conversation or create one.</div>
         </div>
         <div class="header-actions">
+          <div class="view-tabs" role="tablist" aria-label="Session view">
+            <button id="conversation-tab" type="button" role="tab" aria-selected="true" aria-controls="messages" tabindex="0" disabled>Conversation</button>
+            <button id="changes-tab" type="button" role="tab" aria-selected="false" aria-controls="changes-view" tabindex="-1" disabled>Changes <span id="changes-count">0</span></button>
+          </div>
           <span class="connection-pill" id="connection-pill" data-state="idle"><span></span>Not connected</span>
           <button class="icon-button danger" id="delete-session" aria-label="Delete session" title="Delete session" disabled>⌫</button>
         </div>
       </header>
 
-      <section class="messages" id="messages" aria-live="polite">
+      <section class="messages" id="messages" role="tabpanel" aria-labelledby="conversation-tab" aria-live="polite">
         <div class="welcome" id="welcome">
           <div class="welcome-orbit"><span>K</span></div>
           <h1>A workspace that keeps the thread</h1>
           <p>Start with Claude Code, Codex, or OpenCode, then continue the same conversation here or from your terminal.</p>
           <button class="primary-button" id="welcome-new">Create your first session</button>
+        </div>
+      </section>
+
+      <section class="changes-view" id="changes-view" role="tabpanel" aria-labelledby="changes-tab" hidden>
+        <header class="changes-header">
+          <div>
+            <h2>File changes</h2>
+            <p id="changes-summary">No changed files</p>
+          </div>
+        </header>
+        <div class="changes-list" id="changes-list" aria-live="polite">
+          <div class="changes-empty">No file changes yet.</div>
         </div>
       </section>
 

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -13,6 +13,10 @@
   --accent-soft: #e2eee7;
   --danger: #a73f3f;
   --warning: #a16922;
+  --diff-added: #26633f;
+  --diff-added-bg: #e7f3ea;
+  --diff-removed: #9b3f3f;
+  --diff-removed-bg: #f8e8e8;
   --shadow: 0 18px 55px rgba(28, 45, 36, .09);
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -57,6 +61,11 @@ button { color: inherit; }
 .session-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 17px/1.2 Georgia, "Times New Roman", serif; }
 .session-meta { overflow: hidden; margin-top: 5px; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .header-actions { display: flex; align-items: center; gap: 8px; }
+.view-tabs { display: flex; padding: 3px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
+.view-tabs button { padding: 6px 9px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 10.5px; font-weight: 700; cursor: pointer; }
+.view-tabs button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 2px 7px rgba(31,46,38,.08); }
+.view-tabs button:disabled { opacity: .45; cursor: default; }
+.view-tabs span { display: inline-grid; min-width: 17px; height: 17px; place-items: center; margin-left: 3px; padding: 0 4px; border-radius: 999px; background: var(--line-soft); font-size: 9px; }
 .connection-pill { display: inline-flex; align-items: center; gap: 7px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 999px; background: var(--card); color: var(--muted); font-size: 10.5px; font-weight: 700; }
 .connection-pill span { width: 6px; height: 6px; border-radius: 50%; background: #9ba59f; }
 .connection-pill[data-state="connected"] span { background: #4b9a6f; box-shadow: 0 0 0 3px rgba(75,154,111,.12); }
@@ -109,8 +118,33 @@ button { color: inherit; }
 .input-actions button:last-child { border-color: var(--accent); background: var(--accent); color: white; }
 .input-card :disabled { opacity: .55; cursor: default; }
 .diff-card { overflow: hidden; }
-.diff-card summary { padding: 11px 14px; color: var(--muted); font-size: 11px; font-weight: 700; cursor: pointer; }
-.diff-card pre { max-height: 430px; margin: 0; overflow: auto; padding: 14px; border-top: 1px solid var(--line); background: #171d1a; color: #dce7df; font: 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; white-space: pre; }
+.diff-card-header { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 11px 14px; color: var(--muted); font-size: 10px; }
+.diff-card-header strong { color: var(--ink); font-size: 11px; }
+.diff-card .changes-list { gap: 0; }
+.diff-card .file-change { border: 0; border-top: 1px solid var(--line); border-radius: 0; box-shadow: none; }
+.diff-card .diff-lines { max-height: 430px; }
+.changes-view { min-height: 0; overflow-y: auto; padding: 28px max(24px, calc((100% - 1050px) / 2)) 40px; }
+.changes-view[hidden], .messages[hidden], .composer-wrap[hidden] { display: none; }
+.changes-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 18px; }
+.changes-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
+.changes-header p { margin: 6px 0 0; color: var(--muted); font-size: 11px; }
+.changes-list { display: grid; gap: 11px; }
+.changes-empty { min-height: 250px; display: grid; place-items: center; padding: 30px; border: 1px dashed var(--line); border-radius: 14px; color: var(--muted); font-size: 13px; text-align: center; }
+.file-change { min-width: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 13px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.file-change summary { display: grid; grid-template-columns: 10px minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 12px 14px; list-style: none; cursor: pointer; }
+.file-change summary::-webkit-details-marker { display: none; }
+.file-change summary::before { content: "›"; color: var(--faint); font-size: 17px; line-height: 1; transition: transform .12s; }
+.file-change[open] summary::before { transform: rotate(90deg); }
+.file-change-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 11.5px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; }
+.file-change-stat { display: flex; gap: 8px; font: 700 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace; }
+.file-change-added { color: var(--diff-added); }
+.file-change-removed { color: var(--diff-removed); }
+.diff-lines { max-height: 520px; overflow: auto; padding: 10px 0; border-top: 1px solid var(--line); background: #f3f5f2; color: var(--ink); font: 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; }
+.diff-line { min-width: max-content; padding: 0 14px; white-space: pre; }
+.diff-line.added { background: var(--diff-added-bg); color: var(--diff-added); }
+.diff-line.removed { background: var(--diff-removed-bg); color: var(--diff-removed); }
+.diff-line.hunk { color: var(--accent-2); }
+.diff-line.metadata { color: var(--muted); }
 .error-card { padding: 12px 14px; border-color: rgba(167,63,63,.25); background: #fff6f6; color: var(--danger); font-size: 12px; line-height: 1.5; }
 .recovery-card { padding: 12px 14px; border-color: rgba(197,138,62,.3); background: #fff9ef; color: #8a5b1f; font-size: 12px; line-height: 1.5; }
 .turn-divider { height: 1px; margin: 2px 0 22px 40px; background: linear-gradient(90deg,var(--line),transparent); }
@@ -187,7 +221,9 @@ button { color: inherit; }
   .conversation { height: 100%; }
   .conversation-header { padding: 11px 14px; }
   .connection-pill { max-width: 35px; overflow: hidden; padding: 8px; color: transparent; gap: 0; }
+  .view-tabs button { padding: 6px 7px; }
   .messages { padding: 27px 16px; }
+  .changes-view { padding: 24px 16px 32px; }
   .composer-wrap { padding: 10px 13px 15px; }
   .message-bubble, .user-message { max-width: 90%; }
   .form-grid { grid-template-columns: 1fr; }
@@ -196,13 +232,14 @@ button { color: inherit; }
 }
 
 @media (prefers-color-scheme: dark) {
-  :root { color-scheme: dark; --ink:#edf2ee; --muted:#9ba9a0; --faint:#7f8e85; --line:#334039; --line-soft:#29342e; --canvas:#111814; --panel:#171f1a; --card:#1b241f; --accent:#3c8463; --accent-2:#4a9673; --accent-soft:#233a2e; --shadow:0 18px 55px rgba(0,0,0,.25); }
+  :root { color-scheme: dark; --ink:#edf2ee; --muted:#9ba9a0; --faint:#7f8e85; --line:#334039; --line-soft:#29342e; --canvas:#111814; --panel:#171f1a; --card:#1b241f; --accent:#3c8463; --accent-2:#4a9673; --accent-soft:#233a2e; --diff-added:#8bd5a5; --diff-added-bg:#173424; --diff-removed:#ef9a9a; --diff-removed-bg:#3a2020; --shadow:0 18px 55px rgba(0,0,0,.25); }
   .new-session-button, .session-item.active { background: #202a24; }
   .new-session-button:hover, .session-item:hover { background: #242f29; }
   .conversation-header { background: rgba(17,24,20,.88); }
   .user .message-bubble { background: #263b30; }
   .error-card { background: #2d1e1e; }
   .recovery-card { background: #2d281e; color: #e7bd78; }
+  .diff-lines { background: #121915; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
   .form-grid input, .form-grid select { border-color: #3a4740; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds dedicated file changes views to the Session server so users can inspect changed files without searching raw diffs in the conversation transcript.

Each turn-level `file.diff` block now renders its own expandable per-file view with addition and deletion counts. The Session-wide Changes tab keeps the latest diff for every changed path, preserves unrelated entries across live updates, and provides a clear empty state. Added and removed lines use distinct colors in both light and dark color schemes.

#### Which issue(s) this PR is related to:

Fixes #1475

#### Special notes for your reviewer:

Diffs are split on standard Git headers and rendered with text-only DOM APIs. Repeated events for a turn merge into that turn's existing file changes block, while the Session-wide view maintains the latest data per path.

Validation:
- `CODEX_HOME= CODEX_AUTH_JSON= make test`
- `make verify`
- `node --check internal/sessionserver/web/app.js`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
Session server users can inspect per-turn and session-wide file changes in dedicated, color-coded views.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-turn and session-wide File changes views with expandable per-file diffs, a keyboard-accessible Changes tab, and color-coded +/−. Robust path parsing and accurate counts across light/dark themes; fixes #1475.

- **New Features**
  - Changes tab aggregates the latest diff per path, shows a count badge and summary, disables until a session is selected, hides the composer, and shows clear empty states.
  - Turn-level “File changes” cards render one expandable section per file, merge repeated events, and auto-expand when only one file changed.
  - Diff parsing and rendering: split on Git headers and "*** Add/Delete/Update File", normalize a/b prefixes, decode Git-quoted paths (incl. octal), and ignore +++/--- in counts; per-file +/− stats; ARIA tablist with left/right/Home/End keys; themed styles for added/removed/hunk/metadata lines; tests exercise DOM/JS/CSS.

<sup>Written for commit 2cc6801630e0781c347aa547b77f6fc473076e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

