### PR TITLE
Define self-development workspaces for Actions Gateway transfer

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -11,7 +11,7 @@ The nested [`kanon/`](kanon/README.md) directory does the same for the sibling
 
 The nested [`actions-gateway/`](actions-gateway/README.md) directory provides
 general and Kubernetes API reviewers for
-[`gjkim42/actions-gateway`](https://github.com/gjkim42/actions-gateway).
+[`kelos-dev/actions-gateway`](https://github.com/kelos-dev/actions-gateway).
 
 [`cs`](cs) creates persistent interactive Codex environments for developing
 Kelos with the same Workspace, credentials, model, effort, and Git identity as
@@ -455,16 +455,18 @@ Before deploying these examples, you need to create the following resources:
 
 ### 1. Workspace Resources
 
-Tasks and TaskSpawners use the existing `kelos-agent`, `agora-agent`, and
-`kanon-agent` Workspaces. Configure those Workspaces with the GitHub App or
-other credentials intended for non-Session workloads.
+[`workspaces.yaml`](workspaces.yaml) defines the `kelos-agent`, `agora-agent`,
+`kanon-agent`, and `actions-gateway-agent` Workspaces used by Tasks and
+TaskSpawners. They reference the `kelos-agent-credentials` Secret described
+below so GitHub operations use the Kelos bot identity.
 
 Sessions use dedicated Workspaces so they can authenticate with a personal
 token without changing Task credentials. The checked-in manifest includes
-Session Workspaces for Kelos, Agora, Kanon, and `gjkim42/actions-gateway`.
-Apply them after creating the token Secret below:
+Session Workspaces for Kelos, Agora, Kanon, and `kelos-dev/actions-gateway`.
+Apply both manifests after creating their Secrets below:
 
 ```bash
+kubectl apply -f self-development/workspaces.yaml
 kubectl apply -f self-development/session-workspaces.yaml
 ```
 
@@ -482,7 +484,21 @@ spec:
     name: personal-github-token
 ```
 
-### 2. Session GitHub Token Secret
+### 2. Project GitHub App Secret
+
+Create the GitHub App Secret referenced by `workspaces.yaml`:
+
+```bash
+kubectl create secret generic kelos-agent-credentials \
+  --from-literal=appID=<your-github-app-id> \
+  --from-literal=installationID=<your-github-app-installation-id> \
+  --from-file=privateKey=<path-to-private-key.pem>
+```
+
+The GitHub App installation must have access to the repositories used by the
+project Workspaces.
+
+### 3. Session GitHub Token Secret
 
 Create the personal token Secret referenced only by the Session Workspaces:
 
@@ -496,7 +512,7 @@ The token needs these permissions:
 - `repo` (full control of private repositories)
 - `workflow` (if your repo uses GitHub Actions)
 
-### 3. GitHub Webhook Secret and Delivery
+### 4. GitHub Webhook Secret and Delivery
 
 The issue and pull request spawners in this directory are webhook-driven.
 Create a secret with the shared webhook secret GitHub will use:
@@ -516,7 +532,7 @@ Webhook spawners only react to **new** events after deployment. If an issue
 or PR was already in a matching state before the webhook server went live,
 retrigger it with a fresh comment or relabel after deployment.
 
-### 4. Agent Credentials Secret
+### 5. Agent Credentials Secret
 
 Create a secret with your agent credentials. Most checked-in spawners use
 Codex OAuth. The GLM reviewer spawners use OpenCode with Z.AI GLM-5.2 and read

--- a/self-development/actions-gateway/README.md
+++ b/self-development/actions-gateway/README.md
@@ -1,13 +1,15 @@
 # Actions Gateway Reviewers
 
 This directory configures on-demand code and Kubernetes API reviewers for
-[`gjkim42/actions-gateway`](https://github.com/gjkim42/actions-gateway). The
+[`kelos-dev/actions-gateway`](https://github.com/kelos-dev/actions-gateway). The
 reviewers are read-only: they inspect pull requests or issues and publish
 feedback without modifying repository files or branches.
 
-Both TaskSpawners use the `actions-gateway-session-agent` Workspace from
-[`../session-workspaces.yaml`](../session-workspaces.yaml) and the shared
-`base-agent` AgentConfig from [`../base-agent.yaml`](../base-agent.yaml).
+Both TaskSpawners use the `actions-gateway-agent` Workspace from
+[`../workspaces.yaml`](../workspaces.yaml) and the shared `base-agent`
+AgentConfig from [`../base-agent.yaml`](../base-agent.yaml). The Workspace
+references the `kelos-agent-credentials` Secret, which must contain the Kelos
+GitHub App credentials so reviews are published by `kelos-bot[bot]`.
 
 ## Spawners
 
@@ -32,7 +34,7 @@ Apply the shared prerequisites once:
 
 ```bash
 kubectl apply -f self-development/base-agent.yaml
-kubectl apply -f self-development/session-workspaces.yaml
+kubectl apply -f self-development/workspaces.yaml
 ```
 
 Apply the reviewers:

--- a/self-development/actions-gateway/actions-gateway-api-reviewer.yaml
+++ b/self-development/actions-gateway/actions-gateway-api-reviewer.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   when:
     githubWebhook:
-      repository: gjkim42/actions-gateway
+      repository: kelos-dev/actions-gateway
       events:
         - issue_comment
         - pull_request_review
@@ -65,7 +65,7 @@ spec:
   taskTemplate:
     worker:
       workspaceRef:
-        name: actions-gateway-session-agent
+        name: actions-gateway-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex
@@ -97,7 +97,7 @@ spec:
             values: [0]
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
-      You are a Kubernetes API design reviewer for the Actions Gateway project (github.com/gjkim42/actions-gateway).
+      You are a Kubernetes API design reviewer for the Actions Gateway project (github.com/kelos-dev/actions-gateway).
       Your job is to review API design, compatibility, and adherence to Kubernetes API
       conventions for pull requests or issues, then submit structured feedback.
       You do NOT write code, push changes, or modify any files.
@@ -287,16 +287,16 @@ spec:
 
       ```
       comment_author=$(gh api user --jq .login)
-      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/gjkim42/actions-gateway/issues/{{.Number}}/comments?per_page=100" \
+      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments?per_page=100" \
         --paginate \
         --slurp \
         --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- actions-gateway-api-reviewer:sticky-review -->")))) | last | .id // empty')
 
       if [ -n "$comment_id" ]; then
-        gh api --method PATCH "repos/gjkim42/actions-gateway/issues/comments/$comment_id" \
+        gh api --method PATCH "repos/kelos-dev/actions-gateway/issues/comments/$comment_id" \
           -F body=@/tmp/actions-gateway-api-reviewer-comment.md
       else
-        gh api "repos/gjkim42/actions-gateway/issues/{{.Number}}/comments" \
+        gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments" \
           -F body=@/tmp/actions-gateway-api-reviewer-comment.md
       fi
       ```

--- a/self-development/actions-gateway/actions-gateway-reviewer.yaml
+++ b/self-development/actions-gateway/actions-gateway-reviewer.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   when:
     githubWebhook:
-      repository: gjkim42/actions-gateway
+      repository: kelos-dev/actions-gateway
       events:
         - issue_comment
         - pull_request_review
@@ -67,7 +67,7 @@ spec:
   taskTemplate:
     worker:
       workspaceRef:
-        name: actions-gateway-session-agent
+        name: actions-gateway-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex
@@ -99,7 +99,7 @@ spec:
             values: [0]
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
-      You are a code review agent for the Actions Gateway project (github.com/gjkim42/actions-gateway).
+      You are a code review agent for the Actions Gateway project (github.com/kelos-dev/actions-gateway).
       Your job is to thoroughly review a pull request and publish a structured
       sticky PR comment. You do NOT write code, push changes, or modify any files.
 
@@ -346,16 +346,16 @@ spec:
 
       ```
       comment_author=$(gh api user --jq .login)
-      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/gjkim42/actions-gateway/issues/{{.Number}}/comments?per_page=100" \
+      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments?per_page=100" \
         --paginate \
         --slurp \
         --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- actions-gateway-reviewer:sticky-review -->")))) | last | .id // empty')
 
       if [ -n "$comment_id" ]; then
-        gh api --method PATCH "repos/gjkim42/actions-gateway/issues/comments/$comment_id" \
+        gh api --method PATCH "repos/kelos-dev/actions-gateway/issues/comments/$comment_id" \
           -F body=@/tmp/actions-gateway-reviewer-comment.md
       else
-        gh api "repos/gjkim42/actions-gateway/issues/{{.Number}}/comments" \
+        gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments" \
           -F body=@/tmp/actions-gateway-reviewer-comment.md
       fi
       ```

--- a/self-development/agora/README.md
+++ b/self-development/agora/README.md
@@ -55,11 +55,14 @@ maintain (`self-development/agora/*`) live in *this* repository, so they use the
 > Kubernetes CRDs to review) and `kelos-image-update` (it updates
 > coding-agent image versions, not service base images).
 
-Apply the root `base-agent` first, then the whole directory. The directory
-includes `agentconfig.yaml`, which defines the `agora-dev-agent` role
-instructions referenced by the triage and squash-commits spawners:
+Apply the shared Workspaces and root `base-agent` first, then the whole
+directory. The directory includes `agentconfig.yaml`, which defines the
+`agora-dev-agent` role instructions referenced by the triage and
+squash-commits spawners:
 
 ```bash
+kubectl apply -f self-development/workspaces.yaml
+kubectl apply -f self-development/session-workspaces.yaml
 kubectl apply -f self-development/base-agent.yaml
 kubectl apply -f self-development/agora/
 ```
@@ -318,25 +321,15 @@ Three Workspaces are referenced:
   `personal-github-token` Secret.
 
 - **`agora-agent`** — points at the Agora repository and is used by the six
-  TaskSpawners that operate directly on Agora:
-
-  ```yaml
-  apiVersion: kelos.dev/v1alpha2
-  kind: Workspace
-  metadata:
-    name: agora-agent
-  spec:
-    repo: https://github.com/kelos-dev/agora.git
-    ref: main
-    secretRef:
-      name: github-token  # For pushing branches and creating PRs
-  ```
+  TaskSpawners that operate directly on Agora. It is defined in
+  [`workspaces.yaml`](../workspaces.yaml) and references the
+  `kelos-agent-credentials` Secret.
 
 - **`kelos-agent`** — points at this repository (`kelos-dev/kelos`). Used by
   `agora-config-update` and `agora-self-update`, which edit the
-  `self-development/agora/` files that live here. This is the same Workspace
-  `self-development/` already uses, so if you deployed those examples it
-  already exists.
+  `self-development/agora/` files that live here. It is also defined in
+  [`workspaces.yaml`](../workspaces.yaml) and references the
+  `kelos-agent-credentials` Secret.
 
 ### 2. Repository labels
 

--- a/self-development/kanon/README.md
+++ b/self-development/kanon/README.md
@@ -56,11 +56,14 @@ maintain (`self-development/kanon/*`) live in *this* repository, so they use the
 > Kubernetes CRDs/API surface to review) and `kelos-image-update` (Kanon has no
 > coding-agent Dockerfiles to bump).
 
-Apply the root `base-agent` first, then the whole directory. The directory
-includes `agentconfig.yaml`, which defines the `kanon-dev-agent` role
-instructions referenced by the triage and squash-commits spawners:
+Apply the shared Workspaces and root `base-agent` first, then the whole
+directory. The directory includes `agentconfig.yaml`, which defines the
+`kanon-dev-agent` role instructions referenced by the triage and
+squash-commits spawners:
 
 ```bash
+kubectl apply -f self-development/workspaces.yaml
+kubectl apply -f self-development/session-workspaces.yaml
 kubectl apply -f self-development/base-agent.yaml
 kubectl apply -f self-development/kanon/
 ```
@@ -319,25 +322,15 @@ Three Workspaces are referenced:
   `personal-github-token` Secret.
 
 - **`kanon-agent`** — points at the Kanon repository and is used by the six
-  TaskSpawners that operate directly on Kanon:
-
-  ```yaml
-  apiVersion: kelos.dev/v1alpha2
-  kind: Workspace
-  metadata:
-    name: kanon-agent
-  spec:
-    repo: https://github.com/kelos-dev/kanon.git
-    ref: main
-    secretRef:
-      name: github-token  # For pushing branches and creating PRs
-  ```
+  TaskSpawners that operate directly on Kanon. It is defined in
+  [`workspaces.yaml`](../workspaces.yaml) and references the
+  `kelos-agent-credentials` Secret.
 
 - **`kelos-agent`** — points at this repository (`kelos-dev/kelos`). Used by
   `kanon-config-update` and `kanon-self-update`, which edit the
-  `self-development/kanon/` files that live here. This is the same Workspace
-  `self-development/` already uses, so if you deployed those examples it
-  already exists.
+  `self-development/kanon/` files that live here. It is also defined in
+  [`workspaces.yaml`](../workspaces.yaml) and references the
+  `kelos-agent-credentials` Secret.
 
 ### 2. Repository labels
 

--- a/self-development/workspaces.yaml
+++ b/self-development/workspaces.yaml
@@ -1,39 +1,39 @@
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: kelos-session-agent
+  name: kelos-agent
 spec:
   repo: https://github.com/kelos-dev/kelos.git
   ref: main
   secretRef:
-    name: personal-github-token
+    name: kelos-agent-credentials
 ---
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: agora-session-agent
+  name: agora-agent
 spec:
   repo: https://github.com/kelos-dev/agora.git
   ref: main
   secretRef:
-    name: personal-github-token
+    name: kelos-agent-credentials
 ---
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: kanon-session-agent
+  name: kanon-agent
 spec:
   repo: https://github.com/kelos-dev/kanon.git
   ref: main
   secretRef:
-    name: personal-github-token
+    name: kelos-agent-credentials
 ---
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: actions-gateway-session-agent
+  name: actions-gateway-agent
 spec:
   repo: https://github.com/kelos-dev/actions-gateway.git
   ref: main
   secretRef:
-    name: personal-github-token
+    name: kelos-agent-credentials


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the Actions Gateway self-development configuration after the repository moved to `kelos-dev`:

- targets `kelos-dev/actions-gateway` from the session Workspace and reviewer webhooks
- runs the general and API reviewers through the bot-authenticated `actions-gateway-agent` Workspace
- defines all four project Workspaces in `self-development/workspaces.yaml`
- updates reviewer prompts, sticky-comment API paths, and documentation for the transferred repository

This keeps webhook matching, repository checkout, and reviewer comments aligned with the repository's current owner and uses the Kelos GitHub App identity for automated reviews.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

All project Workspaces reference the existing `kelos-agent-credentials` Secret, which must contain the Kelos GitHub App credentials.

Validation: `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update self-development configs for Actions Gateway to target `kelos-dev/actions-gateway` and run reviewers via the bot-authenticated `actions-gateway-agent` Workspace using the `kelos-dev` GitHub App. Adds a shared `workspaces.yaml` for all self-development Workspaces and keeps webhook routing, repo checkout, and sticky comments aligned with the transferred repo.

- **Refactors**
  - Point all webhooks, prompts, and Session Workspace repo refs from `gjkim42/actions-gateway` to `kelos-dev/actions-gateway`.
  - Switch reviewer `workspaceRef` from `actions-gateway-session-agent` to `actions-gateway-agent` using `kelos-agent-credentials`.
  - Add `self-development/workspaces.yaml` defining `kelos-agent`, `agora-agent`, `kanon-agent`, and `actions-gateway-agent` bound to `kelos-agent-credentials`; update READMEs to apply `workspaces.yaml` and `session-workspaces.yaml`.
  - Update sticky-comment API paths to the new org.

- **Migration**
  - Create the `kelos-agent-credentials` Secret (GitHub App `appID`, `installationID`, and `privateKey`) with access to the target repos, then apply `self-development/workspaces.yaml` and `self-development/session-workspaces.yaml`.

<sup>Written for commit 82ebd0b5b15a9dc182d4e8e28636b8ff238049ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

