### PR TITLE
Deploy Actions Gateway self-development resources

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -219,6 +219,9 @@ jobs:
       - name: Apply kanon self-development resources
         run: kubectl apply -f self-development/kanon/ -n "${KELOS_NAMESPACE}"
 
+      - name: Apply Actions Gateway self-development resources
+        run: kubectl apply -f self-development/actions-gateway/ -n "${KELOS_NAMESPACE}"
+
       - name: Show Cloudflare Access logs
         if: failure()
         run: cat "${RUNNER_TEMP}/cloudflared-access.log" 2>/dev/null || true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds an explicit deploy-to-dev step for `self-development/actions-gateway/`.

The workflow applies the top-level self-development manifests and the Agora and Kanon subdirectories separately. Since `kubectl apply -f self-development/` is not recursive, the Actions Gateway reviewer resources were not deployed after their configuration merged.

This step applies the Actions Gateway reviewer TaskSpawners after the shared top-level Workspaces and AgentConfig have been applied.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation: `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit step in the deploy-to-dev workflow to apply `self-development/actions-gateway/` so Actions Gateway reviewer TaskSpawners deploy after shared Workspaces and AgentConfig. Fixes missing deployments caused by non-recursive `kubectl apply -f self-development/`.

<sup>Written for commit 3ffab674d6d785ad0b24b1d6ac42059c4bc7291c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

