### PR TITLE
Generate Sessions from existing Sessions

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -210,6 +210,11 @@ events stay out of the Kubernetes API and are retained on the Session workspace.
 | `status.podName` | Session Pod name | Output |
 | `status.podUID` | Identity of the Pod running the live conversation | Output |
 
+The web creation dialog can generate a new Session from an existing Session in
+the active namespace. This copies the complete `Session.spec` into an editable
+form or YAML manifest and leaves the new name blank. It does not copy the source
+metadata, conversation, or persistent-volume data.
+
 Use `kelos session connect NAME` for terminal chat. Web chat is served by the
 optional shared `kelos-session-server`; both clients use the same event stream
 and provider conversation. Both clients can stream agent and tool activity,
@@ -235,12 +240,14 @@ namespaces while the web application operates on one active namespace at a
 time. Users can switch the active namespace live from the sidebar.
 `sessionServer.defaultNamespace` sets its initial value, and Session, Workspace,
 AgentConfig, and credential options are loaded only from the active namespace.
+Selecting an existing Session as a source populates both the form fields and the
+editable YAML manifest. Settings that the form cannot represent remain editable
+in YAML mode.
 The creation form accepts provider, credentials, model, Workspace, AgentConfig
 references, and an optional persistent volume claim. YAML mode server-side
-applies one `kelos.dev/v1alpha2` Session manifest in the active namespace with
-the same worker fields as the form. The manifest may also include labels,
-annotations, and an optional persistent volume claim. Image and Pod overrides
-require direct Kubernetes API access governed by Kubernetes RBAC.
+applies one `kelos.dev/v1alpha2` Session manifest in the active namespace. The
+manifest may include labels, annotations, the complete `WorkerSpec`, and an
+optional persistent volume claim.
 
 ## WorkerPool
 

--- a/internal/manifests/charts/kelos/README.md
+++ b/internal/manifests/charts/kelos/README.md
@@ -216,13 +216,15 @@ namespace. The web application operates on one active namespace at a time and
 can switch it live from the sidebar. `sessionServer.defaultNamespace` (`default`
 unless overridden) sets the initial active namespace. The selected namespace
 must already exist. Session, Workspace, AgentConfig, and previously used
-credential options are loaded only from the active namespace. The creation form
+credential options are loaded only from the active namespace. The creation
+dialog can generate a new Session from an existing Session in that namespace,
+copying its complete `Session.spec` into the form and editable YAML manifest but
+not copying its metadata, conversation, or volume data. The creation form
 accepts provider, credentials, model, Workspace, AgentConfig references, and an
-optional persistent volume claim. YAML mode server-side applies one
-`kelos.dev/v1alpha2` Session manifest in the active namespace with the same
-worker fields as the form. The manifest may also include labels, annotations,
-and an optional persistent volume claim. Pod and image overrides remain
-available only through the Kubernetes API and its RBAC.
+optional persistent volume claim. In YAML mode, the server applies one
+`kelos.dev/v1alpha2` Session manifest in the active namespace. The manifest may
+also include labels, annotations, the complete `WorkerSpec`, and an optional
+persistent volume claim.
 
 ## Uninstall
 

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -99,6 +99,7 @@ type sessionOptions struct {
 	Credentials  []credentialOption `json:"credentials"`
 	Workspaces   []string           `json:"workspaces"`
 	AgentConfigs []string           `json:"agentConfigs"`
+	Sessions     []string           `json:"sessions"`
 }
 
 type credentialOption struct {
@@ -110,23 +111,15 @@ type credentialOption struct {
 type createSessionRequest struct {
 	Name                string                            `json:"name"`
 	Namespace           string                            `json:"namespace"`
-	Worker              createSessionWorker               `json:"worker"`
+	Worker              kelos.WorkerSpec                  `json:"worker"`
 	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
-}
-
-type createSessionWorker struct {
-	Type            string                       `json:"type"`
-	Credentials     *kelos.Credentials           `json:"credentials"`
-	Model           string                       `json:"model,omitempty"`
-	WorkspaceRef    *kelos.WorkspaceReference    `json:"workspaceRef,omitempty"`
-	AgentConfigRefs []kelos.AgentConfigReference `json:"agentConfigRefs,omitempty"`
 }
 
 type sessionManifest struct {
 	APIVersion string                  `json:"apiVersion"`
 	Kind       string                  `json:"kind"`
 	Metadata   sessionManifestMetadata `json:"metadata"`
-	Spec       sessionManifestSpec     `json:"spec"`
+	Spec       kelos.SessionSpec       `json:"spec"`
 }
 
 type sessionManifestMetadata struct {
@@ -136,19 +129,11 @@ type sessionManifestMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-type sessionManifestSpec struct {
-	Worker              createSessionWorker               `json:"worker"`
-	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
-}
-
-func (w createSessionWorker) workerSpec() kelos.WorkerSpec {
-	return kelos.WorkerSpec{
-		Type:            w.Type,
-		Credentials:     w.Credentials,
-		Model:           w.Model,
-		WorkspaceRef:    w.WorkspaceRef,
-		AgentConfigRefs: w.AgentConfigRefs,
-	}
+type sessionSourceDetail struct {
+	Name      string          `json:"name"`
+	Namespace string          `json:"namespace"`
+	Manifest  sessionManifest `json:"manifest"`
+	YAML      string          `json:"yaml"`
 }
 
 // New validates config and creates the HTTP handler.
@@ -317,6 +302,8 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	switch request.Method {
+	case http.MethodGet:
+		s.getSessionSource(writer, request, namespace, name)
 	case http.MethodDelete:
 		s.deleteSession(writer, request, namespace, name)
 	default:
@@ -362,8 +349,40 @@ func (s *Server) listSessionOptions(writer http.ResponseWriter, request *http.Re
 		Credentials:  credentialOptions(sessions.Items),
 		Workspaces:   objectNames(workspaces.Items, func(item kelos.Workspace) string { return item.Name }),
 		AgentConfigs: objectNames(agentConfigs.Items, func(item kelos.AgentConfig) string { return item.Name }),
+		Sessions:     objectNames(sessions.Items, func(item kelos.Session) string { return item.Name }),
 	}
 	writeJSON(writer, http.StatusOK, options)
+}
+
+func (s *Server) getSessionSource(writer http.ResponseWriter, request *http.Request, namespace, name string) {
+	var session kelos.Session
+	if err := s.client.Get(request.Context(), client.ObjectKey{Namespace: namespace, Name: name}, &session); err != nil {
+		writeKubernetesError(writer, fmt.Sprintf("getting source Session %q", name), err)
+		return
+	}
+	manifest := sessionManifestFromSession(&session)
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("marshaling source Session %q: %v", name, err))
+		return
+	}
+	writeJSON(writer, http.StatusOK, sessionSourceDetail{
+		Name:      name,
+		Namespace: namespace,
+		Manifest:  manifest,
+		YAML:      string(data),
+	})
+}
+
+func sessionManifestFromSession(session *kelos.Session) sessionManifest {
+	return sessionManifest{
+		APIVersion: kelos.GroupVersion.String(),
+		Kind:       "Session",
+		Metadata: sessionManifestMetadata{
+			Namespace: session.Namespace,
+		},
+		Spec: *session.Spec.DeepCopy(),
+	}
 }
 
 func (s *Server) requestNamespace(request *http.Request) string {
@@ -434,7 +453,7 @@ func (s *Server) createSession(writer http.ResponseWriter, request *http.Request
 			Namespace: payload.Namespace,
 		},
 		Spec: kelos.SessionSpec{
-			Worker:              payload.Worker.workerSpec(),
+			Worker:              payload.Worker,
 			VolumeClaimTemplate: payload.VolumeClaimTemplate,
 		},
 	}
@@ -708,10 +727,7 @@ func decodeSessionYAML(reader io.Reader) (*kelos.Session, error) {
 				Labels:      decoded.Metadata.Labels,
 				Annotations: decoded.Metadata.Annotations,
 			},
-			Spec: kelos.SessionSpec{
-				Worker:              decoded.Spec.Worker.workerSpec(),
-				VolumeClaimTemplate: decoded.Spec.VolumeClaimTemplate,
-			},
+			Spec: decoded.Spec,
 		}
 	}
 	if session == nil {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -82,6 +82,8 @@ func TestSessionFormUsesResourceSelectors(t *testing.T) {
 	for _, expected := range []string{
 		`id="namespace-form"`,
 		`id="active-namespace"`,
+		`id="session-source"`,
+		`id="session-source-status"`,
 		`name="namespace" required value="default" autocomplete="off" readonly>`,
 		`id="credential-secret"`,
 		`id="workspace-select"`,
@@ -95,6 +97,29 @@ func TestSessionFormUsesResourceSelectors(t *testing.T) {
 		if !strings.Contains(response.Body.String(), expected) {
 			t.Errorf("new Session form does not contain %s", expected)
 		}
+	}
+}
+
+func TestSessionSourceJavaScriptPreservesSelectedSource(t *testing.T) {
+	source, err := webFiles.ReadFile("web/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	javascript := string(source)
+	for description, expected := range map[string]string{
+		"shared loading and submission guard": "function updateCreationBusyState() {\n  const busy = state.sourceLoading || state.creatingSession;\n  elements.sessionSource.disabled = busy;\n  elements.createButton.disabled = busy;\n}",
+		"submit loading guard":                "if (state.sourceLoading || state.creatingSession) return;",
+		"namespace invalidation reset":        "state.sourceGeneration += 1;\n  setSourceLoading(false);",
+		"explicit StorageClass tracking":      "state.sourceStorageClassNamePresent = Boolean(claim && 'storageClassName' in claim);",
+		"explicit empty StorageClass copy":    "if (storageClassName || state.sourceStorageClassNamePresent) {\n          payload.volumeClaimTemplate.storageClassName = storageClassName;\n        }",
+		"advanced reference warning":          "in YAML for additional namespace-scoped references.",
+	} {
+		if !strings.Contains(javascript, expected) {
+			t.Errorf("Session source JavaScript is missing %s: %s", description, expected)
+		}
+	}
+	if strings.Contains(javascript, "No namespace-scoped references.") {
+		t.Error("Session source JavaScript claims there are no namespace-scoped references without checking advanced settings")
 	}
 }
 
@@ -218,6 +243,10 @@ spec:
     credentials:
       type: none
     model: gpt-5
+    effort: high
+    image: example.com/codex:latest
+    podOverrides:
+      serviceAccountName: kelos-controller
 `
 	request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply?namespace=team-a", strings.NewReader(manifest))
 	request.Header.Set("Authorization", "Bearer secret-token")
@@ -235,8 +264,11 @@ spec:
 	if session.Labels["source"] != "web" {
 		t.Fatalf("Session labels = %v", session.Labels)
 	}
-	if session.Spec.Worker.Model != "gpt-5" {
-		t.Fatalf("worker model = %q, want %q", session.Spec.Worker.Model, "gpt-5")
+	if session.Spec.Worker.Model != "gpt-5" || session.Spec.Worker.Effort != "high" || session.Spec.Worker.Image != "example.com/codex:latest" {
+		t.Fatalf("worker settings = %#v", session.Spec.Worker)
+	}
+	if session.Spec.Worker.PodOverrides == nil || session.Spec.Worker.PodOverrides.ServiceAccountName != "kelos-controller" {
+		t.Fatalf("worker Pod overrides = %#v", session.Spec.Worker.PodOverrides)
 	}
 	if session.Spec.VolumeClaimTemplate == nil {
 		t.Fatal("volumeClaimTemplate is nil")
@@ -282,16 +314,6 @@ func TestSessionYAMLApplyAPIRejectsInvalidManifests(t *testing.T) {
 		{
 			name:       "unknown field",
 			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\nspec:\n  unknown: value\n  worker:\n    type: codex\n    credentials:\n      type: none\n",
-			wantStatus: http.StatusBadRequest,
-		},
-		{
-			name:       "custom image",
-			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n    image: example.invalid/unsafe:latest\n",
-			wantStatus: http.StatusBadRequest,
-		},
-		{
-			name:       "pod overrides",
-			manifest:   "apiVersion: kelos.dev/v1alpha2\nkind: Session\nmetadata:\n  name: chat\nspec:\n  worker:\n    type: codex\n    credentials:\n      type: none\n    podOverrides:\n      serviceAccountName: kelos-controller\n",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
@@ -405,33 +427,39 @@ func TestSessionAPIHappyPath(t *testing.T) {
 	}
 }
 
-func TestSessionAPIRejectsUnsafeWorkerFields(t *testing.T) {
+func TestSessionAPIAcceptsFullWorkerSpec(t *testing.T) {
 	server := testServer(t)
-	for _, test := range []struct {
-		name       string
-		payload    string
-		wantStatus int
-	}{
-		{
-			name:       "custom image",
-			payload:    `{"name":"chat","namespace":"default","worker":{"type":"codex","credentials":{"type":"none"},"image":"example.invalid/unsafe:latest"}}`,
-			wantStatus: http.StatusBadRequest,
-		},
-		{
-			name:       "pod overrides",
-			payload:    `{"name":"chat","namespace":"default","worker":{"type":"codex","credentials":{"type":"none"},"podOverrides":{"serviceAccountName":"kelos-controller"}}}`,
-			wantStatus: http.StatusBadRequest,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(test.payload))
-			request.Header.Set("Authorization", "Bearer secret-token")
-			response := httptest.NewRecorder()
-			server.ServeHTTP(response, request)
-			if response.Code != test.wantStatus {
-				t.Fatalf("status = %d, want %d body = %s", response.Code, test.wantStatus, response.Body.String())
-			}
-		})
+	payload := `{
+  "name": "full-worker",
+  "namespace": "default",
+  "worker": {
+    "type": "codex",
+    "credentials": {"type": "none"},
+    "model": "gpt-5",
+    "effort": "high",
+    "image": "example.com/codex:latest",
+    "podOverrides": {
+      "serviceAccountName": "kelos-controller"
+    }
+  }
+}`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "full-worker"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.Spec.Worker.Effort != "high" || session.Spec.Worker.Image != "example.com/codex:latest" {
+		t.Fatalf("worker settings = %#v", session.Spec.Worker)
+	}
+	if session.Spec.Worker.PodOverrides == nil || session.Spec.Worker.PodOverrides.ServiceAccountName != "kelos-controller" {
+		t.Fatalf("worker Pod overrides = %#v", session.Spec.Worker.PodOverrides)
 	}
 }
 
@@ -579,6 +607,9 @@ func TestSessionOptionsAPI(t *testing.T) {
 	if got := strings.Join(options.AgentConfigs, ","); got != "defaults,tools" {
 		t.Errorf("AgentConfig options = %q, want %q", got, "defaults,tools")
 	}
+	if got := strings.Join(options.Sessions, ","); got != "claude,codex,codex-duplicate,none" {
+		t.Errorf("Session options = %q, want %q", got, "claude,codex,codex-duplicate,none")
+	}
 
 	request = httptest.NewRequest(http.MethodGet, "/api/options?namespace=team-a", nil)
 	request.Header.Set("Authorization", "Bearer secret-token")
@@ -598,6 +629,122 @@ func TestSessionOptionsAPI(t *testing.T) {
 	}
 	if got := strings.Join(options.AgentConfigs, ","); got != "other" {
 		t.Errorf("team-a AgentConfig options = %q, want %q", got, "other")
+	}
+	if got := strings.Join(options.Sessions, ","); got != "other" {
+		t.Errorf("team-a Session options = %q, want %q", got, "other")
+	}
+}
+
+func TestSessionSourceAPIReturnsReusableSpec(t *testing.T) {
+	storageClassName := ""
+	server := testServer(t)
+	source := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "codex-review",
+			Namespace:   "team-a",
+			Labels:      map[string]string{"purpose": "review"},
+			Annotations: map[string]string{"owner": "platform"},
+		},
+		Spec: kelos.SessionSpec{
+			Worker: kelos.WorkerSpec{
+				Type: "codex",
+				Credentials: &kelos.Credentials{
+					Type:      kelos.CredentialTypeOAuth,
+					SecretRef: &kelos.SecretReference{Name: "codex-credentials"},
+				},
+				Model:           "gpt-5",
+				Effort:          "high",
+				Image:           "example.com/codex:latest",
+				WorkspaceRef:    &kelos.WorkspaceReference{Name: "kelos"},
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "defaults"}, {Name: "review-tools"}},
+				PodOverrides: &kelos.PodOverrides{Env: []corev1.EnvVar{{
+					Name:  "REVIEW_MODE",
+					Value: "strict",
+				}}},
+			},
+			VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &storageClassName,
+				Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("20Gi"),
+				}},
+			},
+		},
+		Status: kelos.SessionStatus{Phase: kelos.SessionPhaseReady, PodName: "codex-review-0"},
+	}
+	if err := server.client.Create(t.Context(), source); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions/team-a/codex-review", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("source Session status = %d body = %s", response.Code, response.Body.String())
+	}
+	var detail sessionSourceDetail
+	if err := json.Unmarshal(response.Body.Bytes(), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail.Name != "codex-review" || detail.Namespace != "team-a" {
+		t.Fatalf("source Session identity = %s/%s", detail.Namespace, detail.Name)
+	}
+	manifest := detail.Manifest
+	if manifest.Metadata.Name != "" || manifest.Metadata.Namespace != "team-a" {
+		t.Fatalf("Session manifest identity = %s/%s", manifest.Metadata.Namespace, manifest.Metadata.Name)
+	}
+	if len(manifest.Metadata.Labels) != 0 || len(manifest.Metadata.Annotations) != 0 {
+		t.Fatalf("Session manifest copied source metadata: labels %v annotations %v", manifest.Metadata.Labels, manifest.Metadata.Annotations)
+	}
+	worker := manifest.Spec.Worker
+	if worker.Type != "codex" || worker.Model != "gpt-5" || worker.Effort != "high" || worker.Image != "example.com/codex:latest" || worker.Credentials == nil || worker.Credentials.SecretRef.Name != "codex-credentials" {
+		t.Fatalf("Session manifest worker = %#v", worker)
+	}
+	if worker.WorkspaceRef == nil || worker.WorkspaceRef.Name != "kelos" || len(worker.AgentConfigRefs) != 2 {
+		t.Fatalf("Session manifest references = workspace %#v AgentConfigs %#v", worker.WorkspaceRef, worker.AgentConfigRefs)
+	}
+	if worker.PodOverrides == nil || len(worker.PodOverrides.Env) != 1 || worker.PodOverrides.Env[0].Name != "REVIEW_MODE" {
+		t.Fatalf("Session manifest Pod overrides = %#v", worker.PodOverrides)
+	}
+	if manifest.Spec.VolumeClaimTemplate == nil {
+		t.Fatal("Session manifest volumeClaimTemplate is nil")
+	}
+	if manifest.Spec.VolumeClaimTemplate.StorageClassName == nil || *manifest.Spec.VolumeClaimTemplate.StorageClassName != "" {
+		t.Fatalf("storageClassName = %v, want explicit empty string", manifest.Spec.VolumeClaimTemplate.StorageClassName)
+	}
+	wantStorage := resource.MustParse("20Gi")
+	if storage := manifest.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage]; storage.Cmp(wantStorage) != 0 {
+		t.Fatalf("storage request = %s, want %s", storage.String(), wantStorage.String())
+	}
+	for _, expected := range []string{
+		"apiVersion: kelos.dev/v1alpha2",
+		"kind: Session",
+		`name: ""`,
+		"namespace: team-a",
+		"name: codex-credentials",
+		"effort: high",
+		"image: example.com/codex:latest",
+		"name: REVIEW_MODE",
+		`storageClassName: ""`,
+		"storage: 20Gi",
+	} {
+		if !strings.Contains(detail.YAML, expected) {
+			t.Errorf("generated Session YAML does not contain %q:\n%s", expected, detail.YAML)
+		}
+	}
+	for _, unexpected := range []string{"codex-review-0", "purpose: review", "owner: platform", "status:"} {
+		if strings.Contains(detail.YAML, unexpected) {
+			t.Errorf("generated Session YAML contains source runtime data %q:\n%s", unexpected, detail.YAML)
+		}
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/sessions/team-a/missing", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("missing source Session status = %d body = %s", response.Code, response.Body.String())
 	}
 }
 

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -24,6 +24,8 @@ const elements = {
   namespaceForm: document.querySelector('#namespace-form'),
   activeNamespace: document.querySelector('#active-namespace'),
   namespace: document.querySelector('[name="namespace"]'),
+  sessionSource: document.querySelector('#session-source'),
+  sessionSourceStatus: document.querySelector('#session-source-status'),
   provider: document.querySelector('[name="provider"]'),
   credentialType: document.querySelector('#credential-type'),
   secretField: document.querySelector('#secret-field'),
@@ -67,9 +69,14 @@ const state = {
   defaultNamespace: 'default',
   namespace: 'default',
   namespaceGeneration: 0,
-  options: {credentials: [], workspaces: [], agentConfigs: []},
+  options: {credentials: [], workspaces: [], agentConfigs: [], sessions: []},
   selectedAgentConfigs: [],
   creationMode: 'form',
+  sourceGeneration: 0,
+  sourceLoading: false,
+  creatingSession: false,
+  sourceStorageClassNamePresent: false,
+  loadedSource: null,
 };
 
 const customOption = '__custom__';
@@ -249,6 +256,7 @@ async function loadOptions() {
   }
   if (generation !== state.namespaceGeneration) return;
   state.options = options;
+  renderSessionSourceOptions();
   renderCredentialOptions();
   renderWorkspaceOptions();
   renderAgentConfigOptions();
@@ -256,6 +264,13 @@ async function loadOptions() {
 
 function resetNamespaceReferences() {
   state.selectedAgentConfigs = [];
+  state.sourceGeneration += 1;
+  setSourceLoading(false);
+  state.sourceStorageClassNamePresent = false;
+  state.loadedSource = null;
+  elements.sessionSource.value = '';
+  elements.sessionSourceStatus.hidden = true;
+  elements.sessionSourceStatus.textContent = '';
   elements.credentialSecret.value = '';
   elements.credentialSecretCustom.value = '';
   elements.workspace.value = '';
@@ -265,15 +280,18 @@ function resetNamespaceReferences() {
 async function switchNamespace(namespace) {
   namespace = namespace.trim();
   if (!namespace || namespace === state.namespace) return;
+  const hadLoadedSource = Boolean(state.loadedSource);
   state.namespace = namespace;
   state.namespaceGeneration += 1;
   state.sessions = [];
-  state.options = {credentials: [], workspaces: [], agentConfigs: []};
+  state.options = {credentials: [], workspaces: [], agentConfigs: [], sessions: []};
   window.localStorage.setItem('kelos-session-namespace', namespace);
   elements.activeNamespace.value = namespace;
   elements.namespace.value = namespace;
   resetNamespaceReferences();
   elements.yaml.value = '';
+  if (hadLoadedSource) resetSourceValues();
+  renderSessionSourceOptions();
   renderCredentialOptions();
   renderWorkspaceOptions();
   renderAgentConfigOptions();
@@ -291,6 +309,14 @@ function addOption(select, value, label) {
 
 function credentialTypeLabel(type) {
   return type === 'api-key' ? 'API key' : type === 'oauth' ? 'OAuth' : type;
+}
+
+function renderSessionSourceOptions() {
+  const previous = elements.sessionSource.value;
+  elements.sessionSource.replaceChildren();
+  addOption(elements.sessionSource, '', 'Start from scratch');
+  for (const name of state.options.sessions) addOption(elements.sessionSource, name, name);
+  if (state.options.sessions.includes(previous)) elements.sessionSource.value = previous;
 }
 
 function renderCredentialOptions() {
@@ -411,6 +437,162 @@ function renderSelectedAgentConfigs() {
     chip.append(order, label, remove);
     elements.selectedAgentConfigs.append(chip);
   });
+}
+
+function setSourceCredential(credentials) {
+  const type = credentials?.type || 'none';
+  elements.credentialType.value = type;
+  renderCredentialOptions();
+  const name = credentials?.secretRef?.name || '';
+  const match = Array.from(elements.credentialSecret.options).find(option =>
+    option.dataset.name === name && option.dataset.type === type,
+  );
+  if (match) {
+    elements.credentialSecret.value = match.value;
+    elements.credentialSecretCustom.value = '';
+  } else if (name) {
+    elements.credentialSecret.value = customOption;
+    elements.credentialSecretCustom.value = name;
+  }
+  updateCredentialField();
+}
+
+function setSourceWorkspace(workspaceRef) {
+  const name = workspaceRef?.name || '';
+  renderWorkspaceOptions();
+  if (!name || state.options.workspaces.includes(name)) {
+    elements.workspace.value = name;
+    elements.workspaceCustom.value = '';
+  } else {
+    elements.workspace.value = customOption;
+    elements.workspaceCustom.value = name;
+  }
+  updateWorkspaceField();
+}
+
+function sourceFitsForm(manifest) {
+  const worker = manifest.spec.worker;
+  const allowedWorkerFields = new Set(['type', 'credentials', 'model', 'workspaceRef', 'agentConfigRefs']);
+  if (Object.keys(worker).some(key => !allowedWorkerFields.has(key))) return false;
+  const claim = manifest.spec.volumeClaimTemplate;
+  if (!claim) return true;
+  const allowedClaimFields = new Set(['accessModes', 'resources', 'storageClassName']);
+  if (Object.keys(claim).some(key => !allowedClaimFields.has(key))) return false;
+  if (!Array.isArray(claim.accessModes) || claim.accessModes.length !== 1) return false;
+  const resources = claim.resources || {};
+  if (Object.keys(resources).some(key => key !== 'requests')) return false;
+  const requests = resources.requests || {};
+  return Object.keys(requests).length === 1 && typeof requests.storage === 'string';
+}
+
+function describeSourceReferences(manifest) {
+  const worker = manifest.spec.worker;
+  const references = [];
+  if (worker.credentials?.secretRef?.name) references.push(`Secret ${worker.credentials.secretRef.name}`);
+  if (worker.workspaceRef?.name) references.push(`Workspace ${worker.workspaceRef.name}`);
+  if (worker.agentConfigRefs?.length) {
+    references.push(`AgentConfigs ${worker.agentConfigRefs.map(reference => reference.name).join(', ')}`);
+  }
+  let description = references.length
+    ? ` Namespace references: ${references.join('; ')}.`
+    : ' No direct credential, Workspace, or AgentConfig references.';
+  const advanced = [];
+  if (worker.podOverrides) advanced.push('Pod overrides');
+  if (manifest.spec.volumeClaimTemplate) advanced.push('persistent-volume settings');
+  if (advanced.length) {
+    description += ` Review ${advanced.join(' and ')} in YAML for additional namespace-scoped references.`;
+  }
+  return description;
+}
+
+function populateSessionSource(detail) {
+  const manifest = detail.manifest;
+  const worker = manifest.spec.worker;
+  elements.form.elements.name.value = '';
+  elements.namespace.value = detail.namespace;
+  elements.provider.value = worker.type;
+  elements.form.elements.model.value = worker.model || '';
+  setSourceCredential(worker.credentials);
+  setSourceWorkspace(worker.workspaceRef);
+  state.selectedAgentConfigs = (worker.agentConfigRefs || []).map(reference => reference.name);
+  renderAgentConfigOptions();
+
+  const claim = manifest.spec.volumeClaimTemplate;
+  state.sourceStorageClassNamePresent = Boolean(claim && 'storageClassName' in claim);
+  elements.persistentVolume.checked = Boolean(claim);
+  elements.form.elements.storageRequest.value = claim?.resources?.requests?.storage || '10Gi';
+  elements.form.elements.accessMode.value = claim?.accessModes?.[0] || 'ReadWriteOnce';
+  elements.form.elements.storageClassName.value = claim?.storageClassName ?? '';
+  updateVolumeClaimFields();
+  elements.yaml.value = detail.yaml;
+  const formCompatible = sourceFitsForm(manifest);
+  elements.sessionSourceStatus.textContent =
+    `Loaded reusable settings from Session ${detail.namespace}/${detail.name}. Enter a name for the new Session.` +
+    describeSourceReferences(manifest) +
+    (formCompatible ? '' : ' YAML mode is required to preserve settings that the form cannot represent.');
+  elements.sessionSourceStatus.hidden = false;
+  state.loadedSource = {name: detail.name, namespace: detail.namespace, formCompatible};
+  elements.formMode.disabled = !formCompatible;
+  if (!formCompatible) setCreationMode('yaml');
+}
+
+function resetSourceValues() {
+  const mode = state.creationMode;
+  elements.form.reset();
+  state.selectedAgentConfigs = [];
+  state.sourceStorageClassNamePresent = false;
+  state.loadedSource = null;
+  elements.formMode.disabled = false;
+  elements.namespace.value = state.namespace;
+  elements.yaml.value = '';
+  elements.sessionSourceStatus.hidden = true;
+  elements.sessionSourceStatus.textContent = '';
+  renderSessionSourceOptions();
+  renderCredentialOptions();
+  renderWorkspaceOptions();
+  renderAgentConfigOptions();
+  updateVolumeClaimFields();
+  setCreationMode(mode);
+}
+
+function updateCreationBusyState() {
+  const busy = state.sourceLoading || state.creatingSession;
+  elements.sessionSource.disabled = busy;
+  elements.createButton.disabled = busy;
+}
+
+function setSourceLoading(loading) {
+  state.sourceLoading = loading;
+  updateCreationBusyState();
+}
+
+function setCreatingSession(creating) {
+  state.creatingSession = creating;
+  updateCreationBusyState();
+}
+
+async function loadSessionSource(name) {
+  const generation = ++state.sourceGeneration;
+  if (!name) {
+    setSourceLoading(false);
+    resetSourceValues();
+    return;
+  }
+  const namespace = state.namespace;
+  setSourceLoading(true);
+  elements.dialogError.textContent = '';
+  try {
+    const detail = await api(`/api/sessions/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`);
+    if (generation !== state.sourceGeneration || namespace !== state.namespace) return;
+    populateSessionSource(detail);
+  } catch (error) {
+    if (generation === state.sourceGeneration) {
+      elements.sessionSource.value = state.loadedSource?.name || '';
+      elements.dialogError.textContent = error.message;
+    }
+  } finally {
+    if (generation === state.sourceGeneration) setSourceLoading(false);
+  }
 }
 
 function selectSession(session) {
@@ -1209,6 +1391,7 @@ elements.namespaceForm.addEventListener('submit', async event => {
     showToast(error.message);
   }
 });
+elements.sessionSource.addEventListener('change', () => loadSessionSource(elements.sessionSource.value));
 elements.credentialType.addEventListener('change', () => {
   const option = elements.credentialSecret.selectedOptions[0];
   if (option?.dataset.type && option.dataset.type !== elements.credentialType.value) {
@@ -1236,6 +1419,7 @@ elements.addAgentConfig.addEventListener('click', () => {
 elements.formMode.addEventListener('click', () => setCreationMode('form'));
 elements.yamlMode.addEventListener('click', () => setCreationMode('yaml'));
 elements.persistentVolume.addEventListener('change', updateVolumeClaimFields);
+renderSessionSourceOptions();
 renderCredentialOptions();
 renderWorkspaceOptions();
 renderAgentConfigOptions();
@@ -1244,10 +1428,10 @@ setCreationMode('form');
 
 elements.form.addEventListener('submit', async event => {
   event.preventDefault();
+  if (state.sourceLoading || state.creatingSession) return;
   if (!elements.form.reportValidity()) return;
   elements.dialogError.textContent = '';
-  const submit = elements.createButton;
-  submit.disabled = true;
+  setCreatingSession(true);
   try {
     let created;
     if (state.creationMode === 'yaml') {
@@ -1281,7 +1465,9 @@ elements.form.addEventListener('submit', async event => {
           resources: {requests: {storage: values.get('storageRequest').trim()}},
         };
         const storageClassName = values.get('storageClassName').trim();
-        if (storageClassName) payload.volumeClaimTemplate.storageClassName = storageClassName;
+        if (storageClassName || state.sourceStorageClassNamePresent) {
+          payload.volumeClaimTemplate.storageClassName = storageClassName;
+        }
       }
       created = await api('/api/sessions', {
         method: 'POST',
@@ -1290,11 +1476,19 @@ elements.form.addEventListener('submit', async event => {
     }
     elements.dialog.close();
     elements.form.reset();
+    state.sourceGeneration += 1;
+    setSourceLoading(false);
     state.selectedAgentConfigs = [];
+    state.sourceStorageClassNamePresent = false;
+    state.loadedSource = null;
+    elements.formMode.disabled = false;
     elements.namespace.value = state.namespace;
     elements.yaml.value = '';
+    elements.sessionSourceStatus.hidden = true;
+    elements.sessionSourceStatus.textContent = '';
     updateVolumeClaimFields();
     setCreationMode('form');
+    renderSessionSourceOptions();
     renderCredentialOptions();
     renderWorkspaceOptions();
     renderAgentConfigOptions();
@@ -1304,7 +1498,7 @@ elements.form.addEventListener('submit', async event => {
   } catch (error) {
     elements.dialogError.textContent = error.message;
   } finally {
-    submit.disabled = false;
+    setCreatingSession(false);
   }
 });
 

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -98,6 +98,14 @@
         <button type="button" id="session-mode-form" role="tab" aria-selected="true">Form</button>
         <button type="button" id="session-mode-yaml" role="tab" aria-selected="false">YAML</button>
       </div>
+      <div class="source-picker">
+        <label for="session-source">Generate from Session <em>optional</em></label>
+        <select name="sessionSource" id="session-source">
+          <option value="">Start from scratch</option>
+        </select>
+        <small>Copies the full Session spec, but not metadata, conversation, or volume data.</small>
+        <div class="source-status" id="session-source-status" role="status" hidden></div>
+      </div>
       <fieldset class="mode-panel" id="session-form-fields">
         <div class="form-grid">
         <label>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -176,6 +176,14 @@ button { color: inherit; }
 .mode-switch { width: fit-content; display: flex; margin-top: 20px; padding: 3px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
 .mode-switch button { padding: 6px 13px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 700; cursor: pointer; }
 .mode-switch button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 2px 7px rgba(31,46,38,.08); }
+.mode-switch button:disabled { opacity: .45; cursor: not-allowed; }
+.source-picker { margin-top: 18px; }
+.source-picker > label { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 700; }
+.source-picker em { color: var(--faint); font-size: 9px; font-style: normal; font-weight: 500; text-transform: uppercase; }
+.source-picker select { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
+.source-picker select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.source-picker small { display: block; margin-top: 5px; color: var(--faint); font-size: 9.5px; line-height: 1.4; }
+.source-status { margin-top: 9px; padding: 9px 11px; border: 1px solid var(--accent-soft); border-radius: 9px; background: var(--accent-soft); color: var(--accent-2); font-size: 10px; line-height: 1.45; }
 .mode-panel { min-width: 0; margin: 0; padding: 0; border: 0; }
 .mode-panel[hidden], .nested-grid[hidden] { display: none; }
 .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-top: 23px; }
@@ -242,5 +250,5 @@ button { color: inherit; }
   .diff-lines { background: #121915; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
-  .form-grid input, .form-grid select { border-color: #3a4740; }
+  .form-grid input, .form-grid select, .source-picker select { border-color: #3a4740; }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a reusable Session creation flow based on existing Sessions instead of install-time static templates.

The Session creation dialog lists Sessions from the active namespace. Selecting one copies its complete `Session.spec`, leaves the new Session name blank, and identifies the Secret, Workspace, and AgentConfig references that will be reused. Values supported by the form populate its fields; specs containing advanced worker or persistent-volume settings remain editable in YAML mode so those values are preserved.

The generated Session does not copy source metadata, conversation history, or persistent-volume data. The source Session is not modified.

The Session server now accepts the complete `WorkerSpec` through both JSON creation and YAML apply, including image, effort, and Pod overrides. This also removes the Session template file flag, parser, Helm value, ConfigMap, volume mount, and related documentation.

#### Which issue(s) this PR is related to:

Fixes #1469

#### Special notes for your reviewer:

Credential Secrets, Workspaces, AgentConfigs, and source Sessions are scoped to the namespace active in the UI. Because the server accepts the complete `WorkerSpec`, holders of the shared Session server token can configure the full worker execution environment within the server's Kubernetes Session permissions.

Validation:

- `make update`
- `env -u CODEX_HOME -u CODEX_AUTH_JSON make test`
- `make test-integration` (136 specs passed)
- `env -u CODEX_HOME -u CODEX_AUTH_JSON make verify`
- `node --check internal/sessionserver/web/app.js`

#### Does this PR introduce a user-facing change?

```release-note
Allow new Sessions to reuse the complete spec from existing Sessions in the active namespace.
```
