### PR TITLE
Add actions-gateway session workspace

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -456,8 +456,9 @@ Tasks and TaskSpawners use the existing `kelos-agent`, `agora-agent`, and
 other credentials intended for non-Session workloads.
 
 Sessions use dedicated Workspaces so they can authenticate with a personal
-token without changing Task credentials. Apply the checked-in Session
-Workspaces after creating the token Secret below:
+token without changing Task credentials. The checked-in manifest includes
+Session Workspaces for Kelos, Agora, Kanon, and `gjkim42/actions-gateway`.
+Apply them after creating the token Secret below:
 
 ```bash
 kubectl apply -f self-development/session-workspaces.yaml

--- a/self-development/session-workspaces.yaml
+++ b/self-development/session-workspaces.yaml
@@ -27,3 +27,13 @@ spec:
   ref: main
   secretRef:
     name: personal-github-token
+---
+apiVersion: kelos.dev/v1alpha2
+kind: Workspace
+metadata:
+  name: actions-gateway-session-agent
+spec:
+  repo: https://github.com/gjkim42/actions-gateway.git
+  ref: main
+  secretRef:
+    name: personal-github-token


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds an `actions-gateway-session-agent` Workspace to the shared self-development Session Workspace manifest. This allows persistent Codex Sessions to clone and work on `gjkim42/actions-gateway` using the existing personal GitHub token setup.

Updates the self-development documentation to include the new Session Workspace.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation: `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `actions-gateway-session-agent` Session Workspace so persistent Sessions can clone and work on `gjkim42/actions-gateway` using the existing `personal-github-token`. Updates the self-development README to include the new Workspace.

<sup>Written for commit a5ff9700255adb52d0b6dd8e970005d55b1a909b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

