### PR TITLE
Show sessions waiting for input

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -225,7 +225,7 @@ the Session resource and is visible through the Kubernetes API.
 | `status.lastActivityTime` | When runtime activity was first reported or last changed; Pod replacement does not change it | Output |
 | `status.model` | Model reported by the live Session runtime; empty when the runtime does not report a model | Output |
 | `status.conditions[type=Ready]` | Whether the Session infrastructure is ready for clients | Output |
-| `status.conditions[type=Active]` | Whether the runtime has an unfinished turn; `Unknown` means activity has not been reported | Output |
+| `status.conditions[type=Active]` | Whether the runtime has an unfinished turn; `reason: WaitingForInput` means the turn is waiting for a user response, and `Unknown` means activity has not been reported | Output |
 | `status.branch` | Currently checked-out git branch in the Session workspace | Output |
 | `status.pullRequest.url` | Web URL of the pull request associated with the current branch | Output |
 | `status.pullRequest.state` | Pull request lifecycle state: `Draft`, `Open`, `Merged`, or `Closed` | Output |
@@ -268,7 +268,9 @@ The Session sidebar shows compact relative activity times, and the selected
 Session header shows whether it is active now, when it was last active, or when
 it was created if runtime activity has not been reported. Hover over the
 timestamp to see the exact time in the browser's locale and time zone; the
-exact value is also available to assistive technology.
+exact value is also available to assistive technology. A Session waiting for a
+user response is labeled **Waiting for input** in the sidebar and header, with a
+distinct red indicator in the sidebar.
 
 Sessions can be categorized into sections from the creation form or from the
 section control beneath the selected Session's name. Both controls list the
@@ -318,14 +320,16 @@ StatefulSet is updated and use the updated template when resumed. Changes to
 runtime image also follow it when a Kelos upgrade changes that image; an
 explicitly tagged or digested runtime image remains pinned.
 
-`Active=True` means the runtime has an unfinished turn, including a turn waiting
-for user input; `Active=False` means it is idle. Activity becomes `Unknown` when
+`Active=True` means the runtime has an unfinished turn. Its reason is
+`WaitingForInput` when the turn needs a user response and `TurnActive` while the
+agent is working. `Active=False` means it is idle. Activity becomes `Unknown` when
 it cannot be reported, such as while the Session Pod is being replaced. Clients
-should use condition type and status as the contract; condition reasons and
-messages are informational. The shared web client orders Sessions by recent
-activity, newest first, using `status.lastActivityTime`. Creation counts as the
-initial activity until the runtime first reports its activity state. Replacing a
-Session Pod does not change the order. The web client shows activity,
+can use the `WaitingForInput` reason to highlight turns that need a response;
+other condition reasons and messages are informational. The shared web client
+orders Sessions by recent activity, newest first, using
+`status.lastActivityTime`. Creation counts as the initial activity until the
+runtime first reports its activity state. Replacing a Session Pod does not
+change the order. The web client shows activity,
 `status.model`, `status.branch`, and the pull request with a colored,
 text-labeled state in both the Session sidebar and conversation header.
 

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -60,6 +60,7 @@ type turnRequest struct {
 
 type sessionStatusPublishRequest struct {
 	active                       bool
+	waitingForInput              bool
 	refreshWorkspaceAfterPublish bool
 	// settledTurnID is the completed-turn high-water mark captured when this
 	// request was enqueued. It becomes the persisted activity mark only after an
@@ -107,6 +108,7 @@ type Server struct {
 	updateReport       chan struct{}
 	activeMu           sync.Mutex
 	activeTurn         string
+	pendingInputCount  atomic.Int64
 
 	runtimeStatusMu             sync.RWMutex
 	runtimeStatus               RuntimeStatus
@@ -117,7 +119,7 @@ type Server struct {
 	pendingInputs                map[string]*pendingInput
 	nextInputID                  atomic.Int64
 	refreshWorkspaceStatus       func(context.Context) error
-	publishSessionStatus         func(context.Context, bool) error
+	publishSessionStatus         func(context.Context, bool, bool) error
 	workspaceStatusRefreshes     chan struct{}
 	sessionStatusMu              sync.Mutex
 	sessionStatusPublishQueue    []sessionStatusPublishRequest
@@ -198,9 +200,9 @@ func Run(ctx context.Context, config Config) error {
 		return err
 	}
 	server := NewServer(config, journal, provider)
-	publishSessionStatus := func(ctx context.Context, active bool) error {
+	publishSessionStatus := func(ctx context.Context, active, waitingForInput bool) error {
 		model := server.runtimeStatusSnapshot().Model
-		return publishObservedSessionStatus(ctx, config.PublishSessionStatus, active, model, func(ctx context.Context) (WorkspaceStatus, error) {
+		return publishObservedSessionStatus(ctx, config.PublishSessionStatus, active, waitingForInput, model, func(ctx context.Context) (WorkspaceStatus, error) {
 			return readWorkspaceStatus(ctx, realWorkspaceStatusRunner{}, config.StateDir, config.WorkingDir)
 		})
 	}
@@ -238,9 +240,9 @@ func Run(ctx context.Context, config Config) error {
 	return server.Serve(ctx)
 }
 
-func publishObservedSessionStatus(ctx context.Context, publisher SessionStatusPublisher, active bool, model string, readStatus func(context.Context) (WorkspaceStatus, error)) error {
+func publishObservedSessionStatus(ctx context.Context, publisher SessionStatusPublisher, active, waitingForInput bool, model string, readStatus func(context.Context) (WorkspaceStatus, error)) error {
 	workspaceStatus, readErr := readStatus(ctx)
-	status := ObservedSessionStatus{Active: active, Model: model}
+	status := ObservedSessionStatus{Active: active, WaitingForInput: waitingForInput, Model: model}
 	if readErr == nil {
 		status.WorkspaceStatus = &workspaceStatus
 	} else {
@@ -435,12 +437,16 @@ func (s *Server) queueSessionStatusPublish(force, refreshWorkspaceAfterPublish b
 	}
 	s.activeMu.Lock()
 	active := s.activeTurn != ""
+	waitingForInput := s.pendingInputCount.Load() > 0
 	settledTurnID := s.completedTurnID.Load()
 	s.sessionStatusMu.Lock()
-	queued := force || len(s.sessionStatusPublishQueue) == 0 || s.sessionStatusPublishQueue[len(s.sessionStatusPublishQueue)-1].active != active
+	queued := force || len(s.sessionStatusPublishQueue) == 0 ||
+		s.sessionStatusPublishQueue[len(s.sessionStatusPublishQueue)-1].active != active ||
+		s.sessionStatusPublishQueue[len(s.sessionStatusPublishQueue)-1].waitingForInput != waitingForInput
 	if queued {
 		s.sessionStatusPublishQueue = append(s.sessionStatusPublishQueue, sessionStatusPublishRequest{
 			active:                       active,
+			waitingForInput:              waitingForInput,
 			refreshWorkspaceAfterPublish: refreshWorkspaceAfterPublish,
 			settledTurnID:                settledTurnID,
 		})
@@ -609,7 +615,7 @@ func (s *Server) runSessionStatusPublishes(ctx context.Context) {
 			}
 		}
 		next := s.sessionStatusPublishInterval
-		err := s.publishSessionStatus(ctx, request.active)
+		err := s.publishSessionStatus(ctx, request.active, request.waitingForInput)
 		if err != nil {
 			log.Printf("Unable to publish Session runtime status error=%v", err)
 			next = s.sessionStatusRetryInterval
@@ -1045,10 +1051,14 @@ func (s *turnSink) RequestInput(ctx context.Context, request InputRequest) (map[
 	}
 	s.server.pendingInputs[request.ID] = pending
 	s.server.inputMu.Unlock()
+	s.server.pendingInputCount.Add(1)
+	s.server.requestSessionStatusPublish()
 	defer func() {
 		s.server.inputMu.Lock()
 		delete(s.server.pendingInputs, request.ID)
 		s.server.inputMu.Unlock()
+		s.server.pendingInputCount.Add(-1)
+		s.server.requestSessionStatusPublish()
 	}()
 
 	s.Emit(Event{

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -189,7 +189,7 @@ func TestServerQueuesStatusPublicationAfterWorkspaceRefresh(t *testing.T) {
 		close(refreshed)
 		return nil
 	}
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go server.runWorkspaceStatusRefreshes(ctx)
@@ -233,6 +233,7 @@ func TestPublishObservedSessionStatusPublishesActivityWhenWorkspaceReadFails(t *
 			return nil
 		},
 		true,
+		true,
 		"gpt-5.6-sol",
 		func(context.Context) (WorkspaceStatus, error) {
 			return WorkspaceStatus{}, readErr
@@ -241,7 +242,7 @@ func TestPublishObservedSessionStatusPublishesActivityWhenWorkspaceReadFails(t *
 	if err != nil {
 		t.Fatalf("publishObservedSessionStatus() error = %v, want nil so the drain can advance", err)
 	}
-	if !got.Active || got.Model != "gpt-5.6-sol" || got.WorkspaceStatus != nil {
+	if !got.Active || !got.WaitingForInput || got.Model != "gpt-5.6-sol" || got.WorkspaceStatus != nil {
 		t.Fatalf("published Session status = %#v, want active model with unobserved workspace", got)
 	}
 }
@@ -252,6 +253,7 @@ func TestPublishObservedSessionStatusReturnsPublisherError(t *testing.T) {
 		context.Background(),
 		func(context.Context, ObservedSessionStatus) error { return publishErr },
 		true,
+		false,
 		"gpt-5.6-sol",
 		func(context.Context) (WorkspaceStatus, error) { return WorkspaceStatus{}, nil },
 	)
@@ -268,7 +270,7 @@ func TestServerRetriesSessionStatusPublicationInOrder(t *testing.T) {
 	server.sessionStatusPublishInterval = time.Hour
 	attempts := 0
 	activity := make(chan bool, 3)
-	server.publishSessionStatus = func(_ context.Context, active bool) error {
+	server.publishSessionStatus = func(_ context.Context, active, _ bool) error {
 		attempts++
 		activity <- active
 		if attempts == 1 {
@@ -292,7 +294,7 @@ func TestServerRefreshesWorkspaceStatusAfterPeriodicPublication(t *testing.T) {
 	server := NewServer(Config{}, journal, &fakeProvider{})
 	server.sessionStatusRetryInterval = time.Hour
 	server.sessionStatusPublishInterval = 10 * time.Millisecond
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 	server.refreshWorkspaceStatus = func(context.Context) error { return nil }
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -312,7 +314,7 @@ func TestRunTurnPublishesActivityTransitions(t *testing.T) {
 	server := NewServer(Config{}, journal, provider)
 	server.sessionStatusPublishInterval = time.Hour
 	activity := make(chan bool, 2)
-	server.publishSessionStatus = func(_ context.Context, active bool) error {
+	server.publishSessionStatus = func(_ context.Context, active, _ bool) error {
 		activity <- active
 		return nil
 	}
@@ -341,7 +343,7 @@ func TestRunTurnPreservesShortActivityTransitions(t *testing.T) {
 	server := NewServer(Config{}, journal, &fakeProvider{})
 	server.sessionStatusPublishInterval = time.Hour
 	activity := make(chan bool, 2)
-	server.publishSessionStatus = func(_ context.Context, active bool) error {
+	server.publishSessionStatus = func(_ context.Context, active, _ bool) error {
 		activity <- active
 		return nil
 	}
@@ -353,6 +355,71 @@ func TestRunTurnPreservesShortActivityTransitions(t *testing.T) {
 
 	assertActivity(t, activity, true)
 	assertActivity(t, activity, false)
+}
+
+func TestRequestInputPublishesWaitingForInputTransitions(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	server := NewServer(Config{}, journal, &fakeProvider{})
+	server.sessionStatusPublishInterval = time.Hour
+	type publishedStatus struct {
+		active          bool
+		waitingForInput bool
+	}
+	statuses := make(chan publishedStatus, 2)
+	server.publishSessionStatus = func(_ context.Context, active, waitingForInput bool) error {
+		statuses <- publishedStatus{active: active, waitingForInput: waitingForInput}
+		return nil
+	}
+	server.activeMu.Lock()
+	server.activeTurn = "turn-1"
+	server.activeMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go server.runSessionStatusPublishes(ctx)
+
+	type inputResult struct {
+		answers map[string][]string
+		err     error
+	}
+	result := make(chan inputResult, 1)
+	go func() {
+		answers, err := (&turnSink{server: server, turnID: "turn-1"}).RequestInput(ctx, InputRequest{
+			ID: "claude-request-1",
+			Questions: []InputQuestion{{
+				ID:       "question-1",
+				Question: "Which database?",
+			}},
+		})
+		result <- inputResult{answers: answers, err: err}
+	}()
+
+	assertStatus := func(want publishedStatus) {
+		t.Helper()
+		select {
+		case got := <-statuses:
+			if got != want {
+				t.Fatalf("published Session status = %#v, want %#v", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("Session status %#v was not published", want)
+		}
+	}
+	assertStatus(publishedStatus{active: true, waitingForInput: true})
+
+	if err := server.resolveInput("claude-request-1", map[string][]string{"question-1": {"PostgreSQL"}}, false, "response-1"); err != nil {
+		t.Fatal(err)
+	}
+	assertStatus(publishedStatus{active: true, waitingForInput: false})
+	select {
+	case got := <-result:
+		if got.err != nil || !reflect.DeepEqual(got.answers, map[string][]string{"question-1": {"PostgreSQL"}}) {
+			t.Fatalf("input result = %#v, want PostgreSQL answer", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("input request did not finish")
+	}
 }
 
 func assertActivity(t *testing.T, activity <-chan bool, want bool) {
@@ -1028,7 +1095,7 @@ func TestServerWithholdsIdleDrainUntilActivityPublished(t *testing.T) {
 	server := NewServer(Config{PodUID: podUID}, journal, &fakeProvider{})
 	// A configured status publisher means activity transitions must be durably
 	// published before the runtime reports Drained.
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 
 	if err := server.submitMessage("first", "request-first"); err != nil {
 		t.Fatal(err)
@@ -1090,7 +1157,7 @@ func TestServerWithholdsIdleDrainAfterRecoveringInterruptedWork(t *testing.T) {
 	server := NewServer(Config{PodUID: podUID}, journal, &fakeProvider{})
 	// A configured status publisher means recovered activity must be durably
 	// published before the runtime reports Drained.
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 	server.seedRecoveredActivityPublish()
 
 	request := sessionupdate.NewRequest(podUID, "idle-period")
@@ -1156,7 +1223,7 @@ func TestServerWithholdsIdleDrainForUnpublishedCompletedTurn(t *testing.T) {
 
 	podUID := types.UID("pod-uid")
 	server := NewServer(Config{PodUID: podUID}, journal, &fakeProvider{})
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 	server.nextTurnID.Store(recovery.nextTurnID)
 	server.seedRecoveredActivityPublish()
 
@@ -1228,7 +1295,7 @@ func TestServerDoesNotSettleLaterTurnFromStaleIdlePublication(t *testing.T) {
 
 	// Turns 1-5 are complete and a periodic idle publication was enqueued then.
 	server.completedTurnID.Store(5)
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 	server.requestPeriodicSessionStatusPublish()
 	stale, ok := server.nextSessionStatusPublish()
 	if !ok || stale.active || stale.settledTurnID != 5 {
@@ -1269,7 +1336,7 @@ func TestServerRuntimeUpdateDrainIgnoresPendingPublishes(t *testing.T) {
 	defer journal.Close()
 	podUID := types.UID("pod-uid")
 	server := NewServer(Config{PodUID: podUID}, journal, &fakeProvider{})
-	server.publishSessionStatus = func(context.Context, bool) error { return nil }
+	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 
 	request := sessionupdate.NewRequest(podUID, "desired-revision")
 	encoded, err := sessionupdate.Encode(request)

--- a/internal/sessionruntime/session_status_publisher.go
+++ b/internal/sessionruntime/session_status_publisher.go
@@ -15,8 +15,9 @@ import (
 
 // ObservedSessionStatus contains the status fields owned by one Session runtime.
 type ObservedSessionStatus struct {
-	Active bool
-	Model  string
+	Active          bool
+	WaitingForInput bool
+	Model           string
 	// WorkspaceStatus is omitted when the runtime cannot inspect the workspace.
 	WorkspaceStatus *WorkspaceStatus
 }
@@ -47,6 +48,10 @@ func NewSessionStatusPublisher(client clientv1alpha2.SessionInterface, sessionNa
 			conditionStatus = metav1.ConditionTrue
 			reason = "TurnActive"
 			message = "Session runtime has an unfinished turn"
+			if status.WaitingForInput {
+				reason = "WaitingForInput"
+				message = "Session runtime is waiting for user input"
+			}
 		}
 		previousActive := apiMeta.FindStatusCondition(session.Status.Conditions, kelos.SessionConditionActive)
 		conditions := append([]metav1.Condition(nil), session.Status.Conditions...)

--- a/internal/sessionruntime/session_status_publisher_test.go
+++ b/internal/sessionruntime/session_status_publisher_test.go
@@ -63,7 +63,21 @@ func TestSessionStatusPublisherPatchesLiveSession(t *testing.T) {
 		t.Fatalf("Session lastActivityTime was not initialized: %#v", got.Status)
 	}
 
+	want.WaitingForInput = true
+	if err := publisher(context.Background(), want); err != nil {
+		t.Fatal(err)
+	}
+	got, err = clientset.ApiV1alpha2().Sessions("default").Get(context.Background(), sessionName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	active = apiMeta.FindStatusCondition(got.Status.Conditions, kelos.SessionConditionActive)
+	if active == nil || active.Status != metav1.ConditionTrue || active.Reason != "WaitingForInput" {
+		t.Fatalf("Session Active condition = %#v, want True with reason WaitingForInput", active)
+	}
+
 	want.Active = false
+	want.WaitingForInput = false
 	if err := publisher(context.Background(), want); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -96,20 +96,21 @@ func (c *sessionSocket) WriteMessage(messageType int, data []byte) error {
 }
 
 type sessionSummary struct {
-	Name           string                    `json:"name"`
-	Namespace      string                    `json:"namespace"`
-	UID            string                    `json:"uid,omitempty"`
-	Provider       string                    `json:"provider"`
-	Model          string                    `json:"model,omitempty"`
-	Phase          kelos.SessionPhase        `json:"phase,omitempty"`
-	Active         *bool                     `json:"active,omitempty"`
-	CreatedAt      *metav1.Time              `json:"createdAt,omitempty"`
-	LastActivityAt *metav1.Time              `json:"lastActivityAt,omitempty"`
-	Message        string                    `json:"message,omitempty"`
-	Branch         string                    `json:"branch,omitempty"`
-	PullRequest    *kelos.SessionPullRequest `json:"pullRequest,omitempty"`
-	Section        string                    `json:"section,omitempty"`
-	Resetting      bool                      `json:"resetting,omitempty"`
+	Name            string                    `json:"name"`
+	Namespace       string                    `json:"namespace"`
+	UID             string                    `json:"uid,omitempty"`
+	Provider        string                    `json:"provider"`
+	Model           string                    `json:"model,omitempty"`
+	Phase           kelos.SessionPhase        `json:"phase,omitempty"`
+	Active          *bool                     `json:"active,omitempty"`
+	WaitingForInput bool                      `json:"waitingForInput,omitempty"`
+	CreatedAt       *metav1.Time              `json:"createdAt,omitempty"`
+	LastActivityAt  *metav1.Time              `json:"lastActivityAt,omitempty"`
+	Message         string                    `json:"message,omitempty"`
+	Branch          string                    `json:"branch,omitempty"`
+	PullRequest     *kelos.SessionPullRequest `json:"pullRequest,omitempty"`
+	Section         string                    `json:"section,omitempty"`
+	Resetting       bool                      `json:"resetting,omitempty"`
 }
 
 type sessionOptions struct {
@@ -689,6 +690,7 @@ func summarize(session *kelos.Session) sessionSummary {
 	if condition := sessionActiveCondition(session); condition != nil && condition.Status != metav1.ConditionUnknown {
 		active := condition.Status == metav1.ConditionTrue
 		summary.Active = &active
+		summary.WaitingForInput = active && condition.Reason == "WaitingForInput"
 	}
 	return summary
 }

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -806,7 +806,7 @@ func TestSummarizeIncludesRuntimeStatus(t *testing.T) {
 			Conditions: []metav1.Condition{{
 				Type:   kelos.SessionConditionActive,
 				Status: metav1.ConditionTrue,
-				Reason: "TurnActive",
+				Reason: "WaitingForInput",
 			}},
 			PullRequest: &kelos.SessionPullRequest{
 				URL:   "https://github.com/kelos-dev/kelos/pull/42",
@@ -816,7 +816,7 @@ func TestSummarizeIncludesRuntimeStatus(t *testing.T) {
 	}
 
 	summary := summarize(session)
-	if summary.Active == nil || !*summary.Active || summary.Model != session.Status.Model || summary.Branch != session.Status.Branch || summary.PullRequest == nil || *summary.PullRequest != *session.Status.PullRequest || summary.Section != "Reviews" {
+	if summary.Active == nil || !*summary.Active || !summary.WaitingForInput || summary.Model != session.Status.Model || summary.Branch != session.Status.Branch || summary.PullRequest == nil || *summary.PullRequest != *session.Status.PullRequest || summary.Section != "Reviews" {
 		t.Fatalf("summarize() = %#v", summary)
 	}
 	if summary.CreatedAt == nil || !summary.CreatedAt.Equal(&createdAt) {
@@ -831,6 +831,9 @@ func TestSummarizeIncludesRuntimeStatus(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"model":"gpt-5.6-sol"`) {
 		t.Fatalf("Session summary JSON = %s, want runtime model", data)
+	}
+	if !strings.Contains(string(data), `"waitingForInput":true`) {
+		t.Fatalf("Session summary JSON = %s, want waiting-for-input state", data)
 	}
 }
 
@@ -914,6 +917,7 @@ func TestSessionViewsIncludeRuntimeStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 	for description, expected := range map[string]string{
+		"waiting display status":     `if (session.waitingForInput) return 'Waiting for input';`,
 		"active display status":      `if (session.active === true) return 'Active';`,
 		"idle display status":        `if (session.active === false) return 'Idle';`,
 		"activity status in sidebar": "activity.textContent = `· ${displayStatus}`;",
@@ -943,8 +947,9 @@ func TestSessionViewsIncludeRuntimeStatus(t *testing.T) {
 		t.Error("Session sidebar does not style branch information")
 	}
 	for state, expected := range map[string]string{
-		"idle":   `.phase-dot.ready, .phase-dot.idle {`,
-		"active": `.phase-dot.active {`,
+		"idle":              `.phase-dot.ready, .phase-dot.idle {`,
+		"active":            `.phase-dot.active {`,
+		"waiting for input": `.phase-dot.waiting-for-input {`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session views do not style %s activity", state)

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -378,6 +378,7 @@ function providerInitials(provider) {
 function sessionDisplayStatus(session) {
   if (session.resetting) return 'Resetting';
   if (session.phase !== 'Ready') return session.phase || 'Pending';
+  if (session.waitingForInput) return 'Waiting for input';
   if (session.active === true) return 'Active';
   if (session.active === false) return 'Idle';
   return session.phase;
@@ -556,7 +557,7 @@ function createSessionListItem(session, draggable = false) {
   button.type = 'button';
   const dot = document.createElement('span');
   const displayStatus = sessionDisplayStatus(session);
-  dot.className = `phase-dot ${String(displayStatus).toLowerCase()}`;
+  dot.className = `phase-dot ${String(displayStatus).toLowerCase().replaceAll(' ', '-')}`;
   const text = document.createElement('span');
   const titleRow = document.createElement('div');
   titleRow.className = 'session-item-title-row';

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -77,6 +77,7 @@ button { color: inherit; }
 .phase-dot { width: 7px; height: 7px; margin-top: 5px; border-radius: 50%; background: #9ca69f; }
 .phase-dot.ready, .phase-dot.idle { background: #4b9a6f; box-shadow: 0 0 0 3px rgba(75,154,111,.12); }
 .phase-dot.active { background: #c68a3d; box-shadow: 0 0 0 3px rgba(198,138,61,.14); }
+.phase-dot.waiting-for-input { background: var(--danger); box-shadow: 0 0 0 3px rgba(167,63,63,.14); }
 .phase-dot.failed { background: #c55b5b; }
 .session-item-title-row { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: baseline; gap: 8px; }
 .session-item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 680; }

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -178,6 +178,7 @@ var _ = Describe("Session remote control", func() {
 		})
 		Expect(input.Questions).To(HaveLen(1))
 		Expect(input.Questions[0].Question).To(Equal("Which database?"))
+		waitForSessionActivityReason(f, f.Namespace, sessionName, metav1.ConditionTrue, "WaitingForInput")
 		sendSessionRequest(connection, sessionruntime.ClientRequest{
 			Type:    "input",
 			InputID: input.InputID,
@@ -1007,6 +1008,17 @@ func waitForSessionActivity(f *framework.Framework, namespace, name string, stat
 		}
 		return condition.Status
 	}, time.Minute, time.Second).Should(Equal(status), "Session %s/%s runtime did not report Active=%s", namespace, name, status)
+}
+
+func waitForSessionActivityReason(f *framework.Framework, namespace, name string, status metav1.ConditionStatus, reason string) {
+	Eventually(func(g Gomega) {
+		session, err := f.KelosClientset.ApiV1alpha2().Sessions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		condition := apiMeta.FindStatusCondition(session.Status.Conditions, kelos.SessionConditionActive)
+		g.Expect(condition).NotTo(BeNil())
+		g.Expect(condition.Status).To(Equal(status))
+		g.Expect(condition.Reason).To(Equal(reason))
+	}, time.Minute, time.Second).Should(Succeed(), "Session %s/%s runtime did not report Active=%s with reason %s", namespace, name, status, reason)
 }
 
 func waitForSessionModel(f *framework.Framework, namespace, name, model string) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Session activity currently reports only whether a turn is active, so the Session list cannot distinguish an agent that is working from one blocked on a structured user-input request.

This PR publishes `WaitingForInput` as the reason for an active turn while an input request is pending, exposes that state in Session summaries, and labels it **Waiting for input** in the web sidebar and header, with a distinct red indicator in the sidebar. The runtime returns the reason to `TurnActive` after the input is resolved.

Unit tests cover status publication, input lifecycle transitions, Session summaries, and web rendering. The Claude Code end-to-end flow now verifies the status reason when `AskUserQuestion` blocks a turn.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- Focused waiting-for-input tests through `make test`
- The affected `internal/sessionruntime` and `internal/sessionserver` packages passed during the full `make test` run

The full unit suite remains blocked by two reproducible environment-dependent controller tests unrelated to this diff: `TestCodexEntrypointUsesPersistentSessionHome` and the Codex case in `TestAgentEntrypointsPreserveSkillReferenceFiles`. They observe ambient Codex home contents. The end-to-end assertion is included for CI and was not run locally because e2e tests require a cluster and agent credentials.

#### Does this PR introduce a user-facing change?

```release-note
Session views now distinguish sessions waiting for user input from sessions where the agent is actively working.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show sessions that are blocked on user input. The runtime now publishes `Active=True` with reason `WaitingForInput`, and the web UI labels these as “Waiting for input” with a red indicator.

- **New Features**
  - `internal/sessionruntime`: Publishes `WaitingForInput` while an input request is pending; reverts to `TurnActive` after resolution. Status publishing now includes a `waitingForInput` flag and queues publishes on input start/end.
  - `internal/sessionserver`: Session summaries include `waitingForInput`; UI displays “Waiting for input” and a red `.phase-dot.waiting-for-input` indicator.
  - `docs`: Clarified that `Active=True` can have reason `WaitingForInput`, how clients can use it, and that other reasons/messages are informational.
  - Tests: Added unit tests for status publishing and UI summaries; e2e verifies `WaitingForInput` when `AskUserQuestion` pauses a turn.

<sup>Written for commit 8a8ba57e417fd00b1138918eb8e4a8d0af8aaeb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
