### PR TITLE
Add initial branch and initial prompt to Session

### DIFF
--- a/api/v1alpha2/session_types.go
+++ b/api/v1alpha2/session_types.go
@@ -53,12 +53,29 @@ type SessionPullRequest struct {
 //
 // +kubebuilder:validation:XValidation:rule="has(self.worker.type) && self.worker.type in ['claude-code', 'codex', 'opencode']",message="worker.type must be claude-code, codex, or opencode"
 // +kubebuilder:validation:XValidation:rule="has(self.worker.credentials)",message="worker.credentials is required"
+// +kubebuilder:validation:XValidation:rule="!has(self.initialBranch) || size(self.initialBranch) == 0 || has(self.worker.workspaceRef)",message="worker.workspaceRef is required when initialBranch is set"
 type SessionSpec struct {
 	// Worker defines the agent and execution environment for this Session.
 	Worker WorkerSpec `json:"worker"`
 
+	// InitialBranch is the git branch to check out when initializing the Session
+	// workspace. If the branch exists on the origin remote, the Session checks
+	// it out; otherwise, it creates the branch from the Workspace ref.
+	// Requires worker.workspaceRef.
+	// +optional
+	InitialBranch string `json:"initialBranch,omitempty"`
+
+	// InitialPrompt is submitted automatically when the Session starts without
+	// retained conversation history. Persistent workspace history prevents it
+	// from being submitted again after Pod replacement. An emptyDir workspace
+	// loses that history and may submit the prompt again after Pod replacement.
+	// +optional
+	InitialPrompt string `json:"initialPrompt,omitempty"`
+
 	// VolumeClaimTemplate defines persistent storage for the Session workspace.
-	// Omit this field to use an emptyDir workspace.
+	// Persistent storage is recommended for Sessions that must retain conversation
+	// history and avoid replaying the initial prompt after Pod replacement. Omit
+	// this field to use an ephemeral emptyDir workspace, primarily for development.
 	// +optional
 	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
 }

--- a/cmd/kelos-session-runtime/main.go
+++ b/cmd/kelos-session-runtime/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
@@ -77,6 +78,8 @@ func runServe() {
 		fmt.Fprintln(os.Stderr, "Invalid configuration: KELOS_AGENT_TYPE must be set")
 		os.Exit(1)
 	}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
 	sessionClient, sessionName, podUID, err := sessionClientFromEnvironment()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Invalid configuration: %v\n", err)
@@ -87,6 +90,11 @@ func runServe() {
 		fmt.Fprintf(os.Stderr, "Invalid configuration: %v\n", err)
 		os.Exit(1)
 	}
+	session, err := sessionClient.Get(ctx, sessionName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Loading Session %q failed: %v\n", sessionName, err)
+		os.Exit(1)
+	}
 	config := sessionruntime.Config{
 		SocketPath:           envOrDefault("KELOS_SESSION_SOCKET", sessionruntime.DefaultSocketPath),
 		StateDir:             envOrDefault("KELOS_SESSION_STATE_DIR", sessionruntime.DefaultStateDir),
@@ -95,14 +103,13 @@ func runServe() {
 		Model:                os.Getenv("KELOS_MODEL"),
 		Effort:               os.Getenv("KELOS_EFFORT"),
 		PluginDir:            os.Getenv("KELOS_PLUGIN_DIR"),
+		InitialPrompt:        session.Spec.InitialPrompt,
 		Environment:          os.Environ(),
 		PublishSessionStatus: publisher,
 		SessionName:          sessionName,
 		PodUID:               podUID,
 		SessionClient:        sessionClient,
 	}
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer cancel()
 	if err := sessionruntime.Run(ctx, config); err != nil {
 		fmt.Fprintf(os.Stderr, "Session runtime failed: %v\n", err)
 		os.Exit(1)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -196,8 +196,9 @@ the refreshed value on their next sync and are not supported.
 
 A Session is one interactive Claude Code, Codex, or OpenCode conversation that
 web and terminal clients can share and reconnect to. The spec is immutable.
-Conversation history is retained on the Session workspace rather than in the
-Kubernetes API.
+Conversation events and history are retained on the Session workspace rather
+than in the Kubernetes API. If configured, `spec.initialPrompt` also remains in
+the Session resource and is visible through the Kubernetes API.
 
 | Field | Description | Required |
 |-------|-------------|----------|
@@ -209,7 +210,9 @@ Kubernetes API.
 | `spec.worker.workspaceRef.name` | Workspace cloned into the Session Pod | No |
 | `spec.worker.agentConfigRefs[].name` | Ordered AgentConfig resources | No |
 | `spec.worker.podOverrides` | Pod resources, scheduling, environment, volumes, and sidecars | No |
-| `spec.volumeClaimTemplate` | PersistentVolumeClaimSpec for the Session workspace; omit to use `emptyDir` | No |
+| `spec.initialBranch` | Git branch used to initialize the Session workspace. Checks out the branch from `origin` when it exists, or creates it from the Workspace ref. Requires `spec.worker.workspaceRef` | No |
+| `spec.initialPrompt` | Prompt submitted when the Session starts without retained conversation history. An `emptyDir` workspace may submit it again after Pod replacement | No |
+| `spec.volumeClaimTemplate` | PersistentVolumeClaimSpec for the Session workspace. Recommended for durable Sessions; omit to use an ephemeral `emptyDir` workspace | No |
 | `status.phase` | Infrastructure phase: `Pending`, `Ready`, or `Failed` | Output |
 | `status.podName` | Session Pod name | Output |
 | `status.podUID` | Identity of the Pod running the live conversation | Output |
@@ -264,12 +267,26 @@ activity, newest first. Creation counts as the initial activity. It shows
 activity, `status.branch`, and the pull request with a colored, text-labeled state
 in both the Session sidebar and conversation header.
 
+When `spec.initialBranch` is set, workspace initialization fetches and checks
+out that branch from `origin`, or creates it from `Workspace.spec.ref` when the
+remote branch does not exist. This establishes the initial branch without
+resetting a persistent workspace after the agent has started working.
+
+When `spec.initialPrompt` is non-empty and the workspace has no conversation
+history, the runtime records and submits the prompt before becoming ready.
+This provides once-per-retained-conversation delivery, not once-per-Session
+delivery. Retained history prevents the prompt from being submitted again after
+a runtime restart. An `emptyDir` workspace loses that history when its Pod is
+replaced, so the replacement starts a new conversation and submits the initial
+prompt again.
+
 When `spec.volumeClaimTemplate` is set, conversation history and workspace
 changes survive Pod replacement. The claim remains until the Session is
 deleted, after which PersistentVolume retention follows the StorageClass
 reclaim policy. `Workspace.spec.setupCommand` runs again in each replacement
-container. When the field is omitted, the workspace uses `emptyDir`, so its
-history and changes do not survive Pod replacement.
+container. Persistent storage is recommended for durable Sessions. When the
+field is omitted, the workspace uses `emptyDir`, which is primarily useful for
+development because its history and changes do not survive Pod replacement.
 
 The shared web server can create, list, delete, and connect to Sessions across
 namespaces while the web application operates on one active namespace at a
@@ -280,10 +297,11 @@ Selecting an existing Session as a source populates both the form fields and the
 editable YAML manifest. Settings that the form cannot represent remain editable
 in YAML mode.
 The creation form accepts provider, credentials, model, Workspace, AgentConfig
-references, and an optional persistent volume claim. YAML mode server-side
+references, initial branch, initial prompt, and an optional persistent volume
+claim. YAML mode server-side
 applies one `kelos.dev/v1alpha2` Session manifest in the active namespace. The
-manifest may include labels, annotations, the complete `WorkerSpec`, and an
-optional persistent volume claim.
+manifest may include labels, annotations, `initialBranch`, `initialPrompt`, the complete
+`WorkerSpec`, and an optional persistent volume claim.
 
 ## WorkerPool
 

--- a/examples/16-session/README.md
+++ b/examples/16-session/README.md
@@ -1,7 +1,9 @@
 # Interactive Session
 
 This example creates one Claude Code conversation in a dedicated one-replica
-StatefulSet. Replace the API key placeholder, then apply both files:
+StatefulSet. It checks out an `interactive-review` branch and submits an initial
+prompt before a client connects. Replace the API key placeholder, then apply the
+files:
 
 ```bash
 kubectl apply -f examples/16-session/

--- a/examples/16-session/session.yaml
+++ b/examples/16-session/session.yaml
@@ -4,6 +4,9 @@ metadata:
   name: interactive-review
   namespace: default
 spec:
+  initialBranch: interactive-review
+  initialPrompt: |
+    Inspect this repository and ask what I would like to work on.
   volumeClaimTemplate:
     accessModes:
       - ReadWriteOnce
@@ -16,3 +19,5 @@ spec:
       type: api-key
       secretRef:
         name: claude-credentials
+    workspaceRef:
+      name: kelos

--- a/examples/16-session/workspace.yaml
+++ b/examples/16-session/workspace.yaml
@@ -1,0 +1,8 @@
+apiVersion: kelos.dev/v1alpha2
+kind: Workspace
+metadata:
+  name: kelos
+  namespace: default
+spec:
+  repo: https://github.com/kelos-dev/kelos.git
+  ref: main

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -604,17 +604,34 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 		}
 
 		if task.Spec.Branch != "" {
-			fetchCmd := `git fetch origin "$KELOS_BRANCH":"$KELOS_BRANCH" 2>/dev/null`
+			remoteGit := "git"
 			if workspace.SecretRef != nil {
 				credHelper := gitCredentialHelper()
-				fetchCmd = fmt.Sprintf(`git -c credential.helper= -c credential.helper='%s' fetch origin "$KELOS_BRANCH":"$KELOS_BRANCH" 2>/dev/null`, credHelper)
+				remoteGit = fmt.Sprintf(`git -c credential.helper= -c credential.helper='%s'`, credHelper)
 			}
 			branchSetupScript := fmt.Sprintf(
-				`cd %s/repo && %s; `+
-					`if git rev-parse --verify refs/heads/"$KELOS_BRANCH" >/dev/null 2>&1; then `+
-					`git checkout "$KELOS_BRANCH"; `+
-					`else git checkout -b "$KELOS_BRANCH"; fi`,
-				WorkspaceMountPath, fetchCmd,
+				`set -e
+cd %s/repo
+remote_status=0
+%s ls-remote --exit-code --heads origin "refs/heads/$KELOS_BRANCH" >/dev/null || remote_status=$?
+if [ "$remote_status" -eq 0 ]; then
+  %s fetch origin "refs/heads/$KELOS_BRANCH"
+  if git show-ref --verify --quiet "refs/heads/$KELOS_BRANCH"; then
+    git checkout "$KELOS_BRANCH"
+    git merge --ff-only FETCH_HEAD
+  else
+    git checkout -b "$KELOS_BRANCH" FETCH_HEAD
+  fi
+elif [ "$remote_status" -eq 2 ]; then
+  if git show-ref --verify --quiet "refs/heads/$KELOS_BRANCH"; then
+    git checkout "$KELOS_BRANCH"
+  else
+    git checkout -b "$KELOS_BRANCH"
+  fi
+else
+  exit "$remote_status"
+fi`,
+				WorkspaceMountPath, remoteGit, remoteGit,
 			)
 			branchEnv := make([]corev1.EnvVar, len(workspaceEnvVars), len(workspaceEnvVars)+1)
 			copy(branchEnv, workspaceEnvVars)

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -3854,6 +3854,18 @@ func TestBuildJob_BranchSetupInitContainer(t *testing.T) {
 	if !strings.Contains(script, "git fetch") {
 		t.Error("Expected branch-setup script to include git fetch")
 	}
+	if !strings.Contains(script, `ls-remote --exit-code --heads origin "refs/heads/$KELOS_BRANCH"`) {
+		t.Error("Expected branch-setup script to check whether the remote branch exists")
+	}
+	if !strings.Contains(script, `elif [ "$remote_status" -eq 2 ]`) {
+		t.Error("Expected branch-setup script to create a branch only when the remote ref is absent")
+	}
+	if !strings.Contains(script, `exit "$remote_status"`) {
+		t.Error("Expected branch-setup script to propagate remote lookup failures")
+	}
+	if strings.Contains(script, "2>/dev/null") {
+		t.Error("Expected branch-setup script to retain git failure diagnostics")
+	}
 	// Without secretRef, no credential helper should be used.
 	if strings.Contains(script, "credential.helper") {
 		t.Error("Expected no credential helper without secretRef")

--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -688,6 +688,7 @@ func (r *SessionReconciler) buildSessionStatefulSet(session *kelos.Session, work
 		Spec: kelos.TaskSpec{
 			Worker: worker,
 			Prompt: "session",
+			Branch: session.Spec.InitialBranch,
 		},
 	}
 

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -813,6 +813,61 @@ func TestSessionCodexPodUsesPersistentCodexHome(t *testing.T) {
 	t.Fatal("CODEX_HOME was not injected")
 }
 
+func TestSessionPodUsesInitialBranch(t *testing.T) {
+	t.Parallel()
+	session := testSession("issue-42", "codex")
+	session.Spec.Worker.WorkspaceRef = &kelos.WorkspaceReference{Name: "workspace"}
+	session.Spec.InitialBranch = "issue-42"
+	session.Spec.InitialPrompt = "Investigate $(ANTHROPIC_API_KEY) and $$HOME"
+	workspace := &kelos.WorkspaceSpec{
+		Repo: "https://github.com/kelos-dev/kelos.git",
+		Ref:  "main",
+	}
+
+	statefulSet, _, err := testSessionReconciler(nil, nil).buildSessionStatefulSet(session, workspace, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	podSpec := statefulSet.Spec.Template.Spec
+	mainEnv := map[string]string{}
+	for _, env := range podSpec.Containers[0].Env {
+		mainEnv[env.Name] = env.Value
+	}
+	if mainEnv["KELOS_BRANCH"] != "issue-42" {
+		t.Fatalf("KELOS_BRANCH = %q, want %q", mainEnv["KELOS_BRANCH"], "issue-42")
+	}
+	if _, found := mainEnv["KELOS_SESSION_INITIAL_PROMPT"]; found {
+		t.Fatal("KELOS_SESSION_INITIAL_PROMPT must not be set")
+	}
+	if args := podSpec.Containers[0].Args; len(args) != 1 || args[0] != "serve" {
+		t.Fatalf("Session runtime args = %v, want [serve]", args)
+	}
+
+	var branchSetup *corev1.Container
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == "branch-setup" {
+			branchSetup = &podSpec.InitContainers[i]
+			break
+		}
+	}
+	if branchSetup == nil {
+		t.Fatal("Session Pod has no branch-setup init container")
+	}
+	if len(branchSetup.Command) != 3 || !strings.Contains(branchSetup.Command[2], sessionInitializedPath) {
+		t.Fatalf("branch-setup command = %v", branchSetup.Command)
+	}
+	branchFound := false
+	for _, env := range branchSetup.Env {
+		if env.Name == "KELOS_BRANCH" && env.Value == "issue-42" {
+			branchFound = true
+			break
+		}
+	}
+	if !branchFound {
+		t.Fatalf("branch-setup env = %#v, want KELOS_BRANCH=issue-42", branchSetup.Env)
+	}
+}
+
 func TestSessionClaudePodUsesPersistentConfig(t *testing.T) {
 	t.Parallel()
 	session := testSession("claude-chat", "claude-code")

--- a/internal/manifests/charts/kelos/charts/kelos-crds/templates/session-crd.yaml
+++ b/internal/manifests/charts/kelos/charts/kelos-crds/templates/session-crd.yaml
@@ -56,10 +56,26 @@ spec:
           spec:
             description: SessionSpec defines the desired state of a Session.
             properties:
+              initialBranch:
+                description: |-
+                  InitialBranch is the git branch to check out when initializing the Session
+                  workspace. If the branch exists on the origin remote, the Session checks
+                  it out; otherwise, it creates the branch from the Workspace ref.
+                  Requires worker.workspaceRef.
+                type: string
+              initialPrompt:
+                description: |-
+                  InitialPrompt is submitted automatically when the Session starts without
+                  retained conversation history. Persistent workspace history prevents it
+                  from being submitted again after Pod replacement. An emptyDir workspace
+                  loses that history and may submit the prompt again after Pod replacement.
+                type: string
               volumeClaimTemplate:
                 description: |-
                   VolumeClaimTemplate defines persistent storage for the Session workspace.
-                  Omit this field to use an emptyDir workspace.
+                  Persistent storage is recommended for Sessions that must retain conversation
+                  history and avoid replaying the initial prompt after Pod replacement. Omit
+                  this field to use an ephemeral emptyDir workspace, primarily for development.
                 properties:
                   accessModes:
                     description: |-
@@ -7147,6 +7163,9 @@ spec:
                 'opencode']
             - message: worker.credentials is required
               rule: has(self.worker.credentials)
+            - message: worker.workspaceRef is required when initialBranch is set
+              rule: '!has(self.initialBranch) || size(self.initialBranch) == 0 ||
+                has(self.worker.workspaceRef)'
           status:
             description: SessionStatus defines the observed state of a Session.
             properties:

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -697,10 +697,26 @@ spec:
           spec:
             description: SessionSpec defines the desired state of a Session.
             properties:
+              initialBranch:
+                description: |-
+                  InitialBranch is the git branch to check out when initializing the Session
+                  workspace. If the branch exists on the origin remote, the Session checks
+                  it out; otherwise, it creates the branch from the Workspace ref.
+                  Requires worker.workspaceRef.
+                type: string
+              initialPrompt:
+                description: |-
+                  InitialPrompt is submitted automatically when the Session starts without
+                  retained conversation history. Persistent workspace history prevents it
+                  from being submitted again after Pod replacement. An emptyDir workspace
+                  loses that history and may submit the prompt again after Pod replacement.
+                type: string
               volumeClaimTemplate:
                 description: |-
                   VolumeClaimTemplate defines persistent storage for the Session workspace.
-                  Omit this field to use an emptyDir workspace.
+                  Persistent storage is recommended for Sessions that must retain conversation
+                  history and avoid replaying the initial prompt after Pod replacement. Omit
+                  this field to use an ephemeral emptyDir workspace, primarily for development.
                 properties:
                   accessModes:
                     description: |-
@@ -7788,6 +7804,9 @@ spec:
                 'opencode']
             - message: worker.credentials is required
               rule: has(self.worker.credentials)
+            - message: worker.workspaceRef is required when initialBranch is set
+              rule: '!has(self.initialBranch) || size(self.initialBranch) == 0 ||
+                has(self.worker.workspaceRef)'
           status:
             description: SessionStatus defines the observed state of a Session.
             properties:

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -43,6 +43,7 @@ type Config struct {
 	Model                string
 	Effort               string
 	PluginDir            string
+	InitialPrompt        string
 	Environment          []string
 	PublishSessionStatus SessionStatusPublisher
 	SessionName          string
@@ -245,6 +246,11 @@ func (s *Server) Serve(ctx context.Context) error {
 		go s.runSessionUpdateWatch(serveCtx)
 		go s.runSessionUpdateReporter(serveCtx)
 	}
+	go s.runTurns(serveCtx)
+	if err := s.deliverInitialPrompt(); err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(filepath.Dir(s.config.SocketPath), 0700); err != nil {
 		return fmt.Errorf("creating Session socket directory: %w", err)
 	}
@@ -267,7 +273,6 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 	s.requestWorkspaceStatusRefresh()
 	s.requestSessionStatusPublish()
-	go s.runTurns(serveCtx)
 	go func() {
 		select {
 		case <-serveCtx.Done():
@@ -296,6 +301,16 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 		go s.handleConnection(serveCtx, connection)
 	}
+}
+
+func (s *Server) deliverInitialPrompt() error {
+	if strings.TrimSpace(s.config.InitialPrompt) == "" || len(s.journal.Snapshot()) > 0 {
+		return nil
+	}
+	if err := s.submitMessage(s.config.InitialPrompt, "initial-prompt"); err != nil {
+		return fmt.Errorf("submitting initial Session prompt: %w", err)
+	}
+	return nil
 }
 
 func (s *Server) runTurns(ctx context.Context) {

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -348,6 +348,168 @@ func assertActivity(t *testing.T, activity <-chan bool, want bool) {
 	}
 }
 
+func TestServerSubmitsInitialPromptOnlyWithoutHistory(t *testing.T) {
+	t.Run("empty journal", func(t *testing.T) {
+		stateDir := shortRuntimeTempDir(t)
+		journal := NewJournal()
+		provider := &fakeProvider{}
+		server := NewServer(Config{
+			SocketPath:    filepath.Join(stateDir, "runtime.sock"),
+			StateDir:      stateDir,
+			WorkingDir:    stateDir,
+			AgentType:     "fake",
+			InitialPrompt: "Investigate issue #42",
+		}, journal, provider)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		serveDone := make(chan error, 1)
+		go func() { serveDone <- server.Serve(ctx) }()
+
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			provider.mu.Lock()
+			prompts := append([]string(nil), provider.prompts...)
+			provider.mu.Unlock()
+			if len(prompts) > 0 {
+				if !reflect.DeepEqual(prompts, []string{"Investigate issue #42"}) {
+					t.Fatalf("provider prompts = %v", prompts)
+				}
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("initial prompt was not submitted")
+			}
+			select {
+			case err := <-serveDone:
+				t.Fatalf("Serve() returned before submitting the initial prompt: %v", err)
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+
+		var initialMessage *Event
+		for _, event := range journal.Snapshot() {
+			if event.Type == EventUserMessage {
+				copy := event
+				initialMessage = &copy
+				break
+			}
+		}
+		if initialMessage == nil || initialMessage.RequestID != "initial-prompt" || initialMessage.Text != "Investigate issue #42" {
+			t.Fatalf("initial user message = %#v", initialMessage)
+		}
+
+		cancel()
+		if err := <-serveDone; err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("existing journal", func(t *testing.T) {
+		stateDir := shortRuntimeTempDir(t)
+		journal := NewJournal()
+		if err := journal.Append(Event{Type: EventUserMessage, Text: "Existing conversation"}); err != nil {
+			t.Fatal(err)
+		}
+		provider := &fakeProvider{}
+		server := NewServer(Config{
+			SocketPath:    filepath.Join(stateDir, "runtime.sock"),
+			StateDir:      stateDir,
+			WorkingDir:    stateDir,
+			AgentType:     "fake",
+			InitialPrompt: "Do not submit",
+		}, journal, provider)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		serveDone := make(chan error, 1)
+		go func() { serveDone <- server.Serve(ctx) }()
+		waitForRuntime(t, server.config.SocketPath)
+		time.Sleep(50 * time.Millisecond)
+		provider.mu.Lock()
+		prompts := append([]string(nil), provider.prompts...)
+		provider.mu.Unlock()
+		if len(prompts) != 0 {
+			t.Fatalf("provider prompts = %v, want none", prompts)
+		}
+		cancel()
+		if err := <-serveDone; err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestServerHealthWaitsForInitialPromptSubmission(t *testing.T) {
+	stateDir := shortRuntimeTempDir(t)
+	journal := NewJournal()
+	provider := &fakeProvider{}
+	deliveryStarted := make(chan struct{})
+	release := make(chan struct{})
+	server := NewServer(Config{
+		SocketPath:    filepath.Join(stateDir, "runtime.sock"),
+		StateDir:      stateDir,
+		WorkingDir:    stateDir,
+		AgentType:     "fake",
+		InitialPrompt: "Investigate issue #42",
+	}, journal, provider)
+	appendMessage := server.appendMessage
+	server.appendMessage = func(event Event) error {
+		close(deliveryStarted)
+		<-release
+		return appendMessage(event)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve(ctx) }()
+
+	select {
+	case <-deliveryStarted:
+	case <-time.After(time.Second):
+		cancel()
+		close(release)
+		<-serveDone
+		t.Fatal("initial prompt submission did not start")
+	}
+	if err := Health(server.config.SocketPath); err == nil {
+		cancel()
+		close(release)
+		<-serveDone
+		t.Fatal("Session runtime reported healthy before initial prompt submission completed")
+	}
+	close(release)
+	waitForRuntime(t, server.config.SocketPath)
+	cancel()
+	if err := <-serveDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerClosesResourcesWhenInitialPromptFails(t *testing.T) {
+	stateDir := shortRuntimeTempDir(t)
+	journal := NewJournal()
+	provider := &fakeProvider{}
+	server := NewServer(Config{
+		SocketPath:    filepath.Join(stateDir, "runtime.sock"),
+		StateDir:      stateDir,
+		WorkingDir:    stateDir,
+		AgentType:     "fake",
+		InitialPrompt: "Investigate issue #42",
+	}, journal, provider)
+	server.appendMessage = func(Event) error { return errors.New("journal write failed") }
+
+	err := server.Serve(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "submitting initial Session prompt") {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	provider.mu.Lock()
+	providerClosed := provider.closed
+	provider.mu.Unlock()
+	if !providerClosed {
+		t.Fatal("provider was not closed after initial prompt failure")
+	}
+	if err := journal.Append(Event{Type: EventUserMessage, Text: "after failure"}); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("journal.Append() after Serve() = %v, want closed journal error", err)
+	}
+}
+
 func TestServerSharesConversationAcrossConnections(t *testing.T) {
 	stateDir := shortRuntimeTempDir(t)
 	journal := NewJournal()

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -118,6 +118,8 @@ type createSessionRequest struct {
 	Name                string                            `json:"name"`
 	Namespace           string                            `json:"namespace"`
 	Worker              kelos.WorkerSpec                  `json:"worker"`
+	InitialBranch       string                            `json:"initialBranch,omitempty"`
+	InitialPrompt       string                            `json:"initialPrompt,omitempty"`
 	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
 }
 
@@ -465,6 +467,8 @@ func (s *Server) createSession(writer http.ResponseWriter, request *http.Request
 		},
 		Spec: kelos.SessionSpec{
 			Worker:              payload.Worker,
+			InitialBranch:       payload.InitialBranch,
+			InitialPrompt:       payload.InitialPrompt,
 			VolumeClaimTemplate: payload.VolumeClaimTemplate,
 		},
 	}

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -89,6 +89,9 @@ func TestSessionFormUsesResourceSelectors(t *testing.T) {
 		`name="namespace" required value="default" autocomplete="off" readonly>`,
 		`id="credential-secret"`,
 		`id="workspace-select"`,
+		`name="initialBranch" id="session-initial-branch"`,
+		`name="initialPrompt" id="session-initial-prompt"`,
+		`With emptyDir, Pod replacement loses history and may submit this prompt again; use a persistent volume to prevent replay.`,
 		`id="agent-config-select"`,
 		`id="selected-agent-configs"`,
 		`id="session-mode-yaml"`,
@@ -115,6 +118,10 @@ func TestSessionSourceJavaScriptPreservesSelectedSource(t *testing.T) {
 		"explicit StorageClass tracking":      "state.sourceStorageClassNamePresent = Boolean(claim && 'storageClassName' in claim);",
 		"explicit empty StorageClass copy":    "if (storageClassName || state.sourceStorageClassNamePresent) {\n          payload.volumeClaimTemplate.storageClassName = storageClassName;\n        }",
 		"advanced reference warning":          "in YAML for additional namespace-scoped references.",
+		"source initial branch population":    "elements.form.elements.initialBranch.value = manifest.spec.initialBranch || '';",
+		"source initial prompt population":    "elements.form.elements.initialPrompt.value = manifest.spec.initialPrompt || '';",
+		"initial branch form submission":      "const initialBranch = values.get('initialBranch').trim();\n      if (initialBranch) payload.initialBranch = initialBranch;",
+		"initial prompt form submission":      "const initialPrompt = values.get('initialPrompt');\n      if (initialPrompt.trim()) payload.initialPrompt = initialPrompt;",
 	} {
 		if !strings.Contains(javascript, expected) {
 			t.Errorf("Session source JavaScript is missing %s: %s", description, expected)
@@ -311,7 +318,9 @@ func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
 	payload := `{
 		"name":"persistent-chat",
 		"namespace":"default",
-		"worker":{"type":"codex","credentials":{"type":"none"}},
+		"worker":{"type":"codex","credentials":{"type":"none"},"workspaceRef":{"name":"workspace"}},
+		"initialBranch":"feature/persistent-chat",
+		"initialPrompt":"Investigate the issue interactively",
 		"volumeClaimTemplate":{
 			"accessModes":["ReadWriteOnce"],
 			"storageClassName":"fast",
@@ -334,6 +343,12 @@ func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
 	if claim == nil {
 		t.Fatal("volumeClaimTemplate is nil")
 	}
+	if session.Spec.InitialBranch != "feature/persistent-chat" {
+		t.Fatalf("initialBranch = %q, want %q", session.Spec.InitialBranch, "feature/persistent-chat")
+	}
+	if session.Spec.InitialPrompt != "Investigate the issue interactively" {
+		t.Fatalf("initialPrompt = %q", session.Spec.InitialPrompt)
+	}
 	if len(claim.AccessModes) != 1 || claim.AccessModes[0] != corev1.ReadWriteOnce {
 		t.Fatalf("accessModes = %v", claim.AccessModes)
 	}
@@ -355,6 +370,8 @@ metadata:
   labels:
     source: web
 spec:
+  initialBranch: feature/yaml-chat
+  initialPrompt: Investigate the issue interactively
   volumeClaimTemplate:
     accessModes:
       - ReadWriteOnce
@@ -368,6 +385,8 @@ spec:
     model: gpt-5
     effort: high
     image: example.com/codex:latest
+    workspaceRef:
+      name: workspace
     podOverrides:
       serviceAccountName: kelos-controller
 `
@@ -392,6 +411,12 @@ spec:
 	}
 	if session.Spec.Worker.PodOverrides == nil || session.Spec.Worker.PodOverrides.ServiceAccountName != "kelos-controller" {
 		t.Fatalf("worker Pod overrides = %#v", session.Spec.Worker.PodOverrides)
+	}
+	if session.Spec.InitialBranch != "feature/yaml-chat" {
+		t.Fatalf("initialBranch = %q, want %q", session.Spec.InitialBranch, "feature/yaml-chat")
+	}
+	if session.Spec.InitialPrompt != "Investigate the issue interactively" {
+		t.Fatalf("initialPrompt = %q", session.Spec.InitialPrompt)
 	}
 	if session.Spec.VolumeClaimTemplate == nil {
 		t.Fatal("volumeClaimTemplate is nil")
@@ -970,6 +995,8 @@ func TestSessionSourceAPIReturnsReusableSpec(t *testing.T) {
 			Annotations: map[string]string{"owner": "platform"},
 		},
 		Spec: kelos.SessionSpec{
+			InitialBranch: "feature/codex-review",
+			InitialPrompt: "Investigate the issue interactively",
 			Worker: kelos.WorkerSpec{
 				Type: "codex",
 				Credentials: &kelos.Credentials{
@@ -1022,6 +1049,9 @@ func TestSessionSourceAPIReturnsReusableSpec(t *testing.T) {
 		t.Fatalf("Session manifest copied source metadata: labels %v annotations %v", manifest.Metadata.Labels, manifest.Metadata.Annotations)
 	}
 	worker := manifest.Spec.Worker
+	if manifest.Spec.InitialBranch != "feature/codex-review" || manifest.Spec.InitialPrompt != "Investigate the issue interactively" {
+		t.Fatalf("Session manifest initialBranch/prompt = %q/%q", manifest.Spec.InitialBranch, manifest.Spec.InitialPrompt)
+	}
 	if worker.Type != "codex" || worker.Model != "gpt-5" || worker.Effort != "high" || worker.Image != "example.com/codex:latest" || worker.Credentials == nil || worker.Credentials.SecretRef.Name != "codex-credentials" {
 		t.Fatalf("Session manifest worker = %#v", worker)
 	}
@@ -1050,6 +1080,8 @@ func TestSessionSourceAPIReturnsReusableSpec(t *testing.T) {
 		"effort: high",
 		"image: example.com/codex:latest",
 		"name: REVIEW_MODE",
+		"initialBranch: feature/codex-review",
+		"initialPrompt: Investigate the issue interactively",
 		`storageClassName: ""`,
 		"storage: 20Gi",
 	} {

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -723,6 +723,8 @@ function populateSessionSource(detail) {
   elements.namespace.value = detail.namespace;
   elements.provider.value = worker.type;
   elements.form.elements.model.value = worker.model || '';
+  elements.form.elements.initialBranch.value = manifest.spec.initialBranch || '';
+  elements.form.elements.initialPrompt.value = manifest.spec.initialPrompt || '';
   setSourceCredential(worker.credentials);
   setSourceWorkspace(worker.workspaceRef);
   state.selectedAgentConfigs = (worker.agentConfigRefs || []).map(reference => reference.name);
@@ -2309,6 +2311,10 @@ elements.form.addEventListener('submit', async event => {
         namespace: values.get('namespace').trim(),
         worker,
       };
+      const initialBranch = values.get('initialBranch').trim();
+      if (initialBranch) payload.initialBranch = initialBranch;
+      const initialPrompt = values.get('initialPrompt');
+      if (initialPrompt.trim()) payload.initialPrompt = initialPrompt;
       if (values.get('persistentVolume')) {
         payload.volumeClaimTemplate = {
           accessModes: [values.get('accessMode')],

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -154,6 +154,16 @@
           <span>Model <em>optional</em></span>
           <input name="model" placeholder="Provider default" autocomplete="off">
         </label>
+        <label class="form-wide">
+          <span>Initial branch <em>optional</em></span>
+          <input name="initialBranch" id="session-initial-branch" placeholder="feature/issue-42" autocomplete="off">
+          <small>Checks out an existing remote branch or creates it from the Workspace ref. Requires a Workspace.</small>
+        </label>
+        <label class="form-wide">
+          <span>Initial prompt <em>optional</em></span>
+          <textarea name="initialPrompt" id="session-initial-prompt" rows="4" placeholder="Describe the work to begin when the Session starts."></textarea>
+          <small>Submitted when no conversation history exists. With emptyDir, Pod replacement loses history and may submit this prompt again; use a persistent volume to prevent replay.</small>
+        </label>
         <div class="form-wide form-field">
           <span class="form-label">AgentConfigs <em>optional</em></span>
           <div class="option-picker">
@@ -170,7 +180,7 @@
               <input type="checkbox" name="persistentVolume" id="volume-claim-enabled">
               <span>
                 <strong>Persistent volume</strong>
-                <small>Keep the workspace and conversation history when the Session Pod is replaced.</small>
+                <small>Recommended outside development. Keeps the workspace and conversation history when the Session Pod is replaced.</small>
               </span>
             </label>
             <div class="nested-grid" id="volume-claim-fields" hidden>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -243,8 +243,9 @@ button { color: inherit; }
 .form-wide { grid-column: 1 / -1; }
 .form-grid label > span, .form-label { display: block; margin: 0 0 7px; font-size: 11px; font-weight: 700; }
 .form-grid em { color: var(--faint); font-size: 9px; font-style: normal; font-weight: 500; text-transform: uppercase; }
-.form-grid input, .form-grid select { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
-.form-grid input:focus, .form-grid select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.form-grid input, .form-grid select, .form-grid textarea { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
+.form-grid textarea { min-height: 90px; resize: vertical; line-height: 1.45; }
+.form-grid input:focus, .form-grid select:focus, .form-grid textarea:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
 .form-grid small { display: block; margin-top: 5px; color: var(--faint); font-size: 9.5px; line-height: 1.4; }
 .form-grid select + input { margin-top: 8px; }
 .option-picker { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
@@ -319,5 +320,5 @@ button { color: inherit; }
   .diff-lines { background: #121915; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
-  .form-grid input, .form-grid select, .source-picker select { border-color: #3a4740; }
+  .form-grid input, .form-grid select, .form-grid textarea, .source-picker select { border-color: #3a4740; }
 }

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -408,6 +408,85 @@ var _ = Describe("Session remote control", func() {
 		}, 2*time.Minute, time.Second).Should(Succeed())
 	})
 
+	It("round-trips initial branch and initial prompt through Session web creation", func() {
+		token := os.Getenv(sessionWebTokenEnv)
+		if token == "" {
+			Skip(sessionWebTokenEnv + " not set")
+		}
+
+		workspaceName := "web-options-workspace"
+		_, err := f.KelosClientset.ApiV1alpha2().Workspaces(f.Namespace).Create(context.TODO(), &kelos.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: workspaceName, Namespace: f.Namespace},
+			Spec: kelos.WorkspaceSpec{
+				Repo: "https://github.com/kelos-dev/kelos.git",
+				Ref:  "main",
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			_ = f.KelosClientset.ApiV1alpha2().Workspaces(f.Namespace).Delete(context.TODO(), workspaceName, metav1.DeleteOptions{})
+		})
+
+		baseURL := startSessionServerPortForward()
+		webClient := loginSessionWeb(baseURL, token)
+		initialBranch := "feature/web-options"
+		initialPrompt := "Investigate issue #42 interactively\nand summarize the next steps."
+		sourceName := "web-options-source"
+		createSessionThroughWeb(webClient, baseURL, map[string]any{
+			"name":      sourceName,
+			"namespace": f.Namespace,
+			"worker": kelos.WorkerSpec{
+				Type:         "codex",
+				Credentials:  &kelos.Credentials{Type: kelos.CredentialTypeNone},
+				WorkspaceRef: &kelos.WorkspaceReference{Name: workspaceName},
+			},
+			"initialBranch": initialBranch,
+			"initialPrompt": initialPrompt,
+		})
+		DeferCleanup(func() {
+			_ = f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Delete(context.TODO(), sourceName, metav1.DeleteOptions{})
+		})
+
+		Eventually(func(g Gomega) {
+			session, err := f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Get(context.TODO(), sourceName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(session.Spec.InitialBranch).To(Equal(initialBranch))
+			g.Expect(session.Spec.InitialPrompt).To(Equal(initialPrompt))
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+
+		response, err := webClient.Get(baseURL + "/api/sessions/" + url.PathEscape(f.Namespace) + "/" + url.PathEscape(sourceName))
+		Expect(err).NotTo(HaveOccurred())
+		defer response.Body.Close()
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		var source struct {
+			Manifest struct {
+				Spec kelos.SessionSpec `json:"spec"`
+			} `json:"manifest"`
+		}
+		Expect(json.NewDecoder(response.Body).Decode(&source)).To(Succeed())
+		Expect(source.Manifest.Spec.InitialBranch).To(Equal(initialBranch))
+		Expect(source.Manifest.Spec.InitialPrompt).To(Equal(initialPrompt))
+
+		copyName := "web-options-copy"
+		createSessionThroughWeb(webClient, baseURL, map[string]any{
+			"name":          copyName,
+			"namespace":     f.Namespace,
+			"worker":        source.Manifest.Spec.Worker,
+			"initialBranch": source.Manifest.Spec.InitialBranch,
+			"initialPrompt": source.Manifest.Spec.InitialPrompt,
+		})
+		DeferCleanup(func() {
+			_ = f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Delete(context.TODO(), copyName, metav1.DeleteOptions{})
+		})
+
+		Eventually(func(g Gomega) {
+			session, err := f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Get(context.TODO(), copyName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(session.Spec.InitialBranch).To(Equal(initialBranch))
+			g.Expect(session.Spec.InitialPrompt).To(Equal(initialPrompt))
+		}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+	})
+
 	It("runs an OpenCode conversation through terminal chat", func() {
 		sessionName := "opencode-session"
 		configMapName := sessionName + "-provider"
@@ -836,6 +915,17 @@ func loginSessionWeb(baseURL, token string) *http.Client {
 	defer response.Body.Close()
 	Expect(response.StatusCode).To(Equal(http.StatusOK))
 	return client
+}
+
+func createSessionThroughWeb(client *http.Client, baseURL string, payload any) {
+	data, err := json.Marshal(payload)
+	Expect(err).NotTo(HaveOccurred())
+	response, err := client.Post(baseURL+"/api/sessions", "application/json", bytes.NewReader(data))
+	Expect(err).NotTo(HaveOccurred())
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(response.StatusCode).To(Equal(http.StatusCreated), "Session web create response: %s", body)
 }
 
 func listWebSessions(client *http.Client, baseURL, namespace string) []string {

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -49,6 +49,8 @@ metadata:
   labels:
     source: web
 spec:
+  initialBranch: issue-42
+  initialPrompt: "Investigate issue #42 interactively"
   volumeClaimTemplate:
     accessModes:
       - ReadWriteOnce
@@ -59,6 +61,8 @@ spec:
     type: codex
     credentials:
       type: none
+    workspaceRef:
+      name: workspace
 `, namespace)
 
 		request := httptest.NewRequest(http.MethodPost, "/api/sessions/apply", strings.NewReader(manifest))
@@ -69,6 +73,8 @@ spec:
 
 		var session kelos.Session
 		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "yaml-chat"}, &session)).To(Succeed())
+		Expect(session.Spec.InitialBranch).To(Equal("issue-42"))
+		Expect(session.Spec.InitialPrompt).To(Equal("Investigate issue #42 interactively"))
 		Expect(session.Spec.VolumeClaimTemplate).NotTo(BeNil())
 		storage := session.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage]
 		Expect(storage.Cmp(resource.MustParse("2Gi"))).To(Equal(0))
@@ -200,6 +206,10 @@ spec:
 		missingCredentials := validSession(namespace, "missing-credentials", "codex")
 		missingCredentials.Spec.Worker.Credentials = nil
 		Expect(k8sClient.Create(ctx, missingCredentials)).NotTo(Succeed())
+
+		branchWithoutWorkspace := validSession(namespace, "branch-without-workspace", "codex")
+		branchWithoutWorkspace.Spec.InitialBranch = "issue-42"
+		Expect(k8sClient.Create(ctx, branchWithoutWorkspace)).NotTo(Succeed())
 	})
 
 	It("requires a spec", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `initialBranch` and `initialPrompt` to the v1alpha2 `Session` API so an interactive Session can initialize from a selected Git branch and automatically begin with a prompt.

The controller uses `initialBranch` only during workspace initialization. The runtime reads `initialPrompt` from the immutable Session resource and records and submits it before becoming ready when the workspace has no conversation history. Retained workspace history prevents resubmission after a runtime restart; replacing an `emptyDir`-backed Pod starts a fresh conversation and submits the prompt again.

The web form and YAML API round-trip both fields. Generated CRDs, reference documentation, examples, and tests are updated with the API.

#### Which issue(s) this PR is related to:

Fixes #1477

#### Special notes for your reviewer:

Validation completed:

- `make update`
- `make test`
- `make verify`
- `make test-integration`
- focused Kelos API review
- dual independent code review

#### Does this PR introduce a user-facing change?

```release-note
Sessions can select an initial Git branch and automatically submit an initial prompt when the conversation workspace has no retained history.
```