### PR TITLE
Show Session runtime state in Session server

### DIFF
--- a/cmd/kelos-session-runtime/main.go
+++ b/cmd/kelos-session-runtime/main.go
@@ -49,7 +49,7 @@ func main() {
 		return
 	}
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: kelos-session-runtime <serve|health|client>")
+		fmt.Fprintln(os.Stderr, "Usage: kelos-session-runtime <serve|health|client|status>")
 		os.Exit(2)
 	}
 
@@ -60,6 +60,8 @@ func main() {
 		runHealth()
 	case "client":
 		runClient()
+	case "status":
+		runStatus()
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %q\n", os.Args[1])
 		os.Exit(2)
@@ -111,4 +113,18 @@ func runClient() {
 		fmt.Fprintf(os.Stderr, "Session client failed: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func runStatus() {
+	flags := flag.NewFlagSet("status", flag.ExitOnError)
+	socket := flags.String("socket", envOrDefault("KELOS_SESSION_SOCKET", sessionruntime.DefaultSocketPath), "Session runtime socket")
+	_ = flags.Parse(os.Args[2:])
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+	state, err := sessionruntime.QueryStatus(ctx, *socket)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, state)
 }

--- a/internal/sessionruntime/client.go
+++ b/internal/sessionruntime/client.go
@@ -2,6 +2,7 @@ package sessionruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -49,4 +50,30 @@ func RunJSONClient(ctx context.Context, socketPath string) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// QueryStatus returns the current runtime state from a resident Session runtime.
+func QueryStatus(ctx context.Context, socketPath string) (RuntimeState, error) {
+	connection, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return "", fmt.Errorf("connecting to Session runtime: %w", err)
+	}
+	defer connection.Close()
+	stopClose := context.AfterFunc(ctx, func() { _ = connection.Close() })
+	defer stopClose()
+
+	if err := json.NewEncoder(connection).Encode(ClientRequest{Type: "status"}); err != nil {
+		return "", fmt.Errorf("requesting Session runtime status: %w", err)
+	}
+	var event Event
+	if err := json.NewDecoder(connection).Decode(&event); err != nil {
+		return "", fmt.Errorf("reading Session runtime status: %w", err)
+	}
+	if event.Type != EventRuntimeStatus {
+		return "", fmt.Errorf("reading Session runtime status: unexpected event type %q", event.Type)
+	}
+	if event.RuntimeState != RuntimeStateRunning && event.RuntimeState != RuntimeStateWaiting {
+		return "", fmt.Errorf("reading Session runtime status: invalid state %q", event.RuntimeState)
+	}
+	return event.RuntimeState, nil
 }

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -6,6 +6,7 @@ const (
 	EventHistoryEnd       = "history.end"
 	EventRequestAccepted  = "request.accepted"
 	EventRuntimeRecovered = "runtime.recovered"
+	EventRuntimeStatus    = "runtime.status"
 	EventUserMessage      = "user.message"
 	EventTurnStarted      = "turn.started"
 	EventTurnInterrupting = "turn.interrupting"
@@ -20,19 +21,28 @@ const (
 	EventError            = "error"
 )
 
+// RuntimeState describes whether a ready Session is working or waiting for input.
+type RuntimeState string
+
+const (
+	RuntimeStateRunning RuntimeState = "Running"
+	RuntimeStateWaiting RuntimeState = "Waiting"
+)
+
 // Event is one conversation event exposed through the shared Session control interface.
 type Event struct {
-	ID        int64           `json:"id,omitempty"`
-	Type      string          `json:"type"`
-	RequestID string          `json:"requestId,omitempty"`
-	TurnID    string          `json:"turnId,omitempty"`
-	Text      string          `json:"text,omitempty"`
-	ToolID    string          `json:"toolId,omitempty"`
-	ToolName  string          `json:"toolName,omitempty"`
-	Status    string          `json:"status,omitempty"`
-	InputID   string          `json:"inputId,omitempty"`
-	Questions []InputQuestion `json:"questions,omitempty"`
-	Diff      string          `json:"diff,omitempty"`
+	ID           int64           `json:"id,omitempty"`
+	Type         string          `json:"type"`
+	RequestID    string          `json:"requestId,omitempty"`
+	TurnID       string          `json:"turnId,omitempty"`
+	Text         string          `json:"text,omitempty"`
+	ToolID       string          `json:"toolId,omitempty"`
+	ToolName     string          `json:"toolName,omitempty"`
+	Status       string          `json:"status,omitempty"`
+	InputID      string          `json:"inputId,omitempty"`
+	Questions    []InputQuestion `json:"questions,omitempty"`
+	Diff         string          `json:"diff,omitempty"`
+	RuntimeState RuntimeState    `json:"runtimeState,omitempty"`
 }
 
 // ClientRequest is a command sent by a web or terminal client.

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -417,6 +417,24 @@ func (s *Server) interruptTurn(ctx context.Context, requestID string) error {
 	return nil
 }
 
+func (s *Server) runtimeState() RuntimeState {
+	s.activeMu.Lock()
+	active := s.activeTurn != ""
+	s.activeMu.Unlock()
+	if !active {
+		return RuntimeStateWaiting
+	}
+
+	s.inputMu.Lock()
+	defer s.inputMu.Unlock()
+	for _, input := range s.pendingInputs {
+		if !input.resolved {
+			return RuntimeStateWaiting
+		}
+	}
+	return RuntimeStateRunning
+}
+
 func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 	defer connection.Close()
 	connectionCtx, cancel := context.WithCancel(ctx)
@@ -516,6 +534,8 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 		switch request.Type {
 		case "subscribe":
 			subscribe(request.Since)
+		case "status":
+			out <- Event{Type: EventRuntimeStatus, RuntimeState: s.runtimeState()}
 		case "message":
 			subscribe(0)
 			if err := s.submitMessage(request.Text, request.RequestID); err != nil {

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -396,6 +396,50 @@ func TestServerInterruptsActiveTurn(t *testing.T) {
 	}
 }
 
+func TestServerReportsRuntimeState(t *testing.T) {
+	stateDir := shortRuntimeTempDir(t)
+	journal := NewJournal()
+	server := NewServer(Config{SocketPath: filepath.Join(stateDir, "runtime.sock")}, journal, &fakeProvider{})
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve(ctx) }()
+	waitForRuntime(t, server.config.SocketPath)
+
+	assertState := func(want RuntimeState) {
+		t.Helper()
+		got, err := QueryStatus(t.Context(), server.config.SocketPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("runtime state = %q, want %q", got, want)
+		}
+	}
+
+	assertState(RuntimeStateWaiting)
+	server.activeMu.Lock()
+	server.activeTurn = "turn-1"
+	server.activeMu.Unlock()
+	assertState(RuntimeStateRunning)
+	server.inputMu.Lock()
+	server.pendingInputs["input-1"] = &pendingInput{}
+	server.inputMu.Unlock()
+	assertState(RuntimeStateWaiting)
+	server.inputMu.Lock()
+	server.pendingInputs["input-1"].resolved = true
+	server.inputMu.Unlock()
+	assertState(RuntimeStateRunning)
+	server.activeMu.Lock()
+	server.activeTurn = ""
+	server.activeMu.Unlock()
+	assertState(RuntimeStateWaiting)
+
+	cancel()
+	if err := <-serveDone; err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+}
+
 func TestServerRecoversActiveTurnAfterShutdown(t *testing.T) {
 	journal := NewJournal()
 	defer journal.Close()

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -18,8 +18,10 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +36,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/sessionruntime"
 )
 
 const (
@@ -68,6 +71,7 @@ type Server struct {
 	handler          http.Handler
 	upgrader         websocket.Upgrader
 	bridge           func(context.Context, *sessionSocket, string, string) error
+	runtimeState     func(context.Context, string, string) (sessionruntime.RuntimeState, error)
 }
 
 type sessionSocket struct {
@@ -88,11 +92,12 @@ func (c *sessionSocket) WriteMessage(messageType int, data []byte) error {
 }
 
 type sessionSummary struct {
-	Name      string             `json:"name"`
-	Namespace string             `json:"namespace"`
-	Provider  string             `json:"provider"`
-	Phase     kelos.SessionPhase `json:"phase,omitempty"`
-	Message   string             `json:"message,omitempty"`
+	Name         string                      `json:"name"`
+	Namespace    string                      `json:"namespace"`
+	Provider     string                      `json:"provider"`
+	Phase        kelos.SessionPhase          `json:"phase,omitempty"`
+	Message      string                      `json:"message,omitempty"`
+	RuntimeState sessionruntime.RuntimeState `json:"runtimeState,omitempty"`
 }
 
 type sessionOptions struct {
@@ -182,6 +187,7 @@ func New(config Config) (*Server, error) {
 		},
 	}
 	server.bridge = server.bridgeExec
+	server.runtimeState = server.queryRuntimeState
 	server.handler = server.routes()
 	return server, nil
 }
@@ -336,6 +342,31 @@ func (s *Server) listSessions(writer http.ResponseWriter, request *http.Request)
 	items := make([]sessionSummary, 0, len(list.Items))
 	for i := range list.Items {
 		items = append(items, summarize(&list.Items[i]))
+	}
+	statusContext, cancel := context.WithTimeout(request.Context(), 4*time.Second)
+	defer cancel()
+	group, statusContext := errgroup.WithContext(statusContext)
+	group.SetLimit(8)
+	for i := range list.Items {
+		if list.Items[i].Status.Phase != kelos.SessionPhaseReady {
+			continue
+		}
+		if list.Items[i].Status.PodName == "" {
+			writeError(writer, http.StatusInternalServerError, fmt.Sprintf("getting runtime state for Session %q: ready Session has no Pod", list.Items[i].Name))
+			return
+		}
+		group.Go(func() error {
+			state, err := s.runtimeState(statusContext, list.Items[i].Namespace, list.Items[i].Status.PodName)
+			if err != nil {
+				return fmt.Errorf("getting runtime state for Session %q: %w", list.Items[i].Name, err)
+			}
+			items[i].RuntimeState = state
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		writeError(writer, http.StatusInternalServerError, err.Error())
+		return
 	}
 	writeJSON(writer, http.StatusOK, items)
 }
@@ -639,6 +670,39 @@ func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, name
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func (s *Server) queryRuntimeState(ctx context.Context, namespace, podName string) (sessionruntime.RuntimeState, error) {
+	request := s.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("exec")
+	request.VersionedParams(&corev1.PodExecOptions{
+		Container: kelos.AgentContainerName,
+		Command:   []string{sessionRuntimeClient, "status"},
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, clientgoscheme.ParameterCodec)
+	executor, err := remotecommand.NewSPDYExecutor(s.restConfig, http.MethodPost, request.URL())
+	if err != nil {
+		return "", fmt.Errorf("creating Session status connection: %w", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := executor.StreamWithContext(ctx, remotecommand.StreamOptions{Stdout: &stdout, Stderr: &stderr, Tty: false}); err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return "", fmt.Errorf("querying Session runtime: %w: %s", err, message)
+		}
+		return "", fmt.Errorf("querying Session runtime: %w", err)
+	}
+	state := sessionruntime.RuntimeState(strings.TrimSpace(stdout.String()))
+	if state != sessionruntime.RuntimeStateRunning && state != sessionruntime.RuntimeStateWaiting {
+		return "", fmt.Errorf("querying Session runtime: invalid state %q", state)
+	}
+	return state, nil
 }
 
 func newJSONLineScanner(reader io.Reader) *bufio.Scanner {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/sessionruntime"
 )
 
 func TestAuthenticationProtectsApplicationAndAPI(t *testing.T) {
@@ -392,6 +393,117 @@ func TestSessionAPIListsRequestedNamespace(t *testing.T) {
 				t.Fatalf("listed Sessions = %#v", sessions)
 			}
 		})
+	}
+}
+
+func TestSessionAPIShowsRuntimeStateForEveryReadySession(t *testing.T) {
+	server := testServer(t)
+	for _, session := range []kelos.Session{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "running-chat", Namespace: "default"},
+			Spec:       kelos.SessionSpec{Worker: kelos.WorkerSpec{Type: "codex"}},
+			Status:     kelos.SessionStatus{Phase: kelos.SessionPhaseReady, PodName: "running-pod"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "waiting-chat", Namespace: "default"},
+			Spec:       kelos.SessionSpec{Worker: kelos.WorkerSpec{Type: "claude-code"}},
+			Status:     kelos.SessionStatus{Phase: kelos.SessionPhaseReady, PodName: "waiting-pod"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending-chat", Namespace: "default"},
+			Spec:       kelos.SessionSpec{Worker: kelos.WorkerSpec{Type: "opencode"}},
+			Status:     kelos.SessionStatus{Phase: kelos.SessionPhasePending},
+		},
+	} {
+		if err := server.client.Create(t.Context(), &session); err != nil {
+			t.Fatal(err)
+		}
+	}
+	states := map[string]sessionruntime.RuntimeState{
+		"running-pod": sessionruntime.RuntimeStateRunning,
+		"waiting-pod": sessionruntime.RuntimeStateWaiting,
+	}
+	var stateMu sync.Mutex
+	server.runtimeState = func(_ context.Context, _, podName string) (sessionruntime.RuntimeState, error) {
+		stateMu.Lock()
+		defer stateMu.Unlock()
+		return states[podName], nil
+	}
+
+	list := func() map[string]sessionSummary {
+		t.Helper()
+		request := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		request.Header.Set("Authorization", "Bearer secret-token")
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("list status = %d body = %s", response.Code, response.Body.String())
+		}
+		var sessions []sessionSummary
+		if err := json.Unmarshal(response.Body.Bytes(), &sessions); err != nil {
+			t.Fatal(err)
+		}
+		byName := make(map[string]sessionSummary, len(sessions))
+		for _, session := range sessions {
+			byName[session.Name] = session
+		}
+		return byName
+	}
+
+	sessions := list()
+	if got := sessions["running-chat"].RuntimeState; got != sessionruntime.RuntimeStateRunning {
+		t.Fatalf("running-chat runtime state = %q, want %q", got, sessionruntime.RuntimeStateRunning)
+	}
+	if got := sessions["waiting-chat"].RuntimeState; got != sessionruntime.RuntimeStateWaiting {
+		t.Fatalf("waiting-chat runtime state = %q, want %q", got, sessionruntime.RuntimeStateWaiting)
+	}
+	if got := sessions["pending-chat"].RuntimeState; got != "" {
+		t.Fatalf("pending-chat runtime state = %q, want empty", got)
+	}
+
+	stateMu.Lock()
+	states["running-pod"] = sessionruntime.RuntimeStateWaiting
+	stateMu.Unlock()
+	if got := list()["running-chat"].RuntimeState; got != sessionruntime.RuntimeStateWaiting {
+		t.Fatalf("refreshed running-chat runtime state = %q, want %q", got, sessionruntime.RuntimeStateWaiting)
+	}
+}
+
+func TestSessionApplicationRendersRuntimeState(t *testing.T) {
+	server := testServer(t)
+	for _, asset := range []struct {
+		path string
+		want []string
+	}{
+		{
+			path: "/assets/app.js",
+			want: []string{
+				"status.textContent = `· ${sessionStatus(session)}`;",
+				"elements.meta.textContent = `${session.namespace} · ${providerLabel(session.provider)} · ${sessionStatus(session)}`;",
+				"socket.send(JSON.stringify({type: 'status'}));",
+				"case 'runtime.status':\n      updateSelectedRuntimeState(event.runtimeState);",
+			},
+		},
+		{
+			path: "/assets/styles.css",
+			want: []string{
+				".phase-dot.running { background: #4b9a6f;",
+				".phase-dot.waiting { background: #7e9186;",
+			},
+		},
+	} {
+		request := httptest.NewRequest(http.MethodGet, asset.path, nil)
+		request.Header.Set("Authorization", "Bearer secret-token")
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d body = %s", asset.path, response.Code, response.Body.String())
+		}
+		for _, want := range asset.want {
+			if !strings.Contains(response.Body.String(), want) {
+				t.Errorf("GET %s does not contain %q", asset.path, want)
+			}
+		}
 	}
 }
 

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -100,6 +100,19 @@ function providerInitials(provider) {
   return provider === 'claude-code' ? 'CC' : provider === 'codex' ? 'CX' : provider === 'opencode' ? 'OC' : 'AI';
 }
 
+function sessionStatus(session) {
+  return session.phase === 'Ready' ? session.runtimeState : (session.phase || 'Pending');
+}
+
+function updateSelectedRuntimeState(runtimeState) {
+  if (!state.selected || !['Running', 'Waiting'].includes(runtimeState)) return;
+  state.selected.runtimeState = runtimeState;
+  const listed = state.sessions.find(session => sessionKey(session) === sessionKey(state.selected));
+  if (listed) listed.runtimeState = runtimeState;
+  renderSessions();
+  renderHeader();
+}
+
 function renderSessions() {
   elements.list.replaceChildren();
   if (!state.sessions.length) {
@@ -114,7 +127,7 @@ function renderSessions() {
     button.className = `session-item${state.selected && sessionKey(state.selected) === sessionKey(session) ? ' active' : ''}`;
     button.type = 'button';
     const dot = document.createElement('span');
-    dot.className = `phase-dot ${String(session.phase || '').toLowerCase()}`;
+    dot.className = `phase-dot ${String(sessionStatus(session) || '').toLowerCase()}`;
     const text = document.createElement('span');
     const name = document.createElement('div');
     name.className = 'session-item-name';
@@ -126,7 +139,9 @@ function renderSessions() {
     provider.textContent = providerLabel(session.provider);
     const namespace = document.createElement('span');
     namespace.textContent = `· ${session.namespace}`;
-    meta.append(provider, namespace);
+    const status = document.createElement('span');
+    status.textContent = `· ${sessionStatus(session)}`;
+    meta.append(provider, namespace, status);
     text.append(name, meta);
     button.append(dot, text);
     button.addEventListener('click', () => selectSession(session));
@@ -434,7 +449,7 @@ function renderHeader() {
     return;
   }
   elements.title.textContent = session.name;
-  elements.meta.textContent = `${session.namespace} · ${providerLabel(session.provider)} · ${session.phase || 'Pending'}`;
+  elements.meta.textContent = `${session.namespace} · ${providerLabel(session.provider)} · ${sessionStatus(session)}`;
   if (session.phase !== 'Ready') {
     setConnection(session.phase === 'Failed' ? 'error' : 'connecting', session.phase || 'Pending');
     setComposer(false);
@@ -492,6 +507,7 @@ function connectSocket() {
     if (generation !== state.socketGeneration) return;
     state.reconnectDelay = 800;
     socket.send(JSON.stringify({type: 'subscribe', since: state.lastEventID}));
+    socket.send(JSON.stringify({type: 'status'}));
     setConnection('connected', 'Connected');
     setComposer(true);
     updateComposerAction();
@@ -582,7 +598,11 @@ function handleEvent(event) {
       scrollToBottom(false);
       break;
     case 'runtime.recovered':
+      updateSelectedRuntimeState('Waiting');
       renderRecovery(event);
+      break;
+    case 'runtime.status':
+      updateSelectedRuntimeState(event.runtimeState);
       break;
     case 'user.message':
       renderUser(event);
@@ -591,6 +611,7 @@ function handleEvent(event) {
       endAssistantSegment(event.turnId);
       state.activeTurn = true;
       state.interrupting = false;
+      updateSelectedRuntimeState('Running');
       acceptQueuedMessage(event.turnId);
       updateComposerAction();
       break;
@@ -614,9 +635,11 @@ function handleEvent(event) {
       break;
     case 'input.requested':
       endAssistantSegment(event.turnId);
+      updateSelectedRuntimeState('Waiting');
       renderInputRequest(event);
       break;
     case 'input.resolved':
+      updateSelectedRuntimeState('Running');
       resolveInputCard(event);
       break;
     case 'file.diff':
@@ -870,6 +893,7 @@ function renderError(event) {
     state.interrupting = false;
     updateComposerAction();
   }
+  if (event.status === 'failed') updateSelectedRuntimeState('Waiting');
   ensureConversation();
   const card = document.createElement('div');
   card.className = 'error-card';
@@ -890,6 +914,7 @@ function renderRecovery(event) {
 function renderTurnEnd(event) {
   state.activeTurn = false;
   state.interrupting = false;
+  updateSelectedRuntimeState('Waiting');
   acceptQueuedMessage(event.turnId);
   updateComposerAction();
   if (event.status === 'interrupted') showToast('Active work interrupted');

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -42,7 +42,8 @@ button { color: inherit; }
 .session-item:hover { background: rgba(255,255,255,.55); }
 .session-item.active { background: #fff; box-shadow: 0 4px 14px rgba(35,49,42,.06); }
 .phase-dot { width: 7px; height: 7px; margin-top: 5px; border-radius: 50%; background: #9ca69f; }
-.phase-dot.ready { background: #4b9a6f; box-shadow: 0 0 0 3px rgba(75,154,111,.12); }
+.phase-dot.running { background: #4b9a6f; box-shadow: 0 0 0 3px rgba(75,154,111,.12); animation: pulse 1.1s infinite; }
+.phase-dot.waiting { background: #7e9186; box-shadow: 0 0 0 3px rgba(126,145,134,.1); }
 .phase-dot.failed { background: #c55b5b; }
 .session-item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 680; }
 .session-item-meta { display: flex; gap: 6px; margin-top: 4px; color: var(--faint); font-size: 10.5px; }

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -138,6 +138,9 @@ var _ = Describe("Session remote control", func() {
 		Eventually(func() []string {
 			return listWebSessions(webClient, baseURL, f.Namespace)
 		}, 30*time.Second, 200*time.Millisecond).Should(ContainElement(sessionName))
+		Eventually(func() sessionruntime.RuntimeState {
+			return webSessionRuntimeState(webClient, baseURL, f.Namespace, sessionName)
+		}, 30*time.Second, 200*time.Millisecond).Should(Equal(sessionruntime.RuntimeStateWaiting))
 
 		connection := connectSessionWebSocket(webClient, baseURL, f.Namespace, sessionName)
 		DeferCleanup(func() { _ = connection.Close() })
@@ -169,6 +172,9 @@ var _ = Describe("Session remote control", func() {
 		})
 		Expect(input.Questions).To(HaveLen(1))
 		Expect(input.Questions[0].Question).To(Equal("Which database?"))
+		Eventually(func() sessionruntime.RuntimeState {
+			return webSessionRuntimeState(webClient, baseURL, f.Namespace, sessionName)
+		}, 30*time.Second, 200*time.Millisecond).Should(Equal(sessionruntime.RuntimeStateWaiting))
 		sendSessionRequest(connection, sessionruntime.ClientRequest{
 			Type:    "input",
 			InputID: input.InputID,
@@ -184,11 +190,26 @@ var _ = Describe("Session remote control", func() {
 		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
 			return event.Type == sessionruntime.EventTurnStarted
 		})
+		_ = connection.Close()
+		Eventually(func() sessionruntime.RuntimeState {
+			return webSessionRuntimeState(webClient, baseURL, f.Namespace, sessionName)
+		}, 30*time.Second, 200*time.Millisecond).Should(Equal(sessionruntime.RuntimeStateRunning))
+		connection = connectSessionWebSocket(webClient, baseURL, f.Namespace, sessionName)
+		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "subscribe"})
+		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "status"})
+		for readSessionEvent(connection).Type != sessionruntime.EventHistoryEnd {
+		}
+		status := readSessionEvent(connection)
+		Expect(status.Type).To(Equal(sessionruntime.EventRuntimeStatus))
+		Expect(status.RuntimeState).To(Equal(sessionruntime.RuntimeStateRunning))
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "interrupt"})
 		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
 			return event.Type == sessionruntime.EventTurnInterrupting
 		})
 		waitForTurnCompletion(connection, "interrupted")
+		Eventually(func() sessionruntime.RuntimeState {
+			return webSessionRuntimeState(webClient, baseURL, f.Namespace, sessionName)
+		}, 30*time.Second, 200*time.Millisecond).Should(Equal(sessionruntime.RuntimeStateWaiting))
 
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "message", Text: "after"})
 		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
@@ -524,6 +545,30 @@ func listWebSessions(client *http.Client, baseURL, namespace string) []string {
 		names = append(names, session.Name)
 	}
 	return names
+}
+
+func webSessionRuntimeState(client *http.Client, baseURL, namespace, name string) sessionruntime.RuntimeState {
+	response, err := client.Get(baseURL + "/api/sessions?namespace=" + url.QueryEscape(namespace))
+	if err != nil {
+		return ""
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return ""
+	}
+	var sessions []struct {
+		Name         string                      `json:"name"`
+		RuntimeState sessionruntime.RuntimeState `json:"runtimeState"`
+	}
+	if json.NewDecoder(response.Body).Decode(&sessions) != nil {
+		return ""
+	}
+	for _, session := range sessions {
+		if session.Name == name {
+			return session.RuntimeState
+		}
+	}
+	return ""
 }
 
 func connectSessionWebSocket(client *http.Client, baseURL, namespace, sessionName string) *websocket.Conn {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Ready Sessions currently expose only their infrastructure phase, so users cannot tell whether an agent is actively running a turn or waiting for input.

This PR adds an authoritative runtime status query and exposes `Running` or `Waiting` for every ready Session in the Session server API. The sidebar and selected Session header render that state, while non-ready Sessions continue to show their infrastructure phase. WebSocket clients also request a fresh status snapshot when connecting so reloads and reconnects do not retain stale state.

#### Which issue(s) this PR is related to:

Fixes #1473

#### Special notes for your reviewer:

The Session list queries ready Session Pods concurrently with a bounded limit and a four-second request timeout. Unit coverage exercises running, idle, and input-waiting states; the existing Session e2e flow now verifies status while disconnected and after reconnecting. The e2e suite is intended to run in CI.

Validation:
- `env -u CODEX_HOME -u CODEX_AUTH_JSON make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
Show whether ready Sessions are running a turn or waiting for input in the Session server.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show live runtime state for ready Sessions in the Session server and UI (Fixes #1473). Users can see if an agent is Running or Waiting; WebSocket clients refresh status on connect.

- **New Features**
  - API returns `runtimeState` ("Running" | "Waiting") for ready Sessions; non-ready Sessions still expose `phase`.
  - Runtime adds a `status` client request and `runtime.status` event, plus `kelos-session-runtime status` to query the socket.
  - Session server queries Pods via exec to fetch status, with concurrent requests (limit 8) and a 4s timeout.
  - UI shows status in the session list and header with new dot styles; WS sends a `status` request on connect and updates on incoming events; unit and e2e tests cover running/waiting and reconnects.

<sup>Written for commit e587c1a97609a8a89a3b0ede5dc955187f937492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

