### PR TITLE
Use shared skills in self-development workflows

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -69,6 +69,52 @@ func TestSelfDevelopmentGitHubSpawnersUseWebhooks(t *testing.T) {
 	}
 }
 
+func TestSelfDevelopmentAgentConfigsUseSharedSkills(t *testing.T) {
+	t.Parallel()
+
+	files := []struct {
+		dir  string
+		file string
+	}{
+		{dir: "self-development", file: "agentconfig.yaml"},
+		{dir: "self-development", file: "kelos-api-reviewer.yaml"},
+		{dir: "self-development", file: "kelos-fake-strategist.yaml"},
+		{dir: "self-development", file: "kelos-fake-user.yaml"},
+		{dir: "self-development", file: "kelos-glm-api-reviewer.yaml"},
+		{dir: "self-development", file: "kelos-glm-reviewer.yaml"},
+		{dir: "self-development", file: "kelos-image-update.yaml"},
+		{dir: "self-development", file: "kelos-planner.yaml"},
+		{dir: "self-development", file: "kelos-reviewer.yaml"},
+		{dir: "self-development", file: "kelos-self-update.yaml"},
+		{dir: "self-development", file: "kelos-workers.yaml"},
+		{dir: "self-development/agora", file: "agentconfig.yaml"},
+		{dir: "self-development/agora", file: "agora-fake-strategist.yaml"},
+		{dir: "self-development/agora", file: "agora-fake-user.yaml"},
+		{dir: "self-development/agora", file: "agora-planner.yaml"},
+		{dir: "self-development/agora", file: "agora-reviewer.yaml"},
+		{dir: "self-development/agora", file: "agora-workers.yaml"},
+		{dir: "self-development/kanon", file: "agentconfig.yaml"},
+		{dir: "self-development/kanon", file: "kanon-fake-strategist.yaml"},
+		{dir: "self-development/kanon", file: "kanon-fake-user.yaml"},
+		{dir: "self-development/kanon", file: "kanon-planner.yaml"},
+		{dir: "self-development/kanon", file: "kanon-reviewer.yaml"},
+		{dir: "self-development/kanon", file: "kanon-workers.yaml"},
+	}
+
+	for _, tt := range files {
+		tt := tt
+		t.Run(tt.dir+"/"+tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			config := readAgentConfigFromDir(t, tt.dir, tt.file)
+			want := []kelos.SkillsShSpec{{Source: "gjkim42/kanon-repo"}}
+			if !reflect.DeepEqual(config.Spec.Skills, want) {
+				t.Fatalf("expected %s/%s skills %v, got %v", tt.dir, tt.file, want, config.Spec.Skills)
+			}
+		})
+	}
+}
+
 func TestDevelopmentTaskSpawnersIgnoreDisruptions(t *testing.T) {
 	t.Parallel()
 
@@ -333,6 +379,34 @@ func TestKelosAPIReviewersUseConcreteIssueCommentBodyFile(t *testing.T) {
 			}
 			if strings.Contains(prompt, `--body-file <file>`) {
 				t.Fatalf("%s prompt contains placeholder issue comment body file", tt.file)
+			}
+		})
+	}
+}
+
+func TestDevelopmentReviewersUseReviewSkills(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dir      string
+		file     string
+		workflow string
+	}{
+		{dir: "self-development", file: "kelos-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
+		{dir: "self-development/agora", file: "agora-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
+		{dir: "self-development/kanon", file: "kanon-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
+		{dir: "self-development", file: "kelos-api-reviewer.yaml", workflow: "Use the `api-review` skill for the review analysis"},
+		{dir: "self-development", file: "kelos-glm-api-reviewer.yaml", workflow: "Use the `api-review` skill for the review analysis"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.dir+"/"+tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			spawner := readTaskSpawnerFromDir(t, tt.dir, tt.file)
+			if !strings.Contains(spawner.Spec.TaskTemplate.PromptTemplate, tt.workflow) {
+				t.Fatalf("%s/%s prompt does not require %q", tt.dir, tt.file, tt.workflow)
 			}
 		})
 	}
@@ -945,6 +1019,51 @@ func readTaskSpawnerFromDir(t *testing.T, dir, file string) *kelos.TaskSpawner {
 	}
 
 	t.Fatalf("no TaskSpawner found in %s", path)
+	return nil
+}
+
+func readAgentConfigFromDir(t *testing.T, dir, file string) *kelos.AgentConfig {
+	t.Helper()
+
+	path := filepath.Join("..", "..", dir, file)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	reader := yamlutil.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	for {
+		doc, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading YAML document from %s: %v", path, err)
+		}
+
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		var meta struct {
+			Kind string `yaml:"kind"`
+		}
+		if err := sigyaml.Unmarshal(doc, &meta); err != nil {
+			t.Fatalf("decoding document metadata from %s: %v", path, err)
+		}
+		if meta.Kind != "AgentConfig" {
+			continue
+		}
+
+		var config kelos.AgentConfig
+		if err := sigyaml.Unmarshal(doc, &config); err != nil {
+			t.Fatalf("decoding AgentConfig from %s: %v", path, err)
+		}
+		return &config
+	}
+
+	t.Fatalf("no AgentConfig found in %s", path)
 	return nil
 }
 

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -19,6 +19,11 @@ the `kelos-workers` TaskSpawner.
 
 Each TaskSpawner references an `AgentConfig` that defines git identity, comment signatures, and standard constraints. Some agents (triage, pr-responder, squash-commits, config-update) share the base `agentconfig.yaml` (`kelos-dev-agent`), while others (workers, planner, fake-user, fake-strategist, self-update, image-update) define their own `AgentConfig` inline.
 
+Each self-development `AgentConfig`, including the nested Agora and Kanon
+configurations, also installs all skills from
+[`gjkim42/kanon-repo`](https://github.com/gjkim42/kanon-repo) through
+`spec.skills`, giving every TaskSpawner-created agent the same shared skill set.
+
 Autonomous discovery agents that publish GitHub issues maintain at most one
 open `generated-by-kelos` issue slot per TaskSpawner. The issue body includes a
 `kelos-taskspawner=<name>` marker so later runs can find it. A run may update
@@ -107,6 +112,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review` or 
 | **Concurrency** | 3 |
 
 **Key features:**
+- Uses the `review-all` skill to reconcile two independent reviews of the same diff
 - Reads the full diff and surrounding context to understand changes
 - Checks correctness, tests, project conventions, security, and code quality
 - Reviews test adequacy without rerunning local validation
@@ -158,6 +164,7 @@ Reviews issues and pull requests for Kubernetes API design conventions, compatib
 | **Concurrency** | 3 |
 
 **Key features:**
+- Uses the `api-review` skill for API design analysis and verdicts
 - Works on both issues (API design proposals) and pull requests (API implementation review)
 - Focused on Kubernetes API design concerns (field naming, primitive types, compatibility, CRD validation, naming/docs, defaulting/conversion)
 - References upstream Kubernetes API conventions and API review process documentation
@@ -191,6 +198,7 @@ uses a separate trigger from `kelos-api-reviewer`, which continues to handle
 | **Concurrency** | 3 |
 
 **Key features:**
+- Uses the `api-review` skill for API design analysis and verdicts
 - Uses the same Kubernetes API design checklist and structured output as `kelos-api-reviewer`
 - Works on both issues (API design proposals) and pull requests (API implementation review)
 - For PRs: creates or updates a single GLM-specific sticky PR comment with structured API review feedback

--- a/self-development/agentconfig.yaml
+++ b/self-development/agentconfig.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-dev-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Development Agent
 

--- a/self-development/agora/README.md
+++ b/self-development/agora/README.md
@@ -118,6 +118,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review` or 
 | **Concurrency** | 3 |
 
 **Key features:**
+- Uses the `review-all` skill to reconcile two independent reviews of the same diff
 - Reads the full diff and surrounding context to understand changes
 - Checks correctness, tests, project conventions, security, and code quality
 - Pays special attention to public-contract changes (naming, shape, backward compatibility)

--- a/self-development/agora/agentconfig.yaml
+++ b/self-development/agora/agentconfig.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: agora-dev-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Agora Development Agent
 

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: agora-fake-strategist-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Agora Strategist Agent
 

--- a/self-development/agora/agora-fake-user.yaml
+++ b/self-development/agora/agora-fake-user.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: agora-fake-user-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Agora User Agent
 

--- a/self-development/agora/agora-planner.yaml
+++ b/self-development/agora/agora-planner.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: agora-planner-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Agora Planner Agent
 

--- a/self-development/agora/agora-reviewer.yaml
+++ b/self-development/agora/agora-reviewer.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: agora-reviewer-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Agora Reviewer Agent
 
@@ -127,6 +129,12 @@ spec:
       - Understand the motivation and scope of the change
 
       ### 3. Review the diff
+      Use the `review-all` skill with `origin/main` as the base. Let its two
+      independent review paths examine the committed `origin/main...HEAD` diff,
+      then use the unified findings as the basis for this review. The skill
+      performs analysis only; after it returns, continue with the project-specific
+      checks below and publish the single sticky comment in step 6.
+
       Review the code:
       - Read the full diff: `git diff origin/main...HEAD`
       - For each changed file, read the surrounding context to understand how the

--- a/self-development/agora/agora-workers.yaml
+++ b/self-development/agora/agora-workers.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: agora-workers-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Agora Worker Agent
 

--- a/self-development/kanon/README.md
+++ b/self-development/kanon/README.md
@@ -119,6 +119,7 @@ Reviews open pull requests on demand when a maintainer posts `/kelos review` or 
 | **Concurrency** | 3 |
 
 **Key features:**
+- Uses the `review-all` skill to reconcile two independent reviews of the same diff
 - Reads the full diff and surrounding context to understand changes
 - Checks correctness, tests, project conventions, security, and code quality
 - Pays special attention to CLI/config-surface changes (naming, shape, backward compatibility)

--- a/self-development/kanon/agentconfig.yaml
+++ b/self-development/kanon/agentconfig.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kanon-dev-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kanon Development Agent
 

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kanon-fake-strategist-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kanon Strategist Agent
 

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kanon-fake-user-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kanon User Agent
 

--- a/self-development/kanon/kanon-planner.yaml
+++ b/self-development/kanon/kanon-planner.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kanon-planner-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kanon Planner Agent
 

--- a/self-development/kanon/kanon-reviewer.yaml
+++ b/self-development/kanon/kanon-reviewer.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kanon-reviewer-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kanon Reviewer Agent
 
@@ -128,6 +130,12 @@ spec:
       - Understand the motivation and scope of the change
 
       ### 3. Review the diff
+      Use the `review-all` skill with `origin/main` as the base. Let its two
+      independent review paths examine the committed `origin/main...HEAD` diff,
+      then use the unified findings as the basis for this review. The skill
+      performs analysis only; after it returns, continue with the project-specific
+      checks below and publish the single sticky comment in step 6.
+
       Review the code:
       - Read the full diff: `git diff origin/main...HEAD`
       - For each changed file, read the surrounding context to understand how the

--- a/self-development/kanon/kanon-workers.yaml
+++ b/self-development/kanon/kanon-workers.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kanon-workers-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kanon Worker Agent
 

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-api-reviewer-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos API Reviewer Agent
 
@@ -136,6 +138,11 @@ spec:
       - Understand the motivation and scope of the change or proposal
 
       ### 3. Review
+
+      Use the `api-review` skill for the review analysis, passing it the current
+      pull request or issue as the target. The skill produces an in-task report
+      only; after it returns, use its findings and verdict as the basis for the
+      checks and publishing steps below.
 
       **If this is a pull request:**
       - Read the full diff: `git diff origin/main...HEAD`

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-fake-strategist-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Strategist Agent
 

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-fake-user-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos User Agent
 

--- a/self-development/kelos-glm-api-reviewer.yaml
+++ b/self-development/kelos-glm-api-reviewer.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-glm-api-reviewer-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos GLM API Reviewer Agent
 
@@ -139,6 +141,11 @@ spec:
       - Understand the motivation and scope of the change or proposal
 
       ### 3. Review
+
+      Use the `api-review` skill for the review analysis, passing it the current
+      pull request or issue as the target. The skill produces an in-task report
+      only; after it returns, use its findings and verdict as the basis for the
+      checks and publishing steps below.
 
       **If this is a pull request:**
       - Read the full diff: `git diff origin/main...HEAD`

--- a/self-development/kelos-glm-reviewer.yaml
+++ b/self-development/kelos-glm-reviewer.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-glm-reviewer-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos GLM Reviewer Agent
 

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-image-update-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Image Update Agent
 

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-planner-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Planner Agent
 

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-reviewer-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Reviewer Agent
 
@@ -129,6 +131,12 @@ spec:
       - Understand the motivation and scope of the change
 
       ### 3. Review the diff
+      Use the `review-all` skill with `origin/main` as the base. Let its two
+      independent review paths examine the committed `origin/main...HEAD` diff,
+      then use the unified findings as the basis for this review. The skill
+      performs analysis only; after it returns, continue with the project-specific
+      checks below and publish the single sticky comment in step 6.
+
       Review the code:
       - Read the full diff: `git diff origin/main...HEAD`
       - For each changed file, read the surrounding context to understand how the

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-self-update-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Self-Update Agent
 

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -3,6 +3,8 @@ kind: AgentConfig
 metadata:
   name: kelos-workers-agent
 spec:
+  skills:
+    - source: gjkim42/kanon-repo
   agentsMD: |
     # Kelos Worker Agent
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Installs all skills from `gjkim42/kanon-repo` in every Kelos, Agora, and Kanon self-development `AgentConfig` so spawned agents share the same reusable workflows.

Updates the Codex reviewer prompts to use the `review-all` skill and both Kelos API reviewer prompts to use the `api-review` skill. The general GLM reviewer remains the independent model-family review path because its OpenCode image does not provide the Codex runtime required by `review-all`.

Adds focused tests that keep the skill package and reviewer workflow requirements in sync with the manifests.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The review skills perform analysis only. The surrounding TaskSpawner prompts remain responsible for publishing the existing sticky review comments.

Validation:

- `make verify`
- `make test`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs shared skills from `gjkim42/kanon-repo` across all self-development `AgentConfig`s (Kelos, Agora, Kanon) and switches reviewers to use the `review-all` and `api-review` skills. This standardizes reviewer workflows and adds tests to keep manifests and prompts in sync.

- **New Features**
  - All self-development `AgentConfig`s include shared skills from `gjkim42/kanon-repo`.
  - Reviewers use `review-all` (base `origin/main`) and API reviewers use `api-review`; the GLM general reviewer remains independent due to runtime limits.
  - Added focused tests to assert skills and required prompt text; READMEs updated to document the behavior.

<sup>Written for commit 37cfcc2650e14d9ffebfe6e5eaea64a14ad44600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

