### PR TITLE
Use personal GitHub token for sessions

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -429,9 +429,10 @@ credentials, model, effort, Git identity, and `base-agent` AgentConfig as
 `kelos-workers`. It does not use the worker's resource requests and limits,
 allowing namespace resource defaults to apply.
 
-The Session requires the `base-agent` AgentConfig, `kelos-agent` Workspace, and
-`kelos-credentials` Secret described below. Its `10Gi` workspace persists
-across Pod replacement and is deleted with the Session.
+The Session requires the `base-agent` AgentConfig, `kelos-session-agent`
+Workspace, `personal-github-token` Secret, and `kelos-credentials` Secret
+described below. Its `10Gi` workspace persists across Pod replacement and is
+deleted with the Session.
 
 Add this directory to your `PATH` and run the script from any directory:
 
@@ -448,37 +449,42 @@ connect` command after creation.
 
 Before deploying these examples, you need to create the following resources:
 
-### 1. Workspace Resource
+### 1. Workspace Resources
 
-Create a Workspace that points to your repository:
+Tasks and TaskSpawners use the existing `kelos-agent`, `agora-agent`, and
+`kanon-agent` Workspaces. Configure those Workspaces with the GitHub App or
+other credentials intended for non-Session workloads.
+
+Sessions use dedicated Workspaces so they can authenticate with a personal
+token without changing Task credentials. Apply the checked-in Session
+Workspaces after creating the token Secret below:
+
+```bash
+kubectl apply -f self-development/session-workspaces.yaml
+```
+
+The Kelos Session Workspace is equivalent to:
 
 ```yaml
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: kelos-agent
+  name: kelos-session-agent
 spec:
-  repo: https://github.com/your-org/your-repo.git
+  repo: https://github.com/kelos-dev/kelos.git
   ref: main
   secretRef:
-    name: github-token  # For pushing branches and creating PRs
-  # Or use GitHub App authentication (recommended for production/org use):
-  # secretRef:
-  #   name: github-app-creds
-  # Create the GitHub App secret with:
-  #   kubectl create secret generic github-app-creds \
-  #     --from-literal=appID=12345 \
-  #     --from-literal=installationID=67890 \
-  #     --from-file=privateKey=my-app.private-key.pem
+    name: personal-github-token
 ```
 
-### 2. GitHub Token Secret
+### 2. Session GitHub Token Secret
 
-Create a secret with your GitHub token (needed for `gh` CLI and git authentication):
+Create the personal token Secret referenced only by the Session Workspaces:
 
 ```bash
-kubectl create secret generic github-token \
-  --from-literal=GITHUB_TOKEN=<your-github-token>
+kubectl create secret generic personal-github-token \
+  --from-literal=GITHUB_TOKEN="$(gh auth token)" \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
 The token needs these permissions:
@@ -659,7 +665,9 @@ spawners when those spawners include a matching bot-author filter.
 - Review task logs: `kubectl logs -l job-name=<job-name>`
 
 **Agent not creating PRs:**
-- Ensure the `github-token` secret exists and is referenced in the Workspace
+- For Sessions, ensure `personal-github-token` exists and the corresponding
+  `*-session-agent` Workspace references it
+- For Tasks, check the credentials referenced by the regular project Workspace
 - Verify the token has `repo` permissions
 - Check if git user is configured in the agent prompt (see `kelos-workers.yaml` for example)
 

--- a/self-development/agora/README.md
+++ b/self-development/agora/README.md
@@ -27,8 +27,9 @@ issues and PRs are treated as ongoing human or agent work and are not updated by
 autonomous discovery jobs. This cap does not apply to follow-up issues created
 while a worker or PR responder is handling an explicitly requested issue or PR.
 
-Eight spawners operate directly on the Agora repository through the
-`agora-agent` Workspace. The two meta-maintenance spawners
+The two SessionSpawners operate on the Agora repository through the
+`agora-session-agent` Workspace, which uses the personal Session token. Six
+TaskSpawners use the `agora-agent` Workspace. The two meta-maintenance spawners
 (`agora-config-update`, `agora-self-update`) are different: the files they
 maintain (`self-development/agora/*`) live in *this* repository, so they use the
 `kelos-agent` Workspace and the `kelos-dev-agent` role AgentConfig from
@@ -309,9 +310,15 @@ Before deploying them, set up the following.
 
 ### 1. Workspaces
 
-Two Workspaces are referenced:
+Three Workspaces are referenced:
 
-- **`agora-agent`** — points at the Agora repository (used by all spawners except the two meta-maintenance ones):
+- **`agora-session-agent`** — points at the Agora repository and is used only
+  by `agora-workers` and `agora-pr-responder`. It is defined in
+  [`session-workspaces.yaml`](../session-workspaces.yaml) and references the
+  `personal-github-token` Secret.
+
+- **`agora-agent`** — points at the Agora repository and is used by the six
+  TaskSpawners that operate directly on Agora:
 
   ```yaml
   apiVersion: kelos.dev/v1alpha2
@@ -360,18 +367,19 @@ done
 Unlike this repository, Agora's CI runs on every PR, so there is **no
 `ok-to-test` gate** and the spawners do not apply that label.
 
-### 3. GitHub Token Secret
+### 3. Session GitHub Token Secret
 
-Create a secret with a GitHub token that has write access to both
-`kelos-dev/agora` and `kelos-dev/kelos` (needed for the `gh` CLI and git
-authentication):
+Create the personal token Secret used by the Session-only Workspace. Task
+credentials remain configured through `agora-agent` and `kelos-agent`:
 
 ```bash
-kubectl create secret generic github-token \
-  --from-literal=GITHUB_TOKEN=<your-github-token>
+kubectl create secret generic personal-github-token \
+  --from-literal=GITHUB_TOKEN="$(gh auth token)" \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-The token needs `repo` (full control) and `workflow` (if your repo uses GitHub Actions).
+The token needs write access to `kelos-dev/agora` and `repo` plus `workflow`
+when using a classic personal access token.
 
 ### 4. GitHub Webhook Secret and Delivery
 
@@ -414,7 +422,7 @@ references.
 **Webhook spawner not creating work:**
 - For pick-up, check the SessionSpawner status: `kubectl get sessionspawner <name> -o yaml`
 - For other automation, check the TaskSpawner status: `kubectl get taskspawner <name> -o yaml`
-- Verify the Workspaces exist: `kubectl get workspace agora-agent kelos-agent`
+- Verify the Workspaces exist: `kubectl get workspace agora-session-agent agora-agent kelos-agent`
 - Ensure credentials are configured: `kubectl get secret kelos-credentials`
 - Ensure the GitHub webhook server is enabled and the `github-webhook-secret` exists
 - Review the `kelos-dev/agora` repository webhook's recent deliveries in GitHub

--- a/self-development/agora/agora-pr-responder.yaml
+++ b/self-development/agora/agora-pr-responder.yaml
@@ -33,7 +33,7 @@ spec:
           storage: 10Gi
     worker:
       workspaceRef:
-        name: agora-agent
+        name: agora-session-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex

--- a/self-development/agora/agora-workers.yaml
+++ b/self-development/agora/agora-workers.yaml
@@ -26,7 +26,7 @@ spec:
           storage: 10Gi
     worker:
       workspaceRef:
-        name: agora-agent
+        name: agora-session-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex

--- a/self-development/cs
+++ b/self-development/cs
@@ -35,7 +35,7 @@ spec:
     agentConfigRefs:
       - name: base-agent
     workspaceRef:
-      name: kelos-agent
+      name: kelos-session-agent
     model: gpt-5.6-sol
     effort: xhigh
     type: codex

--- a/self-development/kanon/README.md
+++ b/self-development/kanon/README.md
@@ -28,8 +28,9 @@ issues and PRs are treated as ongoing human or agent work and are not updated by
 autonomous discovery jobs. This cap does not apply to follow-up issues created
 while a worker or PR responder is handling an explicitly requested issue or PR.
 
-Eight spawners operate directly on the Kanon repository through the
-`kanon-agent` Workspace. The two meta-maintenance spawners
+The two SessionSpawners operate on the Kanon repository through the
+`kanon-session-agent` Workspace, which uses the personal Session token. Six
+TaskSpawners use the `kanon-agent` Workspace. The two meta-maintenance spawners
 (`kanon-config-update`, `kanon-self-update`) are different: the files they
 maintain (`self-development/kanon/*`) live in *this* repository, so they use the
 `kelos-agent` Workspace and the `kelos-dev-agent` role AgentConfig from
@@ -310,9 +311,15 @@ Before deploying them, set up the following.
 
 ### 1. Workspaces
 
-Two Workspaces are referenced:
+Three Workspaces are referenced:
 
-- **`kanon-agent`** — points at the Kanon repository (used by all spawners except the two meta-maintenance ones):
+- **`kanon-session-agent`** — points at the Kanon repository and is used only
+  by `kanon-workers` and `kanon-pr-responder`. It is defined in
+  [`session-workspaces.yaml`](../session-workspaces.yaml) and references the
+  `personal-github-token` Secret.
+
+- **`kanon-agent`** — points at the Kanon repository and is used by the six
+  TaskSpawners that operate directly on Kanon:
 
   ```yaml
   apiVersion: kelos.dev/v1alpha2
@@ -361,18 +368,19 @@ done
 Unlike this repository, Kanon's CI runs on every PR, so there is **no
 `ok-to-test` gate** and the spawners do not apply that label.
 
-### 3. GitHub Token Secret
+### 3. Session GitHub Token Secret
 
-Create a secret with a GitHub token that has write access to both
-`kelos-dev/kanon` and `kelos-dev/kelos` (needed for the `gh` CLI and git
-authentication):
+Create the personal token Secret used by the Session-only Workspace. Task
+credentials remain configured through `kanon-agent` and `kelos-agent`:
 
 ```bash
-kubectl create secret generic github-token \
-  --from-literal=GITHUB_TOKEN=<your-github-token>
+kubectl create secret generic personal-github-token \
+  --from-literal=GITHUB_TOKEN="$(gh auth token)" \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-The token needs `repo` (full control) and `workflow` (if your repo uses GitHub Actions).
+The token needs write access to `kelos-dev/kanon` and `repo` plus `workflow`
+when using a classic personal access token.
 
 ### 4. GitHub Webhook Secret and Delivery
 
@@ -415,7 +423,7 @@ references.
 **Webhook spawner not creating work:**
 - For pick-up, check the SessionSpawner status: `kubectl get sessionspawner <name> -o yaml`
 - For other automation, check the TaskSpawner status: `kubectl get taskspawner <name> -o yaml`
-- Verify the Workspaces exist: `kubectl get workspace kanon-agent kelos-agent`
+- Verify the Workspaces exist: `kubectl get workspace kanon-session-agent kanon-agent kelos-agent`
 - Ensure credentials are configured: `kubectl get secret kelos-credentials`
 - Ensure the GitHub webhook server is enabled and the `github-webhook-secret` exists
 - Review the `kelos-dev/kanon` repository webhook's recent deliveries in GitHub

--- a/self-development/kanon/kanon-pr-responder.yaml
+++ b/self-development/kanon/kanon-pr-responder.yaml
@@ -33,7 +33,7 @@ spec:
           storage: 10Gi
     worker:
       workspaceRef:
-        name: kanon-agent
+        name: kanon-session-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex

--- a/self-development/kanon/kanon-workers.yaml
+++ b/self-development/kanon/kanon-workers.yaml
@@ -26,7 +26,7 @@ spec:
           storage: 10Gi
     worker:
       workspaceRef:
-        name: kanon-agent
+        name: kanon-session-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -33,7 +33,7 @@ spec:
           storage: 10Gi
     worker:
       workspaceRef:
-        name: kelos-agent
+        name: kelos-session-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -89,7 +89,7 @@ spec:
           storage: 10Gi
     worker:
       workspaceRef:
-        name: kelos-agent
+        name: kelos-session-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex

--- a/self-development/session-workspaces.yaml
+++ b/self-development/session-workspaces.yaml
@@ -1,0 +1,29 @@
+apiVersion: kelos.dev/v1alpha2
+kind: Workspace
+metadata:
+  name: kelos-session-agent
+spec:
+  repo: https://github.com/kelos-dev/kelos.git
+  ref: main
+  secretRef:
+    name: personal-github-token
+---
+apiVersion: kelos.dev/v1alpha2
+kind: Workspace
+metadata:
+  name: agora-session-agent
+spec:
+  repo: https://github.com/kelos-dev/agora.git
+  ref: main
+  secretRef:
+    name: personal-github-token
+---
+apiVersion: kelos.dev/v1alpha2
+kind: Workspace
+metadata:
+  name: kanon-session-agent
+spec:
+  repo: https://github.com/kelos-dev/kanon.git
+  ref: main
+  secretRef:
+    name: personal-github-token


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds dedicated Session Workspaces for Kelos, Agora, and Kanon that reference the `personal-github-token` Secret.

Updates the interactive `cs` Session and all six self-development SessionSpawners to use those Workspaces. Task and TaskSpawner Workspace references remain unchanged, so their existing GitHub credentials are unaffected.

Updates the self-development documentation with the Session-only authentication setup and troubleshooting guidance.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- Kubernetes server-side dry run for the three Session Workspaces and six SessionSpawner manifests

The personal token value is stored only in a Kubernetes Secret and is not included in this repository.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Sessions to dedicated Workspaces that use a personal GitHub token, isolating Session auth from Task credentials. Adds `self-development/session-workspaces.yaml` and updates Kelos, Agora, Kanon manifests and docs; Task and TaskSpawner Workspaces stay the same.

- **Migration**
  - Create the Secret: `kubectl create secret generic personal-github-token --from-literal=GITHUB_TOKEN="$(gh auth token)" --dry-run=client -o yaml | kubectl apply -f -`
  - Apply Workspaces: `kubectl apply -f self-development/session-workspaces.yaml`

<sup>Written for commit c0669eda97ed9a854fda30fc3c63f6b74f512a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

