### PR TITLE
feat: Add check_run webhook support for CI failure auto-remediation

### DIFF
--- a/api/v1alpha2/taskspawner_types.go
+++ b/api/v1alpha2/taskspawner_types.go
@@ -475,6 +475,18 @@ type GitHubWebhookFilter struct {
 	// keys), then the webhook server's global GitHub token resolver.
 	// +optional
 	FilePatterns *FilePatterns `json:"filePatterns,omitempty"`
+
+	// Conclusion filters check_run events by the check run's conclusion.
+	// Ignored for other event types.
+	// +optional
+	// +kubebuilder:validation:Enum=success;failure;cancelled;timed_out;action_required;neutral;skipped;stale
+	Conclusion string `json:"conclusion,omitempty"`
+
+	// CheckName filters check_run events by the check run's name (exact match
+	// or glob, e.g. "lint", "unit-tests", "build-*"). Ignored for other event
+	// types.
+	// +optional
+	CheckName string `json:"checkName,omitempty"`
 }
 
 // LinearWebhook configures webhook-driven task spawning from Linear events.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -592,6 +592,8 @@ to receive refreshed credentials during long-running work.
 | `spec.when.githubWebhook.filters[].state` | Filter by issue/PR state (`"open"`, `"closed"`) | No |
 | `spec.when.githubWebhook.filters[].branch` | Filter push and create (ref_type=branch) events by branch name (exact match or glob) | No |
 | `spec.when.githubWebhook.filters[].tag` | Filter create (ref_type=tag) and release events by tag name (exact match or glob) | No |
+| `spec.when.githubWebhook.filters[].conclusion` | Filter `check_run` events by the check run's conclusion. One of `success`, `failure`, `cancelled`, `timed_out`, `action_required`, `neutral`, `skipped`, `stale`. Ignored for other events | No |
+| `spec.when.githubWebhook.filters[].checkName` | Filter `check_run` events by the check run's name (exact match or glob, e.g. `"lint"`, `"build-*"`). Ignored for other events | No |
 | `spec.when.githubWebhook.filters[].draft` | Filter PRs by draft status | No |
 | `spec.when.githubWebhook.filters[].author` | Filter by the event sender's username | No |
 | `spec.when.githubWebhook.filters[].excludeAuthors` | Exclude events sent by any of these usernames | No |
@@ -749,6 +751,11 @@ The `promptTemplate` field uses Go `text/template` syntax. Available variables d
 | `{{.CommentBody}}` | Comment or review body | Empty | Empty | Comment/review body (`issue_comment`, `pull_request_review`, `pull_request_review_comment` events) | Empty | Empty | Empty | Empty |
 | `{{.CommentURL}}` | Comment or review URL | Empty | Empty | Comment/review HTML URL (`issue_comment`, `pull_request_review`, `pull_request_review_comment` events) | Empty | Empty | Empty | Empty |
 | `{{.ChangedFiles}}` | Changed file paths (list) | Empty | Empty | Push: files from the payload. PR: changed files, but **only** when a matching filter's `filePatterns` forced a fetch (otherwise empty; see note below). Iterate with `{{range .ChangedFiles}}` | Empty | Empty | Empty | Empty |
+| `{{.CheckName}}` | Check run name | Empty | Empty | Check run name (`check_run` events, e.g. `"lint"`) | Empty | Empty | Empty | Empty |
+| `{{.Conclusion}}` | Check run conclusion | Empty | Empty | Check run conclusion (`check_run` events, e.g. `"failure"`) | Empty | Empty | Empty | Empty |
+| `{{.CheckRunURL}}` | Check run URL | Empty | Empty | Link to the check run / CI logs (`check_run` events) | Empty | Empty | Empty | Empty |
+| `{{.HeadSHA}}` | Head commit SHA | Empty | Empty | Commit SHA under test (`check_run` events) | Empty | Empty | Empty | Empty |
+| `{{.CheckApp}}` | Check app name | Empty | Empty | App that produced the check (`check_run` events, e.g. `"GitHub Actions"`) | Empty | Empty | Empty | Empty |
 | `{{.Time}}` | Trigger time (RFC3339) | Empty | Empty | Empty | Empty | Empty | Empty | Cron tick time (e.g., `"2026-02-07T09:00:00Z"`) |
 | `{{.Schedule}}` | Cron schedule expression | Empty | Empty | Empty | Empty | Empty | Empty | Schedule string (e.g., `"0 * * * *"`) |
 

--- a/examples/17-taskspawner-ci-remediation/README.md
+++ b/examples/17-taskspawner-ci-remediation/README.md
@@ -1,0 +1,75 @@
+# CI/CD Failure Auto-Remediation Example
+
+This example demonstrates a TaskSpawner that watches for failing CI checks and
+dispatches an agent to diagnose and fix them, using GitHub `check_run` webhook
+events.
+
+## Overview
+
+When a CI check (lint, unit tests, build, …) completes with a `failure`
+conclusion on a pull request, GitHub sends a `check_run` webhook. This
+TaskSpawner filters those events by conclusion and check name and spawns a
+`claude-code` Task on the PR's head branch to fix the failure.
+
+The relevant `githubWebhook` filter fields are:
+
+- `conclusion` — matches the check run's conclusion (`success`, `failure`,
+  `cancelled`, `timed_out`, `action_required`, `neutral`, `skipped`, `stale`).
+- `checkName` — matches the check run's name (exact match or glob, e.g.
+  `"lint"`, `"build-*"`).
+
+Both are ignored for non-`check_run` events.
+
+## Template variables for `check_run` events
+
+In addition to the standard webhook variables, `check_run` events expose:
+
+| Variable         | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| `{{.CheckName}}` | Check run name (e.g. `"lint"`)                       |
+| `{{.Conclusion}}`| Check run conclusion (e.g. `"failure"`)              |
+| `{{.CheckRunURL}}`| Link to the check run / CI logs                     |
+| `{{.HeadSHA}}`   | Commit SHA under test                                |
+| `{{.CheckApp}}`  | App that produced the check (e.g. `"GitHub Actions"`)|
+| `{{.Branch}}`    | PR head branch (when the check is linked to a PR)    |
+| `{{.Number}}`    | PR number (when the check is linked to a PR)         |
+
+## Prerequisites
+
+1. **Webhook Server**: the kelos-webhook-server deployed with a GitHub source.
+2. **GitHub Webhook**: your repository configured to send `Check runs` events to
+   your Kelos webhook endpoint.
+3. **Secrets**: the webhook signing secret and the agent credentials
+   (`claude-credentials`).
+
+## Setup
+
+1. Enable the **Check runs** event on your GitHub repository webhook (Settings →
+   Webhooks → your webhook → "Let me select individual events").
+2. Apply the manifests:
+
+   ```bash
+   kubectl apply -f taskspawner.yaml
+   ```
+
+## Notes
+
+- **Naming / deduplication:** `nameTemplate: "ci-fix-{{.ID}}"` names the Task by
+  the check run's unique ID, so redeliveries of the same run collapse into one
+  Task while a rerun — or a failure on a new commit — is a distinct check run and
+  gets its own Task. Naming by PR number instead would silently suppress later
+  failures on the same PR.
+- **Do not set `excludeAuthors`:** the sender of a `check_run` event is the CI
+  app (e.g. `github-actions[bot]`), not the PR author, and spawner-level
+  `excludeAuthors` is applied *before* the conclusion/checkName filters — so
+  excluding bot senders would drop every check run. Scope the workflow with the
+  `conclusion` and `checkName` filters instead.
+- **Check runs without a linked PR:** a `check_run` is not always associated with
+  a pull request (checks on pushes to `main`, tags, or some fork PRs). In those
+  cases `Branch` and `Number` are absent. The manifest renders PR-dependent
+  variables with `{{index . "Branch"}}` (which yields an empty string on a
+  missing key instead of failing) and guards the prompt with
+  `{{if index . "Number"}}`, so an unlinked check run produces a Task that
+  exits without changes rather than causing the webhook delivery to error.
+- Start with cheap, low-risk checks (lint/format) before expanding to test and
+  build failures.

--- a/examples/17-taskspawner-ci-remediation/taskspawner.yaml
+++ b/examples/17-taskspawner-ci-remediation/taskspawner.yaml
@@ -1,0 +1,113 @@
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: ci-failure-fixer
+  namespace: default
+spec:
+  # Watch for failing CI checks and dispatch an agent to diagnose and fix them.
+  when:
+    githubWebhook:
+      repository: myorg/myrepo
+      events:
+        - "check_run"
+
+      # NOTE: do not set excludeAuthors here. The sender of a check_run event is
+      # the CI app (e.g. "github-actions[bot]"), not the PR author, so excluding
+      # bot senders would drop every check run. Scope the workflow with the
+      # conclusion and checkName filters below instead.
+
+      # Only spawn on completed, failed check runs, scoped by check name.
+      # Filters use OR semantics within the same event type.
+      filters:
+        - event: "check_run"
+          action: "completed"
+          conclusion: "failure"
+          checkName: "lint"
+        - event: "check_run"
+          action: "completed"
+          conclusion: "failure"
+          checkName: "unit-tests"
+        - event: "check_run"
+          action: "completed"
+          conclusion: "failure"
+          checkName: "build"
+
+  # Limit how many remediation agents run at once.
+  maxConcurrency: 2
+
+  taskTemplate:
+    type: claude-code
+    credentials:
+      type: api-key
+      secretRef:
+        name: claude-credentials
+    workspaceRef:
+      name: my-repo-workspace
+
+    # Work on the PR head branch the check ran against. A check_run is not always
+    # linked to a pull request (e.g. checks on pushes to main, tags, or some fork
+    # PRs), so Branch may be absent. `index` renders an empty string in that case
+    # instead of failing (unlike `{{.Branch}}`, which errors on a missing key);
+    # an empty branch means the Task uses the workspace default branch.
+    branch: '{{index . "Branch"}}'
+
+    # Name by the check run's unique ID so redeliveries of the same run collapse
+    # into one Task, while a rerun or a failure on a new commit (a distinct check
+    # run) gets its own Task. (.Context values are not available to nameTemplate.)
+    nameTemplate: "ci-fix-{{.ID}}"
+
+    promptTemplate: |
+      {{if index . "Number" -}}
+      A CI check failed on pull request #{{.Number}}. Diagnose and fix it.
+
+      ## CI failure details
+      - Check name: {{.CheckName}}
+      - Conclusion: {{.Conclusion}}
+      - PR #{{.Number}} on branch: {{.Branch}}
+      - Commit: {{.HeadSHA}}
+      - CI logs: {{.CheckRunURL}}
+
+      ## Steps
+      1. Read the PR diff: `gh pr diff {{.Number}}`
+      2. Fetch the failing check's annotations:
+         ```
+         run_id=$(gh api repos/{{.Repository}}/commits/{{.HeadSHA}}/check-runs \
+           --jq '.check_runs[] | select(.name=="{{.CheckName}}") | .id')
+         gh api repos/{{.Repository}}/check-runs/$run_id/annotations --jq '.[]'
+         ```
+      3. Identify the root cause from the logs and annotations.
+      4. Make the minimal change needed to pass the check.
+      5. Run the equivalent local check (e.g. `make verify`, `make test`).
+      6. Commit and push to `origin {{.Branch}}`.
+
+      ## Rules
+      - Do NOT refactor or improve code beyond fixing the CI failure.
+      - If the failure looks flaky (passes locally), comment on the PR instead of pushing.
+      - If you cannot determine the fix, comment on the PR explaining the failure.
+      {{- else -}}
+      Check run {{.ID}} ({{index . "CheckName"}}) is not associated with a pull
+      request, so there is nothing to remediate. Exit without making any changes.
+      {{- end}}
+
+    metadata:
+      labels:
+        kelos.dev/trigger: "webhook"
+      annotations:
+        # CheckName/CheckRunURL go in annotations (not labels): check names may
+        # contain spaces or other characters that are invalid in label values.
+        kelos.dev/github-check: '{{index . "CheckName"}}'
+        kelos.dev/github-check-url: '{{index . "CheckRunURL"}}'
+
+    ttlSecondsAfterFinished: 3600
+
+---
+# Example workspace configuration (referenced above)
+apiVersion: kelos.dev/v1alpha2
+kind: Workspace
+metadata:
+  name: my-repo-workspace
+  namespace: default
+spec:
+  repo: "https://github.com/myorg/myrepo.git"
+  # secretRef:
+  #   name: github-token

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ Ready-to-use patterns and YAML manifests for orchestrating AI agents with Kelos.
 | [14-task-budget](14-task-budget/) | Set observed-spend admission limits for matching Tasks |
 | [15-workerpool](15-workerpool/) | Run Tasks on pre-warmed WorkerPool pods instead of creating per-task Jobs |
 | [16-session](16-session/) | Keep one interactive Claude Code, Codex, or OpenCode conversation across web and terminal chat |
+| [17-taskspawner-ci-remediation](17-taskspawner-ci-remediation/) | Auto-fix failing CI checks via `check_run` webhooks, filtered by conclusion and check name |
 
 ## Additional Guides
 

--- a/internal/conversion/taskspawner_test.go
+++ b/internal/conversion/taskspawner_test.go
@@ -262,6 +262,43 @@ func TestTaskSpawnerConvert_ModernFieldsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestTaskSpawnerConvert_CheckRunFilterFieldsDownConvert verifies that the
+// v1alpha2-only check_run filter fields (Conclusion, CheckName) convert down to
+// v1alpha1 without error. v1alpha1 has no equivalent fields, so they are dropped
+// on down-conversion while the filter's shared fields are preserved.
+func TestTaskSpawnerConvert_CheckRunFilterFieldsDownConvert(t *testing.T) {
+	src := &v1alpha2.TaskSpawner{
+		Spec: v1alpha2.TaskSpawnerSpec{
+			When: v1alpha2.When{
+				GitHubWebhook: &v1alpha2.GitHubWebhook{
+					Events: []string{"check_run"},
+					Filters: []v1alpha2.GitHubWebhookFilter{
+						{
+							Event:      "check_run",
+							Action:     "completed",
+							Conclusion: "failure",
+							CheckName:  "lint*",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dst := &v1alpha1.TaskSpawner{}
+	if err := taskSpawnerFromHub(context.Background(), src, dst); err != nil {
+		t.Fatalf("taskSpawnerFromHub() error = %v", err)
+	}
+
+	if dst.Spec.When.GitHubWebhook == nil || len(dst.Spec.When.GitHubWebhook.Filters) != 1 {
+		t.Fatalf("expected one webhook filter after down-conversion, got %#v", dst.Spec.When.GitHubWebhook)
+	}
+	filter := dst.Spec.When.GitHubWebhook.Filters[0]
+	if filter.Event != "check_run" || filter.Action != "completed" {
+		t.Errorf("shared filter fields not preserved: %#v", filter)
+	}
+}
+
 func TestTaskSpawnerFromHub_BackfillsLegacyFields(t *testing.T) {
 	src := &v1alpha2.TaskSpawner{
 		Spec: v1alpha2.TaskSpawnerSpec{

--- a/internal/manifests/charts/kelos/charts/kelos-crds/templates/sessionspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/charts/kelos-crds/templates/sessionspawner-crd.yaml
@@ -7288,6 +7288,12 @@ spec:
                               description: Branch filters push events by branch name
                                 (exact match or glob).
                               type: string
+                            checkName:
+                              description: |-
+                                CheckName filters check_run events by the check run's name (exact match
+                                or glob, e.g. "lint", "unit-tests", "build-*"). Ignored for other event
+                                types.
+                              type: string
                             commentOn:
                               description: |-
                                 CommentOn scopes issue_comment-event filters to comments posted on a
@@ -7298,6 +7304,20 @@ spec:
                               - Issue
                               - PullRequest
                               - ""
+                              type: string
+                            conclusion:
+                              description: |-
+                                Conclusion filters check_run events by the check run's conclusion.
+                                Ignored for other event types.
+                              enum:
+                              - success
+                              - failure
+                              - cancelled
+                              - timed_out
+                              - action_required
+                              - neutral
+                              - skipped
+                              - stale
                               type: string
                             draft:
                               description: Draft filters PRs by draft status. nil

--- a/internal/manifests/charts/kelos/charts/kelos-crds/templates/taskspawner-crd.yaml
+++ b/internal/manifests/charts/kelos/charts/kelos-crds/templates/taskspawner-crd.yaml
@@ -22876,6 +22876,12 @@ spec:
                               description: Branch filters push events by branch name
                                 (exact match or glob).
                               type: string
+                            checkName:
+                              description: |-
+                                CheckName filters check_run events by the check run's name (exact match
+                                or glob, e.g. "lint", "unit-tests", "build-*"). Ignored for other event
+                                types.
+                              type: string
                             commentOn:
                               description: |-
                                 CommentOn scopes issue_comment-event filters to comments posted on a
@@ -22886,6 +22892,20 @@ spec:
                               - Issue
                               - PullRequest
                               - ""
+                              type: string
+                            conclusion:
+                              description: |-
+                                Conclusion filters check_run events by the check run's conclusion.
+                                Ignored for other event types.
+                              enum:
+                              - success
+                              - failure
+                              - cancelled
+                              - timed_out
+                              - action_required
+                              - neutral
+                              - skipped
+                              - stale
                               type: string
                             draft:
                               description: Draft filters PRs by draft status. nil

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -15232,6 +15232,12 @@ spec:
                               description: Branch filters push events by branch name
                                 (exact match or glob).
                               type: string
+                            checkName:
+                              description: |-
+                                CheckName filters check_run events by the check run's name (exact match
+                                or glob, e.g. "lint", "unit-tests", "build-*"). Ignored for other event
+                                types.
+                              type: string
                             commentOn:
                               description: |-
                                 CommentOn scopes issue_comment-event filters to comments posted on a
@@ -15242,6 +15248,20 @@ spec:
                               - Issue
                               - PullRequest
                               - ""
+                              type: string
+                            conclusion:
+                              description: |-
+                                Conclusion filters check_run events by the check run's conclusion.
+                                Ignored for other event types.
+                              enum:
+                              - success
+                              - failure
+                              - cancelled
+                              - timed_out
+                              - action_required
+                              - neutral
+                              - skipped
+                              - stale
                               type: string
                             draft:
                               description: Draft filters PRs by draft status. nil
@@ -59955,6 +59975,12 @@ spec:
                               description: Branch filters push events by branch name
                                 (exact match or glob).
                               type: string
+                            checkName:
+                              description: |-
+                                CheckName filters check_run events by the check run's name (exact match
+                                or glob, e.g. "lint", "unit-tests", "build-*"). Ignored for other event
+                                types.
+                              type: string
                             commentOn:
                               description: |-
                                 CommentOn scopes issue_comment-event filters to comments posted on a
@@ -59965,6 +59991,20 @@ spec:
                               - Issue
                               - PullRequest
                               - ""
+                              type: string
+                            conclusion:
+                              description: |-
+                                Conclusion filters check_run events by the check run's conclusion.
+                                Ignored for other event types.
+                              enum:
+                              - success
+                              - failure
+                              - cancelled
+                              - timed_out
+                              - action_required
+                              - neutral
+                              - skipped
+                              - stale
                               type: string
                             draft:
                               description: Draft filters PRs by draft status. nil

--- a/internal/webhook/github_filter.go
+++ b/internal/webhook/github_filter.go
@@ -127,6 +127,12 @@ func ParseGitHubWebhook(eventType string, payload []byte) (*GitHubEventData, err
 			data.RepositoryOwner = repo.GetOwner().GetLogin()
 			data.RepositoryName = repo.GetName()
 		}
+	case *github.CheckRunEvent:
+		if repo := e.GetRepo(); repo != nil {
+			data.Repository = repo.GetFullName()
+			data.RepositoryOwner = repo.GetOwner().GetLogin()
+			data.RepositoryName = repo.GetName()
+		}
 	}
 
 	// Extract common fields based on event type
@@ -252,6 +258,26 @@ func ParseGitHubWebhook(eventType string, payload []byte) (*GitHubEventData, err
 			data.Body = release.GetBody()
 			data.URL = release.GetHTMLURL()
 			data.ID = fmt.Sprintf("%d", release.GetID())
+		}
+
+	case *github.CheckRunEvent:
+		data.Action = e.GetAction()
+		data.Sender = e.GetSender().GetLogin()
+		if cr := e.GetCheckRun(); cr != nil {
+			data.ID = fmt.Sprintf("%d", cr.GetID())
+			data.Title = cr.GetName()
+			data.URL = cr.GetHTMLURL()
+			// The check run's head SHA identifies the commit under test.
+			data.HeadSHA = cr.GetHeadSHA()
+			// A check run may be associated with one or more pull requests.
+			// Use the first to expose the PR branch and number to templates.
+			for _, pr := range cr.PullRequests {
+				if head := pr.GetHead(); head != nil {
+					data.Branch = head.GetRef()
+					data.Number = pr.GetNumber()
+					break
+				}
+			}
 		}
 
 	default:
@@ -656,6 +682,26 @@ func matchesFilterWithoutFilePatterns(filter kelos.GitHubWebhookFilter, eventDat
 				}
 			}
 		}
+
+	case *github.CheckRunEvent:
+		if cr := e.GetCheckRun(); cr != nil {
+			// Conclusion filter (exact match).
+			if filter.Conclusion != "" && filter.Conclusion != cr.GetConclusion() {
+				return false
+			}
+
+			// CheckName filter (exact match or glob).
+			if filter.CheckName != "" {
+				matched, err := filepath.Match(filter.CheckName, cr.GetName())
+				if err != nil {
+					filterLog.Error(err, "Invalid checkName glob pattern, rejecting event", "pattern", filter.CheckName)
+					return false
+				}
+				if !matched {
+					return false
+				}
+			}
+		}
 	}
 
 	return true
@@ -741,6 +787,28 @@ func ExtractGitHubWorkItem(eventData *GitHubEventData, changedFiles []string) ma
 	}
 	if eventData.RefType != "" {
 		vars["RefType"] = eventData.RefType
+	}
+
+	// For check_run events, add CI-specific variables so remediation task
+	// templates can reference the failed check, its logs, and the commit.
+	if crEvent, ok := eventData.RawEvent.(*github.CheckRunEvent); ok {
+		if cr := crEvent.GetCheckRun(); cr != nil {
+			if name := cr.GetName(); name != "" {
+				vars["CheckName"] = name
+			}
+			if conclusion := cr.GetConclusion(); conclusion != "" {
+				vars["Conclusion"] = conclusion
+			}
+			if url := cr.GetHTMLURL(); url != "" {
+				vars["CheckRunURL"] = url
+			}
+			if sha := cr.GetHeadSHA(); sha != "" {
+				vars["HeadSHA"] = sha
+			}
+			if app := cr.GetApp(); app != nil && app.GetName() != "" {
+				vars["CheckApp"] = app.GetName()
+			}
+		}
 	}
 
 	return vars

--- a/internal/webhook/github_filter_test.go
+++ b/internal/webhook/github_filter_test.go
@@ -2766,3 +2766,192 @@ func TestExtractGitHubWorkItem_ReleaseEvent(t *testing.T) {
 		t.Errorf("URL = %v, want release URL", vars["URL"])
 	}
 }
+
+// checkRunPayload builds a check_run webhook payload for the given check name
+// and conclusion, associated with PR #7 on branch "feature-branch".
+func checkRunPayload(name, conclusion string) string {
+	return fmt.Sprintf(`{
+		"action":"completed",
+		"sender":{"login":"github-actions[bot]"},
+		"repository":{"full_name":"org/repo","name":"repo","owner":{"login":"org"}},
+		"check_run":{
+			"id":9876,
+			"name":%q,
+			"head_sha":"abc123def456",
+			"html_url":"https://github.com/org/repo/runs/9876",
+			"status":"completed",
+			"conclusion":%q,
+			"app":{"name":"GitHub Actions"},
+			"pull_requests":[{"number":7,"head":{"ref":"feature-branch"}}]
+		}
+	}`, name, conclusion)
+}
+
+func TestMatchesGitHubEvent_CheckRunConclusionAndName(t *testing.T) {
+	spawner := &kelos.GitHubWebhook{
+		Events: []string{"check_run"},
+		Filters: []kelos.GitHubWebhookFilter{
+			{
+				Event:      "check_run",
+				Action:     "completed",
+				Conclusion: "failure",
+				CheckName:  "lint*",
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		checkName  string
+		conclusion string
+		want       bool
+	}{
+		{
+			name:       "failing lint check matches (happy path)",
+			checkName:  "lint",
+			conclusion: "failure",
+			want:       true,
+		},
+		{
+			name:       "failing lint check with glob suffix matches",
+			checkName:  "lint-go",
+			conclusion: "failure",
+			want:       true,
+		},
+		{
+			name:       "successful lint check rejected by conclusion",
+			checkName:  "lint",
+			conclusion: "success",
+			want:       false,
+		},
+		{
+			name:       "failing check with non-matching name rejected",
+			checkName:  "unit-tests",
+			conclusion: "failure",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := []byte(checkRunPayload(tt.checkName, tt.conclusion))
+			got, err := parseAndMatch(t, spawner, "check_run", payload)
+			if err != nil {
+				t.Fatalf("MatchesGitHubEvent() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("MatchesGitHubEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMatchesGitHubEvent_CheckRunEventTypeNotAllowed verifies that a check_run
+// event is rejected when the spawner does not list "check_run" in its events.
+func TestMatchesGitHubEvent_CheckRunEventTypeNotAllowed(t *testing.T) {
+	spawner := &kelos.GitHubWebhook{
+		Events: []string{"pull_request"},
+	}
+
+	got, err := parseAndMatch(t, spawner, "check_run", []byte(checkRunPayload("lint", "failure")))
+	if err != nil {
+		t.Fatalf("MatchesGitHubEvent() error = %v", err)
+	}
+	if got {
+		t.Errorf("MatchesGitHubEvent() = true, want false for unlisted event type")
+	}
+}
+
+func TestParseGitHubWebhook_CheckRunEvent(t *testing.T) {
+	eventData, err := ParseGitHubWebhook("check_run", []byte(checkRunPayload("lint", "failure")))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+
+	if eventData.Repository != "org/repo" {
+		t.Errorf("Repository = %q, want org/repo", eventData.Repository)
+	}
+	if eventData.Sender != "github-actions[bot]" {
+		t.Errorf("Sender = %q, want github-actions[bot]", eventData.Sender)
+	}
+	if eventData.Title != "lint" {
+		t.Errorf("Title = %q, want lint", eventData.Title)
+	}
+	if eventData.HeadSHA != "abc123def456" {
+		t.Errorf("HeadSHA = %q, want abc123def456", eventData.HeadSHA)
+	}
+	if eventData.Branch != "feature-branch" {
+		t.Errorf("Branch = %q, want feature-branch", eventData.Branch)
+	}
+	if eventData.Number != 7 {
+		t.Errorf("Number = %d, want 7", eventData.Number)
+	}
+	if eventData.URL != "https://github.com/org/repo/runs/9876" {
+		t.Errorf("URL = %q, want run URL", eventData.URL)
+	}
+}
+
+func TestExtractGitHubWorkItem_CheckRunEvent(t *testing.T) {
+	eventData, err := ParseGitHubWebhook("check_run", []byte(checkRunPayload("unit-tests", "failure")))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+
+	vars := ExtractGitHubWorkItem(eventData, nil)
+
+	cases := map[string]interface{}{
+		"CheckName":   "unit-tests",
+		"Conclusion":  "failure",
+		"CheckRunURL": "https://github.com/org/repo/runs/9876",
+		"HeadSHA":     "abc123def456",
+		"CheckApp":    "GitHub Actions",
+		"Branch":      "feature-branch",
+		"Number":      7,
+	}
+	for key, want := range cases {
+		if vars[key] != want {
+			t.Errorf("vars[%q] = %v, want %v", key, vars[key], want)
+		}
+	}
+}
+
+// TestExtractGitHubWorkItem_CheckRunEventWithoutPR verifies that a check_run
+// event not associated with a pull request (e.g. a check on a push to a branch)
+// omits the Branch and Number template variables. Templates that must handle
+// these events therefore have to reference those keys defensively (via `index`
+// / `if index`) rather than with `{{.Branch}}`, which would fail under
+// missingkey=error.
+func TestExtractGitHubWorkItem_CheckRunEventWithoutPR(t *testing.T) {
+	payload := `{
+		"action":"completed",
+		"sender":{"login":"github-actions[bot]"},
+		"repository":{"full_name":"org/repo","name":"repo","owner":{"login":"org"}},
+		"check_run":{
+			"id":9876,
+			"name":"lint",
+			"head_sha":"abc123def456",
+			"html_url":"https://github.com/org/repo/runs/9876",
+			"status":"completed",
+			"conclusion":"failure",
+			"app":{"name":"GitHub Actions"},
+			"pull_requests":[]
+		}
+	}`
+	eventData, err := ParseGitHubWebhook("check_run", []byte(payload))
+	if err != nil {
+		t.Fatalf("ParseGitHubWebhook() error = %v", err)
+	}
+
+	vars := ExtractGitHubWorkItem(eventData, nil)
+
+	if _, ok := vars["Branch"]; ok {
+		t.Errorf("Branch should be omitted for a check_run without a linked PR, got %v", vars["Branch"])
+	}
+	if _, ok := vars["Number"]; ok {
+		t.Errorf("Number should be omitted for a check_run without a linked PR, got %v", vars["Number"])
+	}
+	// CI-specific fields that do not depend on a PR must still be present.
+	if vars["CheckName"] != "lint" || vars["HeadSHA"] != "abc123def456" {
+		t.Errorf("expected CheckName/HeadSHA to be populated, got CheckName=%v HeadSHA=%v", vars["CheckName"], vars["HeadSHA"])
+	}
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -888,6 +888,12 @@ func webhookSourceKind(eventType string, eventData *GitHubEventData) string {
 			return "pull-request"
 		}
 		return "issue"
+	case "check_run":
+		// A check_run is associated with a PR when the webhook payload links one.
+		if eventData.Number > 0 {
+			return "pull-request"
+		}
+		return "issue"
 	default:
 		return "issue"
 	}

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -858,6 +858,18 @@ func TestWebhookSourceKind(t *testing.T) {
 			eventData: &GitHubEventData{Event: "push"},
 			want:      "issue",
 		},
+		{
+			name:      "check_run linked to PR",
+			eventType: "check_run",
+			eventData: &GitHubEventData{Event: "check_run", Number: 7},
+			want:      "pull-request",
+		},
+		{
+			name:      "check_run without linked PR",
+			eventType: "check_run",
+			eventData: &GitHubEventData{Event: "check_run"},
+			want:      "issue",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds first-class support for **CI/CD failure auto-remediation** by teaching the
GitHub webhook path to understand `check_run` events. Previously `check_run`
events fell through to the generic default handler (only `sender` + `action`
extracted), and `GitHubWebhookFilter` had no way to filter by conclusion or
check name — so a CI auto-fix spawner would trigger on every completed check run
(pass or fail) and could not distinguish lint from test from build failures.

This PR makes the framework changes needed to build a spawner that watches for a
specific failing check and dispatches an agent to fix it, all additive and
backward-compatible:

- **API** (`api/v1alpha2`): two new optional fields on `GitHubWebhookFilter`:
  - `conclusion` — filters `check_run` events by conclusion (kubebuilder enum:
    `success`, `failure`, `cancelled`, `timed_out`, `action_required`,
    `neutral`, `skipped`, `stale`).
  - `checkName` — filters `check_run` events by check run name (exact match or
    glob, e.g. `lint`, `build-*`).
- **Parsing** (`ParseGitHubWebhook`): a `*github.CheckRunEvent` case that
  populates repository info, `Title` (check name), `HeadSHA`, `URL`, and the
  associated PR `Branch`/`Number`.
- **Matching** (`matchesFilterWithoutFilePatterns`): conclusion (exact) and
  checkName (glob) matching for `check_run` events.
- **Templates** (`ExtractGitHubWorkItem`): new CI-specific variables
  `{{.CheckName}}`, `{{.Conclusion}}`, `{{.CheckRunURL}}`, `{{.HeadSHA}}`,
  `{{.CheckApp}}`.
- **Reporting** (`webhookSourceKind`): maps `check_run` to `pull-request` when
  the check is linked to a PR, so status reporting attaches to the PR.

`go-github/v66` already provides `github.CheckRunEvent`, so no new dependency is
introduced.

#### Which issue(s) this PR is related to:

Fixes #946

#### Special notes for your reviewer:

- **API version:** the fields are added only to `api/v1alpha2` (the current
  served/storage version). The issue text referenced `api/v1alpha1`, which
  predates the version bump; per project convention new API surface lands only
  in the latest version. Conversion is a JSON round-trip, so the new
  v1alpha2-only fields are dropped cleanly on down-conversion to v1alpha1
  (covered by `TestTaskSpawnerConvert_CheckRunFilterFieldsDownConvert`).
- **Scope:** limited to `check_run`. The godoc hints that `workflow_run` shares
  `conclusion` values, but that is intentionally left as a follow-up rather than
  adding speculative API.
- **Shared type:** `GitHubWebhookFilter` is used by both TaskSpawner and
  SessionSpawner, so the regenerated CRDs for both pick up the new fields.
- **Overlap with #809:** #809 proposes the same CI-remediation use case via a
  polling approach (`checkConclusion`/`checkNames` on the `githubPullRequests`
  source). This PR implements the webhook/push approach from #946. If this is
  merged, #809 should likely be closed as superseded.
- **Tests:** added `check_run` parsing, conclusion/checkName matching (including
  a positive happy-path case), event-type-not-allowed, template-variable
  extraction, and the conversion down-convert test. Docs
  (`docs/reference.md`) and a runnable example
  (`examples/17-taskspawner-ci-remediation/`) are included.
- Ran `make verify` and `make test` — both pass.

#### Does this PR introduce a user-facing change?

```release-note
TaskSpawner/SessionSpawner `githubWebhook` filters now support `check_run` events: added `conclusion` and `checkName` filter fields and new template variables (`CheckName`, `Conclusion`, `CheckRunURL`, `HeadSHA`, `CheckApp`) for building CI-failure auto-remediation pipelines.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class `check_run` webhook support for CI failure auto-remediation. Spawners can target specific failing checks by conclusion and name, with CI-specific template vars and correct PR-linked reporting (aligns with `Kelos-946`).

- New Features
  - `api/v1alpha2`: add `conclusion` (enum) and `checkName` (glob) to `GitHubWebhookFilter` for `check_run`; regenerate CRDs for TaskSpawner/SessionSpawner.
  - Parse `check_run` payloads to extract repo, check name, `HeadSHA`, URL, and linked PR `Branch`/`Number`; match by `conclusion` (exact) and `checkName` (glob).
  - Expose template vars: `CheckName`, `Conclusion`, `CheckRunURL`, `HeadSHA`, `CheckApp`; map `check_run` to `pull-request` reporting when linked (else `issue`).
  - Update docs; add tests (parsing, matching, event-type-not-allowed, template extraction, v1alpha2→v1alpha1 down-conversion); include `examples/17-taskspawner-ci-remediation` showing task naming by check run ID, avoiding `excludeAuthors`, and guarding PR-less runs with `index`/`if`.

<sup>Written for commit 5711fa009ab605a606d01516dfa0dee17236d9a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

