### PR TITLE
feat: expose changed files as {{.ChangedFiles}} in webhook prompt templates

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -725,10 +725,13 @@ The `promptTemplate` field uses Go `text/template` syntax. Available variables d
 | `{{.IssueID}}` | Parent issue ID | Empty | Empty | Empty | Empty | Parent issue ID (Comment events only) | Empty | Empty |
 | `{{.CommentBody}}` | Comment or review body | Empty | Empty | Comment/review body (`issue_comment`, `pull_request_review`, `pull_request_review_comment` events) | Empty | Empty | Empty | Empty |
 | `{{.CommentURL}}` | Comment or review URL | Empty | Empty | Comment/review HTML URL (`issue_comment`, `pull_request_review`, `pull_request_review_comment` events) | Empty | Empty | Empty | Empty |
+| `{{.ChangedFiles}}` | Changed file paths (list) | Empty | Empty | Push: files from the payload. PR: changed files, but **only** when a matching filter's `filePatterns` forced a fetch (otherwise empty; see note below). Iterate with `{{range .ChangedFiles}}` | Empty | Empty | Empty | Empty |
 | `{{.Time}}` | Trigger time (RFC3339) | Empty | Empty | Empty | Empty | Empty | Empty | Cron tick time (e.g., `"2026-02-07T09:00:00Z"`) |
 | `{{.Schedule}}` | Cron schedule expression | Empty | Empty | Empty | Empty | Empty | Empty | Schedule string (e.g., `"0 * * * *"`) |
 
 > **Generic Webhook only:** any additional keys declared in `spec.when.webhook.fieldMapping` are also exposed as top-level template variables (e.g., `fieldMapping: {severity: "$.level"}` makes `{{.severity}}` available).
+
+> **`{{.ChangedFiles}}` and `filePatterns`:** For pull request webhook events, the changed-file list is fetched lazily and only when a filter's `filePatterns` needs it to decide a match. As a result, `{{.ChangedFiles}}` is populated for PR events **only when the matching filter declares `filePatterns`**; without it, `{{.ChangedFiles}}` renders as an empty list. Push events populate `{{.ChangedFiles}}` from the payload regardless.
 
 > **Context sources:** when `spec.taskTemplate.contextSources` is configured, each entry's fetched value is exposed as `{{.Context.NAME}}` (e.g., a source named `jira` is available as `{{.Context.jira}}`). The same `.Context` map is also available in `spec.taskTemplate.branch` and `spec.taskTemplate.metadata` templates. See [Context Sources](#context-sources) for details.
 

--- a/internal/taskbuilder/builder_test.go
+++ b/internal/taskbuilder/builder_test.go
@@ -41,6 +41,53 @@ func TestBuildTask_ForwardsEffort(t *testing.T) {
 	}
 }
 
+func TestBuildTask_RendersChangedFiles(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &kelos.TaskTemplate{
+		Type: "codex",
+		Credentials: &kelos.Credentials{
+			Type:      kelos.CredentialTypeAPIKey,
+			SecretRef: &kelos.SecretReference{Name: "credentials"},
+		},
+		PromptTemplate: "Review:{{range .ChangedFiles}} {{.}}{{end}}",
+	}
+
+	task, err := tb.BuildTask("task-1", "default", template, map[string]interface{}{
+		"Title":        "the bug",
+		"ChangedFiles": []string{"main.go", "docs/guide.md"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildTask() returned error: %v", err)
+	}
+	if want := "Review: main.go docs/guide.md"; task.Spec.Prompt != want {
+		t.Fatalf("task.Spec.Prompt = %q, want %q", task.Spec.Prompt, want)
+	}
+}
+
+func TestBuildTask_RendersEmptyChangedFiles(t *testing.T) {
+	tb := &TaskBuilder{}
+	template := &kelos.TaskTemplate{
+		Type: "codex",
+		Credentials: &kelos.Credentials{
+			Type:      kelos.CredentialTypeAPIKey,
+			SecretRef: &kelos.SecretReference{Name: "credentials"},
+		},
+		// Referencing {{.ChangedFiles}} must not trip missingkey=error when empty.
+		PromptTemplate: "Files: {{.ChangedFiles}}",
+	}
+
+	task, err := tb.BuildTask("task-1", "default", template, map[string]interface{}{
+		"Title":        "the bug",
+		"ChangedFiles": []string(nil),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildTask() returned error: %v", err)
+	}
+	if want := "Files: []"; task.Spec.Prompt != want {
+		t.Fatalf("task.Spec.Prompt = %q, want %q", task.Spec.Prompt, want)
+	}
+}
+
 func TestBuildTask_ForwardsPodFailurePolicy(t *testing.T) {
 	tb := &TaskBuilder{}
 	template := &kelos.TaskTemplate{

--- a/internal/webhook/github_filter.go
+++ b/internal/webhook/github_filter.go
@@ -46,9 +46,9 @@ type GitHubEventData struct {
 	// ChangedFiles lists file paths modified by the event.
 	// For push events, populated from the payload. For PR events, lazily
 	// fetched from the GitHub API when a webhook filter uses FilePatterns.
-	// NOTE: intentionally not exposed in ExtractGitHubWorkItem template vars
-	// yet — the {{.ChangedFiles}} template variable is deferred to a follow-up
-	// to resolve API design questions (slice vs pre-joined string, fetch gating).
+	// Exposed to prompt templates as {{.ChangedFiles}} via ExtractGitHubWorkItem.
+	// Because PR fetching is gated on FilePatterns, {{.ChangedFiles}} is only
+	// populated for PR events when a filter's filePatterns forced the fetch.
 	ChangedFiles []string
 	// Tag is the tag name for create (ref_type=tag) and release events.
 	Tag string
@@ -339,6 +339,23 @@ func githubWebhookNeedsChangedFiles(spawner *kelos.GitHubWebhook, eventType stri
 	}
 
 	return false
+}
+
+// changedFilesForSpawner returns the changed-file list to expose to a spawner's
+// prompt template as {{.ChangedFiles}}. The list lives on eventData as a
+// delivery-scoped fetch cache shared across every spawner, so it must only be
+// surfaced to a spawner that actually relies on it: a push event (files come
+// from the payload) or a spawner whose matching filter declares filePatterns.
+// Returning it unconditionally would leak a list fetched for one spawner into
+// another spawner's prompt depending on iteration order. Returns nil otherwise.
+func changedFilesForSpawner(spawner *kelos.GitHubWebhook, eventType string, eventData *GitHubEventData) []string {
+	if eventData == nil {
+		return nil
+	}
+	if eventType == "push" || githubWebhookNeedsChangedFiles(spawner, eventType, eventData) {
+		return eventData.ChangedFiles
+	}
+	return nil
 }
 
 // matchesFilter checks if event data matches a specific filter.
@@ -673,8 +690,13 @@ func needsBranchEnrichment(eventData *GitHubEventData) bool {
 	return eventData.Branch == "" && eventData.PullRequestAPIURL != ""
 }
 
-// ExtractGitHubWorkItem extracts template variables from GitHub webhook events for task creation.
-func ExtractGitHubWorkItem(eventData *GitHubEventData) map[string]interface{} {
+// ExtractGitHubWorkItem extracts template variables from GitHub webhook events
+// for task creation. changedFiles is the changed-file list to surface as
+// {{.ChangedFiles}}; callers pass it explicitly (rather than reading
+// eventData.ChangedFiles) because that field is a delivery-scoped fetch cache
+// shared across spawners and must only be surfaced to a spawner that relies on
+// it — see changedFilesForSpawner.
+func ExtractGitHubWorkItem(eventData *GitHubEventData, changedFiles []string) map[string]interface{} {
 	vars := map[string]interface{}{
 		"Event":           eventData.Event,
 		"Action":          eventData.Action,
@@ -688,6 +710,11 @@ func ExtractGitHubWorkItem(eventData *GitHubEventData) map[string]interface{} {
 		"ID":    eventData.ID,
 		"Title": eventData.Title,
 		"Kind":  "webhook",
+		// ChangedFiles is the list of changed file paths. It is always present
+		// (so {{.ChangedFiles}} never trips missingkey=error) but is only
+		// populated when this spawner relies on changed files (a push event, or
+		// a matching filter that declares filePatterns); otherwise it is empty.
+		"ChangedFiles": changedFiles,
 	}
 
 	// Add number, body, URL if available

--- a/internal/webhook/github_filter_test.go
+++ b/internal/webhook/github_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1836,14 +1837,114 @@ func TestMatchesGitHubEvent_FilePatterns(t *testing.T) {
 	}
 }
 
-func TestExtractGitHubWorkItemNoChangedFiles(t *testing.T) {
+func TestExtractGitHubWorkItemChangedFilesEmpty(t *testing.T) {
 	eventData := &GitHubEventData{
 		Event: "issues",
 	}
 
-	vars := ExtractGitHubWorkItem(eventData)
-	if _, ok := vars["ChangedFiles"]; ok {
-		t.Error("ChangedFiles should not be set in template vars")
+	// ChangedFiles is always present so {{.ChangedFiles}} never trips
+	// missingkey=error, but it is empty when the caller passes no files.
+	vars := ExtractGitHubWorkItem(eventData, nil)
+	files, ok := vars["ChangedFiles"]
+	if !ok {
+		t.Fatal("ChangedFiles should always be present in template vars")
+	}
+	if got := files.([]string); len(got) != 0 {
+		t.Errorf("ChangedFiles = %v, want empty", got)
+	}
+}
+
+func TestExtractGitHubWorkItemChangedFilesPopulated(t *testing.T) {
+	eventData := &GitHubEventData{
+		Event: "pull_request",
+	}
+
+	vars := ExtractGitHubWorkItem(eventData, []string{"main.go", "docs/guide.md"})
+	files, ok := vars["ChangedFiles"].([]string)
+	if !ok {
+		t.Fatal("ChangedFiles should be a []string in template vars")
+	}
+	if len(files) != 2 || files[0] != "main.go" || files[1] != "docs/guide.md" {
+		t.Errorf("ChangedFiles = %v, want [main.go docs/guide.md]", files)
+	}
+}
+
+// TestChangedFilesForSpawner locks in the order-independence contract: the
+// changed-file list on eventData is a delivery-scoped cache shared across
+// spawners, and must only be surfaced to a spawner that relies on it.
+func TestChangedFilesForSpawner(t *testing.T) {
+	// A populated cache simulates a list already fetched for an earlier spawner.
+	prEvent := &GitHubEventData{
+		Event:        "pull_request",
+		Action:       "opened",
+		ChangedFiles: []string{"main.go", "docs/guide.md"},
+	}
+	pushEvent := &GitHubEventData{
+		Event:        "push",
+		ChangedFiles: []string{"main.go"},
+	}
+
+	withFilePatterns := &kelos.GitHubWebhook{
+		Events: []string{"pull_request"},
+		Filters: []kelos.GitHubWebhookFilter{
+			{Event: "pull_request", FilePatterns: &kelos.FilePatterns{Include: []string{"**/*.go"}}},
+		},
+	}
+	withoutFilePatterns := &kelos.GitHubWebhook{
+		Events: []string{"pull_request"},
+		Filters: []kelos.GitHubWebhookFilter{
+			{Event: "pull_request", Action: "opened"},
+		},
+	}
+	pushSpawner := &kelos.GitHubWebhook{
+		Events:  []string{"push"},
+		Filters: []kelos.GitHubWebhookFilter{{Event: "push"}},
+	}
+
+	tests := []struct {
+		name      string
+		spawner   *kelos.GitHubWebhook
+		eventType string
+		eventData *GitHubEventData
+		want      []string
+	}{
+		{
+			name:      "PR spawner with filePatterns receives the files",
+			spawner:   withFilePatterns,
+			eventType: "pull_request",
+			eventData: prEvent,
+			want:      []string{"main.go", "docs/guide.md"},
+		},
+		{
+			name:      "PR spawner without filePatterns does not receive the leaked cache",
+			spawner:   withoutFilePatterns,
+			eventType: "pull_request",
+			eventData: prEvent,
+			want:      nil,
+		},
+		{
+			name:      "push spawner receives payload files regardless of filePatterns",
+			spawner:   pushSpawner,
+			eventType: "push",
+			eventData: pushEvent,
+			want:      []string{"main.go"},
+		},
+		{
+			name:      "nil spawner on a non-push event receives nothing",
+			spawner:   nil,
+			eventType: "pull_request",
+			eventData: prEvent,
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := changedFilesForSpawner(tt.spawner, tt.eventType, tt.eventData)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("changedFilesForSpawner() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -2033,7 +2134,7 @@ func TestExtractGitHubWorkItemCommentFields(t *testing.T) {
 		CommentURL:  "https://github.com/org/repo/pull/99#discussion_r456",
 	}
 
-	vars := ExtractGitHubWorkItem(eventData)
+	vars := ExtractGitHubWorkItem(eventData, nil)
 	if vars["CommentBody"] != "nit: rename this" {
 		t.Errorf("CommentBody = %v, want %q", vars["CommentBody"], "nit: rename this")
 	}
@@ -2047,7 +2148,7 @@ func TestExtractGitHubWorkItemNoCommentFields(t *testing.T) {
 		Event: "push",
 	}
 
-	vars := ExtractGitHubWorkItem(eventData)
+	vars := ExtractGitHubWorkItem(eventData, nil)
 	if _, ok := vars["CommentBody"]; ok {
 		t.Error("CommentBody should not be set for non-comment events")
 	}
@@ -2619,7 +2720,7 @@ func TestExtractGitHubWorkItem_CreateTagEvent(t *testing.T) {
 		RepositoryName:  "repo",
 	}
 
-	vars := ExtractGitHubWorkItem(eventData)
+	vars := ExtractGitHubWorkItem(eventData, nil)
 
 	if vars["Tag"] != "v1.0.0" {
 		t.Errorf("Tag = %v, want v1.0.0", vars["Tag"])
@@ -2650,7 +2751,7 @@ func TestExtractGitHubWorkItem_ReleaseEvent(t *testing.T) {
 		RepositoryName:  "repo",
 	}
 
-	vars := ExtractGitHubWorkItem(eventData)
+	vars := ExtractGitHubWorkItem(eventData, nil)
 
 	if vars["Tag"] != "v2.0.0" {
 		t.Errorf("Tag = %v, want v2.0.0", vars["Tag"])

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -563,7 +563,8 @@ func (h *WebhookHandler) createTask(ctx context.Context, spawner *kelos.TaskSpaw
 
 	switch h.source {
 	case GitHubSource:
-		templateVars = ExtractGitHubWorkItem(parsed.GitHub)
+		changedFiles := changedFilesForSpawner(spawner.Spec.When.GitHubWebhook, eventType, parsed.GitHub)
+		templateVars = ExtractGitHubWorkItem(parsed.GitHub, changedFiles)
 
 	case LinearSource:
 		templateVars = ExtractLinearWorkItem(parsed.Linear)
@@ -727,7 +728,8 @@ func (h *WebhookHandler) processSessionSpawner(ctx context.Context, spawner *kel
 		return false, nil
 	}
 
-	templateVars := ExtractGitHubWorkItem(eventData)
+	changedFiles := changedFilesForSpawner(githubWebhook, eventType, eventData)
+	templateVars := ExtractGitHubWorkItem(eventData, changedFiles)
 	sessionName := webhookSpawnName(spawner.Name, eventType, deliveryID)
 	gvks, _, gvkErr := h.client.Scheme().ObjectKinds(spawner)
 	if gvkErr != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Kelos already fetches a pull request's changed-file list for `filePatterns` filtering (`fetchPRChangedFilesWithToken` in `internal/webhook/github_files.go`) and then discards it once matching is done. This PR exposes that list to prompt templates as `{{.ChangedFiles}}` via `ExtractGitHubWorkItem`, so spawners can pass the set of touched files into the task prompt without an extra runtime `gh` call.

Details:
- `ChangedFiles` is **always** present in the template var map so `{{.ChangedFiles}}` never trips the renderer's `missingkey=error`.
- For PR events it is only populated when a matching filter's `filePatterns` forced the changed-files fetch (fetching is gated on `filePatterns`); otherwise it renders as an empty list.
- Push events populate `{{.ChangedFiles}}` from the payload regardless.
- Iterate with `{{range .ChangedFiles}}`.

This resolves the "deferred to a follow-up" NOTE previously left on the `ChangedFiles` field. Scope is intentionally limited to `.ChangedFiles` only — `.Diff` would require fetching per-file patch content (larger payloads, truncation concerns) and is left as a future change, consistent with keeping API surfaces minimal.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`{{.ChangedFiles}}` for PR events depends on `filePatterns` being set on the matching filter, because that is the only thing that triggers the lazy fetch. This coupling is documented in `docs/reference.md`. Adding a `.Diff` variable or fetching files when the prompt references `{{.ChangedFiles}}` without `filePatterns` are possible follow-ups.

#### Does this PR introduce a user-facing change?

```release-note
TaskSpawner/SessionSpawner GitHub webhook prompt templates can now reference `{{.ChangedFiles}}`, the list of changed file paths. It is populated for push events, and for pull request events when the matching filter declares `filePatterns`.
```