### PR TITLE
feat: Add optional Prometheus Operator PodMonitor to Helm chart

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1155,6 +1155,23 @@ Each spawner pod emits metrics scoped to its own TaskSpawner:
 | `kelos_spawner_tasks_created_total` | Counter | Tasks created by this spawner |
 | `kelos_spawner_discovery_duration_seconds` | Histogram | Duration of discovery cycles |
 
+### Scraping with Prometheus Operator
+
+The Helm chart can ship optional [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)
+`PodMonitor` resources (`monitoring.coreos.com/v1`). They are disabled by
+default so the chart installs on clusters without the Prometheus Operator CRDs.
+Enable them via the `podMonitor` values:
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `podMonitor.enabled` | `false` | Ship a PodMonitor for the control-plane pods (controller manager, webhook servers, slack server). They all expose the `metrics` port (8080). Target discovery spans both `kelos-system` (where the controller manager runs) and the release namespace (where the webhook and slack servers run); under `kelos install` these are the same namespace. The session server is not scraped — its 8080 port serves the web app, not metrics. |
+| `podMonitor.interval` | `30s` | Scrape interval. |
+| `podMonitor.scrapeTimeout` | `10s` | Per-scrape timeout. |
+| `podMonitor.honorLabels` | `false` | Keep target-exposed labels when they collide with labels Prometheus would add. |
+| `podMonitor.labels` | `{}` | Extra labels on the PodMonitor object(s); commonly used to match a Prometheus instance's `podMonitorSelector`. |
+| `podMonitor.annotations` | `{}` | Extra annotations on the PodMonitor object(s). |
+| `podMonitor.spawners.enabled` | `false` | Additionally ship a PodMonitor for long-lived spawner pods (event- and poll-based TaskSpawners). Spawner pods run in arbitrary namespaces, so this PodMonitor discovers pod targets across all namespaces (`spec.namespaceSelector.any: true`); the scraping Prometheus's service account must have RBAC to read/scrape pods in those namespaces. Cron-based (one-shot) spawners expose no metrics port and are not scraped. |
+
 ## Telemetry
 
 Kelos collects anonymous, aggregate usage data to help improve the project. A `kelos-telemetry` CronJob runs daily at 06:00 UTC and reports the following:

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -682,6 +682,257 @@ func TestRender_WebhookServiceTypeRejectsUnsupported(t *testing.T) {
 	}
 }
 
+func TestRender_PodMonitorDisabledByDefault(t *testing.T) {
+	data, err := Render(manifests.ChartFS, nil)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	output := string(data)
+	if strings.Contains(output, "kind: PodMonitor") {
+		t.Error("expected no PodMonitor in default render")
+	}
+	if strings.Contains(output, "monitoring.coreos.com/v1") {
+		t.Error("expected no monitoring.coreos.com/v1 resources in default render")
+	}
+}
+
+func TestRender_PodMonitorEnabled(t *testing.T) {
+	vals := map[string]interface{}{
+		"podMonitor": map[string]interface{}{
+			"enabled":       true,
+			"interval":      "45s",
+			"scrapeTimeout": "12s",
+		},
+	}
+	data, err := Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	output := string(data)
+
+	pm := decodePodMonitor(t, output, "kelos-controlplane")
+	if pm["apiVersion"] != "monitoring.coreos.com/v1" {
+		t.Errorf("expected apiVersion monitoring.coreos.com/v1, got: %v", pm["apiVersion"])
+	}
+
+	// Assert on spec.selector specifically — the app.kubernetes.io/name label is
+	// also present under metadata.labels, so a whole-document substring match
+	// would not actually verify the selector.
+	selector := mapAt(t, specOf(t, pm), "selector")
+	matchLabels := mapAt(t, selector, "matchLabels")
+	if matchLabels["app.kubernetes.io/name"] != "kelos" {
+		t.Errorf("expected spec.selector.matchLabels app.kubernetes.io/name=kelos, got: %v", matchLabels)
+	}
+	// session-server shares the name label but is not a metrics endpoint, so the
+	// selector must exclude it explicitly rather than rely on the port name.
+	if !selectorExcludesComponent(selector, "session-server") {
+		t.Errorf("expected spec.selector.matchExpressions to exclude session-server via NotIn, got: %v", selector)
+	}
+
+	// Control-plane target discovery must cover kelos-system, where the
+	// controller manager always runs even when the release namespace differs.
+	nsNames := stringSliceAt(t, mapAt(t, specOf(t, pm), "namespaceSelector"), "matchNames")
+	if !containsString(nsNames, "kelos-system") {
+		t.Errorf("expected spec.namespaceSelector.matchNames to include kelos-system, got: %v", nsNames)
+	}
+
+	endpoint := firstEndpoint(t, pm)
+	if endpoint["port"] != "metrics" {
+		t.Errorf("expected podMetricsEndpoints[0].port=metrics, got: %v", endpoint["port"])
+	}
+	if endpoint["interval"] != "45s" {
+		t.Errorf("expected interval override 45s, got: %v", endpoint["interval"])
+	}
+	if endpoint["scrapeTimeout"] != "12s" {
+		t.Errorf("expected scrapeTimeout override 12s, got: %v", endpoint["scrapeTimeout"])
+	}
+	if strings.Contains(output, "name: kelos-spawners") {
+		t.Error("expected no spawner PodMonitor when podMonitor.spawners.enabled is false")
+	}
+}
+
+func TestRender_PodMonitorSpawnersEnabled(t *testing.T) {
+	vals := map[string]interface{}{
+		"podMonitor": map[string]interface{}{
+			"enabled": true,
+			"spawners": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}
+	data, err := Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	output := string(data)
+
+	// Control-plane PodMonitor still renders.
+	extractPodMonitorSpec(t, output, "kelos-controlplane")
+
+	pm := decodePodMonitor(t, output, "kelos-spawners")
+	spec := specOf(t, pm)
+	matchLabels := mapAt(t, mapAt(t, spec, "selector"), "matchLabels")
+	if matchLabels["kelos.dev/component"] != "spawner" {
+		t.Errorf("expected spec.selector.matchLabels kelos.dev/component=spawner, got: %v", matchLabels)
+	}
+	if nsAny := mapAt(t, spec, "namespaceSelector")["any"]; nsAny != true {
+		t.Errorf("expected spec.namespaceSelector.any=true for cross-namespace spawner scraping, got: %v", nsAny)
+	}
+}
+
+func TestRender_PodMonitorSpawnersRequiresParentEnabled(t *testing.T) {
+	vals := map[string]interface{}{
+		"podMonitor": map[string]interface{}{
+			"enabled": false,
+			"spawners": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}
+	data, err := Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	if strings.Contains(string(data), "kind: PodMonitor") {
+		t.Error("expected no PodMonitor when podMonitor.enabled is false, even with spawners.enabled true")
+	}
+}
+
+func TestRender_PodMonitorLabelsAnnotations(t *testing.T) {
+	vals := map[string]interface{}{
+		"podMonitor": map[string]interface{}{
+			"enabled":     true,
+			"labels":      map[string]interface{}{"release": "kube-prometheus-stack"},
+			"annotations": map[string]interface{}{"owner": "platform-team"},
+		},
+	}
+	data, err := Render(manifests.ChartFS, vals)
+	if err != nil {
+		t.Fatalf("rendering chart: %v", err)
+	}
+	spec := extractPodMonitorSpec(t, string(data), "kelos-controlplane")
+	if !strings.Contains(spec, "release: kube-prometheus-stack") {
+		t.Errorf("expected custom label release: kube-prometheus-stack, got:\n%s", spec)
+	}
+	if !strings.Contains(spec, "owner: platform-team") {
+		t.Errorf("expected custom annotation owner: platform-team, got:\n%s", spec)
+	}
+}
+
+// extractPodMonitorSpec returns the YAML body for the PodMonitor named name from
+// the rendered chart output, or fails the test if not found.
+func extractPodMonitorSpec(t *testing.T, output, name string) string {
+	t.Helper()
+	docs := strings.Split(output, "---\n")
+	marker := "name: " + name + "\n"
+	for _, doc := range docs {
+		if !strings.Contains(doc, "kind: PodMonitor") {
+			continue
+		}
+		if !strings.Contains(doc, marker) {
+			continue
+		}
+		return doc
+	}
+	t.Fatalf("PodMonitor %q not found in rendered output", name)
+	return ""
+}
+
+// decodePodMonitor extracts and YAML-decodes the PodMonitor named name so tests
+// can assert on specific fields (e.g. spec.selector) rather than substring-match
+// the whole document, which would collide with metadata.labels.
+func decodePodMonitor(t *testing.T, output, name string) map[string]interface{} {
+	t.Helper()
+	doc := extractPodMonitorSpec(t, output, name)
+	var pm map[string]interface{}
+	if err := sigyaml.Unmarshal([]byte(doc), &pm); err != nil {
+		t.Fatalf("decoding PodMonitor %q: %v\n%s", name, err, doc)
+	}
+	return pm
+}
+
+func specOf(t *testing.T, pm map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	return mapAt(t, pm, "spec")
+}
+
+// mapAt returns m[key] as a map, failing the test if it is missing or not a map.
+func mapAt(t *testing.T, m map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	v, ok := m[key].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected %q to be a map, got: %v", key, m[key])
+	}
+	return v
+}
+
+// stringSliceAt returns m[key] as a []string, failing the test if it is missing
+// or not a list of strings.
+func stringSliceAt(t *testing.T, m map[string]interface{}, key string) []string {
+	t.Helper()
+	raw, ok := m[key].([]interface{})
+	if !ok {
+		t.Fatalf("expected %q to be a list, got: %v", key, m[key])
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("expected %q entries to be strings, got: %v", key, v)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// firstEndpoint returns spec.podMetricsEndpoints[0] of the PodMonitor.
+func firstEndpoint(t *testing.T, pm map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	eps, ok := specOf(t, pm)["podMetricsEndpoints"].([]interface{})
+	if !ok || len(eps) == 0 {
+		t.Fatalf("expected at least one podMetricsEndpoints entry, got: %v", specOf(t, pm)["podMetricsEndpoints"])
+	}
+	ep, ok := eps[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected podMetricsEndpoints[0] to be a map, got: %v", eps[0])
+	}
+	return ep
+}
+
+// selectorExcludesComponent reports whether the label selector carries a
+// matchExpressions entry excluding the given app.kubernetes.io/component value.
+func selectorExcludesComponent(selector map[string]interface{}, component string) bool {
+	exprs, ok := selector["matchExpressions"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, e := range exprs {
+		m, ok := e.(map[string]interface{})
+		if !ok || m["key"] != "app.kubernetes.io/component" || m["operator"] != "NotIn" {
+			continue
+		}
+		vals, ok := m["values"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, v := range vals {
+			if v == component {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsString(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestRender_ParseableOutput(t *testing.T) {
 	vals := map[string]interface{}{
 		"image": map[string]interface{}{

--- a/internal/manifests/charts/kelos/templates/podmonitor.yaml
+++ b/internal/manifests/charts/kelos/templates/podmonitor.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.podMonitor.enabled }}
+---
+# PodMonitor for the Kelos control-plane pods (controller manager, webhook
+# servers, slack server). They all carry app.kubernetes.io/name: kelos and
+# expose the metrics port (8080). session-server is explicitly excluded: it
+# shares the app.kubernetes.io/name: kelos label but its 8080 port serves the
+# web app (named "http"), not Prometheus metrics.
+#
+# The controller manager always runs in the kelos-system namespace, while the
+# webhook and slack servers run in the release namespace, so target discovery
+# spans both. (Under `kelos install` these are the same namespace.)
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kelos-controlplane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kelos
+    app.kubernetes.io/component: manager
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - kelos-system
+      {{- if ne .Release.Namespace "kelos-system" }}
+      - {{ .Release.Namespace }}
+      {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kelos
+    matchExpressions:
+      # Exclude the session-server web app, which shares the name label but does
+      # not expose a Prometheus metrics port.
+      - key: app.kubernetes.io/component
+        operator: NotIn
+        values:
+          - session-server
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ .Values.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.podMonitor.honorLabels }}
+{{- if .Values.podMonitor.spawners.enabled }}
+---
+# PodMonitor for long-lived spawner pods (event- and poll-based TaskSpawners run
+# as Deployments). Spawner pods use the kelos.dev/* label scheme (not
+# app.kubernetes.io/name) and run in arbitrary namespaces, so namespaceSelector
+# spans all namespaces for target discovery. Cron-based TaskSpawners run as
+# one-shot Jobs with the same labels but no metrics port; they exit immediately,
+# so port: metrics simply yields no target for them.
+#
+# This selects pod targets cluster-wide; the scraping Prometheus's service
+# account still needs RBAC to read/scrape pods in those namespaces. (This
+# PodMonitor object itself lives in the release namespace and is discovered like
+# any other, via the Prometheus podMonitorNamespaceSelector.)
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kelos-spawners
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kelos
+    app.kubernetes.io/component: spawner
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      kelos.dev/name: kelos
+      kelos.dev/component: spawner
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ .Values.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.podMonitor.honorLabels }}
+{{- end }}
+{{- end }}

--- a/internal/manifests/charts/kelos/values.yaml
+++ b/internal/manifests/charts/kelos/values.yaml
@@ -9,6 +9,33 @@ image:
 telemetry:
   enabled: true
 
+# podMonitor optionally ships Prometheus Operator PodMonitor resources
+# (monitoring.coreos.com/v1) for scraping Kelos metrics. This requires the
+# Prometheus Operator CRDs to be installed in the cluster; leave disabled if
+# they are not present, otherwise the chart will fail to install.
+podMonitor:
+  # Scrape the control-plane pods (controller manager, webhook servers, slack
+  # server) in the release namespace. They all expose the metrics port (8080).
+  enabled: false
+  # Scrape interval and per-scrape timeout.
+  interval: 30s
+  scrapeTimeout: 10s
+  # honorLabels keeps metric labels exposed by the target when they collide
+  # with labels Prometheus would add.
+  honorLabels: false
+  # Extra labels and annotations on the PodMonitor object(s). Labels are
+  # commonly used to match a Prometheus instance's podMonitorSelector.
+  labels: {}
+  annotations: {}
+  spawners:
+    # Also ship a PodMonitor for long-lived spawner pods (event- and poll-based
+    # TaskSpawners). These run in arbitrary namespaces, so the PodMonitor
+    # discovers pod targets across all namespaces (spec.namespaceSelector.any).
+    # The scraping Prometheus's service account must have RBAC to read/scrape
+    # pods in those namespaces. Cron-based (one-shot) spawners expose no metrics
+    # port and are not scraped.
+    enabled: false
+
 # codexAuthRefresher lets the controller manage one scheduled Codex-image
 # CronJob in the target namespace per Secret labeled
 # kelos.dev/codex-oauth-refresh=true, keeping Codex OAuth credentials valid even


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds optional **Prometheus Operator** `PodMonitor` resources to the Kelos Helm
chart so operators can wire up metrics scraping declaratively, without writing
manual Prometheus scrape config.

The chart already exposes Prometheus metrics on `:8080` for the control-plane
pods, but shipped nothing to tell a Prometheus Operator to scrape them — the
`values.yaml` comments even pointed users at "a PodMonitor" they had to build
themselves. This PR closes that gap. It is fully additive and disabled by
default, so clusters without the Prometheus Operator CRDs are unaffected.

- **`values.yaml`**: new documented `podMonitor` block:
  - `podMonitor.enabled` (default `false`) — scrape the control-plane pods
    (controller manager, webhook servers, slack server) in the release
    namespace.
  - `interval`, `scrapeTimeout`, `honorLabels`, `labels`, `annotations`.
  - `podMonitor.spawners.enabled` (default `false`) — additionally scrape the
    dynamically-created spawner pods.
- **`templates/podmonitor.yaml`** (new): two conditionally-rendered
  `monitoring.coreos.com/v1` `PodMonitor` documents:
  - `kelos-controlplane` — selects `app.kubernetes.io/name: kelos` and scrapes
    the named `metrics` port (8080). This uniformly covers the controller
    manager, all webhook sources, and the slack server, and skips the session
    server (whose `:8080` serves the web app, not metrics).
  - `kelos-spawners` — selects `kelos.dev/component: spawner` with
    `namespaceSelector.any: true`, since spawner pods run in arbitrary
    namespaces.
- **`docs/reference.md`**: new "Scraping with Prometheus Operator" subsection
  under "Prometheus Metrics" documenting the `podMonitor` values.
- **`internal/helmchart/render_test.go`**: render tests for disabled-by-default,
  enabled (selector/port/interval overrides), spawners-enabled (both monitors +
  cross-namespace selector), spawners-require-parent-enabled, and
  labels/annotations propagation.

No new dependency and no Go controller/API changes.

#### Which issue(s) this PR is related to:

Fixes #1213

#### Special notes for your reviewer:

- **PodMonitor instead of the ServiceMonitor named in the issue.** The issue's
  proposed template assumes a single metrics `Service` and `kelos.fullname` /
  `kelos.labels` helpers. In reality the controller manager and slack server
  expose metrics **on the pod only** — there is no metrics `Service` to select —
  and the chart has no `_helpers.tpl` (labels are hard-coded
  `app.kubernetes.io/name: kelos` + `component`). A `ServiceMonitor` would
  therefore have to add new Services for the controller and slack server, or
  silently cover only the webhook sources. A `PodMonitor` selecting the shared
  pod label gives uniform coverage with no new Services, and matches both the
  existing `values.yaml` guidance ("scrape metrics via a PodMonitor") and the
  in-tree GKE `PodMonitoring` precedent from #821.
- **Control-plane vs spawner pods are disjoint populations.** Control-plane pods
  use `app.kubernetes.io/name: kelos` in the release namespace; spawner pods use
  the `kelos.dev/*` label scheme in arbitrary namespaces. One selector cannot
  match both, so they are two separate PodMonitors. The spawner one is behind
  its own sub-toggle (default off) because cross-namespace scraping requires the
  Prometheus instance to be configured to select PodMonitors cluster-wide.
- **Session server is intentionally excluded** — its `:8080` port is the web app
  (`http`), not a Prometheus metrics endpoint.
- Ran `make verify` and `make test` — both pass.

#### Does this PR introduce a user-facing change?

```release-note
The Helm chart can now ship optional Prometheus Operator PodMonitor resources for scraping Kelos metrics, via a new `podMonitor` values block (disabled by default). `podMonitor.enabled` scrapes the control-plane pods (controller, webhook servers, slack server) and `podMonitor.spawners.enabled` additionally scrapes spawner pods.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Prometheus Operator `PodMonitor` resources to the Kelos Helm chart to scrape control‑plane metrics on port 8080, plus an opt‑in monitor for spawner pods. Disabled by default so clusters without the CRDs are unaffected. Fixes #1213.

- **New Features**
  - Control‑plane `PodMonitor` selects `app.kubernetes.io/name=kelos`, scrapes the `metrics` port (8080), excludes `session-server`, and discovers pods in `kelos-system` and the release namespace.
  - Optional spawner `PodMonitor` behind `podMonitor.spawners.enabled` (requires `podMonitor.enabled`); selects `kelos.dev/component=spawner` across namespaces (`namespaceSelector.any: true`) and targets long‑lived spawners.
  - New `values.yaml` `podMonitor` block: `enabled`, `interval`, `scrapeTimeout`, `honorLabels`, `labels`, `annotations`; docs call out namespace discovery and RBAC; render tests cover defaults, overrides, spawner gating, and label/annotation propagation.

<sup>Written for commit 2188b9b4b95998853403f85ea8c9e277a9061e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

