### PR TITLE
Keep Session prompt drafts separate

### DIFF
--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -333,6 +333,27 @@ func TestSessionComposerUsesOneSendAndInterruptAction(t *testing.T) {
 	}
 }
 
+func TestSessionComposerKeepsDraftsPerSession(t *testing.T) {
+	source, err := webFiles.ReadFile("web/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for description, expected := range map[string]string{
+		"draft storage":           `promptDrafts: new Map()`,
+		"draft save key":          `state.promptDrafts.set(sessionKey(session), elements.input.value)`,
+		"draft clear key":         `state.promptDrafts.delete(sessionKey(session))`,
+		"Session selection save":  "function selectSession(session) {\n  savePromptDraft(state.selected);",
+		"Session draft restore":   `state.promptDrafts.get(sessionKey(session))`,
+		"prompt submission clear": "state.socket.send(JSON.stringify({type: 'message', text}));\n    clearPromptDraft(state.selected);",
+		"Session deletion clear":  "selectSession(null);\n    clearPromptDraft(session);",
+		"composer input save":     "elements.input.addEventListener('input', () => {\n  savePromptDraft(state.selected);",
+	} {
+		if !strings.Contains(string(source), expected) {
+			t.Errorf("Session composer is missing %s: %s", description, expected)
+		}
+	}
+}
+
 func TestSessionAPIHappyPath(t *testing.T) {
 	server := testServer(t)
 	request := httptest.NewRequest(http.MethodGet, "/api/config", nil)

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -61,6 +61,7 @@ const state = {
   diffs: new Map(),
   fileChanges: new Map(),
   queuedMessages: new Map(),
+  promptDrafts: new Map(),
   activeTurn: false,
   interrupting: false,
   defaultNamespace: 'default',
@@ -99,6 +100,30 @@ function showToast(message) {
 
 function sessionKey(session) {
   return `${session.namespace}/${session.name}`;
+}
+
+function savePromptDraft(session) {
+  if (!session) return;
+  if (elements.input.value) {
+    state.promptDrafts.set(sessionKey(session), elements.input.value);
+  } else {
+    state.promptDrafts.delete(sessionKey(session));
+  }
+}
+
+function restorePromptDraft(session) {
+  elements.input.value = session ? state.promptDrafts.get(sessionKey(session)) || '' : '';
+  resizeComposer();
+}
+
+function clearPromptDraft(session) {
+  if (!session) return;
+  state.promptDrafts.delete(sessionKey(session));
+  if (state.selected && sessionKey(state.selected) === sessionKey(session)) {
+    elements.input.value = '';
+    resizeComposer();
+    updateComposerAction();
+  }
 }
 
 function providerLabel(provider) {
@@ -389,6 +414,7 @@ function renderSelectedAgentConfigs() {
 }
 
 function selectSession(session) {
+  savePromptDraft(state.selected);
   closeSocket();
   state.selected = session;
   state.lastEventID = 0;
@@ -404,6 +430,7 @@ function selectSession(session) {
   state.interrupting = false;
   setActiveView('conversation');
   renderFileChanges();
+  restorePromptDraft(session);
   elements.messages.replaceChildren();
   renderSessions();
   renderHeader();
@@ -1134,9 +1161,7 @@ elements.composer.addEventListener('submit', event => {
   if (!state.socket || state.socket.readyState !== WebSocket.OPEN) return;
   if (text) {
     state.socket.send(JSON.stringify({type: 'message', text}));
-    elements.input.value = '';
-    resizeComposer();
-    updateComposerAction();
+    clearPromptDraft(state.selected);
   } else if (state.activeTurn) {
     interruptActiveTurn();
   }
@@ -1149,6 +1174,7 @@ elements.input.addEventListener('keydown', event => {
   }
 });
 elements.input.addEventListener('input', () => {
+  savePromptDraft(state.selected);
   resizeComposer();
   updateComposerAction();
 });
@@ -1288,6 +1314,7 @@ elements.deleteButton.addEventListener('click', async () => {
   try {
     await api(`/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}`, {method: 'DELETE'});
     selectSession(null);
+    clearPromptDraft(session);
     await loadSessions();
     showToast('Session deleted');
   } catch (error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Session server web client kept composer text in one shared textarea. Switching Sessions could therefore expose another Session's unsent prompt and make it easy to send text to the wrong conversation.

This change keeps prompt drafts in memory keyed by Session namespace and name, preserves and restores each draft when switching Sessions, clears only the selected Session's draft after submission, and removes the deleted Session's saved draft. It also adds a focused embedded-client contract test for the draft lifecycle.

#### Which issue(s) this PR is related to:

Fixes #1472

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Session server prompt drafts are separated for each Session.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Session composer drafts per Session so switching Sessions never shows or sends another Session’s unsent prompt. Saves the current draft on switch, restores it on return, and clears only the active Session’s draft on submit or delete. Fixes #1472.

- **Bug Fixes**
  - Store drafts in `state.promptDrafts` keyed by `namespace/name`.
  - Save drafts on input and when switching away; restore when selecting a Session.
  - Clear only the active Session’s draft on submit; also clear on Session delete.
  - Add a focused test to verify save/restore/clear wiring.

<sup>Written for commit c7b598c93f8bcffc63e3ba5a4e1c7bc6a267da78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

