### PR TITLE
Use dev endpoint hostnames

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -21,8 +21,8 @@ jobs:
     env:
       KELOS_NAMESPACE: ${{ vars.KELOS_NAMESPACE || 'default' }}
       KELOS_API_HOSTNAME: dev-cluster.kelos.dev
-      KELOS_SESSION_HOSTNAME: session.kelos.dev
-      KELOS_WEBHOOK_HOSTNAME: webhook.kelos.dev
+      KELOS_SESSION_HOSTNAME: dev-session.kelos.dev
+      KELOS_WEBHOOK_HOSTNAME: dev-webhook.kelos.dev
       CLOUDFLARED_VERSION: 2026.7.1
       CLOUDFLARED_DEB_SHA256: 79f790b45e6a9152c6cf63f60f4901e3d8a029f7f4be1345a24cd2373aba8e7d
     steps:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the development deployment's public endpoint checks to use `dev-session.kelos.dev` and `dev-webhook.kelos.dev`, matching the Cloudflare Tunnel routes for the local development cluster.

The workflow previously checked the old session and webhook hostnames, so a successful deployment did not verify the endpoints exposed by this cluster.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The development session health endpoint returned HTTP 200, and an unsigned request to the development webhook returned the expected HTTP 401. Validation completed with `make verify` and `git diff --check`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dev deployment endpoint checks by switching session and webhook hostnames to `dev-session.kelos.dev` and `dev-webhook.kelos.dev`. This aligns the workflow with the Cloudflare Tunnel routes for the local dev cluster and prevents false positives from checking old hostnames.

<sup>Written for commit 9d6c7fa9c1237b02f9db0f139a42c6911a60402d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

