### PR TITLE
fix: Add nameTemplate to TaskSpawner for deterministic Task naming and dedup

### DIFF
--- a/api/v1alpha2/taskspawner_types.go
+++ b/api/v1alpha2/taskspawner_types.go
@@ -901,7 +901,7 @@ type TaskTemplate struct {
 	// Available variables (all sources): {{.ID}}, {{.Title}}, {{.Kind}}
 	// GitHub issue/Jira sources: {{.Number}}, {{.Body}}, {{.URL}}, {{.Labels}}, {{.Comments}}
 	// GitHub pull request sources additionally expose: {{.Branch}}, {{.ReviewState}}, {{.ReviewComments}}
-	// GitHub webhook sources: {{.Event}}, {{.Action}}, {{.Sender}}, {{.Ref}}, {{.Repository}}, {{.Payload}} (full payload access)
+	// GitHub webhook sources: {{.Event}}, {{.Action}}, {{.Sender}}, {{.Ref}}, {{.Repository}}, {{.Payload}} (full payload access); issue and pull request events also expose {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}} (plus {{.Branch}} for pull requests)
 	// Linear webhook sources: {{.Type}}, {{.Action}}, {{.State}}, {{.Labels}}, {{.IssueID}}, {{.Payload}}
 	// Cron sources: {{.Time}}, {{.Schedule}}
 	// When contextSources are configured: .Context.NAME for each source
@@ -912,12 +912,45 @@ type TaskTemplate struct {
 	// Available variables (all sources): {{.ID}}, {{.Title}}, {{.Kind}}
 	// GitHub issue/Jira sources: {{.Number}}, {{.Body}}, {{.URL}}, {{.Labels}}, {{.Comments}}
 	// GitHub pull request sources additionally expose: {{.Branch}}, {{.ReviewState}}, {{.ReviewComments}}
-	// GitHub webhook sources: {{.Event}}, {{.Action}}, {{.Sender}}, {{.Ref}}, {{.Repository}}, {{.Payload}} (full payload access)
+	// GitHub webhook sources: {{.Event}}, {{.Action}}, {{.Sender}}, {{.Ref}}, {{.Repository}}, {{.Payload}} (full payload access); issue and pull request events also expose {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}} (plus {{.Branch}} for pull requests)
 	// Linear webhook sources: {{.Type}}, {{.Action}}, {{.State}}, {{.Labels}}, {{.IssueID}}, {{.Payload}}
 	// Cron sources: {{.Time}}, {{.Schedule}}
 	// When contextSources are configured: .Context.NAME for each source
 	// +optional
 	PromptTemplate string `json:"promptTemplate,omitempty"`
+
+	// NameTemplate is a Go text/template for rendering the spawned Task's name.
+	// The rendered value is lowercased and sanitized into a valid Kubernetes
+	// resource name (invalid characters replaced with "-") and truncated to 63
+	// characters. When unset, the spawner falls back to its default naming.
+	// Use a deterministic template (e.g. "{{.Number}}") to deduplicate Tasks:
+	// events that render to the same name reuse the existing Task instead of
+	// creating a duplicate, but only when that Task is owned by this TaskSpawner.
+	// This is the recommended way to avoid duplicate Tasks from multiple GitHub
+	// webhook deliveries for the same pull request.
+	// Task names are unique across the whole namespace, so the rendered name must
+	// be namespace-unique: a collision with a Task owned by a different
+	// TaskSpawner (or any unrelated Task) is an error, not deduplication. Include
+	// a TaskSpawner-specific prefix, and — because a webhook endpoint may receive
+	// events from multiple repositories where a bare number collides across
+	// repos — a repository identifier (e.g. {{.Repository}}) or a scoped source
+	// (when.githubWebhook.repository).
+	// Because the name is truncated to 63 characters, keep the identifying part
+	// of the template (e.g. the number) within the first 63 characters: names
+	// that differ only past that point collapse to the same value and would
+	// reuse a single Task for distinct work items.
+	// Available variables (all sources): {{.ID}}, {{.Title}}, {{.Kind}}
+	// GitHub issue/Jira sources: {{.Number}}, {{.Body}}, {{.URL}}, {{.Labels}}, {{.Comments}}
+	// GitHub pull request sources additionally expose: {{.Branch}}, {{.ReviewState}}, {{.ReviewComments}}
+	// GitHub webhook sources: {{.Event}}, {{.Action}}, {{.Sender}}, {{.Ref}}, {{.Repository}}, {{.Payload}} (full payload access); issue and pull request events also expose {{.Number}}, {{.Title}}, {{.Body}}, {{.URL}} (plus {{.Branch}} for pull requests)
+	// Linear webhook sources: {{.Type}}, {{.Action}}, {{.State}}, {{.Labels}}, {{.IssueID}}, {{.Payload}}
+	// Cron sources: {{.Time}}, {{.Schedule}}
+	// Context sources (.Context.NAME) are not available to nameTemplate on any
+	// source: a Task's identity must not depend on mutable external data, so
+	// context is excluded from name rendering and a nameTemplate that references
+	// .Context fails to render.
+	// +optional
+	NameTemplate string `json:"nameTemplate,omitempty"`
 
 	// TTLSecondsAfterFinished limits the lifetime of a Task that has finished
 	// execution (either Succeeded or Failed). If set, spawned Tasks will be
@@ -949,7 +982,8 @@ type TaskTemplate struct {
 
 	// ContextSources declares external data sources to query before task
 	// creation. Each source's response is available as .Context.NAME
-	// in promptTemplate, branch, and metadata templates. Sources are
+	// in promptTemplate, branch, and metadata templates (but not in
+	// nameTemplate, whose output must not depend on mutable data). Sources are
 	// fetched in parallel during the discovery cycle.
 	// +optional
 	// +kubebuilder:validation:MaxItems=8

--- a/cmd/kelos-spawner/main.go
+++ b/cmd/kelos-spawner/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -297,6 +298,14 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 	activeTasks := 0
 	for i := range existingTaskList.Items {
 		t := &existingTaskList.Items[i]
+		// The label selector can match Tasks left by a since-recreated
+		// TaskSpawner of the same name (stale controller owner UID). Only Tasks
+		// this spawner actually owns count for deduplication and concurrency; a
+		// same-name Task owned by someone else must fall through to the create
+		// path and surface as a collision rather than silently suppress work.
+		if !taskbuilder.TaskBelongsToSpawner(t, ts.Name, ts.UID) {
+			continue
+		}
 		existingTaskMap[t.Name] = t
 		if t.Status.Phase != kelos.TaskPhaseSucceeded && t.Status.Phase != kelos.TaskPhaseFailed {
 			activeTasks++
@@ -305,7 +314,18 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 
 	var newItems []source.WorkItem
 	for _, item := range items {
-		taskName := taskNameForWorkItem(ts.Name, item.ID)
+		// Resolve the Task name the same way BuildTask will, so a configured
+		// nameTemplate is honored when matching against existing Tasks for
+		// deduplication. The name template renders from the work item's base
+		// variables (context sources are not available at this stage).
+		taskName, err := taskbuilder.ResolveTaskName(taskNameForWorkItem(ts.Name, item.ID), &ts.Spec.TaskTemplate, source.WorkItemToTemplateVars(item))
+		if err != nil {
+			// A name resolution failure is a configuration problem (bad template,
+			// missing key, empty result) affecting every item. Fail the cycle and
+			// record it on the TaskSpawner status instead of silently dropping all
+			// matching items while reporting a successful discovery.
+			return recordCycleFailure(ctx, cl, key, fmt.Errorf("resolving task name for item %s: %w", item.ID, err))
+		}
 		existing, found := existingTaskMap[taskName]
 		if !found {
 			newItems = append(newItems, item)
@@ -358,6 +378,7 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 	}
 
 	newTasksCreated := 0
+	var createErrs []error
 	for _, item := range newItems {
 		// Enforce max concurrency limit
 		if maxConcurrency > 0 && int32(activeTasks) >= maxConcurrency {
@@ -371,7 +392,9 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 			break
 		}
 
-		taskName := taskNameForWorkItem(ts.Name, item.ID)
+		// Default name used when no nameTemplate is configured; BuildTask
+		// resolves the final name (honoring nameTemplate) and sets task.Name.
+		defaultName := taskNameForWorkItem(ts.Name, item.ID)
 
 		templateVars := source.WorkItemToTemplateVars(item)
 
@@ -380,6 +403,7 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 			contextData, err := contextFetcher.FetchAll(ctx, ts.Spec.TaskTemplate.ContextSources, templateVars)
 			if err != nil {
 				log.Error(err, "Fetching context sources", "item", item.ID)
+				createErrs = append(createErrs, fmt.Errorf("item %s: fetching context sources: %w", item.ID, err))
 				continue
 			}
 			templateVars["Context"] = contextData
@@ -388,11 +412,12 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 		tb, err := taskbuilder.NewTaskBuilder(cl)
 		if err != nil {
 			log.Error(err, "creating task builder", "item", item.ID)
+			createErrs = append(createErrs, fmt.Errorf("item %s: creating task builder: %w", item.ID, err))
 			continue
 		}
 
 		task, err := tb.BuildTask(
-			taskName,
+			defaultName,
 			ts.Namespace,
 			&ts.Spec.TaskTemplate,
 			templateVars,
@@ -405,6 +430,7 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 		)
 		if err != nil {
 			log.Error(err, "building task", "item", item.ID)
+			createErrs = append(createErrs, fmt.Errorf("item %s: building task: %w", item.ID, err))
 			continue
 		}
 
@@ -430,14 +456,30 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 
 		if err := cl.Create(ctx, task); err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				log.Info("Task already exists, skipping", "task", taskName)
+				// The dedup map only holds this spawner's Tasks, so a collision
+				// here is with a Task not in it. Confirm ownership before treating
+				// it as a benign duplicate; a clash with an unrelated Task (e.g.
+				// another spawner rendering the same nameTemplate) is a config
+				// error that must surface rather than silently drop this item.
+				existing := &kelos.Task{}
+				if getErr := cl.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: task.Name}, existing); getErr != nil {
+					log.Error(getErr, "Reading existing Task after create conflict", "task", task.Name)
+					createErrs = append(createErrs, fmt.Errorf("item %s: reading existing Task %s: %w", item.ID, task.Name, getErr))
+				} else if taskbuilder.TaskBelongsToSpawner(existing, ts.Name, ts.UID) {
+					log.Info("Task already exists, skipping", "task", task.Name)
+				} else {
+					err := fmt.Errorf("task %s name collides with an existing Task not owned by spawner %s", task.Name, ts.Name)
+					log.Error(err, "creating Task", "task", task.Name)
+					createErrs = append(createErrs, fmt.Errorf("item %s: %w", item.ID, err))
+				}
 			} else {
-				log.Error(err, "creating Task", "task", taskName)
+				log.Error(err, "creating Task", "task", task.Name)
+				createErrs = append(createErrs, fmt.Errorf("item %s: creating Task %s: %w", item.ID, task.Name, err))
 			}
 			continue
 		}
 
-		log.Info("Created Task", "task", taskName, "item", item.ID)
+		log.Info("Created Task", "task", task.Name, "item", item.ID)
 		newTasksCreated++
 		activeTasks++
 	}
@@ -449,6 +491,8 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 		return fmt.Errorf("re-fetching TaskSpawner for status update: %w", err)
 	}
 
+	cycleErr := errors.Join(createErrs...)
+
 	now := metav1.Now()
 	ts.Status.Phase = kelos.TaskSpawnerPhaseRunning
 	ts.Status.LastDiscoveryTime = &now
@@ -456,6 +500,14 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 	ts.Status.TotalTasksCreated += newTasksCreated
 	ts.Status.ActiveTasks = activeTasks
 	ts.Status.Message = fmt.Sprintf("Discovered %d items, created %d tasks total", ts.Status.TotalDiscovered, ts.Status.TotalTasksCreated)
+	if cycleErr != nil {
+		ts.Status.Message = fmt.Sprintf("Discovered %d items, created %d tasks total; %d creation error(s): %v", ts.Status.TotalDiscovered, ts.Status.TotalTasksCreated, len(createErrs), cycleErr)
+	}
+
+	// Record whether task creation hit errors this cycle so a persistent
+	// namespace name collision surfaces on the resource instead of the spawner
+	// reporting healthy.
+	setDiscoveryErrorCondition(&ts, cycleErr)
 
 	// Clear Suspended condition since we are running
 	meta.SetStatusCondition(&ts.Status.Conditions, metav1.Condition{
@@ -491,10 +543,64 @@ func runCycleWithSourceCore(ctx context.Context, cl client.Client, key types.Nam
 		return fmt.Errorf("updating TaskSpawner status: %w", err)
 	}
 
+	// Surface per-item creation failures (e.g. a rendered name colliding with a
+	// Task owned by another spawner) after status has been updated, so the
+	// reconciler records the error and other items are still processed. A cycle
+	// that hit creation errors is not a success, so do not count it as one.
+	if cycleErr != nil {
+		return cycleErr
+	}
+
 	// Count the cycle as successful only after the status write commits.
 	discoveryTotal.Inc()
 
 	return nil
+}
+
+// conditionDiscoveryError is set on a TaskSpawner when a discovery cycle fails
+// to create one or more Tasks (e.g. a name collision or an unresolvable
+// nameTemplate), so the failure is visible on the resource.
+const conditionDiscoveryError = "DiscoveryError"
+
+// setDiscoveryErrorCondition records (or clears) the DiscoveryError condition
+// based on whether the cycle hit creation errors.
+func setDiscoveryErrorCondition(ts *kelos.TaskSpawner, cycleErr error) {
+	status := metav1.ConditionFalse
+	reason := "NoErrors"
+	message := "Task creation succeeded for all discovered items"
+	if cycleErr != nil {
+		status = metav1.ConditionTrue
+		reason = "TaskCreationFailed"
+		message = cycleErr.Error()
+	}
+	meta.SetStatusCondition(&ts.Status.Conditions, metav1.Condition{
+		Type:               conditionDiscoveryError,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: ts.Generation,
+	})
+}
+
+// recordCycleFailure marks the TaskSpawner as failed with an actionable message
+// for cycle-level errors that abort before the normal status update (e.g. an
+// unresolvable nameTemplate), then returns the original error.
+func recordCycleFailure(ctx context.Context, cl client.Client, key types.NamespacedName, cycleErr error) error {
+	var ts kelos.TaskSpawner
+	if getErr := cl.Get(ctx, key, &ts); getErr != nil {
+		return errors.Join(cycleErr, fmt.Errorf("fetching TaskSpawner to record failure: %w", getErr))
+	}
+	// Do not advance LastDiscoveryTime: the cycle aborted without processing the
+	// discovered ticks, and CronSource uses that watermark as the lower bound for
+	// the next discovery. Advancing it here would permanently skip the ticks that
+	// this failed cycle did not create Tasks for once the configuration is fixed.
+	ts.Status.Phase = kelos.TaskSpawnerPhaseFailed
+	ts.Status.Message = cycleErr.Error()
+	setDiscoveryErrorCondition(&ts, cycleErr)
+	if updErr := cl.Status().Update(ctx, &ts); updErr != nil {
+		return errors.Join(cycleErr, fmt.Errorf("updating TaskSpawner status: %w", updErr))
+	}
+	return cycleErr
 }
 
 // sourceAnnotations returns annotations that stamp GitHub source metadata

--- a/cmd/kelos-spawner/main_test.go
+++ b/cmd/kelos-spawner/main_test.go
@@ -2942,9 +2942,10 @@ func TestRunCycleWithSource_ContextSources_RequiredFailure(t *testing.T) {
 		},
 	}
 
-	// Cycle should succeed (error is per-item, not cycle-level) but no task created.
-	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	// A required context-source failure produces no Task, so the cycle must
+	// surface an error (not report a healthy, zero-Task discovery).
+	if err := runCycleWithSource(context.Background(), cl, key, src); err == nil {
+		t.Fatal("Expected cycle error when a required context source fails")
 	}
 
 	var taskList kelos.TaskList
@@ -2953,5 +2954,244 @@ func TestRunCycleWithSource_ContextSources_RequiredFailure(t *testing.T) {
 	}
 	if len(taskList.Items) != 0 {
 		t.Fatalf("Expected 0 tasks (required context source failed), got %d", len(taskList.Items))
+	}
+
+	// The failure must be recorded on the TaskSpawner status.
+	var got kelos.TaskSpawner
+	if err := cl.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("Get TaskSpawner: %v", err)
+	}
+	if !hasCondition(got.Status.Conditions, conditionDiscoveryError, metav1.ConditionTrue) {
+		t.Errorf("expected DiscoveryError condition True, conditions = %#v", got.Status.Conditions)
+	}
+}
+
+// TestRunCycleWithSource_AbortedCyclePreservesWatermark ensures a cycle that
+// aborts before creating Tasks (here, an unresolvable nameTemplate) does not
+// advance LastDiscoveryTime. CronSource uses that watermark as the lower bound
+// for the next discovery, so advancing it would permanently skip the ticks the
+// failed cycle never processed once the configuration is fixed.
+func TestRunCycleWithSource_AbortedCyclePreservesWatermark(t *testing.T) {
+	ts := newTaskSpawner("cron-spawner", "default", nil)
+	ts.Spec.When = kelos.When{Cron: &kelos.Cron{Schedule: "0 * * * *"}}
+	ts.Spec.TaskTemplate.NameTemplate = "task-{{.Missing}}" // unresolvable
+	cl, key := setupTest(t, ts)
+
+	watermark := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	var cur kelos.TaskSpawner
+	if err := cl.Get(context.Background(), key, &cur); err != nil {
+		t.Fatalf("Get TaskSpawner: %v", err)
+	}
+	cur.Status.LastDiscoveryTime = &watermark
+	if err := cl.Status().Update(context.Background(), &cur); err != nil {
+		t.Fatalf("seeding LastDiscoveryTime: %v", err)
+	}
+
+	src := &fakeSource{items: []source.WorkItem{{ID: "1", Title: "tick"}}}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err == nil {
+		t.Fatal("expected cycle to fail on unresolvable nameTemplate")
+	}
+
+	var got kelos.TaskSpawner
+	if err := cl.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("Get TaskSpawner: %v", err)
+	}
+	if got.Status.LastDiscoveryTime == nil || !got.Status.LastDiscoveryTime.Time.Equal(watermark.Time) {
+		t.Errorf("LastDiscoveryTime advanced on aborted cycle: got %v, want %v", got.Status.LastDiscoveryTime, watermark.Time)
+	}
+}
+
+func TestRunCycleWithSource_NameTemplate(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	ts.Spec.TaskTemplate.NameTemplate = "custom-{{.ID}}"
+	cl, key := setupTest(t, ts)
+
+	src := &fakeSource{
+		items: []source.WorkItem{
+			{ID: "1", Title: "Item 1"},
+		},
+	}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var taskList kelos.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("Expected 1 task, got %d", len(taskList.Items))
+	}
+	if got := taskList.Items[0].Name; got != "custom-1" {
+		t.Errorf("task name = %q, want %q (nameTemplate not applied)", got, "custom-1")
+	}
+}
+
+func TestRunCycleWithSource_NameTemplateResolutionErrorFailsCycle(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	ts.Spec.TaskTemplate.NameTemplate = "task-{{.Missing}}" // missing key -> render error
+	cl, key := setupTest(t, ts)
+
+	src := &fakeSource{items: []source.WorkItem{{ID: "1", Title: "Item 1"}}}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err == nil {
+		t.Fatal("expected cycle to fail on unresolvable nameTemplate")
+	}
+
+	var taskList kelos.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 0 {
+		t.Fatalf("expected no tasks created on resolution error, got %d", len(taskList.Items))
+	}
+
+	// The failure must surface on the TaskSpawner status.
+	var got kelos.TaskSpawner
+	if err := cl.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("Get TaskSpawner: %v", err)
+	}
+	if got.Status.Phase != kelos.TaskSpawnerPhaseFailed {
+		t.Errorf("Phase = %q, want %q", got.Status.Phase, kelos.TaskSpawnerPhaseFailed)
+	}
+	if !hasCondition(got.Status.Conditions, conditionDiscoveryError, metav1.ConditionTrue) {
+		t.Errorf("expected DiscoveryError condition True, conditions = %#v", got.Status.Conditions)
+	}
+}
+
+func hasCondition(conditions []metav1.Condition, condType string, status metav1.ConditionStatus) bool {
+	for _, c := range conditions {
+		if c.Type == condType {
+			return c.Status == status
+		}
+	}
+	return false
+}
+
+// TestRunCycleWithSource_NameTemplateCollisionWithOtherSpawner ensures a
+// rendered name that collides with a Task owned by a different spawner surfaces
+// an error instead of being silently treated as deduplication.
+func TestRunCycleWithSource_NameTemplateCollisionWithOtherSpawner(t *testing.T) {
+	ts := newTaskSpawner("spawner-b", "default", nil)
+	ts.Spec.TaskTemplate.NameTemplate = "shared-{{.ID}}"
+	// A Task with the same rendered name already exists, owned by spawner-a.
+	other := newTask("shared-1", "default", "spawner-a", kelos.TaskPhaseRunning)
+	cl, key := setupTest(t, ts, other)
+
+	src := &fakeSource{items: []source.WorkItem{{ID: "1", Title: "Item 1"}}}
+
+	// A cycle that hits a collision is not a success and must not increment the
+	// success counter.
+	beforeTotal := testutil.ToFloat64(discoveryTotal)
+	err := runCycleWithSource(context.Background(), cl, key, src)
+	if err == nil {
+		t.Fatal("expected error on cross-spawner name collision")
+	}
+	if delta := testutil.ToFloat64(discoveryTotal) - beforeTotal; delta != 0 {
+		t.Errorf("discoveryTotal changed by %f on a failed cycle, want 0", delta)
+	}
+
+	var taskList kelos.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("expected the other spawner's Task to remain the only Task, got %d", len(taskList.Items))
+	}
+	if got := taskList.Items[0].Labels["kelos.dev/taskspawner"]; got != "spawner-a" {
+		t.Errorf("existing Task ownership changed: label = %q, want %q", got, "spawner-a")
+	}
+
+	// The collision must surface on the TaskSpawner status.
+	var got kelos.TaskSpawner
+	if err := cl.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("Get TaskSpawner: %v", err)
+	}
+	if !hasCondition(got.Status.Conditions, conditionDiscoveryError, metav1.ConditionTrue) {
+		t.Errorf("expected DiscoveryError condition True, conditions = %#v", got.Status.Conditions)
+	}
+}
+
+// TestRunCycleWithSource_StaleOwnerUIDDoesNotDedup ensures a Task carrying this
+// spawner's label but a controller owner reference from a different (recreated)
+// spawner instance is not treated as owned for deduplication — it must surface
+// as a collision instead of silently suppressing the work item.
+func TestRunCycleWithSource_StaleOwnerUIDDoesNotDedup(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	ts.Spec.TaskTemplate.NameTemplate = "shared-{{.ID}}"
+
+	controller := true
+	stale := kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-1",
+			Namespace: "default",
+			Labels:    map[string]string{"kelos.dev/taskspawner": "spawner"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kelos.GroupVersion.String(),
+				Kind:       "TaskSpawner",
+				Name:       "spawner",
+				UID:        "old-uid", // different from ts.UID ("spawner-uid")
+				Controller: &controller,
+			}},
+		},
+		Spec:   kelos.TaskSpec{Type: "claude-code", Prompt: "stale"},
+		Status: kelos.TaskStatus{Phase: kelos.TaskPhaseRunning},
+	}
+	cl, key := setupTest(t, ts, stale)
+
+	src := &fakeSource{items: []source.WorkItem{{ID: "1", Title: "Item 1"}}}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err == nil {
+		t.Fatal("expected collision error: a stale-owner Task must not deduplicate the item")
+	}
+
+	var taskList kelos.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("expected only the stale Task to remain, got %d", len(taskList.Items))
+	}
+}
+
+// TestRunCycleWithSource_NameTemplateDedup verifies the dedup lookup uses the
+// rendered name: an existing Task whose name matches the nameTemplate output is
+// not recreated, while a new item is.
+func TestRunCycleWithSource_NameTemplateDedup(t *testing.T) {
+	ts := newTaskSpawner("spawner", "default", nil)
+	ts.Spec.TaskTemplate.NameTemplate = "custom-{{.ID}}"
+	existing := newTask("custom-1", "default", "spawner", kelos.TaskPhaseRunning)
+	cl, key := setupTest(t, ts, existing)
+
+	src := &fakeSource{
+		items: []source.WorkItem{
+			{ID: "1", Title: "Item 1"}, // already exists as custom-1
+			{ID: "2", Title: "Item 2"}, // new
+		},
+	}
+
+	if err := runCycleWithSource(context.Background(), cl, key, src); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var taskList kelos.TaskList
+	if err := cl.List(context.Background(), &taskList, client.InNamespace("default")); err != nil {
+		t.Fatalf("Listing tasks: %v", err)
+	}
+	names := make([]string, 0, len(taskList.Items))
+	for _, task := range taskList.Items {
+		names = append(names, task.Name)
+	}
+	if len(taskList.Items) != 2 {
+		t.Fatalf("Expected 2 tasks (custom-1, custom-2), got %d: %v", len(taskList.Items), names)
+	}
+	got := map[string]bool{}
+	for _, n := range names {
+		got[n] = true
+	}
+	if !got["custom-1"] || !got["custom-2"] {
+		t.Errorf("Expected tasks custom-1 and custom-2, got %v", names)
 	}
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -593,12 +593,13 @@ to receive refreshed credentials during long-running work.
 | `spec.taskTemplate.promptTemplate` | Go text/template for prompt (see [template variables](#prompttemplate-variables) below) | No |
 | `spec.taskTemplate.dependsOn` | Task names that spawned Tasks depend on. Not supported with `workerPoolRef` | No |
 | `spec.taskTemplate.branch` | Git branch template for spawned Tasks (supports Go template variables, e.g., `kelos-task-{{.Number}}`). Not supported with `workerPoolRef` | No |
+| `spec.taskTemplate.nameTemplate` | Go text/template for the spawned Task's name (overrides the default naming below). The rendered value is lowercased, sanitized to a valid resource name, and truncated to 63 characters. Use a deterministic template (e.g. `{{.Number}}`) to deduplicate Tasks: work items that render to the same name reuse the existing Task instead of creating a duplicate — the recommended way to avoid duplicate Tasks from multiple GitHub webhook deliveries for the same pull request. Names must be unique across the whole namespace; a collision with a Task owned by a different TaskSpawner (or any unrelated Task) is an error, not deduplication (see [Generated Task Names](#generated-task-names)). Keep the identifying part within the first 63 characters. `.Context.NAME` is not available to `nameTemplate` on any source — a Task's identity must not depend on mutable external data | No |
 | `spec.taskTemplate.ttlSecondsAfterFinished` | Auto-delete spawned tasks after N seconds | No |
 | `spec.taskTemplate.podFailurePolicy` | Kubernetes Job pod failure policy copied to spawned Tasks as `Task.spec.podFailurePolicy` | No |
 | `spec.taskTemplate.podOverrides` | **(Deprecated)** Pod customization — use `taskTemplate.worker.podOverrides` instead | Legacy |
 | `spec.taskTemplate.metadata.labels` | Labels merged into spawned Tasks; values support the same Go template variables as `branch`/`promptTemplate`; the `kelos.dev/taskspawner` label is always set to the TaskSpawner name and overrides any user value for that key | No |
 | `spec.taskTemplate.metadata.annotations` | Annotations merged into spawned Tasks; values support the same Go template variables as `branch`/`promptTemplate`; source annotations (e.g. `kelos.dev/source-kind`) are applied after rendering and override conflicting user values | No |
-| `spec.taskTemplate.contextSources` | External data sources fetched in parallel before task creation; each source's value is exposed as `{{.Context.NAME}}` in `branch`, `promptTemplate`, and `metadata` templates (see [Context Sources](#context-sources) below). Maximum 8 entries; names must be unique | No |
+| `spec.taskTemplate.contextSources` | External data sources fetched in parallel before task creation; each source's value is exposed as `{{.Context.NAME}}` in `branch`, `promptTemplate`, and `metadata` templates — but not in `nameTemplate` (see [Context Sources](#context-sources) below). Maximum 8 entries; names must be unique | No |
 | `spec.taskTemplate.upstreamRepo` | Upstream repository in `owner/repo` format; injected as `KELOS_UPSTREAM_REPO` into the agent container. Typically auto-derived from `githubIssues.repo`/`githubPullRequests.repo`, but can be set explicitly for fork workflows | No |
 | `spec.maxConcurrency` | Limit max concurrent running tasks (important for cost control) | No |
 | `spec.maxTotalTasks` | Lifetime limit on total tasks created by this spawner | No |
@@ -613,6 +614,25 @@ lowercases the work item ID when forming the Task name:
 Lowercasing the Task name does not change the source data exposed to templates
 and logs. In particular, `{{.ID}}` remains the raw work item ID (for example,
 `ENG-42`). Webhook-backed TaskSpawners use delivery-based Task names instead.
+
+When `spec.taskTemplate.nameTemplate` is set, it overrides these default schemes
+for all sources: the Task name is the rendered template (lowercased, sanitized,
+and truncated to 63 characters). A deterministic template deduplicates Tasks —
+work items or webhook deliveries that render to the same name reuse the existing
+Task instead of creating a duplicate.
+
+Deduplication is **ownership-scoped**, not per spawner name. A Task name is unique
+across the entire namespace, so a rendered name is reused only when the existing
+Task belongs to the same TaskSpawner (matched by controller owner-reference UID,
+or the `kelos.dev/taskspawner` label for ownerless legacy Tasks). If a rendered
+name collides with a Task owned by a different TaskSpawner — or any unrelated Task
+using that name — Kelos does **not** silently reuse it: the webhook path returns
+an error (HTTP 500, so the delivery is retried), the polling path records a
+`DiscoveryError` condition and failure on the TaskSpawner, and the Slack path
+surfaces the error in the server logs. Ensure each TaskSpawner's
+`nameTemplate` renders names that are unique across the namespace (for example by
+including the TaskSpawner-specific prefix, and a repository qualifier when one
+endpoint serves multiple repositories).
 
 ### Manual Task Creation
 
@@ -646,7 +666,9 @@ not apply `spec.suspend`, `spec.maxConcurrency`, or `spec.maxTotalTasks`, does
 not enable source reporting, and does not update TaskSpawner status. The Task
 has no TaskSpawner owner reference or `kelos.dev/taskspawner` label. Instead,
 Kelos records its origin with `kelos.dev/created-from-taskspawner`,
-`kelos.dev/trigger-type`, and `kelos.dev/trigger-time` annotations.
+`kelos.dev/trigger-type`, and `kelos.dev/trigger-time` annotations. Manual runs
+also ignore `spec.taskTemplate.nameTemplate`: the Task is named from `--name`
+when provided, otherwise `<taskspawner>-manual-<suffix>`.
 
 Configured `contextSources` are fetched after the values are resolved, matching
 automatic Task creation. `--dry-run` still connects to the cluster to read the

--- a/examples/10-taskspawner-github-webhook/README.md
+++ b/examples/10-taskspawner-github-webhook/README.md
@@ -104,8 +104,40 @@ The webhook server validates GitHub signatures using HMAC-SHA256:
 
 ### Idempotency
 - Webhook deliveries are tracked by `X-GitHub-Delivery` header
-- Duplicate deliveries (e.g., retries) are ignored
+- Duplicate deliveries (e.g., retries) with the same delivery ID are ignored
 - Delivery cache entries expire after 24 hours
+
+### Deduplicating Tasks for the Same Pull Request
+By default each delivery produces a Task with a unique, delivery-derived name, so
+GitHub sending several distinct deliveries for one PR (for example an `opened`
+event plus one `labeled` event per label, all within a second) creates one Task
+per delivery. Set `taskTemplate.nameTemplate` to a deterministic value to collapse
+these into a single Task (see the `pr-burst-responder` spawner in
+[`taskspawner.yaml`](./taskspawner.yaml)):
+
+```yaml
+taskTemplate:
+  # Deliveries that render to the same name reuse the existing Task instead of
+  # creating a duplicate. This spawner is scoped to one repository
+  # (when.githubWebhook.repository), so a bare PR number is a stable, unique
+  # identity. The rendered value is lowercased, sanitized to a valid resource
+  # name, and truncated to 63 characters.
+  nameTemplate: "pr-burst-responder-{{.Number}}"
+```
+
+Once a Task with the rendered name exists, later deliveries that render to the
+same name are skipped. Choose a template that identifies the underlying work item
+(the PR number) rather than the delivery, and use it only for burst events for the
+same PR state — not for repeatable `issue_comment`/`pull_request_review` commands,
+which want a fresh Task each time (leave `nameTemplate` unset there).
+
+The rendered name must be unique across everything the endpoint serves. Scope the
+spawner to one repository (as above), or include a repository qualifier — but put
+the bounded PR number first, e.g. `pr-{{.Number}}-{{.Repository}}`, because the
+name is truncated to 63 characters: an unbounded repository value placed first can
+fill the budget before the number and collapse every PR in that repo to one name.
+`.Context.NAME` values are not available to `nameTemplate` (a Task's identity must
+not depend on mutable external data).
 
 ### Fault Isolation
 - Per-source webhook servers provide fault isolation

--- a/examples/10-taskspawner-github-webhook/taskspawner.yaml
+++ b/examples/10-taskspawner-github-webhook/taskspawner.yaml
@@ -69,6 +69,12 @@ spec:
     # Template for the git branch (optional)
     branch: "kelos-webhook-{{.Event}}-{{.ID}}"
 
+    # This spawner listens for repeatable triggers (issue_comment,
+    # pull_request_review), so it intentionally omits nameTemplate: each delivery
+    # gets its own Task via the default per-delivery name, and every "/kelos"
+    # comment or submitted review creates a fresh Task. See the second spawner
+    # below for deterministic per-PR naming (deduplication) on burst events.
+
     # Template for the task prompt
     promptTemplate: |
       # GitHub {{.Event}} Event: {{.Action}}
@@ -122,6 +128,54 @@ spec:
         kelos.dev/github-sender: "{{.Sender}}"
 
     # Auto-cleanup completed tasks after 1 hour
+    ttlSecondsAfterFinished: 3600
+
+---
+# Deduplication example: collapse the burst of deliveries GitHub sends for a
+# single pull request state change (e.g. "opened" plus one "labeled" per label,
+# all within a second) into a single Task.
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: pr-burst-responder
+  namespace: default
+spec:
+  when:
+    githubWebhook:
+      # Scope to a single repository so a bare PR number is a stable, unique
+      # identity. Serving multiple repositories from one endpoint would require a
+      # repository qualifier in nameTemplate to avoid PR-number collisions across
+      # repos — and the identifying part must stay within the first 63 characters
+      # (put the bounded PR number first if you add an unbounded repo value).
+      repository: myorg/myrepo
+      # Only burst events for the same PR state — not repeatable comment/review
+      # commands, which want a fresh Task each time.
+      events:
+        - "pull_request"
+      filters:
+        - event: "pull_request"
+          action: "opened"
+          draft: false
+        - event: "pull_request"
+          action: "labeled"
+          labels: ["review-requested"]
+        - event: "pull_request"
+          action: "ready_for_review"
+  taskTemplate:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials
+    workspaceRef:
+      name: my-repo-workspace
+    # Deterministic per-PR name: the several deliveries for the same PR render to
+    # this name, so the first creates the Task and the rest reuse it. (.Context
+    # values are not available to nameTemplate.)
+    nameTemplate: "pr-burst-responder-{{.Number}}"
+    promptTemplate: |
+      Review pull request #{{.Number}}: {{.Title}}
+      {{with index . "URL"}}URL: {{.}}{{end}}
     ttlSecondsAfterFinished: 3600
 
 ---

--- a/internal/cli/run_from_taskspawner.go
+++ b/internal/cli/run_from_taskspawner.go
@@ -189,7 +189,12 @@ func buildTaskFromTaskSpawner(ctx context.Context, cl client.Client, namespace, 
 	if err != nil {
 		return nil, fmt.Errorf("creating Task builder for TaskSpawner %s: %w", spawner.Name, err)
 	}
-	task, err := builder.BuildTask(taskName, namespace, &spawner.Spec.TaskTemplate, vars, nil)
+	// Manual runs manage their own name (an explicit --name or a unique
+	// -manual- suffix), so bypass the spawner's nameTemplate: it targets
+	// automated deduplication and its variables may be absent for a manual run.
+	taskTemplate := spawner.Spec.TaskTemplate
+	taskTemplate.NameTemplate = ""
+	task, err := builder.BuildTask(taskName, namespace, &taskTemplate, vars, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building task %s from TaskSpawner %s: %w", taskName, spawner.Name, err)
 	}

--- a/internal/cli/run_from_taskspawner_test.go
+++ b/internal/cli/run_from_taskspawner_test.go
@@ -123,6 +123,28 @@ func TestBuildTaskFromTaskSpawnerMissingTemplateValue(t *testing.T) {
 	}
 }
 
+func TestBuildTaskFromTaskSpawnerIgnoresNameTemplate(t *testing.T) {
+	spawner := testManualTaskSpawner("webhook-spawner")
+	spawner.Spec.When.GenericWebhook = &kelos.GenericWebhook{Source: "alerts"}
+	spawner.Spec.TaskTemplate.PromptTemplate = "Investigate {{.Title}}"
+	// A nameTemplate referencing a variable a manual run does not provide must
+	// not break the manual run, and the explicit --name must win.
+	spawner.Spec.TaskTemplate.NameTemplate = "responder-pr-{{.Number}}"
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(spawner).Build()
+
+	task, err := buildTaskFromTaskSpawner(context.Background(), cl, "default", spawner.Name, runFromTaskSpawnerOptions{
+		Name:   "manual-webhook-task",
+		Values: map[string]interface{}{"Title": "API latency"},
+		Now:    time.Date(2026, 7, 10, 1, 2, 3, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("buildTaskFromTaskSpawner: %v", err)
+	}
+	if task.Name != "manual-webhook-task" {
+		t.Errorf("task name = %q, want %q (nameTemplate should be ignored for manual runs)", task.Name, "manual-webhook-task")
+	}
+}
+
 func TestBuildTaskFromTaskSpawnerPreservesIntegerValues(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "values.yaml")
 	if err := os.WriteFile(path, []byte("Number: 42\n"), 0o600); err != nil {

--- a/internal/conversion/taskspawner.go
+++ b/internal/conversion/taskspawner.go
@@ -7,8 +7,14 @@ import (
 	v1alpha2 "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
+// preservedNameTemplateAnnotation carries taskTemplate.nameTemplate (a
+// v1alpha2-only field) across a v1alpha1 round-trip so a client that reads and
+// writes the object through v1alpha1 does not silently drop it. v1alpha1 does
+// not gain the capability — the value only survives in this annotation.
+const preservedNameTemplateAnnotation = "kelos.dev/v1alpha2-name-template"
+
 func taskSpawnerToHub(_ context.Context, src *v1alpha1.TaskSpawner, dst *v1alpha2.TaskSpawner) error {
-	dst.ObjectMeta = src.ObjectMeta
+	src.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
 	if err := convertViaJSON(&src.Spec, &dst.Spec); err != nil {
 		return err
 	}
@@ -16,11 +22,13 @@ func taskSpawnerToHub(_ context.Context, src *v1alpha1.TaskSpawner, dst *v1alpha
 		return err
 	}
 	foldTaskSpawnerForward(&src.Spec, &dst.Spec)
+	restorePreservedNameTemplate(src.Annotations, &dst.Spec.TaskTemplate)
+	deleteAnnotation(dst.Annotations, preservedNameTemplateAnnotation)
 	return nil
 }
 
 func taskSpawnerFromHub(_ context.Context, src *v1alpha2.TaskSpawner, dst *v1alpha1.TaskSpawner) error {
-	dst.ObjectMeta = src.ObjectMeta
+	src.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
 	if err := convertViaJSON(&src.Spec, &dst.Spec); err != nil {
 		return err
 	}
@@ -28,7 +36,28 @@ func taskSpawnerFromHub(_ context.Context, src *v1alpha2.TaskSpawner, dst *v1alp
 		return err
 	}
 	backfillTaskSpawnerLegacy(&dst.Spec)
+	setPreservedNameTemplateAnnotation(dst, src.Spec.TaskTemplate.NameTemplate)
 	return convertViaJSON(&src.Status, &dst.Status)
+}
+
+func setPreservedNameTemplateAnnotation(dst *v1alpha1.TaskSpawner, nameTemplate string) {
+	if nameTemplate == "" {
+		deleteAnnotation(dst.Annotations, preservedNameTemplateAnnotation)
+		return
+	}
+	if dst.Annotations == nil {
+		dst.Annotations = map[string]string{}
+	}
+	dst.Annotations[preservedNameTemplateAnnotation] = nameTemplate
+}
+
+func restorePreservedNameTemplate(annotations map[string]string, dst *v1alpha2.TaskTemplate) {
+	if dst.NameTemplate != "" {
+		return
+	}
+	if v, ok := annotations[preservedNameTemplateAnnotation]; ok {
+		dst.NameTemplate = v
+	}
 }
 
 func foldTaskSpawnerForward(src *v1alpha1.TaskSpawnerSpec, dst *v1alpha2.TaskSpawnerSpec) {

--- a/internal/conversion/taskspawner_test.go
+++ b/internal/conversion/taskspawner_test.go
@@ -330,3 +330,50 @@ func TestTaskSpawnerFromHub_LeavesPolicyWithAuthorizationModern(t *testing.T) {
 		t.Errorf("triggerComment = %q, want empty to keep v1alpha1 validation valid", pr.TriggerComment)
 	}
 }
+
+func TestTaskSpawnerConvert_NameTemplateRoundTrips(t *testing.T) {
+	const nameTemplate = "responder-{{.Repository}}-pr-{{.Number}}"
+	hub := &v1alpha2.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "responder", Namespace: "default"},
+		Spec: v1alpha2.TaskSpawnerSpec{
+			When:         v1alpha2.When{GitHubWebhook: &v1alpha2.GitHubWebhook{Events: []string{"pull_request"}}},
+			TaskTemplate: v1alpha2.TaskTemplate{NameTemplate: nameTemplate},
+		},
+	}
+
+	// hub -> spoke: v1alpha1 has no nameTemplate field, so it is preserved in an
+	// internal annotation rather than dropped.
+	spoke := &v1alpha1.TaskSpawner{}
+	if err := taskSpawnerFromHub(context.Background(), hub, spoke); err != nil {
+		t.Fatalf("taskSpawnerFromHub() error = %v", err)
+	}
+	if got := spoke.Annotations[preservedNameTemplateAnnotation]; got != nameTemplate {
+		t.Fatalf("preserved annotation = %q, want %q", got, nameTemplate)
+	}
+
+	// spoke -> hub: the field is restored and the internal annotation removed.
+	back := &v1alpha2.TaskSpawner{}
+	if err := taskSpawnerToHub(context.Background(), spoke, back); err != nil {
+		t.Fatalf("taskSpawnerToHub() error = %v", err)
+	}
+	if got := back.Spec.TaskTemplate.NameTemplate; got != nameTemplate {
+		t.Errorf("round-tripped NameTemplate = %q, want %q", got, nameTemplate)
+	}
+	if _, ok := back.Annotations[preservedNameTemplateAnnotation]; ok {
+		t.Error("internal preservation annotation leaked onto hub object")
+	}
+}
+
+func TestTaskSpawnerFromHub_NoNameTemplateOmitsAnnotation(t *testing.T) {
+	hub := &v1alpha2.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "responder", Namespace: "default"},
+		Spec:       v1alpha2.TaskSpawnerSpec{When: v1alpha2.When{Cron: &v1alpha2.Cron{Schedule: "0 9 * * 1"}}},
+	}
+	spoke := &v1alpha1.TaskSpawner{}
+	if err := taskSpawnerFromHub(context.Background(), hub, spoke); err != nil {
+		t.Fatalf("taskSpawnerFromHub() error = %v", err)
+	}
+	if _, ok := spoke.Annotations[preservedNameTemplateAnnotation]; ok {
+		t.Error("annotation should not be set when nameTemplate is empty")
+	}
+}

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -347,15 +347,16 @@ func TestRender_TaskSpawnerTemplatePlaceholdersRemainLiteral(t *testing.T) {
 		t.Error("expected branch placeholder example to remain literal in rendered CRD output")
 	}
 	// Each placeholder appears in the Branch and PromptTemplate godoc of
-	// TaskTemplate across the served TaskSpawner CRD schemas.
+	// TaskTemplate across both served TaskSpawner CRD schemas (4), plus the
+	// NameTemplate godoc that exists only in the latest version (1).
 	for _, expected := range []string{
 		"Available variables (all sources): {{.ID}}, {{.Title}}, {{.Kind}}",
 		"GitHub issue/Jira sources: {{.Number}}, {{.Body}}, {{.URL}}, {{.Labels}}, {{.Comments}}",
 		"GitHub pull request sources additionally expose: {{.Branch}}, {{.ReviewState}}, {{.ReviewComments}}",
 		"Cron sources: {{.Time}}, {{.Schedule}}",
 	} {
-		if count := strings.Count(output, expected); count != 4 {
-			t.Errorf("expected %q to appear four times in TaskSpawner CRD descriptions, got %d", expected, count)
+		if count := strings.Count(output, expected); count != 5 {
+			t.Errorf("expected %q to appear five times in TaskSpawner CRD descriptions, got %d", expected, count)
 		}
 	}
 }

--- a/internal/manifests/charts/kelos/charts/kelos-crds/templates/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/charts/kelos-crds/templates/taskspawner-crd.yaml
@@ -8249,7 +8249,7 @@ spec:
                       Available variables (all sources): {{ "{{.ID}}" }}, {{ "{{.Title}}" }}, {{ "{{.Kind}}" }}
                       GitHub issue/Jira sources: {{ "{{.Number}}" }}, {{ "{{.Body}}" }}, {{ "{{.URL}}" }}, {{ "{{.Labels}}" }}, {{ "{{.Comments}}" }}
                       GitHub pull request sources additionally expose: {{ "{{.Branch}}" }}, {{ "{{.ReviewState}}" }}, {{ "{{.ReviewComments}}" }}
-                      GitHub webhook sources: {{ "{{.Event}}" }}, {{ "{{.Action}}" }}, {{ "{{.Sender}}" }}, {{ "{{.Ref}}" }}, {{ "{{.Repository}}" }}, {{ "{{.Payload}}" }} (full payload access)
+                      GitHub webhook sources: {{ "{{.Event}}" }}, {{ "{{.Action}}" }}, {{ "{{.Sender}}" }}, {{ "{{.Ref}}" }}, {{ "{{.Repository}}" }}, {{ "{{.Payload}}" }} (full payload access); issue and pull request events also expose {{ "{{.Number}}" }}, {{ "{{.Title}}" }}, {{ "{{.Body}}" }}, {{ "{{.URL}}" }} (plus {{ "{{.Branch}}" }} for pull requests)
                       Linear webhook sources: {{ "{{.Type}}" }}, {{ "{{.Action}}" }}, {{ "{{.State}}" }}, {{ "{{.Labels}}" }}, {{ "{{.IssueID}}" }}, {{ "{{.Payload}}" }}
                       Cron sources: {{ "{{.Time}}" }}, {{ "{{.Schedule}}" }}
                       When contextSources are configured: .Context.NAME for each source
@@ -8258,7 +8258,8 @@ spec:
                     description: |-
                       ContextSources declares external data sources to query before task
                       creation. Each source's response is available as .Context.NAME
-                      in promptTemplate, branch, and metadata templates. Sources are
+                      in promptTemplate, branch, and metadata templates (but not in
+                      nameTemplate, whose output must not depend on mutable data). Sources are
                       fetched in parallel during the discovery cycle.
                     items:
                       description: |-
@@ -8486,6 +8487,39 @@ spec:
                       Model optionally overrides the default model.
 
                       Deprecated: use taskTemplate.worker.model instead.
+                    type: string
+                  nameTemplate:
+                    description: |-
+                      NameTemplate is a Go text/template for rendering the spawned Task's name.
+                      The rendered value is lowercased and sanitized into a valid Kubernetes
+                      resource name (invalid characters replaced with "-") and truncated to 63
+                      characters. When unset, the spawner falls back to its default naming.
+                      Use a deterministic template (e.g. "{{ "{{.Number}}" }}") to deduplicate Tasks:
+                      events that render to the same name reuse the existing Task instead of
+                      creating a duplicate, but only when that Task is owned by this TaskSpawner.
+                      This is the recommended way to avoid duplicate Tasks from multiple GitHub
+                      webhook deliveries for the same pull request.
+                      Task names are unique across the whole namespace, so the rendered name must
+                      be namespace-unique: a collision with a Task owned by a different
+                      TaskSpawner (or any unrelated Task) is an error, not deduplication. Include
+                      a TaskSpawner-specific prefix, and — because a webhook endpoint may receive
+                      events from multiple repositories where a bare number collides across
+                      repos — a repository identifier (e.g. {{ "{{.Repository}}" }}) or a scoped source
+                      (when.githubWebhook.repository).
+                      Because the name is truncated to 63 characters, keep the identifying part
+                      of the template (e.g. the number) within the first 63 characters: names
+                      that differ only past that point collapse to the same value and would
+                      reuse a single Task for distinct work items.
+                      Available variables (all sources): {{ "{{.ID}}" }}, {{ "{{.Title}}" }}, {{ "{{.Kind}}" }}
+                      GitHub issue/Jira sources: {{ "{{.Number}}" }}, {{ "{{.Body}}" }}, {{ "{{.URL}}" }}, {{ "{{.Labels}}" }}, {{ "{{.Comments}}" }}
+                      GitHub pull request sources additionally expose: {{ "{{.Branch}}" }}, {{ "{{.ReviewState}}" }}, {{ "{{.ReviewComments}}" }}
+                      GitHub webhook sources: {{ "{{.Event}}" }}, {{ "{{.Action}}" }}, {{ "{{.Sender}}" }}, {{ "{{.Ref}}" }}, {{ "{{.Repository}}" }}, {{ "{{.Payload}}" }} (full payload access); issue and pull request events also expose {{ "{{.Number}}" }}, {{ "{{.Title}}" }}, {{ "{{.Body}}" }}, {{ "{{.URL}}" }} (plus {{ "{{.Branch}}" }} for pull requests)
+                      Linear webhook sources: {{ "{{.Type}}" }}, {{ "{{.Action}}" }}, {{ "{{.State}}" }}, {{ "{{.Labels}}" }}, {{ "{{.IssueID}}" }}, {{ "{{.Payload}}" }}
+                      Cron sources: {{ "{{.Time}}" }}, {{ "{{.Schedule}}" }}
+                      Context sources (.Context.NAME) are not available to nameTemplate on any
+                      source: a Task's identity must not depend on mutable external data, so
+                      context is excluded from name rendering and a nameTemplate that references
+                      .Context fails to render.
                     type: string
                   podFailurePolicy:
                     description: |-
@@ -15411,7 +15445,7 @@ spec:
                       Available variables (all sources): {{ "{{.ID}}" }}, {{ "{{.Title}}" }}, {{ "{{.Kind}}" }}
                       GitHub issue/Jira sources: {{ "{{.Number}}" }}, {{ "{{.Body}}" }}, {{ "{{.URL}}" }}, {{ "{{.Labels}}" }}, {{ "{{.Comments}}" }}
                       GitHub pull request sources additionally expose: {{ "{{.Branch}}" }}, {{ "{{.ReviewState}}" }}, {{ "{{.ReviewComments}}" }}
-                      GitHub webhook sources: {{ "{{.Event}}" }}, {{ "{{.Action}}" }}, {{ "{{.Sender}}" }}, {{ "{{.Ref}}" }}, {{ "{{.Repository}}" }}, {{ "{{.Payload}}" }} (full payload access)
+                      GitHub webhook sources: {{ "{{.Event}}" }}, {{ "{{.Action}}" }}, {{ "{{.Sender}}" }}, {{ "{{.Ref}}" }}, {{ "{{.Repository}}" }}, {{ "{{.Payload}}" }} (full payload access); issue and pull request events also expose {{ "{{.Number}}" }}, {{ "{{.Title}}" }}, {{ "{{.Body}}" }}, {{ "{{.URL}}" }} (plus {{ "{{.Branch}}" }} for pull requests)
                       Linear webhook sources: {{ "{{.Type}}" }}, {{ "{{.Action}}" }}, {{ "{{.State}}" }}, {{ "{{.Labels}}" }}, {{ "{{.IssueID}}" }}, {{ "{{.Payload}}" }}
                       Cron sources: {{ "{{.Time}}" }}, {{ "{{.Schedule}}" }}
                       When contextSources are configured: .Context.NAME for each source

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -416,14 +416,25 @@ func (h *SlackHandler) createTask(ctx context.Context, spawner *kelos.TaskSpawne
 	}
 
 	if err := h.client.Create(ctx, task); err != nil {
+		// A configured nameTemplate can render a deterministic name; a collision
+		// is deduplication only when the existing Task belongs to this spawner.
+		// A clash with an unrelated Task must surface as an error rather than
+		// silently dropping the Slack message.
 		if apierrors.IsAlreadyExists(err) {
-			h.log.Info("Task already exists, skipping", "task", taskName)
-			return nil
+			existing := &kelos.Task{}
+			if getErr := h.client.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: task.Name}, existing); getErr != nil {
+				return fmt.Errorf("reading existing Task %s after create conflict: %w", task.Name, getErr)
+			}
+			if taskbuilder.TaskBelongsToSpawner(existing, spawner.Name, spawner.UID) {
+				h.log.Info("Task already exists for spawner, skipping", "task", task.Name)
+				return nil
+			}
+			return fmt.Errorf("task %s name collides with an existing Task not owned by spawner %s", task.Name, spawner.Name)
 		}
 		return fmt.Errorf("Creating task: %w", err)
 	}
 
-	h.log.Info("Created task from Slack message", "task", taskName, "spawner", spawner.Name)
+	h.log.Info("Created task from Slack message", "task", task.Name, "spawner", spawner.Name)
 	return nil
 }
 

--- a/internal/slack/handler_test.go
+++ b/internal/slack/handler_test.go
@@ -335,6 +335,48 @@ func TestCreateTaskAlreadyExists(t *testing.T) {
 	}
 }
 
+// TestCreateTaskNameCollisionWithUnrelatedTask ensures a nameTemplate that
+// renders a name already used by a Task owned by a different spawner surfaces an
+// error instead of silently suppressing the Slack message as deduplication.
+func TestCreateTaskNameCollisionWithUnrelatedTask(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kelos.AddToScheme(scheme))
+
+	spawner := &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{Name: "spawner-b", Namespace: "default", UID: "uid-b"},
+		Spec: kelos.TaskSpawnerSpec{
+			TaskTemplate: kelos.TaskTemplate{
+				Type:           "claude-code",
+				Credentials:    &kelos.Credentials{Type: kelos.CredentialTypeNone},
+				NameTemplate:   "shared-name",
+				PromptTemplate: "{{.Body}}",
+			},
+		},
+	}
+	msg := &SlackMessageData{UserID: "U1", ChannelID: "C1", Text: "hi", Body: "hi", Timestamp: "1.1"}
+
+	unrelated := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-name",
+			Namespace: "default",
+			Labels:    map[string]string{"kelos.dev/taskspawner": "spawner-a"},
+		},
+		Spec: kelos.TaskSpec{Type: "claude-code", Prompt: "other"},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unrelated).Build()
+	tb, err := taskbuilder.NewTaskBuilder(nil)
+	if err != nil {
+		t.Fatalf("NewTaskBuilder: %v", err)
+	}
+	h := &SlackHandler{client: cl, log: logr.Discard(), taskBuilder: tb}
+
+	if err := h.createTask(context.Background(), spawner, msg); err == nil {
+		t.Fatal("expected error on name collision with an unrelated Task, got nil")
+	}
+}
+
 func TestHandleMemberJoinedChannelIgnoresOtherUsers(t *testing.T) {
 	h := &SlackHandler{
 		log:         logr.Discard(),

--- a/internal/taskbuilder/builder.go
+++ b/internal/taskbuilder/builder.go
@@ -3,14 +3,21 @@ package taskbuilder
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
+	"text/template/parse"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
+
+// SpawnerLabel is set on Tasks created by a TaskSpawner and names the owning
+// spawner.
+const SpawnerLabel = "kelos.dev/taskspawner"
 
 // TaskBuilder creates Tasks from templates and work item data.
 type TaskBuilder struct {
@@ -36,12 +43,22 @@ func NewTaskBuilder(client client.Client) (*TaskBuilder, error) {
 // BuildTask creates a Task from a template and template variables.
 // If spawnerRef is non-nil the kelos.dev/taskspawner label and a controller
 // owner reference are set on the resulting Task.
+//
+// When taskTemplate.NameTemplate is set it is rendered, sanitized into a valid
+// Kubernetes resource name, and used as the Task name; otherwise the passed-in
+// name is used unchanged.
 func (tb *TaskBuilder) BuildTask(
 	name, namespace string,
 	taskTemplate *kelos.TaskTemplate,
 	templateVars map[string]interface{},
 	spawnerRef *SpawnerRef,
 ) (*kelos.Task, error) {
+	// Resolve the Task name, rendering the name template when configured.
+	name, err := ResolveTaskName(name, taskTemplate, templateVars)
+	if err != nil {
+		return nil, err
+	}
+
 	// Render the prompt template
 	promptTemplate := taskTemplate.PromptTemplate
 	if promptTemplate == "" {
@@ -152,7 +169,7 @@ func (tb *TaskBuilder) BuildTask(
 		if task.Labels == nil {
 			task.Labels = make(map[string]string)
 		}
-		task.Labels["kelos.dev/taskspawner"] = spawnerRef.Name
+		task.Labels[SpawnerLabel] = spawnerRef.Name
 
 		isController := true
 		task.OwnerReferences = append(task.OwnerReferences, metav1.OwnerReference{
@@ -165,6 +182,207 @@ func (tb *TaskBuilder) BuildTask(
 	}
 
 	return task, nil
+}
+
+// ResolveTaskName determines the name of the Task to build. When
+// taskTemplate.NameTemplate is set it is rendered with templateVars and
+// sanitized into a valid Kubernetes resource name; otherwise defaultName is
+// returned unchanged. Callers that deduplicate Tasks by name (e.g. the polling
+// spawner) must use this to compute their lookup key so it matches the name
+// BuildTask assigns.
+func ResolveTaskName(defaultName string, taskTemplate *kelos.TaskTemplate, templateVars map[string]interface{}) (string, error) {
+	if taskTemplate.NameTemplate == "" {
+		return defaultName, nil
+	}
+	// A Task's identity must not depend on mutable external data, so context
+	// sources are not permitted in nameTemplate. Reject any reference at parse
+	// time — value-level guards (stripping the key + missingkey=error) cannot
+	// catch every form, e.g. {{if index . "Context"}}x{{else}}y{{end}} consumes
+	// the missing value and renders a constant.
+	if err := checkNoContextReference(taskTemplate.NameTemplate); err != nil {
+		return "", err
+	}
+	// Also strip the key and rely on missingkey=error as defense in depth.
+	rendered, err := renderTemplate("name", taskTemplate.NameTemplate, nameTemplateVars(templateVars))
+	if err != nil {
+		return "", fmt.Errorf("failed to render name template: %w", err)
+	}
+	// Reject any other missing/unavailable value that rendered to Go's
+	// "<no value>" placeholder (e.g. an index lookup of an absent key), which
+	// would sanitize to a constant and collapse distinct work items to one name.
+	if strings.Contains(rendered, "<no value>") {
+		return "", fmt.Errorf("nameTemplate references a missing or unavailable value: %q", rendered)
+	}
+	name := sanitizeName(rendered)
+	if name == "" {
+		return "", fmt.Errorf("nameTemplate rendered to an empty name after sanitization: %q", rendered)
+	}
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		return "", fmt.Errorf("nameTemplate produced an invalid Task name %q: %s", name, strings.Join(errs, "; "))
+	}
+	return name, nil
+}
+
+// TaskBelongsToSpawner reports whether task was created by the identified
+// TaskSpawner. When the Task carries a controller owner reference, its UID must
+// equal spawnerUID — so a Task owned by a since-deleted spawner that shared this
+// name is not mistaken for the current one. Only Tasks with no controller owner
+// reference fall back to matching the kelos.dev/taskspawner label (legacy or
+// manually-created Tasks). Used to decide whether an AlreadyExists collision is
+// a genuine deduplication or a clash with an unrelated Task.
+func TaskBelongsToSpawner(task *kelos.Task, spawnerName string, spawnerUID types.UID) bool {
+	hasController := false
+	for _, ref := range task.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			hasController = true
+			if ref.UID == spawnerUID {
+				return true
+			}
+		}
+	}
+	if hasController {
+		return false
+	}
+	return task.Labels[SpawnerLabel] == spawnerName
+}
+
+// nameTemplateForbiddenKey is the template variable a nameTemplate must not
+// reference: a Task's identity must not depend on mutable context data.
+const nameTemplateForbiddenKey = "Context"
+
+// checkNoContextReference parses tmplStr and returns an error if it references
+// the Context variable in any form (.Context, .Context.x, {{index . "Context"}},
+// or those nested in a conditional/pipeline). Parsing via the template package
+// makes builtins like index available so the tree matches execution.
+func checkNoContextReference(tmplStr string) error {
+	tmpl, err := template.New("name").Option("missingkey=error").Parse(tmplStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse name template: %w", err)
+	}
+	if tmpl.Tree != nil && treeReferencesContext(tmpl.Tree.Root) {
+		return fmt.Errorf("nameTemplate must not reference context sources (.Context or index %q)", nameTemplateForbiddenKey)
+	}
+	return nil
+}
+
+// treeReferencesContext reports whether any node in the parse tree references
+// the forbidden Context key, as a field identifier or a string index key.
+func treeReferencesContext(node parse.Node) bool {
+	switch n := node.(type) {
+	case nil:
+		return false
+	case *parse.ListNode:
+		if n == nil {
+			return false
+		}
+		for _, c := range n.Nodes {
+			if treeReferencesContext(c) {
+				return true
+			}
+		}
+	case *parse.ActionNode:
+		return treeReferencesContext(n.Pipe)
+	case *parse.PipeNode:
+		if n == nil {
+			return false
+		}
+		for _, cmd := range n.Cmds {
+			if treeReferencesContext(cmd) {
+				return true
+			}
+		}
+	case *parse.CommandNode:
+		for _, arg := range n.Args {
+			if treeReferencesContext(arg) {
+				return true
+			}
+		}
+	case *parse.IfNode:
+		return branchReferencesContext(n.Pipe, n.List, n.ElseList)
+	case *parse.RangeNode:
+		return branchReferencesContext(n.Pipe, n.List, n.ElseList)
+	case *parse.WithNode:
+		return branchReferencesContext(n.Pipe, n.List, n.ElseList)
+	case *parse.TemplateNode:
+		return treeReferencesContext(n.Pipe)
+	case *parse.FieldNode:
+		return len(n.Ident) > 0 && n.Ident[0] == nameTemplateForbiddenKey
+	case *parse.ChainNode:
+		if treeReferencesContext(n.Node) {
+			return true
+		}
+		for _, f := range n.Field {
+			if f == nameTemplateForbiddenKey {
+				return true
+			}
+		}
+	case *parse.VariableNode:
+		for _, id := range n.Ident {
+			if id == nameTemplateForbiddenKey {
+				return true
+			}
+		}
+	case *parse.StringNode:
+		return n.Text == nameTemplateForbiddenKey
+	}
+	return false
+}
+
+func branchReferencesContext(pipe *parse.PipeNode, list, elseList *parse.ListNode) bool {
+	return treeReferencesContext(pipe) || treeReferencesContext(list) || treeReferencesContext(elseList)
+}
+
+// nameTemplateVars returns templateVars without the "Context" key so context
+// sources cannot be referenced from nameTemplate. The original map is not
+// modified.
+func nameTemplateVars(templateVars map[string]interface{}) map[string]interface{} {
+	if _, ok := templateVars[nameTemplateForbiddenKey]; !ok {
+		return templateVars
+	}
+	out := make(map[string]interface{}, len(templateVars))
+	for k, v := range templateVars {
+		if k != nameTemplateForbiddenKey {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// sanitizeName converts an arbitrary string into a valid Kubernetes resource
+// name (RFC 1123 subdomain): lowercased, with any character that is not a
+// lowercase alphanumeric, '-' or '.' replaced by '-', truncated to 63
+// characters, and with each '.'-separated label trimmed of leading/trailing
+// '-' and empty labels dropped so the result never contains an empty label or a
+// label bounded by '-' (e.g. "a..b" and "a.-b" both become "a.b").
+// Note: two inputs that differ only past character 63 sanitize to the same
+// name; callers that rely on the name for deduplication must keep the
+// identifying portion within the first 63 characters.
+func sanitizeName(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	name := b.String()
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	// Normalize each dot-separated label so the name is a valid subdomain even
+	// when the raw value has consecutive dots or '-' next to a dot. Truncation
+	// happens first so trimming a label the cut left dangling is handled here.
+	labels := strings.Split(name, ".")
+	cleaned := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if label = strings.Trim(label, "-"); label != "" {
+			cleaned = append(cleaned, label)
+		}
+	}
+	return strings.Join(cleaned, ".")
 }
 
 // renderTemplate renders a Go text template with the given variables.

--- a/internal/taskbuilder/builder_test.go
+++ b/internal/taskbuilder/builder_test.go
@@ -1,10 +1,13 @@
 package taskbuilder
 
 import (
+	"strings"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
@@ -87,5 +90,235 @@ func TestBuildTask_ForwardsPodFailurePolicy(t *testing.T) {
 	}
 	if conditions[0] != wantCondition {
 		t.Fatalf("task.Spec.PodFailurePolicy.Rules[0].OnPodConditions[0] = %#v, want %#v", conditions[0], wantCondition)
+	}
+}
+
+func TestBuildTask_NameTemplate(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &kelos.TaskTemplate{
+		Type:           "codex",
+		NameTemplate:   "responder-pr-{{.Number}}",
+		PromptTemplate: "{{.Title}}",
+	}
+
+	task, err := tb.BuildTask("default-name", "default", template, map[string]interface{}{
+		"Number": 42,
+		"Title":  "the bug",
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildTask() returned error: %v", err)
+	}
+
+	if task.Name != "responder-pr-42" {
+		t.Fatalf("task.Name = %q, want %q", task.Name, "responder-pr-42")
+	}
+}
+
+func TestBuildTask_NameTemplateUnsetUsesDefault(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &kelos.TaskTemplate{PromptTemplate: "{{.Title}}"}
+
+	task, err := tb.BuildTask("default-name", "default", template, map[string]interface{}{
+		"Title": "the bug",
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildTask() returned error: %v", err)
+	}
+
+	if task.Name != "default-name" {
+		t.Fatalf("task.Name = %q, want %q", task.Name, "default-name")
+	}
+}
+
+func TestBuildTask_NameTemplateSanitized(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &kelos.TaskTemplate{
+		NameTemplate:   "{{.Title}}",
+		PromptTemplate: "{{.Title}}",
+	}
+
+	task, err := tb.BuildTask("default-name", "default", template, map[string]interface{}{
+		"Title": "Fix THE Bug: crash on startup!",
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildTask() returned error: %v", err)
+	}
+
+	if task.Name != "fix-the-bug--crash-on-startup" {
+		t.Fatalf("task.Name = %q, want %q", task.Name, "fix-the-bug--crash-on-startup")
+	}
+}
+
+func TestBuildTask_NameTemplateEmptyAfterSanitizationErrors(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &kelos.TaskTemplate{
+		NameTemplate:   "{{.Sep}}",
+		PromptTemplate: "{{.Title}}",
+	}
+
+	_, err := tb.BuildTask("default-name", "default", template, map[string]interface{}{
+		"Sep":   "---",
+		"Title": "the bug",
+	}, nil)
+	if err == nil {
+		t.Fatal("BuildTask() expected error for empty sanitized name, got nil")
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"already-valid", "already-valid"},
+		{"UPPER_case", "upper-case"},
+		{"pr #42", "pr--42"},
+		{"-leading-and-trailing.", "leading-and-trailing"},
+		{"emoji🥚label", "emoji-label"},
+		{"v1.2.3", "v1.2.3"},
+		{"", ""},
+		{"---", ""},
+		// Dot-boundary cases that must not yield an invalid subdomain.
+		{"a..b", "a.b"},
+		{"a.-b", "a.b"},
+		{"a-.b", "a.b"},
+		{".foo.", "foo"},
+		{"foo.-", "foo"},
+		{"..", ""},
+		{"org/repo:tag", "org-repo-tag"},
+	}
+	for _, tc := range cases {
+		if got := sanitizeName(tc.in); got != tc.want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSanitizeNameProducesValidSubdomain(t *testing.T) {
+	inputs := []string{
+		"a..b", "a.-b", "a-.b", ".foo.", "foo.-", "org/repo:tag",
+		"Fix THE Bug: crash!!", "----.----", "v1.2.3", strings.Repeat("a.", 40),
+	}
+	for _, in := range inputs {
+		got := sanitizeName(in)
+		if got == "" {
+			continue // empty is handled/rejected by callers, not a name to validate
+		}
+		if errs := validation.IsDNS1123Subdomain(got); len(errs) > 0 {
+			t.Errorf("sanitizeName(%q) = %q is not a valid DNS-1123 subdomain: %v", in, got, errs)
+		}
+	}
+}
+
+func TestSanitizeNameTruncatesTo63(t *testing.T) {
+	long := ""
+	for i := 0; i < 100; i++ {
+		long += "a"
+	}
+	got := sanitizeName(long)
+	if len(got) != 63 {
+		t.Fatalf("sanitizeName truncated length = %d, want 63", len(got))
+	}
+}
+
+func TestResolveTaskName(t *testing.T) {
+	// Unset template falls back to the default name.
+	name, err := ResolveTaskName("default-name", &kelos.TaskTemplate{}, nil)
+	if err != nil {
+		t.Fatalf("ResolveTaskName() returned error: %v", err)
+	}
+	if name != "default-name" {
+		t.Fatalf("ResolveTaskName() = %q, want %q", name, "default-name")
+	}
+
+	// Set template renders and sanitizes.
+	name, err = ResolveTaskName("default-name", &kelos.TaskTemplate{NameTemplate: "PR-{{.Number}}"}, map[string]interface{}{"Number": 7})
+	if err != nil {
+		t.Fatalf("ResolveTaskName() returned error: %v", err)
+	}
+	if name != "pr-7" {
+		t.Fatalf("ResolveTaskName() = %q, want %q", name, "pr-7")
+	}
+
+	// Missing variable errors (missingkey=error).
+	if _, err := ResolveTaskName("default-name", &kelos.TaskTemplate{NameTemplate: "PR-{{.Missing}}"}, map[string]interface{}{}); err == nil {
+		t.Fatal("ResolveTaskName() expected error for missing key, got nil")
+	}
+}
+
+func TestTaskBelongsToSpawner(t *testing.T) {
+	controller := true
+	ownedByUID := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          map[string]string{SpawnerLabel: "spawner"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "spawner", UID: "uid-1", Controller: &controller}},
+		},
+	}
+	// Controller owner reference present but a different UID (spawner recreated
+	// with the same name): must NOT be treated as owned despite the label match.
+	staleOwner := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          map[string]string{SpawnerLabel: "spawner"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "spawner", UID: "old-uid", Controller: &controller}},
+		},
+	}
+	// Ownerless legacy Task: fall back to the label.
+	labelOnly := &kelos.Task{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{SpawnerLabel: "spawner"}}}
+	unrelated := &kelos.Task{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{SpawnerLabel: "other"}}}
+
+	cases := []struct {
+		name string
+		task *kelos.Task
+		want bool
+	}{
+		{"owned by uid", ownedByUID, true},
+		{"stale controller uid rejected despite label", staleOwner, false},
+		{"ownerless label match", labelOnly, true},
+		{"unrelated label", unrelated, false},
+	}
+	for _, tc := range cases {
+		if got := TaskBelongsToSpawner(tc.task, "spawner", "uid-1"); got != tc.want {
+			t.Errorf("%s: TaskBelongsToSpawner = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveTaskName_ContextExcluded(t *testing.T) {
+	vars := map[string]interface{}{
+		"Number":  7,
+		"Context": map[string]interface{}{"foo": "bar"},
+	}
+
+	// A template that ignores context still resolves even when context is present.
+	name, err := ResolveTaskName("default", &kelos.TaskTemplate{NameTemplate: "pr-{{.Number}}"}, vars)
+	if err != nil {
+		t.Fatalf("ResolveTaskName() returned error: %v", err)
+	}
+	if name != "pr-7" {
+		t.Fatalf("ResolveTaskName() = %q, want %q", name, "pr-7")
+	}
+
+	// Referencing .Context fails even though the value is present, so names never
+	// depend on mutable external data (missingkey=error after stripping Context).
+	if _, err := ResolveTaskName("default", &kelos.TaskTemplate{NameTemplate: "{{.Context.foo}}"}, vars); err == nil {
+		t.Fatal("ResolveTaskName() expected error for .Context reference, got nil")
+	}
+
+	// The index builtin bypasses missingkey=error and would render "<no value>";
+	// it must be rejected too so it cannot collapse work items to one name.
+	if _, err := ResolveTaskName("default", &kelos.TaskTemplate{NameTemplate: `{{index . "Context"}}`}, vars); err == nil {
+		t.Fatal("ResolveTaskName() expected error for index-based .Context reference, got nil")
+	}
+
+	// A conditional that consumes the missing value and renders a constant must
+	// also be rejected (parse-time Context detection, not just "<no value>").
+	for _, tmpl := range []string{
+		`{{if index . "Context"}}x{{else}}same{{end}}`,
+		`{{with .Context}}{{.foo}}{{end}}-{{.Number}}`,
+		`{{$c := index . "Context"}}job-{{.Number}}`,
+	} {
+		if _, err := ResolveTaskName("default", &kelos.TaskTemplate{NameTemplate: tmpl}, vars); err == nil {
+			t.Errorf("ResolveTaskName(%q) expected error for Context reference, got nil", tmpl)
+		}
 	}
 }

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -382,6 +382,7 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 
 	tasksCreated := 0
 	linearLabelsEnriched := false
+	var taskSpawnerErrors []error
 
 	for _, spawner := range spawners {
 		spawnerLog := log.WithValues("spawner", spawner.Name, "namespace", spawner.Namespace)
@@ -432,14 +433,19 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 		spawnerLog.Info("Webhook matches spawner filters - creating task")
 
 		// Create task for this spawner
-		err = h.createTask(ctx, spawner, eventType, parsed, deliveryID)
+		created, err := h.createTask(ctx, spawner, eventType, parsed, deliveryID)
 		if err != nil {
 			spawnerLog.Error(err, "Failed to create task")
+			taskSpawnerErrors = append(taskSpawnerErrors, fmt.Errorf("spawner %s: %w", spawner.Name, err))
 			continue
 		}
 
-		tasksCreated++
-		spawnerLog.Info("Successfully created task from webhook")
+		if created {
+			tasksCreated++
+			spawnerLog.Info("Successfully created task from webhook")
+		} else {
+			spawnerLog.Info("Webhook deduplicated against existing task, no new task created")
+		}
 	}
 
 	sessionsProcessed := 0
@@ -457,7 +463,7 @@ func (h *WebhookHandler) processWebhook(ctx context.Context, eventType string, p
 	}
 
 	log.Info("Webhook processing completed", "taskSpawners", len(spawners), "sessionSpawners", len(sessionSpawners), "tasksCreated", tasksCreated, "sessionsProcessed", sessionsProcessed)
-	return tasksCreated > 0 || sessionsProcessed > 0, errors.Join(sessionErrors...)
+	return tasksCreated > 0 || sessionsProcessed > 0, errors.Join(append(taskSpawnerErrors, sessionErrors...)...)
 }
 
 // getMatchingSpawners returns TaskSpawners that match the webhook source.
@@ -546,8 +552,10 @@ func (h *WebhookHandler) matchesSpawner(ctx context.Context, spawner *kelos.Task
 	}
 }
 
-// createTask creates a new Task from the webhook event.
-func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpawner, eventType string, parsed *ParsedWebhook, deliveryID string) error {
+// createTask creates a Task from the webhook event. It returns true when a
+// new Task was created, and false when the delivery was deduplicated against a
+// Task this spawner already owns.
+func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpawner, eventType string, parsed *ParsedWebhook, deliveryID string) (bool, error) {
 	log := h.log.WithValues("spawner", spawner.Name, "namespace", spawner.Namespace, "eventType", eventType, "deliveryID", deliveryID)
 
 	// Extract template variables based on source
@@ -564,10 +572,34 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpaw
 		templateVars = ExtractGenericWorkItem(parsed.Generic)
 
 	default:
-		return fmt.Errorf("unsupported source: %s", h.source)
+		return false, fmt.Errorf("unsupported source: %s", h.source)
 	}
 
 	log.Info("Extracted template variables", "ID", templateVars["ID"], "Title", templateVars["Title"], "Action", templateVars["Action"])
+
+	// Pre-Create deduplication: when a deterministic nameTemplate is configured,
+	// the name is context-independent, so resolve it and skip if this spawner
+	// already owns a Task with it — before fetching context sources or building.
+	// This avoids failing a duplicate delivery (and making external calls) just
+	// because a context source is temporarily unavailable. A post-Create check
+	// below still handles races where the Task is created concurrently.
+	if spawner.Spec.TaskTemplate.NameTemplate != "" {
+		resolvedName, err := taskbuilder.ResolveTaskName("", &spawner.Spec.TaskTemplate, templateVars)
+		if err != nil {
+			return false, fmt.Errorf("resolving task name: %w", err)
+		}
+		existing := &kelos.Task{}
+		switch getErr := h.client.Get(ctx, client.ObjectKey{Namespace: spawner.Namespace, Name: resolvedName}, existing); {
+		case getErr == nil:
+			if taskbuilder.TaskBelongsToSpawner(existing, spawner.Name, spawner.UID) {
+				log.Info("Task already exists for spawner, skipping duplicate", "task", resolvedName)
+				return false, nil
+			}
+			return false, fmt.Errorf("task %s name collides with an existing Task not owned by spawner %s", resolvedName, spawner.Name)
+		case !apierrors.IsNotFound(getErr):
+			return false, fmt.Errorf("reading existing Task %s: %w", resolvedName, getErr)
+		}
+	}
 
 	// Enrich with external context sources
 	if len(spawner.Spec.TaskTemplate.ContextSources) > 0 {
@@ -579,17 +611,22 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpaw
 		}
 		contextData, err := fetcher.FetchAll(ctx, spawner.Spec.TaskTemplate.ContextSources, templateVars)
 		if err != nil {
-			return fmt.Errorf("fetching context sources: %w", err)
+			return false, fmt.Errorf("fetching context sources: %w", err)
 		}
 		templateVars["Context"] = contextData
 	}
 
+	// Default task name uses a hash of the delivery ID, so every delivery
+	// produces a distinct Task. Configure taskTemplate.nameTemplate with a
+	// deterministic value (e.g. "{{.Number}}") to deduplicate Tasks across
+	// multiple deliveries for the same pull request. When nameTemplate is set,
+	// BuildTask renders the name from it and this default is ignored.
 	taskName := webhookSpawnName(spawner.Name, eventType, deliveryID)
 
 	// Resolve GVK for the spawner owner reference
 	gvks, _, err := h.client.Scheme().ObjectKinds(spawner)
 	if err != nil || len(gvks) == 0 {
-		return fmt.Errorf("failed to get GVK for TaskSpawner: %w", err)
+		return false, fmt.Errorf("failed to get GVK for TaskSpawner: %w", err)
 	}
 	gvk := gvks[0]
 
@@ -607,7 +644,7 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpaw
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("failed to build task: %w", err)
+		return false, fmt.Errorf("failed to build task: %w", err)
 	}
 
 	// Stamp reporting annotations for GitHub webhook sources when reporting is configured.
@@ -637,10 +674,27 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpaw
 	}
 
 	if err := h.client.Create(ctx, task); err != nil {
-		return fmt.Errorf("failed to create task: %w", err)
+		// A configured nameTemplate makes Task names deterministic, so a second
+		// delivery for the same work item collides with the Task already created
+		// for it. Treat that as a successful no-op — the intended deduplication
+		// path — but only when the existing Task belongs to this spawner. A name
+		// collision with an unrelated Task must surface as an error rather than
+		// silently dropping this event.
+		if apierrors.IsAlreadyExists(err) {
+			existing := &kelos.Task{}
+			if getErr := h.client.Get(ctx, client.ObjectKey{Namespace: task.Namespace, Name: task.Name}, existing); getErr != nil {
+				return false, fmt.Errorf("failed to read existing Task %s after create conflict: %w", task.Name, getErr)
+			}
+			if taskbuilder.TaskBelongsToSpawner(existing, spawner.Name, spawner.UID) {
+				log.Info("Task already exists for spawner, skipping duplicate", "task", task.Name)
+				return false, nil
+			}
+			return false, fmt.Errorf("task %s name collides with an existing Task not owned by spawner %s", task.Name, spawner.Name)
+		}
+		return false, fmt.Errorf("failed to create task: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // webhookSpawnName preserves the deterministic naming used for webhook-created

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -2183,5 +2184,173 @@ func TestServeHTTP_ChecksOnlyWithoutCommentReporting(t *testing.T) {
 	}
 	if task.Annotations[reporting.AnnotationSourceSHA] != "aaa111bbb222" {
 		t.Errorf("Expected source-sha 'aaa111bbb222', got %q", task.Annotations[reporting.AnnotationSourceSHA])
+	}
+}
+
+// nameTemplateSpawner returns a pull_request spawner whose taskTemplate names
+// Tasks deterministically from the PR number, so repeated deliveries for the
+// same PR deduplicate.
+func nameTemplateSpawner() *kelos.TaskSpawner {
+	return &kelos.TaskSpawner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "responder",
+			Namespace: "default",
+			UID:       "responder-uid",
+		},
+		Spec: kelos.TaskSpawnerSpec{
+			When: kelos.When{
+				GitHubWebhook: &kelos.GitHubWebhook{
+					Events: []string{"pull_request"},
+				},
+			},
+			TaskTemplate: kelos.TaskTemplate{
+				Type:           "claude-code",
+				Credentials:    &kelos.Credentials{Type: "api-key"},
+				WorkspaceRef:   &kelos.WorkspaceReference{Name: "test-workspace"},
+				NameTemplate:   "responder-pr-{{.Number}}",
+				PromptTemplate: "{{.Title}}",
+			},
+		},
+	}
+}
+
+// prWebhookPayload builds a minimal pull_request webhook payload for the given
+// PR number.
+func prWebhookPayload(number int) []byte {
+	return []byte(fmt.Sprintf(`{
+		"action": "opened",
+		"sender": {"login": "testuser"},
+		"repository": {"full_name": "org/repo", "name": "repo", "owner": {"login": "org"}},
+		"pull_request": {
+			"number": %d,
+			"title": "Test PR",
+			"body": "PR body",
+			"html_url": "https://github.com/org/repo/pull/%d",
+			"state": "open",
+			"head": {"ref": "feature-branch"}
+		}
+	}`, number, number))
+}
+
+// sendPRWebhook delivers a pull_request webhook with the given delivery ID.
+func sendPRWebhook(t *testing.T, handler *WebhookHandler, payload []byte, deliveryID string) {
+	t.Helper()
+	sig := signPayload(payload, []byte(testSecret))
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set(GitHubEventHeader, "pull_request")
+	req.Header.Set(GitHubSignatureHeader, sig)
+	req.Header.Set(GitHubDeliveryHeader, deliveryID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Delivery %s: expected %d, got %d", deliveryID, http.StatusOK, rr.Code)
+	}
+}
+
+// TestServeHTTP_DuplicateTasksDedupedByNameTemplate covers issue #1155: when a
+// spawner configures a deterministic nameTemplate, multiple webhook deliveries
+// for the same PR (each with a unique X-GitHub-Delivery) collapse to one Task.
+func TestServeHTTP_DuplicateTasksDedupedByNameTemplate(t *testing.T) {
+	handler := newTestHandler(t, nameTemplateSpawner())
+
+	payload := prWebhookPayload(123)
+	// Five distinct deliveries for the same PR, as GitHub would send for an
+	// "opened" plus several "labeled" events within the same second.
+	for _, id := range []string{"d-1", "d-2", "d-3", "d-4", "d-5"} {
+		sendPRWebhook(t, handler, payload, id)
+	}
+
+	var taskList kelos.TaskList
+	if err := handler.client.List(context.Background(), &taskList); err != nil {
+		t.Fatal(err)
+	}
+	if len(taskList.Items) != 1 {
+		names := make([]string, 0, len(taskList.Items))
+		for _, task := range taskList.Items {
+			names = append(names, task.Name)
+		}
+		t.Fatalf("Expected 1 task for PR #123, got %d: %s", len(taskList.Items), strings.Join(names, ", "))
+	}
+	if got := taskList.Items[0].Name; got != "responder-pr-123" {
+		t.Errorf("task name = %q, want %q", got, "responder-pr-123")
+	}
+}
+
+// TestCreateTask_NameCollisionWithUnrelatedTaskErrors ensures a rendered name
+// that collides with a Task NOT owned by this spawner surfaces an error instead
+// of silently succeeding as a dedup no-op.
+func TestCreateTask_NameCollisionWithUnrelatedTaskErrors(t *testing.T) {
+	spawner := nameTemplateSpawner()
+	unrelated := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "responder-pr-123", // matches nameTemplate output for PR 123
+			Namespace: "default",
+		},
+		Spec: kelos.TaskSpec{Type: "claude-code", Prompt: "unrelated"},
+	}
+	handler := newTestHandler(t, spawner, unrelated)
+
+	eventData, err := ParseGitHubWebhook("pull_request", prWebhookPayload(123))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook: %v", err)
+	}
+	parsed := &ParsedWebhook{GitHub: eventData}
+
+	_, err = handler.createTask(context.Background(), spawner, "pull_request", parsed, "delivery-collide")
+	if err == nil {
+		t.Fatal("expected error when rendered name collides with an unrelated Task, got nil")
+	}
+	if !strings.Contains(err.Error(), "responder-pr-123") {
+		t.Errorf("error should name the colliding Task, got: %v", err)
+	}
+}
+
+// TestServeHTTP_UnrelatedNameCollisionReturns500 ensures a rendered name that
+// collides with a Task not owned by the spawner fails the delivery (HTTP 500)
+// so GitHub retries, rather than being silently swallowed as a dedup no-op.
+func TestServeHTTP_UnrelatedNameCollisionReturns500(t *testing.T) {
+	spawner := nameTemplateSpawner()
+	unrelated := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "responder-pr-123", Namespace: "default"},
+		Spec:       kelos.TaskSpec{Type: "claude-code", Prompt: "unrelated"},
+	}
+	handler := newTestHandler(t, spawner, unrelated)
+
+	payload := prWebhookPayload(123)
+	sig := signPayload(payload, []byte(testSecret))
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set(GitHubEventHeader, "pull_request")
+	req.Header.Set(GitHubSignatureHeader, sig)
+	req.Header.Set(GitHubDeliveryHeader, "delivery-collide")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP 500 on unrelated name collision, got %d", rr.Code)
+	}
+
+	var taskList kelos.TaskList
+	if err := handler.client.List(context.Background(), &taskList); err != nil {
+		t.Fatal(err)
+	}
+	if len(taskList.Items) != 1 {
+		t.Fatalf("expected the unrelated Task to remain the only Task, got %d", len(taskList.Items))
+	}
+}
+
+// TestServeHTTP_DistinctPRsCreateSeparateTasks ensures the nameTemplate dedup
+// does not over-collapse: different PRs still get their own Tasks.
+func TestServeHTTP_DistinctPRsCreateSeparateTasks(t *testing.T) {
+	handler := newTestHandler(t, nameTemplateSpawner())
+
+	sendPRWebhook(t, handler, prWebhookPayload(1), "pr-1")
+	sendPRWebhook(t, handler, prWebhookPayload(2), "pr-2")
+
+	var taskList kelos.TaskList
+	if err := handler.client.List(context.Background(), &taskList); err != nil {
+		t.Fatal(err)
+	}
+	if len(taskList.Items) != 2 {
+		t.Fatalf("Expected 2 tasks for 2 distinct PRs, got %d", len(taskList.Items))
 	}
 }

--- a/test/e2e/taskspawner_test.go
+++ b/test/e2e/taskspawner_test.go
@@ -214,6 +214,62 @@ var _ = Describe("Cron TaskSpawner", func() {
 		}, 3*time.Minute, 2*time.Second).ShouldNot(BeEmpty())
 	})
 
+	It("should deduplicate Tasks across cron ticks when nameTemplate is deterministic", func() {
+		By("creating OAuth credentials secret")
+		f.CreateSecret("claude-credentials",
+			"CLAUDE_CODE_OAUTH_TOKEN="+oauthToken)
+
+		By("creating an every-minute cron TaskSpawner with a constant nameTemplate")
+		// A constant nameTemplate renders the same Task name every tick, so after
+		// the first Task all later ticks must reuse it (owned deduplication)
+		// rather than create duplicates or error.
+		f.CreateTaskSpawner(&kelos.TaskSpawner{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cron-dedup",
+			},
+			Spec: kelos.TaskSpawnerSpec{
+				When: kelos.When{
+					Cron: &kelos.Cron{
+						Schedule: "* * * * *",
+					},
+				},
+				TaskTemplate: kelos.TaskTemplate{
+					Type:  "claude-code",
+					Model: claudeCodeModel,
+					Credentials: &kelos.Credentials{
+						Type:      kelos.CredentialTypeOAuth,
+						SecretRef: &kelos.SecretReference{Name: "claude-credentials"},
+					},
+					NameTemplate:   "cron-dedup-fixed",
+					PromptTemplate: "Print 'Hello from cron dedup'",
+				},
+			},
+		})
+
+		By("waiting for CronJob to be created")
+		f.WaitForCronJobCreated("cron-dedup")
+
+		By("waiting for the deterministically named Task to be created")
+		Eventually(func() []string {
+			return f.ListTaskNames("kelos.dev/taskspawner=cron-dedup")
+		}, 3*time.Minute, 2*time.Second).Should(ConsistOf("cron-dedup-fixed"))
+
+		By("verifying later cron ticks reuse the same Task instead of creating duplicates")
+		Consistently(func() []string {
+			return f.ListTaskNames("kelos.dev/taskspawner=cron-dedup")
+		}, 75*time.Second, 5*time.Second).Should(ConsistOf("cron-dedup-fixed"))
+
+		By("verifying the spawner stayed healthy (owned dedup, not an error)")
+		Expect(f.GetTaskSpawnerPhase("cron-dedup")).To(Equal("Running"))
+		spawner, err := f.KelosClientset.ApiV1alpha2().TaskSpawners(f.Namespace).Get(context.TODO(), "cron-dedup", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, c := range spawner.Status.Conditions {
+			if c.Type == "DiscoveryError" {
+				Expect(string(c.Status)).To(Equal("False"), "dedup must not raise DiscoveryError")
+			}
+		}
+	})
+
 	It("should be accessible via CLI with cron source info", func() {
 		By("creating a cron TaskSpawner")
 		f.CreateTaskSpawner(&kelos.TaskSpawner{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an optional `nameTemplate` field to `TaskSpawner.spec.taskTemplate` that
renders the spawned Task's name from a Go text/template.

This gives operators control over Task names and, more importantly, a way to
**deduplicate Tasks**. GitHub frequently sends several distinct webhook
deliveries for a single pull request within a second (e.g. an `opened` event
plus one `labeled` event per label). Because the webhook handler derives Task
names from `sha256(deliveryID)`, each of those deliveries has a unique
`X-GitHub-Delivery` header and therefore creates a separately named Task — so
one PR spawns multiple duplicate Tasks (issue #1155).

With a deterministic `nameTemplate` (e.g. `"{{.Number}}"`), every delivery for
the same PR renders to the same Task name. The first delivery creates the Task;
later ones collide on the name and are treated as deduplication, so exactly one
Task is created. This mirrors how the polling spawner already deduplicates by
naming Tasks `<spawner>-<item.ID>`.

Behavior details:

- `nameTemplate` is optional. When unset, the polling, webhook, and Slack paths
  keep their existing default naming, so this is fully backward compatible.
- The rendered value is lowercased and sanitized into a valid Kubernetes
  resource name (invalid characters replaced with `-`, each DNS label trimmed of
  `-` and empty labels dropped so values like `a..b`/`a.-b` become `a.b`), then
  truncated to 63 characters. The result is validated with Kubernetes' DNS-1123
  helper; a value that renders empty or invalid is rejected up front rather than
  failing later at Task creation.
- `.Context.NAME` (context sources) is excluded from name rendering on every
  source, so a Task's identity never depends on mutable external data; a
  `nameTemplate` that references `.Context` fails to render.
- Deduplication is **ownership-scoped** on every creation path. A rendered
  name's uniqueness scope is the whole namespace, so an `AlreadyExists` collision
  is treated as a benign duplicate only when the existing Task belongs to the
  same TaskSpawner (matched by controller owner-reference UID, falling back to
  the `kelos.dev/taskspawner` label for ownerless legacy Tasks). A collision with
  an unrelated Task surfaces an actionable error instead of silently dropping
  work.
- Failures surface instead of being swallowed: the webhook handler returns
  spawner errors so the delivery responds HTTP 500 and GitHub retries; the
  polling cycle fails when a name cannot be resolved (bad template, missing key,
  or empty result) rather than reporting a successful zero-Task discovery.
- The polling spawner computes its deduplication lookup key from the rendered
  name so it matches the name the Task is actually created with.
- Manual CLI runs (`kelos run --from-taskspawner`) intentionally ignore
  `nameTemplate`: they manage their own name (an explicit `--name` or a unique
  `-manual-` suffix), and the template's variables may not be available for a
  manual invocation.
- The field is added only to the latest API version (`v1alpha2`). `v1alpha1`
  remains served; because it has no such field, `nameTemplate` is preserved
  across a v1alpha1 read/modify/write round-trip via an internal conversion
  annotation (the capability is not added to v1alpha1).

#### Which issue(s) this PR is related to:

Fixes #1155

#### Special notes for your reviewer:

- This is the explicit, opt-in fix discussed on the issue (the maintainer's
  proposed `taskName`/template approach). It does not add automatic, source-
  specific deduplication when `nameTemplate` is unset — operators enable the
  behavior by configuring the field.
- The live `self-development/` spawners are intentionally **not** changed.
  None of them is the duplicate-firing "babysitter" case from the issue, and
  the `kelos-pr-responder` is deliberately re-triggered by `/kelos pick-up`
  comments — giving it a deterministic name would make repeat pick-ups on the
  same PR silently skip until its TTL expired, which would be a regression.
  Enabling `nameTemplate` on real spawners is better done as a separate,
  deliberate config change.
- Multi-repo / repeatable-trigger guidance is documented: a rendered name must be
  namespace-unique, so scope a dedup spawner to one repository (or include a
  bounded identifier before an unbounded `{{.Repository}}`, given the 63-char
  cap), and reserve deterministic naming for burst events — repeatable
  `issue_comment`/`pull_request_review` commands want a fresh Task each time. The
  webhook example is split accordingly.
- Tests added/updated:
  - `internal/taskbuilder`: name rendering, sanitization incl. DNS-label
    normalization and DNS-1123 validity, truncation, empty/invalid rejection,
    `.Context` exclusion, and `TaskBelongsToSpawner` (owner-UID precedence).
  - `internal/webhook`: duplicate deliveries collapse to one Task; distinct PRs
    stay separate; an unrelated name collision returns HTTP 500 (retryable).
  - `cmd/kelos-spawner`: `nameTemplate` applied; dedup lookup uses the rendered
    name; resolution error fails the cycle; cross-spawner collision errors.
  - `internal/slack`: cross-spawner name collision errors.
  - `internal/conversion`: `nameTemplate` survives a v1alpha1 round-trip.
  - `internal/cli`: manual runs ignore `nameTemplate`.
  - `internal/helmchart`: updated the CRD doc-string occurrence count for the
    added field.
- Generated files (CRD YAMLs) were regenerated with `make update`;
  `make verify` and `make test` pass.

#### Does this PR introduce a user-facing change?

```release-note
TaskSpawner task templates now support a `nameTemplate` field that renders the spawned Task's name from a Go text/template. Configure a deterministic template (e.g. `nameTemplate: "{{.Number}}"`) to deduplicate Tasks so that multiple GitHub webhook deliveries for the same pull request reuse a single Task instead of creating duplicates.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `nameTemplate` to `TaskSpawner.spec.taskTemplate` to render deterministic Task names and deduplicate repeated GitHub webhook deliveries, Slack messages, and polling/cron items so they reuse a single Task. Dedup is ownership-scoped, errors surface on status, and aborted cycles do not advance cron watermarks.

- **New Features**
  - `nameTemplate` renders the Task name; output is lowercased, DNS-1123–sanitized, and truncated to 63 chars (empty/invalid is rejected). `.Context.*` is not available; referencing it fails. Keep the identifying part within 63 chars and ensure names are unique across repos (include `{{.Repository}}` when needed).
  - Dedup semantics: polling computes its lookup key from the rendered name; webhooks pre-check by resolved name (before context fetch) and skip if the existing Task belongs to the same spawner; Slack does the same. Cross-spawner collisions return an error (webhooks respond HTTP 500). When `nameTemplate` is unset, default naming is unchanged. Manual CLI runs (`kelos run --from-taskspawner`) ignore `nameTemplate`; `--name` or the manual suffix is used.
  - Status and reliability: per-cycle creation errors (e.g., name resolution or cross-spawner collisions) set a `DiscoveryError` condition and do not count as successful runs; aborted cycles (e.g., unresolvable `nameTemplate`) do not advance `LastDiscoveryTime` for cron sources.
  - GitHub webhook templates for issue/PR events expose `.Number`, `.Title`, `.Body`, `.URL` (plus `.Branch` for PRs). Available in API v1alpha2; CRDs, `docs/reference.md`, examples, and the webhook/Slack handlers were updated. API v1alpha1 round-trips preserve `nameTemplate` via an internal annotation.

- **Migration**
  - No changes needed if `nameTemplate` is unset.
  - To deduplicate PR webhooks, set `taskTemplate.nameTemplate: "responder-{{.Repository}}-pr-{{.Number}}"` (or similar).

<sup>Written for commit c727c70863a13f7c7d847eb13b9b72db7ca924b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

