### PR TITLE
Rename actions-gateway self-development resources

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -219,8 +219,8 @@ jobs:
       - name: Apply kanon self-development resources
         run: kubectl apply -f self-development/kanon/ -n "${KELOS_NAMESPACE}"
 
-      - name: Apply Actions Gateway self-development resources
-        run: kubectl apply -f self-development/actions-gateway/ -n "${KELOS_NAMESPACE}"
+      - name: Apply Open Actions self-development resources
+        run: kubectl apply -f self-development/open-actions/ -n "${KELOS_NAMESPACE}"
 
       - name: Show Cloudflare Access logs
         if: failure()

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -9,9 +9,9 @@ repository while keeping the configuration in this repo.
 The nested [`kanon/`](kanon/README.md) directory does the same for the sibling
 [`kelos-dev/kanon`](https://github.com/kelos-dev/kanon) repository.
 
-The nested [`actions-gateway/`](actions-gateway/README.md) directory provides
+The nested [`open-actions/`](open-actions/README.md) directory provides
 general and Kubernetes API reviewers for
-[`kelos-dev/actions-gateway`](https://github.com/kelos-dev/actions-gateway).
+[`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions).
 
 [`cs`](cs) creates persistent interactive Codex environments for developing
 Kelos with the same Workspace, credentials, model, effort, and Git identity as
@@ -22,7 +22,7 @@ the `kelos-workers` SessionSpawner.
 <img width="2694" height="1966" alt="kelos-self-development" src="https://github.com/user-attachments/assets/10719599-426e-4c3d-87a0-cde43e1b3113" />
 
 Every self-development Task, TaskSpawner, Session, and SessionSpawner in this
-directory and its nested Agora, Kanon, and Actions Gateway directories references
+directory and its nested Agora, Kanon, and Open Actions directories references
 [`base-agent.yaml`](base-agent.yaml), which copies
 [`gjkim42/kanon-repo`'s `instructions/AGENTS.md`](https://github.com/gjkim42/kanon-repo/blob/main/instructions/AGENTS.md)
 and installs all skills from that repository through `spec.skills`.
@@ -456,13 +456,13 @@ Before deploying these examples, you need to create the following resources:
 ### 1. Workspace Resources
 
 [`workspaces.yaml`](workspaces.yaml) defines the `kelos-agent`, `agora-agent`,
-`kanon-agent`, and `actions-gateway-agent` Workspaces used by Tasks and
+`kanon-agent`, and `open-actions-agent` Workspaces used by Tasks and
 TaskSpawners. They reference the `kelos-agent-credentials` Secret described
 below so GitHub operations use the Kelos bot identity.
 
 Sessions use dedicated Workspaces so they can authenticate with a personal
 token without changing Task credentials. The checked-in manifest includes
-Session Workspaces for Kelos, Agora, Kanon, and `kelos-dev/actions-gateway`.
+Session Workspaces for Kelos, Agora, Kanon, and `kelos-dev/open-actions`.
 Apply both manifests after creating their Secrets below:
 
 ```bash

--- a/self-development/open-actions/README.md
+++ b/self-development/open-actions/README.md
@@ -1,11 +1,11 @@
-# Actions Gateway Reviewers
+# Open Actions Reviewers
 
 This directory configures on-demand code and Kubernetes API reviewers for
-[`kelos-dev/actions-gateway`](https://github.com/kelos-dev/actions-gateway). The
+[`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions). The
 reviewers are read-only: they inspect pull requests or issues and publish
 feedback without modifying repository files or branches.
 
-Both TaskSpawners use the `actions-gateway-agent` Workspace from
+Both TaskSpawners use the `open-actions-agent` Workspace from
 [`../workspaces.yaml`](../workspaces.yaml) and the shared `base-agent`
 AgentConfig from [`../base-agent.yaml`](../base-agent.yaml). The Workspace
 references the `kelos-agent-credentials` Secret, which must contain the Kelos
@@ -15,15 +15,15 @@ GitHub App credentials so reviews are published by `kelos-bot[bot]`.
 
 | Spawner | Trigger | Agent | Scope |
 |---|---|---|---|
-| **actions-gateway-reviewer** | PR comment or review `/kelos review` | Codex | General correctness, tests, security, and project conventions |
-| **actions-gateway-api-reviewer** | Issue/PR comment or review `/kelos api-review` | Codex | Kubernetes API design, compatibility, schemas, and documentation |
+| **open-actions-reviewer** | PR comment or review `/kelos review` | Codex | General correctness, tests, security, and project conventions |
+| **open-actions-api-reviewer** | Issue/PR comment or review `/kelos api-review` | Codex | Kubernetes API design, compatibility, schemas, and documentation |
 
 The general reviewer creates or updates one sticky pull request comment. The
 API reviewer does the same for pull requests and posts a normal comment for
 issue-based design proposals. Each trigger accepts commands from `gjkim42`;
 comments from `kelos-bot[bot]` are also accepted for automated handoffs.
 
-The review prompts use Actions Gateway's Makefile targets and treat CRD types,
+The review prompts use Open Actions' Makefile targets and treat CRD types,
 generated schemas, samples, labels, annotations, flags, configuration, and
 webhook contracts as user-facing API surfaces. API reviews also check
 `docs/api-design.md` and the repository's schema tests.
@@ -40,6 +40,6 @@ kubectl apply -f self-development/workspaces.yaml
 Apply the reviewers:
 
 ```bash
-kubectl apply -f self-development/actions-gateway/actions-gateway-reviewer.yaml
-kubectl apply -f self-development/actions-gateway/actions-gateway-api-reviewer.yaml
+kubectl apply -f self-development/open-actions/open-actions-reviewer.yaml
+kubectl apply -f self-development/open-actions/open-actions-api-reviewer.yaml
 ```

--- a/self-development/open-actions/open-actions-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-api-reviewer.yaml
@@ -1,10 +1,10 @@
 apiVersion: kelos.dev/v1alpha2
 kind: AgentConfig
 metadata:
-  name: actions-gateway-api-reviewer-agent
+  name: open-actions-api-reviewer-agent
 spec:
   agentsMD: |
-    # Actions Gateway API Reviewer Agent
+    # Open Actions API Reviewer Agent
 
     ## Environment
     You are running in an ephemeral container environment. Your file system
@@ -12,7 +12,7 @@ spec:
     issues, or comments.
 
     ## Identity
-    - When commenting on issues or PRs, always start with "🤖 **Actions Gateway API Reviewer Agent** @gjkim42\n\n"
+    - When commenting on issues or PRs, always start with "🤖 **Open Actions API Reviewer Agent** @gjkim42\n\n"
       so it is clearly distinguishable from human comments and triggers a notification
 
     ## Standards
@@ -26,18 +26,18 @@ spec:
       - `make update` — update generated Go types, CRDs, formatting, and module metadata
       - `make test` — run all unit tests
       - `make test-e2e` — run the Kind end-to-end test
-      - `make build` — build the Actions Gateway binary
+      - `make build` — build the Open Actions binary
     - Logging conventions: start log messages with capital letters and do not end with punctuation
     - Commit messages: do not include PR links in commit messages
 ---
 apiVersion: kelos.dev/v1alpha2
 kind: TaskSpawner
 metadata:
-  name: actions-gateway-api-reviewer
+  name: open-actions-api-reviewer
 spec:
   when:
     githubWebhook:
-      repository: kelos-dev/actions-gateway
+      repository: kelos-dev/open-actions
       events:
         - issue_comment
         - pull_request_review
@@ -65,7 +65,7 @@ spec:
   taskTemplate:
     worker:
       workspaceRef:
-        name: actions-gateway-agent
+        name: open-actions-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex
@@ -83,7 +83,7 @@ spec:
             ephemeral-storage: "4Gi"
       agentConfigRefs:
         - name: base-agent
-        - name: actions-gateway-api-reviewer-agent
+        - name: open-actions-api-reviewer-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -97,7 +97,7 @@ spec:
             values: [0]
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
-      You are a Kubernetes API design reviewer for the Actions Gateway project (github.com/kelos-dev/actions-gateway).
+      You are a Kubernetes API design reviewer for the Open Actions project (github.com/kelos-dev/open-actions).
       Your job is to review API design, compatibility, and adherence to Kubernetes API
       conventions for pull requests or issues, then submit structured feedback.
       You do NOT write code, push changes, or modify any files.
@@ -233,7 +233,7 @@ spec:
       - Does the feature/type name accurately describe what it does, and will
         it still make sense as the feature evolves? A wrong name is hard to
         fix once shipped.
-      - Are field and type names consistent with existing Actions Gateway CRDs under
+      - Are field and type names consistent with existing Open Actions CRDs under
         `api/`? Look for similar concepts already named — reuse the same term
         instead of inventing a synonym.
       - Are names consistent with Kubernetes native resources (Pod, Deployment,
@@ -283,32 +283,32 @@ spec:
       existing sticky comment when it exists; otherwise create it. Do NOT submit
       a GitHub PR review and do NOT create inline review comments.
 
-      Write the full comment body to `/tmp/actions-gateway-api-reviewer-comment.md`, then run:
+      Write the full comment body to `/tmp/open-actions-api-reviewer-comment.md`, then run:
 
       ```
       comment_author=$(gh api user --jq .login)
-      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments?per_page=100" \
+      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/open-actions/issues/{{.Number}}/comments?per_page=100" \
         --paginate \
         --slurp \
-        --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- actions-gateway-api-reviewer:sticky-review -->")))) | last | .id // empty')
+        --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- open-actions-api-reviewer:sticky-review -->")))) | last | .id // empty')
 
       if [ -n "$comment_id" ]; then
-        gh api --method PATCH "repos/kelos-dev/actions-gateway/issues/comments/$comment_id" \
-          -F body=@/tmp/actions-gateway-api-reviewer-comment.md
+        gh api --method PATCH "repos/kelos-dev/open-actions/issues/comments/$comment_id" \
+          -F body=@/tmp/open-actions-api-reviewer-comment.md
       else
-        gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments" \
-          -F body=@/tmp/actions-gateway-api-reviewer-comment.md
+        gh api "repos/kelos-dev/open-actions/issues/{{.Number}}/comments" \
+          -F body=@/tmp/open-actions-api-reviewer-comment.md
       fi
       ```
 
-      **For issues**, post a comment using `gh issue comment {{.Number}} --body-file /tmp/actions-gateway-api-reviewer-comment.md`.
+      **For issues**, post a comment using `gh issue comment {{.Number}} --body-file /tmp/open-actions-api-reviewer-comment.md`.
 
       Format the PR comment body as:
 
       ```
-      🤖 **Actions Gateway API Reviewer Agent** @gjkim42
+      🤖 **Open Actions API Reviewer Agent** @gjkim42
 
-      <!-- actions-gateway-api-reviewer:sticky-review -->
+      <!-- open-actions-api-reviewer:sticky-review -->
 
       ## API Design Review
 

--- a/self-development/open-actions/open-actions-reviewer.yaml
+++ b/self-development/open-actions/open-actions-reviewer.yaml
@@ -1,10 +1,10 @@
 apiVersion: kelos.dev/v1alpha2
 kind: AgentConfig
 metadata:
-  name: actions-gateway-reviewer-agent
+  name: open-actions-reviewer-agent
 spec:
   agentsMD: |
-    # Actions Gateway Reviewer Agent
+    # Open Actions Reviewer Agent
 
     ## Environment
     You are running in an ephemeral container environment. Your file system
@@ -12,7 +12,7 @@ spec:
     issues, or comments.
 
     ## Identity
-    - When commenting on issues or PRs, always start with "🤖 **Actions Gateway Reviewer Agent** @gjkim42\n\n"
+    - When commenting on issues or PRs, always start with "🤖 **Open Actions Reviewer Agent** @gjkim42\n\n"
       so it is clearly distinguishable from human comments and triggers a notification
 
     ## Standards
@@ -26,18 +26,18 @@ spec:
       - `make update` — update generated Go types, CRDs, formatting, and module metadata
       - `make test` — run all unit tests
       - `make test-e2e` — run the Kind end-to-end test
-      - `make build` — build the Actions Gateway binary
+      - `make build` — build the Open Actions binary
     - Logging conventions: start log messages with capital letters and do not end with punctuation
     - Commit messages: do not include PR links in commit messages
 ---
 apiVersion: kelos.dev/v1alpha2
 kind: TaskSpawner
 metadata:
-  name: actions-gateway-reviewer
+  name: open-actions-reviewer
 spec:
   when:
     githubWebhook:
-      repository: kelos-dev/actions-gateway
+      repository: kelos-dev/open-actions
       events:
         - issue_comment
         - pull_request_review
@@ -67,7 +67,7 @@ spec:
   taskTemplate:
     worker:
       workspaceRef:
-        name: actions-gateway-agent
+        name: open-actions-agent
       model: gpt-5.6-sol
       effort: xhigh
       type: codex
@@ -85,7 +85,7 @@ spec:
             ephemeral-storage: "4Gi"
       agentConfigRefs:
         - name: base-agent
-        - name: actions-gateway-reviewer-agent
+        - name: open-actions-reviewer-agent
     ttlSecondsAfterFinished: 864000
     podFailurePolicy:
       rules:
@@ -99,7 +99,7 @@ spec:
             values: [0]
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
-      You are a code review agent for the Actions Gateway project (github.com/kelos-dev/actions-gateway).
+      You are a code review agent for the Open Actions project (github.com/kelos-dev/open-actions).
       Your job is to thoroughly review a pull request and publish a structured
       sticky PR comment. You do NOT write code, push changes, or modify any files.
 
@@ -148,7 +148,7 @@ spec:
       > belongs to `/kelos api-review`. Do not duplicate that checklist here.
       > Still flag the obvious permanence risks during this review:
       > - New fields whose **name** is misleading, inconsistent with existing
-      >   Actions Gateway CRDs, or clashes with Kubernetes-native semantics
+      >   Open Actions CRDs, or clashes with Kubernetes-native semantics
       >   (`template`, `selector`, `replicas`, `conditions`, `phase`,
       >   `observedGeneration`).
       > - Field shapes that will be hard to extend (bare scalar/bool where a
@@ -304,9 +304,9 @@ spec:
       Format the PR comment body as:
 
       ```
-      🤖 **Actions Gateway Reviewer Agent** @gjkim42
+      🤖 **Open Actions Reviewer Agent** @gjkim42
 
-      <!-- actions-gateway-reviewer:sticky-review -->
+      <!-- open-actions-reviewer:sticky-review -->
 
       ## Review Summary
 
@@ -342,21 +342,21 @@ spec:
       - <1–3 bullets highlighting the most important points from the review>
       ```
 
-      Write the full comment body to `/tmp/actions-gateway-reviewer-comment.md`, then run:
+      Write the full comment body to `/tmp/open-actions-reviewer-comment.md`, then run:
 
       ```
       comment_author=$(gh api user --jq .login)
-      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments?per_page=100" \
+      comment_id=$(STICKY_COMMENT_AUTHOR="$comment_author" gh api "repos/kelos-dev/open-actions/issues/{{.Number}}/comments?per_page=100" \
         --paginate \
         --slurp \
-        --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- actions-gateway-reviewer:sticky-review -->")))) | last | .id // empty')
+        --jq 'flatten | map(select(.user.login == env.STICKY_COMMENT_AUTHOR and (.body | contains("<!-- open-actions-reviewer:sticky-review -->")))) | last | .id // empty')
 
       if [ -n "$comment_id" ]; then
-        gh api --method PATCH "repos/kelos-dev/actions-gateway/issues/comments/$comment_id" \
-          -F body=@/tmp/actions-gateway-reviewer-comment.md
+        gh api --method PATCH "repos/kelos-dev/open-actions/issues/comments/$comment_id" \
+          -F body=@/tmp/open-actions-reviewer-comment.md
       else
-        gh api "repos/kelos-dev/actions-gateway/issues/{{.Number}}/comments" \
-          -F body=@/tmp/actions-gateway-reviewer-comment.md
+        gh api "repos/kelos-dev/open-actions/issues/{{.Number}}/comments" \
+          -F body=@/tmp/open-actions-reviewer-comment.md
       fi
       ```
 

--- a/self-development/session-workspaces.yaml
+++ b/self-development/session-workspaces.yaml
@@ -31,9 +31,9 @@ spec:
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: actions-gateway-session-agent
+  name: open-actions-session-agent
 spec:
-  repo: https://github.com/kelos-dev/actions-gateway.git
+  repo: https://github.com/kelos-dev/open-actions.git
   ref: main
   secretRef:
     name: personal-github-token

--- a/self-development/workspaces.yaml
+++ b/self-development/workspaces.yaml
@@ -31,9 +31,9 @@ spec:
 apiVersion: kelos.dev/v1alpha2
 kind: Workspace
 metadata:
-  name: actions-gateway-agent
+  name: open-actions-agent
 spec:
-  repo: https://github.com/kelos-dev/actions-gateway.git
+  repo: https://github.com/kelos-dev/open-actions.git
   ref: main
   secretRef:
     name: kelos-agent-credentials


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Renames the Actions Gateway self-development resources to Open Actions to match the repository rename.

- Updates Workspace names and repository URLs
- Renames the reviewer directory, manifests, resources, prompts, and sticky comment markers
- Updates the development deployment workflow and self-development documentation

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The `ActionsGateway` CRD terminology remains unchanged because it is an API kind rather than the repository name.

Validation: `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed Actions Gateway self-development resources to Open Actions to match the repository rename, updating paths, names, and URLs across manifests and the dev deploy workflow. No API kinds were renamed; `ActionsGateway` CRD terminology stays as-is.

- **Refactors**
  - Moved `self-development/actions-gateway` to `self-development/open-actions` and updated `.github/workflows/deploy-dev.yaml`.
  - Switched repo refs from `kelos-dev/actions-gateway` to `kelos-dev/open-actions`.
  - Renamed Workspaces to `open-actions-agent` and `open-actions-session-agent`.
  - Updated reviewer TaskSpawner/AgentConfig names, prompts, and sticky comment markers to `open-actions-*`.
  - Kept `ActionsGateway` CRD naming unchanged (API kind, not repo name).

- **Migration**
  - Re-apply updated resources: `kubectl apply -f self-development/workspaces.yaml` and `kubectl apply -f self-development/open-actions/`.

<sup>Written for commit 65e242873703457ea077acb3216890f54c329318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

