### PR TITLE
fix: Emit assistant.message per text block in Claude runtime

### DIFF
--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -210,8 +210,11 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 				}
 				write("%s", event.Text)
 			case sessionruntime.EventAssistantMessage:
-				if !streaming && event.Text != "" {
-					write("%s%s", formatter.assistantPrefix(), event.Text)
+				if streaming {
+					write("\n")
+					streaming = false
+				} else if event.Text != "" {
+					write("%s%s\n", formatter.assistantPrefix(), event.Text)
 				}
 			case sessionruntime.EventToolStarted:
 				if streaming {

--- a/internal/cli/session_terminal_test.go
+++ b/internal/cli/session_terminal_test.go
@@ -69,6 +69,48 @@ func TestSessionTerminalRendersANSIEvents(t *testing.T) {
 	}
 }
 
+func TestSessionTerminalSeparatesStreamedTextBlocks(t *testing.T) {
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryEnd},
+		{Type: sessionruntime.EventAssistantDelta, Text: "First block"},
+		{Type: sessionruntime.EventAssistantMessage, Text: "First block"},
+		{Type: sessionruntime.EventAssistantDelta, Text: "Second block"},
+		{Type: sessionruntime.EventAssistantMessage, Text: "Second block"},
+		{Type: sessionruntime.EventTurnCompleted},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	var requests bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, &requests, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got := output.String()
+	// Each streamed block closes on its assistant.message and renders on its own
+	// prefixed line, so the two blocks are not concatenated into one bubble.
+	if want := "agent › First block\nagent › Second block\n"; !strings.Contains(got, want) {
+		t.Fatalf("terminal output = %q, want it to contain %q", got, want)
+	}
+	// The closing assistant.message must not re-print the streamed block text.
+	if n := strings.Count(got, "First block"); n != 1 {
+		t.Fatalf("terminal output contains %q %d times, want 1", "First block", n)
+	}
+	if n := strings.Count(got, "Second block"); n != 1 {
+		t.Fatalf("terminal output contains %q %d times, want 1", "Second block", n)
+	}
+}
+
 func TestSessionTerminalFormatterUsesANSIStyles(t *testing.T) {
 	formatter := sessionTerminalFormatter{color: true}
 	if got, want := formatter.userMessage("hello"), "\x1b[7m  hello  \x1b[0m"; got != want {

--- a/internal/sessionruntime/claude.go
+++ b/internal/sessionruntime/claude.go
@@ -54,6 +54,7 @@ type ClaudeProvider struct {
 	interactionCancel context.CancelFunc
 	seenTools         map[string]string
 	hadTextDelta      bool
+	blockText         map[int]*strings.Builder
 	interrupted       bool
 
 	sessionMu sync.Mutex
@@ -155,6 +156,7 @@ func (p *ClaudeProvider) RunTurn(ctx context.Context, prompt string, sink EventS
 	p.interactionCancel = interactionCancel
 	p.seenTools = map[string]string{}
 	p.hadTextDelta = false
+	p.blockText = map[int]*strings.Builder{}
 	p.interrupted = false
 	p.activeMu.Unlock()
 	defer func() {
@@ -165,6 +167,7 @@ func (p *ClaudeProvider) RunTurn(ctx context.Context, prompt string, sink EventS
 		p.interactionCtx = nil
 		p.interactionCancel = nil
 		p.seenTools = nil
+		p.blockText = nil
 		p.interrupted = false
 		p.activeMu.Unlock()
 	}()
@@ -545,6 +548,7 @@ func (p *ClaudeProvider) emitClaudeStreamEvent(raw json.RawMessage, sink EventSi
 	}
 	var event struct {
 		Type         string `json:"type"`
+		Index        int    `json:"index"`
 		ContentBlock struct {
 			Type string `json:"type"`
 			ID   string `json:"id"`
@@ -563,12 +567,30 @@ func (p *ClaudeProvider) emitClaudeStreamEvent(raw json.RawMessage, sink EventSi
 		if event.Delta.Type == "text_delta" && event.Delta.Text != "" {
 			p.activeMu.Lock()
 			p.hadTextDelta = true
+			if p.blockText != nil {
+				builder := p.blockText[event.Index]
+				if builder == nil {
+					builder = &strings.Builder{}
+					p.blockText[event.Index] = builder
+				}
+				builder.WriteString(event.Delta.Text)
+			}
 			p.activeMu.Unlock()
 			sink.Emit(Event{Type: EventAssistantDelta, Text: event.Delta.Text})
 		}
 	case "content_block_start":
 		if event.ContentBlock.Type == "tool_use" {
 			p.emitClaudeToolStart(event.ContentBlock.ID, event.ContentBlock.Name, sink)
+		}
+	case "content_block_stop":
+		// Close the streamed text bubble for this block so clients render
+		// each text block separately instead of concatenating a turn's text.
+		p.activeMu.Lock()
+		builder := p.blockText[event.Index]
+		delete(p.blockText, event.Index)
+		p.activeMu.Unlock()
+		if builder != nil && builder.Len() > 0 {
+			sink.Emit(Event{Type: EventAssistantMessage, Text: builder.String()})
 		}
 	}
 }

--- a/internal/sessionruntime/claude_test.go
+++ b/internal/sessionruntime/claude_test.go
@@ -1,0 +1,107 @@
+package sessionruntime
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestClaudeProviderClosesEachTextBlock verifies that a streamed turn with two
+// text blocks emits an assistant.message after each block's deltas, so clients
+// render them as separate bubbles instead of concatenating the whole turn.
+func TestClaudeProviderClosesEachTextBlock(t *testing.T) {
+	provider := &ClaudeProvider{blockText: map[int]*strings.Builder{}}
+	sink := newOpenCodeTestSink(nil)
+
+	events := []string{
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Second block"}}`,
+		`{"type":"content_block_stop","index":1}`,
+	}
+	for _, raw := range events {
+		provider.emitClaudeStreamEvent(json.RawMessage(raw), sink)
+	}
+
+	want := []Event{
+		{Type: EventAssistantDelta, Text: "Hello"},
+		{Type: EventAssistantDelta, Text: " there"},
+		{Type: EventAssistantMessage, Text: "Hello there"},
+		{Type: EventAssistantDelta, Text: "Second block"},
+		{Type: EventAssistantMessage, Text: "Second block"},
+	}
+	if got := sink.snapshot(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Claude events = %#v, want %#v", got, want)
+	}
+}
+
+// TestClaudeProviderStreamedToolBlockEmitsNoMessage verifies that closing a
+// non-text content block (a tool_use) does not emit an empty assistant.message.
+func TestClaudeProviderStreamedToolBlockEmitsNoMessage(t *testing.T) {
+	provider := &ClaudeProvider{blockText: map[int]*strings.Builder{}}
+	sink := newOpenCodeTestSink(nil)
+
+	events := []string{
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-1","name":"Bash"}}`,
+		`{"type":"content_block_stop","index":0}`,
+	}
+	for _, raw := range events {
+		provider.emitClaudeStreamEvent(json.RawMessage(raw), sink)
+	}
+
+	want := []Event{
+		{Type: EventToolStarted, ToolID: "tool-1", ToolName: "Bash", Status: "running"},
+	}
+	if got := sink.snapshot(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Claude events = %#v, want %#v", got, want)
+	}
+}
+
+// TestClaudeProviderEmitsMessageWithoutStreaming verifies that when no text
+// deltas were streamed, the assembled assistant message still emits one
+// assistant.message per text block.
+func TestClaudeProviderEmitsMessageWithoutStreaming(t *testing.T) {
+	provider := &ClaudeProvider{}
+	sink := newOpenCodeTestSink(nil)
+
+	message := `{"content":[{"type":"text","text":"First"},{"type":"text","text":"Second"}]}`
+	provider.emitClaudeMessage("assistant", json.RawMessage(message), sink)
+
+	want := []Event{
+		{Type: EventAssistantMessage, Text: "First"},
+		{Type: EventAssistantMessage, Text: "Second"},
+	}
+	if got := sink.snapshot(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Claude events = %#v, want %#v", got, want)
+	}
+}
+
+// TestClaudeProviderStreamingSuppressesAssembledMessage verifies that once text
+// deltas have streamed (and been closed per block), the assembled assistant
+// message does not re-emit the same text as duplicate assistant.message events.
+func TestClaudeProviderStreamingSuppressesAssembledMessage(t *testing.T) {
+	provider := &ClaudeProvider{blockText: map[int]*strings.Builder{}}
+	sink := newOpenCodeTestSink(nil)
+
+	stream := []string{
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Streamed"}}`,
+		`{"type":"content_block_stop","index":0}`,
+	}
+	for _, raw := range stream {
+		provider.emitClaudeStreamEvent(json.RawMessage(raw), sink)
+	}
+	provider.emitClaudeMessage("assistant", json.RawMessage(`{"content":[{"type":"text","text":"Streamed"}]}`), sink)
+
+	want := []Event{
+		{Type: EventAssistantDelta, Text: "Streamed"},
+		{Type: EventAssistantMessage, Text: "Streamed"},
+	}
+	if got := sink.snapshot(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Claude events = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes assistant text blocks concatenating into a single bubble within a turn in
Claude-backed sessions.

The Claude session provider (`internal/sessionruntime/claude.go`) only emitted
`assistant.message` via the *assembled* message envelope, and even then only
when no streaming deltas had occurred (`!hadTextDelta`). During normal streaming
it never emitted a bubble-closing `assistant.message` at all, so every text
block in a turn accumulated into one bubble.

Emitting the close events from the assembled envelope wouldn't fix it either:
all deltas arrive before the envelope, producing `delta, delta, message, message`
instead of the interleaved `delta, message, delta, message` that clients expect.

This PR:
- Accumulates streamed text per content-block index and emits `assistant.message`
  on each `content_block_stop`, interleaved in the stream where the reducer
  expects it. Non-text blocks (e.g. `tool_use`) accumulate no text and emit
  nothing. This mirrors the Codex provider, which already emits deltas plus a
  closing message per block.
- Leaves the assembled-message path unchanged, so the non-streaming fallback
  still works and there is no duplicate emission.
- Updates the plain terminal (`internal/cli/session_terminal.go`) to end the
  current streamed line on a mid-stream `assistant.message` so blocks render
  separately there too. The TUI already handled this via `finishStreaming()`
  and needed no change.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Behavior across the three event consumers after this change:
- **gravity-web reducer** — receives `delta … message … delta … message` and
  renders separate bubbles.
- **TUI** (`session_terminal_tui.go`) — already called `finishStreaming()` on a
  mid-stream `assistant.message`; it ignores the message text while streaming
  (uses accumulated deltas), so there is no duplication.
- **Plain terminal** — now closes the streamed line per block.

Added `internal/sessionruntime/claude_test.go` covering: two-block separation,
a `tool_use` block emitting no message, the non-streaming fallback, and
confirmation that the assembled message does not re-emit streamed text.

Note: `make verify` fails on this branch, but only on pre-existing issues
unrelated to this change — YAML linting of stale `.claude/worktrees/` copies and
a generated-files drift check. This is a pure Go-logic change with no
CRD/API/codegen impact. `gofmt`, `go vet`, and the `internal/sessionruntime` and
`internal/cli` package tests all pass.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Claude-backed sessions concatenating multiple assistant text blocks from a single turn into one message; each text block now renders as a separate message.
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude-backed sessions concatenating multiple assistant text blocks into one message by emitting `assistant.message` per block, interleaved with deltas. Web and terminal UIs now render separate bubbles/lines for each block.

- **Bug Fixes**
  - In `internal/sessionruntime/claude.go`, accumulate streamed text per content-block index and emit `assistant.message` on each `content_block_stop`; non-text blocks emit nothing. The assembled-message path stays unchanged to avoid duplicates and matches the Codex provider.
  - Event order is now `delta, message, delta, message`, so the web reducer renders separate bubbles.
  - In `internal/cli/session_terminal.go`, end the current streamed line on mid-stream `assistant.message` so blocks print separately. Added tests for two-block separation, `tool_use` no-op, non-streaming fallback, and no duplicate emission.

<sup>Written for commit 3a8fa57ba1e242b0ae56619a2a89e6a4195716f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



