### PR TITLE
Sync session runtime version with controller

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -196,9 +196,24 @@ jobs:
             --patch '{"spec":{"ports":[{"name":"webhook","nodePort":30081,"port":8443,"protocol":"TCP","targetPort":"webhook"}]}}'
           kubectl rollout restart deployment/kelos-controller-manager -n kelos-system
           kubectl rollout status deployment/kelos-controller-manager -n kelos-system --timeout=120s
+          mapfile -t session_statefulsets < <(
+            kubectl get statefulset --all-namespaces \
+              -l kelos.dev/component=session \
+              -o 'jsonpath={range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}'
+          )
+          for statefulset in "${session_statefulsets[@]}"; do
+            namespace="${statefulset%%/*}"
+            name="${statefulset#*/}"
+            kubectl rollout restart "statefulset/${name}" -n "${namespace}"
+          done
           kubectl rollout restart deployment/kelos-session-server -n kelos-system
           kubectl rollout restart deployment -l kelos.dev/component=spawner -n "${KELOS_NAMESPACE}"
           kubectl rollout restart deployment/kelos-webhook-github -n kelos-system
+          for statefulset in "${session_statefulsets[@]}"; do
+            namespace="${statefulset%%/*}"
+            name="${statefulset#*/}"
+            kubectl rollout status "statefulset/${name}" -n "${namespace}" --timeout=120s
+          done
           kubectl rollout status deployment/kelos-session-server -n kelos-system --timeout=120s
           kubectl rollout status deployment -l kelos.dev/component=spawner -n "${KELOS_NAMESPACE}" --timeout=120s
           kubectl rollout status deployment/kelos-webhook-github -n kelos-system --timeout=120s

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Build and push image
         env:
           VERSION: ${{ needs.determine-version.outputs.version }}
-        run: make image IMAGE_PLATFORMS=linux/${{ matrix.arch }} PUSH=true VERSION="$VERSION-${{ matrix.arch }}"
+        run: make image IMAGE_PLATFORMS=linux/${{ matrix.arch }} PUSH=true VERSION="$VERSION-${{ matrix.arch }}" KELOS_VERSION="$VERSION"
 
   merge-manifests:
     needs: [determine-version, build-images]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 # Image configuration
 REGISTRY ?= ghcr.io/kelos-dev
 VERSION ?= latest
+# Release image tags may be architecture-specific while KELOS_VERSION remains shared.
+KELOS_VERSION ?= $(VERSION)
 IMAGE_DIRS ?= cmd/kelos-controller cmd/kelos-spawner cmd/kelos-worker-runner cmd/kelos-session-runtime cmd/kelos-session-server cmd/ghproxy cmd/kelos-webhook-server claude-code codex gemini opencode cursor cmd/kelos-slack-server
 LOCAL_ARCH ?= $(shell go env GOARCH)
 
-# Version injection for the kelos CLI – only set ldflags when an explicit
-# version is given so that dev builds fall through to runtime/debug info.
+# Version injection – only set ldflags when an explicit version is given so
+# that dev builds fall through to runtime/debug info and latest image tags.
 VERSION_PKG = github.com/kelos-dev/kelos/internal/version
-ifneq ($(VERSION),latest)
-LDFLAGS ?= -X $(VERSION_PKG).Version=$(VERSION)
+ifneq ($(KELOS_VERSION),latest)
+LDFLAGS ?= -X $(VERSION_PKG).Version=$(KELOS_VERSION)
 endif
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/cmd/kelos-controller/main.go
+++ b/cmd/kelos-controller/main.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/distribution/reference"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -26,6 +28,7 @@ import (
 	"github.com/kelos-dev/kelos/internal/githubapp"
 	"github.com/kelos-dev/kelos/internal/logging"
 	"github.com/kelos-dev/kelos/internal/telemetry"
+	"github.com/kelos-dev/kelos/internal/version"
 )
 
 var (
@@ -39,10 +42,40 @@ func init() {
 	utilruntime.Must(kelos.AddToScheme(scheme))
 }
 
+func validateImageVersion(imageVersion string) error {
+	if strings.TrimSpace(imageVersion) == "" {
+		return fmt.Errorf("--version must not be empty")
+	}
+	named, err := reference.ParseNormalizedNamed("example.com/image")
+	if err != nil {
+		return err
+	}
+	if _, err := reference.WithTag(named, imageVersion); err != nil {
+		return fmt.Errorf("invalid --version %q: %w", imageVersion, err)
+	}
+	return nil
+}
+
+func imageForVersion(image, imageVersion string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", err
+	}
+	if !reference.IsNameOnly(named) {
+		return image, nil
+	}
+	tagged, err := reference.WithTag(named, imageVersion)
+	if err != nil {
+		return "", err
+	}
+	return reference.FamiliarString(tagged), nil
+}
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var kelosVersion string
 	var claudeCodeImage string
 	var claudeCodeImagePullPolicy string
 	var codexImage string
@@ -76,21 +109,22 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&claudeCodeImage, "claude-code-image", controller.ClaudeCodeImage, "The image to use for Claude Code agent containers.")
+	flag.StringVar(&kelosVersion, "version", version.Version, "The shared tag applied to untagged managed images.")
+	flag.StringVar(&claudeCodeImage, "claude-code-image", controller.ClaudeCodeImageRepository, "The image repository or tagged image to use for Claude Code agent containers.")
 	flag.StringVar(&claudeCodeImagePullPolicy, "claude-code-image-pull-policy", "", "The image pull policy for Claude Code agent containers (e.g., Always, Never, IfNotPresent).")
-	flag.StringVar(&codexImage, "codex-image", controller.CodexImage, "The image to use for Codex agent containers.")
+	flag.StringVar(&codexImage, "codex-image", controller.CodexImageRepository, "The image repository or tagged image to use for Codex agent containers.")
 	flag.StringVar(&codexImagePullPolicy, "codex-image-pull-policy", "", "The image pull policy for Codex agent containers (e.g., Always, Never, IfNotPresent).")
-	flag.StringVar(&geminiImage, "gemini-image", controller.GeminiImage, "The image to use for Gemini CLI agent containers.")
+	flag.StringVar(&geminiImage, "gemini-image", controller.GeminiImageRepository, "The image repository or tagged image to use for Gemini CLI agent containers.")
 	flag.StringVar(&geminiImagePullPolicy, "gemini-image-pull-policy", "", "The image pull policy for Gemini CLI agent containers (e.g., Always, Never, IfNotPresent).")
-	flag.StringVar(&openCodeImage, "opencode-image", controller.OpenCodeImage, "The image to use for OpenCode agent containers.")
+	flag.StringVar(&openCodeImage, "opencode-image", controller.OpenCodeImageRepository, "The image repository or tagged image to use for OpenCode agent containers.")
 	flag.StringVar(&openCodeImagePullPolicy, "opencode-image-pull-policy", "", "The image pull policy for OpenCode agent containers (e.g., Always, Never, IfNotPresent).")
-	flag.StringVar(&cursorImage, "cursor-image", controller.CursorImage, "The image to use for Cursor CLI agent containers.")
+	flag.StringVar(&cursorImage, "cursor-image", controller.CursorImageRepository, "The image repository or tagged image to use for Cursor CLI agent containers.")
 	flag.StringVar(&cursorImagePullPolicy, "cursor-image-pull-policy", "", "The image pull policy for Cursor CLI agent containers (e.g., Always, Never, IfNotPresent).")
-	flag.StringVar(&spawnerImage, "spawner-image", controller.DefaultSpawnerImage, "The image to use for spawner Deployments.")
+	flag.StringVar(&spawnerImage, "spawner-image", controller.SpawnerImageRepository, "The image repository or tagged image to use for spawner Deployments.")
 	flag.StringVar(&spawnerImagePullPolicy, "spawner-image-pull-policy", "", "The image pull policy for spawner Deployments (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&spawnerResourceRequests, "spawner-resource-requests", "", "Resource requests for spawner containers as comma-separated name=value pairs (e.g., cpu=250m,memory=512Mi).")
 	flag.StringVar(&spawnerResourceLimits, "spawner-resource-limits", "", "Resource limits for spawner containers as comma-separated name=value pairs (e.g., cpu=1,memory=1Gi).")
-	flag.StringVar(&ghProxyImage, "ghproxy-image", controller.DefaultGHProxyImage, "The image to use for workspace ghproxy Deployments.")
+	flag.StringVar(&ghProxyImage, "ghproxy-image", controller.GHProxyImageRepository, "The image repository or tagged image to use for workspace ghproxy Deployments.")
 	flag.StringVar(&ghProxyImagePullPolicy, "ghproxy-image-pull-policy", "", "The image pull policy for workspace ghproxy Deployments (e.g., Always, Never, IfNotPresent).")
 	flag.StringVar(&ghProxyResourceRequests, "ghproxy-resource-requests", "", "Resource requests for workspace ghproxy containers as comma-separated name=value pairs (e.g., cpu=50m,memory=64Mi).")
 	flag.StringVar(&ghProxyResourceLimits, "ghproxy-resource-limits", "", "Resource limits for workspace ghproxy containers as comma-separated name=value pairs (e.g., cpu=200m,memory=128Mi).")
@@ -99,9 +133,9 @@ func main() {
 	flag.StringVar(&telemetryEndpoint, "telemetry-endpoint", telemetry.DefaultPostHogEndpoint, "The PostHog endpoint for sending telemetry reports.")
 	flag.StringVar(&telemetryEnvironment, "telemetry-environment", "production", "The environment label for telemetry reports (e.g., production, development).")
 	flag.StringVar(&codexAuthRefresherSchedule, "codex-auth-refresher-schedule", controller.DefaultCodexAuthRefreshSchedule, "Cron schedule for managed Codex OAuth refresher CronJobs.")
-	flag.StringVar(&workerRunnerImage, "worker-runner-image", controller.DefaultWorkerRunnerImage, "The image to use for worker-runner containers in WorkerPool StatefulSets.")
+	flag.StringVar(&workerRunnerImage, "worker-runner-image", controller.WorkerRunnerImageRepository, "The image repository or tagged image to use for worker-runner containers in WorkerPool StatefulSets.")
 	flag.StringVar(&workerRunnerImagePullPolicy, "worker-runner-image-pull-policy", "", "The image pull policy for worker-runner containers (e.g., Always, Never, IfNotPresent).")
-	flag.StringVar(&sessionRuntimeImage, "session-runtime-image", controller.DefaultSessionRuntimeImage, "The image used to inject the runtime into Session Pods.")
+	flag.StringVar(&sessionRuntimeImage, "session-runtime-image", controller.SessionRuntimeImageRepository, "The image repository or tagged image used to inject the runtime into Session Pods.")
 	flag.StringVar(&sessionRuntimeImagePullPolicy, "session-runtime-image-pull-policy", "", "The image pull policy for the Session runtime image (e.g., Always, Never, IfNotPresent).")
 
 	opts, applyVerbosity := logging.SetupZapOptions(flag.CommandLine)
@@ -110,6 +144,32 @@ func main() {
 	if err := applyVerbosity(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+	if err := validateImageVersion(kelosVersion); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	imageFlags := []struct {
+		name  string
+		value *string
+	}{
+		{name: "claude-code-image", value: &claudeCodeImage},
+		{name: "codex-image", value: &codexImage},
+		{name: "gemini-image", value: &geminiImage},
+		{name: "opencode-image", value: &openCodeImage},
+		{name: "cursor-image", value: &cursorImage},
+		{name: "spawner-image", value: &spawnerImage},
+		{name: "ghproxy-image", value: &ghProxyImage},
+		{name: "worker-runner-image", value: &workerRunnerImage},
+		{name: "session-runtime-image", value: &sessionRuntimeImage},
+	}
+	for _, imageFlag := range imageFlags {
+		resolved, err := imageForVersion(*imageFlag.value, kelosVersion)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid --%s %q: %v\n", imageFlag.name, *imageFlag.value, err)
+			os.Exit(1)
+		}
+		*imageFlag.value = resolved
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(opts)))

--- a/cmd/kelos-controller/main_test.go
+++ b/cmd/kelos-controller/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import "testing"
+
+func TestValidateImageVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "release", version: "v1.2.3"},
+		{name: "development", version: "main"},
+		{name: "empty", wantErr: true},
+		{name: "whitespace", version: "  ", wantErr: true},
+		{name: "invalid tag", version: "release/candidate", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateImageVersion(tt.version)
+			if tt.wantErr && err == nil {
+				t.Fatal("validateImageVersion() error = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateImageVersion() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestImageForVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		image   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "repository",
+			image: "ghcr.io/kelos-dev/kelos-session-runtime",
+			want:  "ghcr.io/kelos-dev/kelos-session-runtime:v1.2.3",
+		},
+		{name: "short repository", image: "runtime", want: "runtime:v1.2.3"},
+		{name: "tagged override", image: "runtime:custom", want: "runtime:custom"},
+		{
+			name:  "digest override",
+			image: "runtime@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			want:  "runtime@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{name: "invalid image", image: "https://ghcr.io/kelos-dev/runtime", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := imageForVersion(tt.image, "v1.2.3")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("imageForVersion() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("imageForVersion() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("imageForVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -221,6 +221,16 @@ automatically. The terminal client also does not retry a request whose delivery
 cannot be confirmed; it reports that uncertainty so the user can decide whether
 to submit it again.
 
+The controller's `--version` flag defaults to its build version and applies to
+every managed image argument that does not already include a tag or digest. A
+tagged or digested image argument remains an explicit override. When the
+resolved `--session-runtime-image` changes, the controller updates every
+existing Session StatefulSet, and the StatefulSet replaces its Pod through a
+rolling update. Active work is interrupted and is not submitted again
+automatically. Helm passes the shared `image.tag` value through `--version`, so
+upgrading to a chart with a different image tag rolls existing Session Pods as
+well as the controller.
+
 When `spec.volumeClaimTemplate` is set, the StatefulSet provisions the Session
 workspace from that template and reuses it across Pod replacement. Built-in
 workspace initialization is skipped after the persistent workspace has been

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/distribution/reference v0.6.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-github/v66 v66.0.0
 	github.com/google/uuid v1.6.0
@@ -101,6 +102,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
@@ -221,6 +223,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.3 h1:eTX+W6dobAYfFeGC2PV6RwXRu/MyT+cQguijutvkpSM=
 github.com/onsi/gomega v1.38.3/go.mod h1:ZCU1pkQcXDO5Sl9/VVEGlDyp+zm0m1cmeG5TOzLgdh4=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -253,15 +253,19 @@ func TestRenderChart_ImageArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rendering chart: %v", err)
 	}
-	versionedArgs := []string{
-		"--claude-code-image=ghcr.io/kelos-dev/claude-code:v0.3.0",
-		"--codex-image=ghcr.io/kelos-dev/codex:v0.3.0",
-		"--gemini-image=ghcr.io/kelos-dev/gemini:v0.3.0",
-		"--opencode-image=ghcr.io/kelos-dev/opencode:v0.3.0",
-		"--spawner-image=ghcr.io/kelos-dev/kelos-spawner:v0.3.0",
-		"--worker-runner-image=ghcr.io/kelos-dev/kelos-worker-runner:v0.3.0",
+	controllerArgs := []string{
+		"--version=v0.3.0",
+		"--claude-code-image=ghcr.io/kelos-dev/claude-code",
+		"--codex-image=ghcr.io/kelos-dev/codex",
+		"--gemini-image=ghcr.io/kelos-dev/gemini",
+		"--opencode-image=ghcr.io/kelos-dev/opencode",
+		"--cursor-image=ghcr.io/kelos-dev/cursor",
+		"--spawner-image=ghcr.io/kelos-dev/kelos-spawner",
+		"--worker-runner-image=ghcr.io/kelos-dev/kelos-worker-runner",
+		"--session-runtime-image=ghcr.io/kelos-dev/kelos-session-runtime",
+		"--ghproxy-image=ghcr.io/kelos-dev/ghproxy",
 	}
-	for _, arg := range versionedArgs {
+	for _, arg := range controllerArgs {
 		if !bytes.Contains(data, []byte(arg)) {
 			t.Errorf("expected rendered chart to contain %q", arg)
 		}

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -16,20 +16,26 @@ import (
 )
 
 const (
+	ClaudeCodeImageRepository = "ghcr.io/kelos-dev/claude-code"
+	CodexImageRepository      = "ghcr.io/kelos-dev/codex"
+	GeminiImageRepository     = "ghcr.io/kelos-dev/gemini"
+	OpenCodeImageRepository   = "ghcr.io/kelos-dev/opencode"
+	CursorImageRepository     = "ghcr.io/kelos-dev/cursor"
+
 	// ClaudeCodeImage is the default image for Claude Code agent.
-	ClaudeCodeImage = "ghcr.io/kelos-dev/claude-code:latest"
+	ClaudeCodeImage = ClaudeCodeImageRepository + ":latest"
 
 	// CodexImage is the default image for OpenAI Codex agent.
-	CodexImage = "ghcr.io/kelos-dev/codex:latest"
+	CodexImage = CodexImageRepository + ":latest"
 
 	// GeminiImage is the default image for Google Gemini CLI agent.
-	GeminiImage = "ghcr.io/kelos-dev/gemini:latest"
+	GeminiImage = GeminiImageRepository + ":latest"
 
 	// OpenCodeImage is the default image for OpenCode agent.
-	OpenCodeImage = "ghcr.io/kelos-dev/opencode:latest"
+	OpenCodeImage = OpenCodeImageRepository + ":latest"
 
 	// CursorImage is the default image for Cursor CLI agent.
-	CursorImage = "ghcr.io/kelos-dev/cursor:latest"
+	CursorImage = CursorImageRepository + ":latest"
 
 	// AgentTypeClaudeCode is the agent type for Claude Code.
 	AgentTypeClaudeCode = "claude-code"

--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -29,19 +29,20 @@ import (
 )
 
 const (
-	// DefaultSessionRuntimeImage is the default image used to inject the Session runtime.
-	DefaultSessionRuntimeImage = "ghcr.io/kelos-dev/kelos-session-runtime:latest"
+	SessionRuntimeImageRepository = "ghcr.io/kelos-dev/kelos-session-runtime"
+	DefaultSessionRuntimeImage    = SessionRuntimeImageRepository + ":latest"
 
-	sessionRuntimeVolumeName = "kelos-session-runtime"
-	sessionRuntimeMountPath  = "/kelos/bin"
-	sessionRuntimeBinary     = sessionRuntimeMountPath + "/kelos-session-runtime"
-	sessionClaudeConfigDir   = "/workspace/.kelos/session/claude-config"
-	sessionCodexHome         = "/workspace/.kelos/session/codex-home"
-	sessionOpenCodeConfigDir = "/workspace/.kelos/session/opencode-config"
-	sessionOpenCodeDataDir   = "/workspace/.kelos/session/opencode-data"
-	sessionInitializedPath   = "/workspace/.kelos/session/initialized"
-	sessionNameAnnotation    = "kelos.dev/session-name"
-	sessionReadyCondition    = "Ready"
+	sessionRuntimeContainerName = "kelos-session-runtime"
+	sessionRuntimeVolumeName    = "kelos-session-runtime"
+	sessionRuntimeMountPath     = "/kelos/bin"
+	sessionRuntimeBinary        = sessionRuntimeMountPath + "/kelos-session-runtime"
+	sessionClaudeConfigDir      = "/workspace/.kelos/session/claude-config"
+	sessionCodexHome            = "/workspace/.kelos/session/codex-home"
+	sessionOpenCodeConfigDir    = "/workspace/.kelos/session/opencode-config"
+	sessionOpenCodeDataDir      = "/workspace/.kelos/session/opencode-data"
+	sessionInitializedPath      = "/workspace/.kelos/session/initialized"
+	sessionNameAnnotation       = "kelos.dev/session-name"
+	sessionReadyCondition       = "Ready"
 )
 
 // SessionReconciler reconciles a Session object.
@@ -62,7 +63,7 @@ type SessionReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;patch
 
 // Reconcile creates and observes the StatefulSet that owns a Session conversation.
 func (r *SessionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -94,6 +95,9 @@ func (r *SessionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	if statefulSet.DeletionTimestamp != nil {
 		return ctrl.Result{}, r.updateSessionStatus(ctx, &session, nil, kelos.SessionPhasePending, "Session StatefulSet is terminating and will be recreated", "StatefulSetTerminating")
+	}
+	if err := r.ensureSessionRuntimeImage(ctx, &statefulSet); err != nil {
+		return ctrl.Result{}, err
 	}
 	if err := r.ensureSessionService(ctx, &session); err != nil {
 		message := fmt.Sprintf("Failed to prepare Session governing Service: %v", err)
@@ -196,6 +200,29 @@ func (r *SessionReconciler) createSessionStatefulSet(ctx context.Context, sessio
 	}
 
 	return ctrl.Result{Requeue: true}, nil
+}
+
+func (r *SessionReconciler) ensureSessionRuntimeImage(ctx context.Context, statefulSet *appsv1.StatefulSet) error {
+	original := statefulSet.DeepCopy()
+	for i := range statefulSet.Spec.Template.Spec.InitContainers {
+		container := &statefulSet.Spec.Template.Spec.InitContainers[i]
+		if container.Name != sessionRuntimeContainerName {
+			continue
+		}
+		pullPolicyMatches := r.SessionRuntimeImagePullPolicy == "" || container.ImagePullPolicy == r.SessionRuntimeImagePullPolicy
+		if container.Image == r.SessionRuntimeImage && pullPolicyMatches {
+			return nil
+		}
+		container.Image = r.SessionRuntimeImage
+		if r.SessionRuntimeImagePullPolicy != "" {
+			container.ImagePullPolicy = r.SessionRuntimeImagePullPolicy
+		}
+		if err := r.Patch(ctx, statefulSet, client.MergeFrom(original)); err != nil {
+			return fmt.Errorf("patching Session StatefulSet %q runtime image: %w", statefulSet.Name, err)
+		}
+		return nil
+	}
+	return fmt.Errorf("Session StatefulSet %q has no session runtime init container", statefulSet.Name)
 }
 
 func (r *SessionReconciler) ensureSessionService(ctx context.Context, session *kelos.Session) error {
@@ -558,7 +585,7 @@ func (r *SessionReconciler) buildSessionStatefulSet(session *kelos.Session, work
 		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 	})
 	podSpec.InitContainers = append([]corev1.Container{{
-		Name:            "kelos-session-runtime",
+		Name:            sessionRuntimeContainerName,
 		Image:           r.SessionRuntimeImage,
 		ImagePullPolicy: r.SessionRuntimeImagePullPolicy,
 		Args:            []string{"--self-copy", sessionRuntimeBinary},

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -29,6 +29,60 @@ import (
 	"github.com/kelos-dev/kelos/internal/githubapp"
 )
 
+func TestSessionReconcilerUpdatesStatefulSetRuntimeImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		configuredPull corev1.PullPolicy
+		wantPull       corev1.PullPolicy
+	}{
+		{name: "configured pull policy", configuredPull: corev1.PullIfNotPresent, wantPull: corev1.PullIfNotPresent},
+		{name: "default pull policy", wantPull: corev1.PullAlways},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scheme := runtime.NewScheme()
+			if err := appsv1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := kelos.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+
+			session := testSession("chat", "claude-code")
+			statefulSet := testSessionStatefulSet(session)
+			statefulSet.Spec.Template.Spec.InitContainers[0].Image = "runtime:old"
+			statefulSet.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullAlways
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&kelos.Session{}, &corev1.Pod{}, &appsv1.StatefulSet{}).
+				WithObjects(session, statefulSet).
+				Build()
+			reconciler := testSessionReconciler(cl, scheme)
+			reconciler.SessionRuntimeImagePullPolicy = tt.configuredPull
+			request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(session)}
+			if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+				t.Fatalf("Reconcile() error = %v", err)
+			}
+
+			var updated appsv1.StatefulSet
+			if err := cl.Get(context.Background(), client.ObjectKeyFromObject(statefulSet), &updated); err != nil {
+				t.Fatalf("getting updated Session StatefulSet: %v", err)
+			}
+			runtimeContainer := updated.Spec.Template.Spec.InitContainers[0]
+			if runtimeContainer.Image != "runtime:test" {
+				t.Fatalf("runtime init container image = %q, want %q", runtimeContainer.Image, "runtime:test")
+			}
+			if runtimeContainer.ImagePullPolicy != tt.wantPull {
+				t.Fatalf("runtime init container imagePullPolicy = %q, want %q", runtimeContainer.ImagePullPolicy, tt.wantPull)
+			}
+		})
+	}
+}
+
 func TestSessionReconcilerCreatesStatefulSetAndObservesPod(t *testing.T) {
 	t.Parallel()
 	scheme := runtime.NewScheme()
@@ -578,6 +632,16 @@ func testSessionStatefulSet(session *kelos.Session) *appsv1.StatefulSet {
 			Namespace:       session.Namespace,
 			UID:             types.UID(sessionWorkloadName(session) + "-uid"),
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(session, kelos.GroupVersion.WithKind("Session"))},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name:  sessionRuntimeContainerName,
+						Image: "runtime:test",
+					}},
+				},
+			},
 		},
 	}
 }

--- a/internal/controller/taskspawner_deployment_builder.go
+++ b/internal/controller/taskspawner_deployment_builder.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
+	SpawnerImageRepository = "ghcr.io/kelos-dev/kelos-spawner"
+
 	// DefaultSpawnerImage is the default image for the spawner binary.
-	DefaultSpawnerImage = "ghcr.io/kelos-dev/kelos-spawner:latest"
+	DefaultSpawnerImage = SpawnerImageRepository + ":latest"
 
 	// SpawnerServiceAccount is the service account used by spawner Deployments.
 	SpawnerServiceAccount = "kelos-spawner"

--- a/internal/controller/workerpool_controller.go
+++ b/internal/controller/workerpool_controller.go
@@ -55,10 +55,11 @@ import (
 )
 
 const (
-	WorkerRunnerServiceAccount = "kelos-worker-runner"
-	WorkerRunnerClusterRole    = "kelos-worker-runner-role"
-	WorkerComponentLabel       = "worker"
-	DefaultWorkerRunnerImage   = "ghcr.io/kelos-dev/kelos-worker-runner:latest"
+	WorkerRunnerServiceAccount  = "kelos-worker-runner"
+	WorkerRunnerClusterRole     = "kelos-worker-runner-role"
+	WorkerComponentLabel        = "worker"
+	WorkerRunnerImageRepository = "ghcr.io/kelos-dev/kelos-worker-runner"
+	DefaultWorkerRunnerImage    = WorkerRunnerImageRepository + ":latest"
 
 	labelWorkerPool    = "kelos.dev/workerpool"
 	labelComponent     = "kelos.dev/component"

--- a/internal/controller/workspace_ghproxy_builder.go
+++ b/internal/controller/workspace_ghproxy_builder.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
+	GHProxyImageRepository = "ghcr.io/kelos-dev/ghproxy"
+
 	// DefaultGHProxyImage is the default image for workspace ghproxy Deployments.
-	DefaultGHProxyImage = "ghcr.io/kelos-dev/ghproxy:latest"
+	DefaultGHProxyImage = GHProxyImageRepository + ":latest"
 
 	workspaceProxyPort       = 8888
 	workspaceProxyNamePrefix = "ghproxy-"

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -94,6 +94,40 @@ func TestRender_VersionOverride(t *testing.T) {
 	if !strings.Contains(output, ":v1.2.3") {
 		t.Error("expected :v1.2.3 tags in rendered output")
 	}
+	for _, expected := range []string{
+		"--version=v1.2.3",
+		"--claude-code-image=ghcr.io/kelos-dev/claude-code",
+		"--codex-image=ghcr.io/kelos-dev/codex",
+		"--gemini-image=ghcr.io/kelos-dev/gemini",
+		"--opencode-image=ghcr.io/kelos-dev/opencode",
+		"--cursor-image=ghcr.io/kelos-dev/cursor",
+		"--spawner-image=ghcr.io/kelos-dev/kelos-spawner",
+		"--worker-runner-image=ghcr.io/kelos-dev/kelos-worker-runner",
+		"--session-runtime-image=ghcr.io/kelos-dev/kelos-session-runtime",
+		"--ghproxy-image=ghcr.io/kelos-dev/ghproxy",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected controller arguments to contain %q", expected)
+		}
+	}
+	if strings.Contains(output, "--session-runtime-image=ghcr.io/kelos-dev/kelos-session-runtime:v1.2.3") {
+		t.Error("expected the controller to apply the shared version to the Session runtime image")
+	}
+}
+
+func TestRender_TaggedManagedImageOverride(t *testing.T) {
+	data, err := Render(manifests.ChartFS, map[string]interface{}{
+		"image": map[string]interface{}{"tag": "v1.2.3"},
+		"sessionRuntime": map[string]interface{}{
+			"image": "example.com/session-runtime:custom",
+		},
+	})
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	if !strings.Contains(string(data), "--session-runtime-image=example.com/session-runtime:custom") {
+		t.Error("expected tagged Session runtime image override to remain unchanged")
+	}
 }
 
 func TestRender_PullPolicy(t *testing.T) {

--- a/internal/manifests/charts/kelos/README.md
+++ b/internal/manifests/charts/kelos/README.md
@@ -127,6 +127,14 @@ helm upgrade kelos oci://ghcr.io/kelos-dev/charts/kelos \
   --set crds.install=false
 ```
 
+The chart passes `image.tag` to the controller through `--version`. The
+controller applies that version to untagged managed image values, including
+`sessionRuntime.image`; tagged and digested values remain explicit overrides.
+When an upgrade changes the resolved runtime image, each existing Session
+StatefulSet replaces its Pod through a rolling update. Active work is interrupted
+and is not submitted again automatically. Persistent Session workspaces survive
+the replacement, while `emptyDir` workspaces do not.
+
 If Helm owns the CRDs and the release includes CRD changes, upgrade in two
 phases so the new webhook is ready before Helm applies conversion-backed CRDs:
 

--- a/internal/manifests/charts/kelos/templates/deployment.yaml
+++ b/internal/manifests/charts/kelos/templates/deployment.yaml
@@ -36,27 +36,30 @@ spec:
           {{- end }}
           args:
             - --leader-elect
-            - --claude-code-image={{ .Values.claudeCodeImage }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            {{- if .Values.image.tag }}
+            - --version={{ .Values.image.tag }}
+            {{- end }}
+            - --claude-code-image={{ .Values.claudeCodeImage }}
             {{- if .Values.image.pullPolicy }}
             - --claude-code-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --codex-image={{ .Values.codexImage }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --codex-image={{ .Values.codexImage }}
             {{- if .Values.image.pullPolicy }}
             - --codex-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --gemini-image={{ .Values.geminiImage }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --gemini-image={{ .Values.geminiImage }}
             {{- if .Values.image.pullPolicy }}
             - --gemini-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --opencode-image={{ .Values.opencodeImage }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --opencode-image={{ .Values.opencodeImage }}
             {{- if .Values.image.pullPolicy }}
             - --opencode-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --cursor-image={{ .Values.cursorImage }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --cursor-image={{ .Values.cursorImage }}
             {{- if .Values.image.pullPolicy }}
             - --cursor-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --spawner-image={{ .Values.spawner.image }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --spawner-image={{ .Values.spawner.image }}
             {{- if .Values.image.pullPolicy }}
             - --spawner-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
@@ -66,15 +69,15 @@ spec:
             {{- if .Values.spawner.resources.limits }}
             - --spawner-resource-limits={{ .Values.spawner.resources.limits }}
             {{- end }}
-            - --worker-runner-image={{ .Values.workerRunner.image }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --worker-runner-image={{ .Values.workerRunner.image }}
             {{- if .Values.image.pullPolicy }}
             - --worker-runner-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --session-runtime-image={{ .Values.sessionRuntime.image }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --session-runtime-image={{ .Values.sessionRuntime.image }}
             {{- if .Values.image.pullPolicy }}
             - --session-runtime-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}
-            - --ghproxy-image={{ .Values.ghproxy.image }}{{- if .Values.image.tag }}:{{ .Values.image.tag }}{{- end }}
+            - --ghproxy-image={{ .Values.ghproxy.image }}
             {{- if .Values.image.pullPolicy }}
             - --ghproxy-image-pull-policy={{ .Values.image.pullPolicy }}
             {{- end }}

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/controller"
 	"github.com/kelos-dev/kelos/internal/sessionserver"
 )
 
@@ -128,6 +129,31 @@ spec:
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(session), &current)).To(Succeed())
 			g.Expect(current.Status.Phase).To(Equal(kelos.SessionPhaseReady))
 			g.Expect(current.Status.PodName).To(Equal(pod.Name))
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
+	It("updates the runtime image of an existing StatefulSet", func() {
+		session := validSession(namespace, "runtime-update", "codex")
+		Expect(k8sClient.Create(ctx, session)).To(Succeed())
+
+		key := client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}
+		var statefulSet appsv1.StatefulSet
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, key, &statefulSet)).To(Succeed())
+			g.Expect(statefulSet.Spec.Template.Spec.InitContainers).NotTo(BeEmpty())
+			g.Expect(statefulSet.Spec.UpdateStrategy.Type).To(Equal(appsv1.RollingUpdateStatefulSetStrategyType))
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+
+		statefulSet.Spec.Template.Spec.InitContainers[0].Image = "runtime:old"
+		statefulSet.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullAlways
+		Expect(k8sClient.Update(ctx, &statefulSet)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			var updated appsv1.StatefulSet
+			g.Expect(k8sClient.Get(ctx, key, &updated)).To(Succeed())
+			g.Expect(updated.Spec.Template.Spec.InitContainers).NotTo(BeEmpty())
+			g.Expect(updated.Spec.Template.Spec.InitContainers[0].Image).To(Equal(controller.DefaultSessionRuntimeImage))
+			g.Expect(updated.Spec.Template.Spec.InitContainers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a controller `--version` flag that defaults to the binary build version and applies that tag to every untagged managed image argument. Explicit tagged or digested image arguments remain overrides. The resolved images feed Task, Session, WorkerPool, spawner, workspace ghproxy, and Codex auth refresher workloads.

The Helm chart passes `image.tag` once through `--version` and passes managed image repositories separately. Release builds inject the unsuffixed Kelos version independently from architecture-specific image tags.

The Session reconciler patches the runtime init-container image in existing StatefulSet pod templates. Kubernetes then rolls the Session Pods through the StatefulSet's `RollingUpdate` strategy, so existing Sessions move to the controller's configured runtime version during a Kelos upgrade.

The controller validates the shared version and every managed image argument at startup before constructing reconcilers. The Session reference and Helm upgrade guide document version propagation, override precedence, rollout behavior, and its effect on active work and workspace storage.

The development deployment keeps the mutable `main` tag and explicitly restarts all Session StatefulSets after the controller rollout, allowing their `Always` pull policy to fetch the current runtime image.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Rolling a Session Pod interrupts active work and does not resubmit it automatically. Persistent Session workspaces survive the replacement; `emptyDir` workspaces do not.

Validation:

- `make test`
- `make verify`
- `make test-integration` (125 specs passed)
- Controller build with `VERSION=v9.8.7-amd64 KELOS_VERSION=v9.8.7` defaults `--version` to `v9.8.7`
- Empty and invalid `--version` values exit before controller startup
- Unit tests cover repository tagging and tagged/digested override precedence

#### Does this PR introduce a user-facing change?

```release-note
Kelos now propagates the controller version to managed images and automatically rolls existing Session Pods when their resolved runtime image changes.
```
