### PR TITLE
Preserve workspace repository usernames during authentication

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -543,12 +543,26 @@ The secret contains a single key:
 
 | Key | Description |
 |-----|-------------|
-| `GITHUB_TOKEN` | GitHub Personal Access Token for git auth and `gh` CLI |
+| `GITHUB_TOKEN` | Personal access token for HTTPS git authentication and the GitHub `gh` CLI |
 
 ```bash
 kubectl create secret generic github-token \
   --from-literal=GITHUB_TOKEN=<your-pat>
 ```
+
+For repositories that require a username with PAT authentication, include the
+username in `spec.repo` and store the PAT in the Secret's `GITHUB_TOKEN` key:
+
+```yaml
+spec:
+  repo: https://username@bitbucket.example/scm/team/repo.git
+  secretRef:
+    name: github-token
+```
+
+Kelos preserves a username included in the repository URL. When the URL omits
+the username, Kelos uses `x-access-token`, which is compatible with GitHub PATs
+and GitHub App installation tokens.
 
 **GitHub App (recommended for production/org use):**
 

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -108,6 +108,8 @@ const (
 	// GitHubTokenMountPath + "/" + GitHubTokenSecretKey.
 	GitHubTokenSecretKey = "GITHUB_TOKEN"
 
+	gitCredentialDefaultUsername = "x-access-token"
+
 	// AgentUID is the UID shared between the git-clone init
 	// container and the agent container. Custom agent images must run
 	// as this UID so that both containers can read and write the
@@ -561,16 +563,16 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 			initContainer.Args = []string{"--", workspace.Repo, targetPath, workspace.Ref}
 		} else if workspace.SecretRef != nil {
 			credentialHelper := gitCredentialHelper()
+			credentialConfig := workspaceGitCredentialConfigScript(credentialHelper)
 			// Clear inherited credential helpers with an empty -c credential.helper=
 			// before setting the workspace helper, then persist the same
 			// configuration into the repo so the agent container is
 			// independent from global/system helpers.
 			initContainer.Command = []string{"sh", "-c",
 				fmt.Sprintf(
-					`git -c credential.helper= -c credential.helper='%s' "$@" && { `+
-						`git -C %s/repo config --unset-all credential.helper 2>/dev/null || true; `+
-						`git -C %s/repo config --add credential.helper '%s'; }`,
-					credentialHelper, WorkspaceMountPath, WorkspaceMountPath, credentialHelper,
+					`git -c credential.helper= -c credential.helper='%s' -c credential.username=%s "$@" && { `+
+						`%s; }`,
+					credentialHelper, gitCredentialDefaultUsername, credentialConfig,
 				),
 			}
 			initContainer.Args = append([]string{"--"}, cloneArgs...)
@@ -609,7 +611,10 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 			remoteGit := "git"
 			if workspace.SecretRef != nil {
 				credHelper := gitCredentialHelper()
-				remoteGit = fmt.Sprintf(`git -c credential.helper= -c credential.helper='%s'`, credHelper)
+				remoteGit = fmt.Sprintf(
+					`git -c credential.helper= -c credential.helper='%s' -c credential.username=%s`,
+					credHelper, gitCredentialDefaultUsername,
+				)
 			}
 			branchSetupScript := fmt.Sprintf(
 				`set -e
@@ -1032,7 +1037,10 @@ func isFullGitCommitSHA(ref string) bool {
 func buildCommitRefCheckoutScript(credentialHelper string) string {
 	fetchCmd := `git -C "$target" fetch --depth 1 origin "$ref"`
 	if credentialHelper != "" {
-		fetchCmd = fmt.Sprintf(`git -C "$target" -c credential.helper= -c credential.helper='%s' fetch --depth 1 origin "$ref"`, credentialHelper)
+		fetchCmd = fmt.Sprintf(
+			`git -C "$target" -c credential.helper= -c credential.helper='%s' -c credential.username=%s fetch --depth 1 origin "$ref"`,
+			credentialHelper, gitCredentialDefaultUsername,
+		)
 	}
 
 	lines := []string{
@@ -1050,6 +1058,7 @@ func buildCommitRefCheckoutScript(credentialHelper string) string {
 		lines = append(lines,
 			`git -C "$target" config --unset-all credential.helper 2>/dev/null || true`,
 			fmt.Sprintf(`git -C "$target" config --add credential.helper '%s'`, credentialHelper),
+			fmt.Sprintf(`git -C "$target" config credential.username %s`, gitCredentialDefaultUsername),
 		)
 	}
 
@@ -1061,12 +1070,28 @@ func buildCommitRefCheckoutScript(credentialHelper string) string {
 // falling back to the inherited $GITHUB_TOKEN env var when the file is not
 // present. Reading the file each time lets git pick up controller-side
 // token refreshes (e.g. for GitHub App installation tokens that expire
-// in ~1h) without restarting the pod.
+// in ~1h) without restarting the pod. Git's credential.username configuration
+// supplies the default username separately so a username in the remote URL
+// takes precedence.
 func gitCredentialHelper() string {
 	tokenFile := GitHubTokenMountPath + "/" + GitHubTokenSecretKey
+	return gitCredentialHelperForTokenFile(tokenFile)
+}
+
+func gitCredentialHelperForTokenFile(tokenFile string) string {
 	return fmt.Sprintf(
-		`!f() { echo "username=x-access-token"; if [ -r %q ]; then echo "password=$(cat %q)"; else echo "password=$GITHUB_TOKEN"; fi; }; f`,
+		`!f() { if [ -r %q ]; then echo "password=$(cat %q)"; else echo "password=$GITHUB_TOKEN"; fi; }; f`,
 		tokenFile, tokenFile,
+	)
+}
+
+func workspaceGitCredentialConfigScript(credentialHelper string) string {
+	return fmt.Sprintf(
+		`git -C %s/repo config --unset-all credential.helper 2>/dev/null || true; `+
+			`git -C %s/repo config --add credential.helper '%s' && `+
+			`git -C %s/repo config credential.username %s`,
+		WorkspaceMountPath, WorkspaceMountPath, credentialHelper,
+		WorkspaceMountPath, gitCredentialDefaultUsername,
 	)
 }
 

--- a/internal/controller/job_builder_test.go
+++ b/internal/controller/job_builder_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -316,6 +319,8 @@ func TestBuildClaudeCodeJob_WorkspaceWithCommitRefFetchesDetached(t *testing.T) 
 		`checkout --detach FETCH_HEAD`,
 		"-c credential.helper= -c credential.helper=",
 		"--add credential.helper",
+		"-c credential.username=" + gitCredentialDefaultUsername,
+		"config credential.username " + gitCredentialDefaultUsername,
 	} {
 		if !strings.Contains(script, want) {
 			t.Errorf("Expected commit checkout script to contain %q, got %q", want, script)
@@ -736,6 +741,12 @@ func TestBuildClaudeCodeJob_WorkspaceWithSecretRefPersistsCredentialHelper(t *te
 	if !strings.Contains(script, "--add credential.helper") {
 		t.Error("Expected init container script to --add credential helper in repo config")
 	}
+	if !strings.Contains(script, "-c credential.username="+gitCredentialDefaultUsername) {
+		t.Error("Expected init container script to set the default credential username for clone")
+	}
+	if !strings.Contains(script, "config credential.username "+gitCredentialDefaultUsername) {
+		t.Error("Expected init container script to persist the default credential username")
+	}
 }
 
 func containsVolumeMount(mounts []corev1.VolumeMount, name, path string) bool {
@@ -942,6 +953,65 @@ func TestBuildClaudeCodeJob_CredentialHelperReadsFromTokenFile(t *testing.T) {
 	}
 }
 
+func TestGitCredentialHelperUsername(t *testing.T) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is not available")
+	}
+	tokenFile := filepath.Join(t.TempDir(), GitHubTokenSecretKey)
+
+	tests := []struct {
+		name               string
+		credentialIn       string
+		configuredUsername string
+		wantUsername       string
+	}{
+		{
+			name:         "preserves URL username",
+			credentialIn: "protocol=https\nhost=bitbucket.example\nusername=bitbucket-user\n\n",
+			wantUsername: "bitbucket-user",
+		},
+		{
+			name:         "defaults missing username",
+			credentialIn: "protocol=https\nhost=github.com\n\n",
+			wantUsername: gitCredentialDefaultUsername,
+		},
+		{
+			name:               "overrides configured username when URL omits it",
+			credentialIn:       "protocol=https\nhost=github.com\n\n",
+			configuredUsername: "configured-user",
+			wantUsername:       gitCredentialDefaultUsername,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{
+				"-c", "credential.helper=",
+			}
+			if tt.configuredUsername != "" {
+				args = append(args, "-c", "credential.username="+tt.configuredUsername)
+			}
+			args = append(args,
+				"-c", "credential.helper="+gitCredentialHelperForTokenFile(tokenFile),
+				"-c", "credential.username="+gitCredentialDefaultUsername,
+				"credential", "fill",
+			)
+			cmd := exec.Command(gitPath, args...)
+			cmd.Stdin = strings.NewReader(tt.credentialIn)
+			cmd.Env = append(os.Environ(), "GITHUB_TOKEN=test-token", "GIT_TERMINAL_PROMPT=0")
+
+			output, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("git credential fill failed: %v", err)
+			}
+			if want := "username=" + tt.wantUsername + "\n"; !strings.Contains(string(output), want) {
+				t.Errorf("git credential fill output missing %q", strings.TrimSpace(want))
+			}
+		})
+	}
+}
+
 func TestBuildClaudeCodeJob_EnterpriseWorkspaceSetsGHHostAndEnterpriseToken(t *testing.T) {
 	builder := NewJobBuilder()
 	task := &kelos.Task{
@@ -1021,7 +1091,7 @@ func TestBuildClaudeCodeJob_EnterpriseWorkspaceSetsGHHostAndEnterpriseToken(t *t
 	}
 }
 
-func TestBuildClaudeCodeJob_GithubComWorkspaceUsesGHToken(t *testing.T) {
+func TestBuildClaudeCodeJob_GithubComWorkspaceWithUsernameUsesGHToken(t *testing.T) {
 	builder := NewJobBuilder()
 	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1039,7 +1109,7 @@ func TestBuildClaudeCodeJob_GithubComWorkspaceUsesGHToken(t *testing.T) {
 	}
 
 	workspace := &kelos.WorkspaceSpec{
-		Repo: "https://github.com/my-org/my-repo.git",
+		Repo: "https://username@github.com/my-org/my-repo.git",
 		SecretRef: &kelos.SecretReference{
 			Name: "github-token",
 		},
@@ -3911,6 +3981,9 @@ func TestBuildJob_BranchSetupWithSecretRefUsesCredentialHelper(t *testing.T) {
 	if !strings.Contains(script, "-c credential.helper= -c credential.helper=") {
 		t.Error("Expected branch-setup script to clear inherited credential helpers before setting workspace helper")
 	}
+	if !strings.Contains(script, "-c credential.username="+gitCredentialDefaultUsername) {
+		t.Error("Expected branch-setup script to set the default credential username")
+	}
 
 	// Verify GITHUB_TOKEN env var is present on branch-setup.
 	var foundToken bool
@@ -5316,6 +5389,12 @@ func TestBuildJob_CredentialHelperClearsInheritedHelpers(t *testing.T) {
 	}
 	if !strings.Contains(script, "--add credential.helper") {
 		t.Error("Expected repo config to --add credential.helper")
+	}
+	if !strings.Contains(script, "-c credential.username="+gitCredentialDefaultUsername) {
+		t.Error("Expected clone to set the default credential username")
+	}
+	if !strings.Contains(script, "config credential.username "+gitCredentialDefaultUsername) {
+		t.Error("Expected repo config to persist the default credential username")
 	}
 }
 

--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -1474,7 +1474,11 @@ func (r *SessionReconciler) buildSessionStatefulSet(session *kelos.Session, work
 			WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
 		}
 	}
-	if err := prepareSessionWorkspaceInit(podSpec.InitContainers); err != nil {
+	credentialHelper := ""
+	if workspace != nil && workspace.SecretRef != nil {
+		credentialHelper = gitCredentialHelper()
+	}
+	if err := prepareSessionWorkspaceInit(podSpec.InitContainers, credentialHelper); err != nil {
 		return nil, nil, err
 	}
 
@@ -1593,12 +1597,19 @@ func sessionSelectorLabels(session *kelos.Session) map[string]string {
 	}
 }
 
-func prepareSessionWorkspaceInit(containers []corev1.Container) error {
+func prepareSessionWorkspaceInit(containers []corev1.Container, credentialHelper string) error {
 	for i := range containers {
 		container := &containers[i]
 		switch container.Name {
 		case "git-clone":
-			prefix := `if [ -f ` + sessionInitializedPath + ` ]; then exit 0; fi
+			initializedAction := "exit 0"
+			if credentialHelper != "" {
+				initializedAction = fmt.Sprintf(
+					`{ %s; } || exit $?; exit 0`,
+					workspaceGitCredentialConfigScript(credentialHelper),
+				)
+			}
+			prefix := `if [ -f ` + sessionInitializedPath + ` ]; then ` + initializedAction + `; fi
 rm -rf -- /workspace/repo
 `
 			if len(container.Command) == 0 {

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -1668,7 +1668,7 @@ func TestPrepareSessionWorkspaceInitPreservesCloneCommands(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			containers := []corev1.Container{tt.container}
-			if err := prepareSessionWorkspaceInit(containers); err != nil {
+			if err := prepareSessionWorkspaceInit(containers, ""); err != nil {
 				t.Fatal(err)
 			}
 			script := ""
@@ -1687,6 +1687,29 @@ func TestPrepareSessionWorkspaceInitPreservesCloneCommands(t *testing.T) {
 				t.Fatalf("prepared args = %#v, want suffix %#v", containers[0].Args, tt.wantArgs)
 			}
 		})
+	}
+}
+
+func TestPrepareSessionWorkspaceInitRefreshesCredentials(t *testing.T) {
+	credentialHelper := gitCredentialHelperForTokenFile("/test/GITHUB_TOKEN")
+	containers := []corev1.Container{{
+		Name:    "git-clone",
+		Command: []string{"sh", "-c", `git -c credential.helper= "$@"`},
+		Args:    []string{"--", "clone", "repo", "/workspace/repo"},
+	}}
+
+	if err := prepareSessionWorkspaceInit(containers, credentialHelper); err != nil {
+		t.Fatal(err)
+	}
+	script := containers[0].Command[2]
+	marker := strings.Index(script, sessionInitializedPath)
+	config := strings.Index(script, "config credential.username "+gitCredentialDefaultUsername)
+	exit := strings.Index(script, "exit 0")
+	if marker == -1 || config <= marker || exit <= config {
+		t.Fatalf("prepared command does not refresh credentials before exiting: %q", script)
+	}
+	if !strings.Contains(script, credentialHelper) {
+		t.Fatal("prepared command does not persist the credential helper")
 	}
 }
 

--- a/internal/controller/taskspawner_deployment_builder.go
+++ b/internal/controller/taskspawner_deployment_builder.go
@@ -323,7 +323,11 @@ func parseGitHubRepo(repoURL string) (host, owner, repo string) {
 	repoURL = strings.TrimSuffix(repoURL, ".git")
 
 	if m := httpsRepoRe.FindStringSubmatch(repoURL); len(m) == 4 {
-		return m[1], m[2], m[3]
+		host := m[1]
+		if parsed, err := url.Parse(repoURL); err == nil && parsed.Host != "" {
+			host = parsed.Host
+		}
+		return host, m[2], m[3]
 	}
 	if m := sshRepoRe.FindStringSubmatch(repoURL); len(m) == 4 {
 		return m[1], m[2], m[3]

--- a/internal/controller/taskspawner_deployment_builder_test.go
+++ b/internal/controller/taskspawner_deployment_builder_test.go
@@ -109,6 +109,13 @@ func TestParseGitHubRepo(t *testing.T) {
 			wantRepo:  "kelos",
 		},
 		{
+			name:      "github.com HTTPS with username",
+			repoURL:   "https://username@github.com/kelos-dev/kelos.git",
+			wantHost:  "github.com",
+			wantOwner: "kelos-dev",
+			wantRepo:  "kelos",
+		},
+		{
 			name:      "github.com SSH",
 			repoURL:   "git@github.com:kelos-dev/kelos.git",
 			wantHost:  "github.com",

--- a/internal/controller/workerpool_controller.go
+++ b/internal/controller/workerpool_controller.go
@@ -749,29 +749,34 @@ func (r *WorkerPoolReconciler) buildStatefulSet(pool *kelos.WorkerPool, stsName,
 			},
 		}
 
+		credentialHelper := ""
+		credentialConfig := ""
+		if workspace.SecretRef != nil {
+			credentialHelper = gitCredentialHelper()
+			credentialConfig = workspaceGitCredentialConfigScript(credentialHelper)
+		}
+
 		if commitRef {
-			credentialHelper := ""
-			if workspace.SecretRef != nil {
-				credentialHelper = gitCredentialHelper()
+			existingRepoAction := "exit 0"
+			if credentialConfig != "" {
+				existingRepoAction = fmt.Sprintf(`{ %s; } || exit $?; exit 0`, credentialConfig)
 			}
 			gitClone.Command = []string{"sh", "-c",
-				fmt.Sprintf("if [ -d '%s/repo/.git' ]; then echo 'Workspace exists, skipping clone'; exit 0; fi; %s",
-					WorkspaceMountPath, buildCommitRefCheckoutScript(credentialHelper)),
+				fmt.Sprintf("if [ -d '%s/repo/.git' ]; then echo 'Workspace exists, skipping clone'; %s; fi; %s",
+					WorkspaceMountPath, existingRepoAction, buildCommitRefCheckoutScript(credentialHelper)),
 			}
 			gitClone.Args = []string{"--", workspace.Repo, targetPath, workspace.Ref}
 		} else if workspace.SecretRef != nil {
-			credentialHelper := gitCredentialHelper()
 			// Build the inner clone command with credential helper
 			innerCmd := fmt.Sprintf(
-				`git -c credential.helper= -c credential.helper='%s' "$@" && { `+
-					`git -C %s/repo config --unset-all credential.helper 2>/dev/null || true; `+
-					`git -C %s/repo config --add credential.helper '%s'; }`,
-				credentialHelper, WorkspaceMountPath, WorkspaceMountPath, credentialHelper,
+				`git -c credential.helper= -c credential.helper='%s' -c credential.username=%s "$@" && { `+
+					`%s; }`,
+				credentialHelper, gitCredentialDefaultUsername, credentialConfig,
 			)
 			// Wrap with exists check so it skips if workspace already exists on PVC
 			gitClone.Command = []string{"sh", "-c",
-				fmt.Sprintf("if [ -d '%s/repo/.git' ]; then echo 'Workspace exists, skipping clone'; exit 0; fi; %s",
-					WorkspaceMountPath, innerCmd),
+				fmt.Sprintf("if [ -d '%s/repo/.git' ]; then echo 'Workspace exists, skipping clone'; { %s; } || exit $?; exit 0; fi; %s",
+					WorkspaceMountPath, credentialConfig, innerCmd),
 			}
 			gitClone.Args = append([]string{"--"}, cloneArgs...)
 		} else {

--- a/internal/controller/workerpool_controller_test.go
+++ b/internal/controller/workerpool_controller_test.go
@@ -245,6 +245,57 @@ func TestWorkerPoolReconciler_CommitRefWorkspaceUsesCheckoutScript(t *testing.T)
 	}
 }
 
+func TestWorkerPoolReconciler_ExistingWorkspaceRefreshesCredentialConfig(t *testing.T) {
+	refs := map[string]string{
+		"branch": "main",
+		"commit": "0123456789abcdef0123456789abcdef01234567",
+	}
+	for name, ref := range refs {
+		t.Run(name, func(t *testing.T) {
+			scheme := newWorkerPoolTestScheme()
+			pool := newTestWorkerPool("my-pool", "default", 1)
+			ws := newTestWorkspace("default")
+			ws.Spec.Ref = ref
+			ws.Spec.SecretRef = &kelos.SecretReference{Name: "github-token"}
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "github-token", Namespace: "default"},
+				StringData: map[string]string{GitHubTokenSecretKey: "test-token"},
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&kelos.WorkerPool{}).
+				WithObjects(pool, ws, secret).
+				Build()
+			r := newWorkerPoolReconciler(cl, scheme)
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "my-pool", Namespace: "default"},
+			})
+			require.NoError(t, err)
+
+			var sts appsv1.StatefulSet
+			require.NoError(t, cl.Get(context.Background(), types.NamespacedName{
+				Name: "wp-my-pool", Namespace: "default",
+			}, &sts))
+			var script string
+			for _, container := range sts.Spec.Template.Spec.InitContainers {
+				if container.Name == "git-clone" {
+					require.Len(t, container.Command, 3)
+					script = container.Command[2]
+					break
+				}
+			}
+			require.NotEmpty(t, script)
+			config := strings.Index(script, "config credential.username "+gitCredentialDefaultUsername)
+			exit := strings.Index(script, "exit 0")
+			if config == -1 || exit <= config {
+				t.Fatalf("git-clone command does not refresh credentials before exiting: %q", script)
+			}
+		})
+	}
+}
+
 func TestWorkerPoolReconciler_RejectsExtraContainerInitContainerNameCollision(t *testing.T) {
 	scheme := newWorkerPoolTestScheme()
 	pool := newTestWorkerPool("my-pool", "default", 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Preserves usernames supplied in Workspace repository URLs when the Git credential helper provides a token password. Repository URLs without a username continue to default to `x-access-token` for GitHub authentication.

The credential configuration is persisted after clone and refreshed for existing WorkerPool and Session workspaces. GitHub repository parsing also ignores URL userinfo when deriving `GH_HOST`.

#### Which issue(s) this PR is related to:

Fixes #1571

#### Special notes for your reviewer:

Tests exercise Git credential resolution without printing token values, cover explicit and default usernames, verify persistent-workspace credential migration, and check GitHub URLs containing userinfo.

#### Does this PR introduce a user-facing change?

```release-note
Workspace Git authentication now preserves usernames embedded in repository URLs, enabling PAT authentication with servers such as Bitbucket Server.
```