### PR TITLE
Track sticky issue validity verdicts

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -41,13 +41,14 @@ All other AgentConfigs provide only role- or repository-specific instructions;
 they do not duplicate the shared skills.
 
 Autonomous discovery agents that publish GitHub issues maintain at most one
-open `generated-by-kelos` issue slot per TaskSpawner. The issue body includes a
-`kelos-taskspawner=<name>` marker so later runs can find it. A run may update
-the unassigned slot when it finds a clearly more impactful or important
-candidate, but it exits without changes when the slot has assignees. Assigned
-issues and PRs are treated as ongoing human or agent work and are not updated by
-autonomous discovery jobs. This cap does not apply to follow-up issues created
-while a worker or PR responder is handling an explicitly requested issue or PR.
+open `generated-by-kelos` issue slot per TaskSpawner. Its title starts with the
+TaskSpawner name in brackets, and its body includes both a
+`kelos-taskspawner=<name>` marker and one replaceable `Latest verdict` section.
+Each run checks whether an unassigned slot is still valid against the current
+repository before retaining, replacing, or closing it. Assigned issues and PRs
+are treated as ongoing human or agent work and are not updated by autonomous
+discovery jobs. This cap does not apply to follow-up issues created while a
+worker or PR responder is handling an explicitly requested issue or PR.
 
 ## Spawners
 

--- a/self-development/agora/README.md
+++ b/self-development/agora/README.md
@@ -19,13 +19,14 @@ instructions where needed: triage and squash-commits share `agentconfig.yaml`
 define their own AgentConfig inline.
 
 Autonomous discovery agents that publish GitHub issues maintain at most one
-open `generated-by-kelos` issue slot per TaskSpawner. The issue body includes a
-`kelos-taskspawner=<name>` marker so later runs can find it. A run may update
-the unassigned slot when it finds a clearly more impactful or important
-candidate, but it exits without changes when the slot has assignees. Assigned
-issues and PRs are treated as ongoing human or agent work and are not updated by
-autonomous discovery jobs. This cap does not apply to follow-up issues created
-while a worker or PR responder is handling an explicitly requested issue or PR.
+open `generated-by-kelos` issue slot per TaskSpawner. Its title starts with the
+TaskSpawner name in brackets, and its body includes both a
+`kelos-taskspawner=<name>` marker and one replaceable `Latest verdict` section.
+Each run checks whether an unassigned slot is still valid against the current
+repository before retaining, replacing, or closing it. Assigned issues and PRs
+are treated as ongoing human or agent work and are not updated by autonomous
+discovery jobs. This cap does not apply to follow-up issues created while a
+worker or PR responder is handling an explicitly requested issue or PR.
 
 The two SessionSpawners operate on the Agora repository through the
 `agora-session-agent` Workspace, which uses the personal Session token. Six

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -106,17 +106,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[agora-fake-strategist] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=agora-fake-strategist -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
@@ -130,4 +152,4 @@ spec:
         - Self-development workflow improvements, prompt tuning, config alignment → agora-self-update
         - Documentation, API/UI UX, error messages → agora-fake-user
         - Agent configuration based on PR reviews → agora-config-update
-      - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/agora/agora-fake-user.yaml
+++ b/self-development/agora/agora-fake-user.yaml
@@ -104,17 +104,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[agora-fake-user] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=agora-fake-user -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
@@ -126,4 +148,4 @@ spec:
         - Strategic proposals, new use cases, integrations, new API/UI/deployment capabilities → agora-fake-strategist
         - Self-development workflow improvements, prompt tuning, config alignment → agora-self-update
         - Agent configuration based on PR reviews → agora-config-update
-      - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -93,17 +93,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[agora-self-update] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=agora-self-update -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
@@ -117,4 +139,4 @@ spec:
         - Strategic proposals, new use cases, integrations, new API/UI/deployment capabilities → agora-fake-strategist
         - Documentation, API/UI UX, error messages → agora-fake-user
         - Agent configuration based on PR reviews → agora-config-update
-      - If after review you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/kanon/README.md
+++ b/self-development/kanon/README.md
@@ -20,13 +20,14 @@ instructions where needed: triage and squash-commits share `agentconfig.yaml`
 define their own AgentConfig inline.
 
 Autonomous discovery agents that publish GitHub issues maintain at most one
-open `generated-by-kelos` issue slot per TaskSpawner. The issue body includes a
-`kelos-taskspawner=<name>` marker so later runs can find it. A run may update
-the unassigned slot when it finds a clearly more impactful or important
-candidate, but it exits without changes when the slot has assignees. Assigned
-issues and PRs are treated as ongoing human or agent work and are not updated by
-autonomous discovery jobs. This cap does not apply to follow-up issues created
-while a worker or PR responder is handling an explicitly requested issue or PR.
+open `generated-by-kelos` issue slot per TaskSpawner. Its title starts with the
+TaskSpawner name in brackets, and its body includes both a
+`kelos-taskspawner=<name>` marker and one replaceable `Latest verdict` section.
+Each run checks whether an unassigned slot is still valid against the current
+repository before retaining, replacing, or closing it. Assigned issues and PRs
+are treated as ongoing human or agent work and are not updated by autonomous
+discovery jobs. This cap does not apply to follow-up issues created while a
+worker or PR responder is handling an explicitly requested issue or PR.
 
 The two SessionSpawners operate on the Kanon repository through the
 `kanon-session-agent` Workspace, which uses the personal Session token. Six

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -104,17 +104,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[kanon-fake-strategist] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kanon-fake-strategist -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
@@ -128,4 +150,4 @@ spec:
         - Self-development workflow improvements, prompt tuning, config alignment → kanon-self-update
         - Documentation, CLI UX, error messages → kanon-fake-user
         - Agent configuration based on PR reviews → kanon-config-update
-      - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -102,17 +102,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[kanon-fake-user] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kanon-fake-user -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
@@ -124,4 +146,4 @@ spec:
         - Strategic proposals, new use cases, integrations, new managed-settings types → kanon-fake-strategist
         - Self-development workflow improvements, prompt tuning, config alignment → kanon-self-update
         - Agent configuration based on PR reviews → kanon-config-update
-      - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -93,17 +93,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[kanon-self-update] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kanon-self-update -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
@@ -117,4 +139,4 @@ spec:
         - Strategic proposals, new use cases, integrations, new managed-settings types → kanon-fake-strategist
         - Documentation, CLI UX, error messages → kanon-fake-user
         - Agent configuration based on PR reviews → kanon-config-update
-      - If after review you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -108,17 +108,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[kelos-fake-strategist] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kelos-fake-strategist -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
       - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
@@ -133,4 +155,4 @@ spec:
         - Documentation, CLI UX, error messages → kelos-fake-user
         - Agent configuration based on PR reviews → kelos-config-update
         - Coding agent image version updates → kelos-image-update
-      - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -105,17 +105,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[kelos-fake-user] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kelos-fake-user -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
@@ -128,4 +150,4 @@ spec:
         - Self-development workflow improvements, prompt tuning, config alignment → kelos-self-update
         - Agent configuration based on PR reviews → kelos-config-update
         - Coding agent image version updates → kelos-image-update
-      - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -119,17 +119,39 @@ spec:
         ```
         - If an open slot exists and has assignees, treat it as ongoing. Do not
           edit it, do not update related PRs, and do not create another issue.
-        - If an open unassigned slot exists, compare your candidate with the
-          existing issue. Update the issue only when the candidate is clearly
-          more impactful or important than the current issue; otherwise exit
-          without creating or editing anything.
-        - If no open slot exists, create exactly one GitHub issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[kelos-self-update] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
       - Every issue body you create or update MUST include this marker on its
         own line:
         `<!-- kelos-taskspawner=kelos-self-update -->`
-      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-        to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-        to create the first slot.
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
       - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
 
       Constraints:
@@ -144,4 +166,4 @@ spec:
         - Documentation, CLI UX, error messages → kelos-fake-user
         - Agent configuration based on PR reviews → kelos-config-update
         - Coding agent image version updates → kelos-image-update
-      - If after review you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output
+      - If no open slot exists and you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -77,17 +77,39 @@ spec:
       gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=kelos-fake-strategist -->")))'
       - If an open slot exists and has assignees, treat it as ongoing. Do not
         edit it, do not update related PRs, and do not create another issue.
-      - If an open unassigned slot exists, compare your candidate with the
-        existing issue. Update the issue only when the candidate is clearly
-        more impactful or important than the current issue; otherwise exit
-        without creating or editing anything.
-      - If no open slot exists, create exactly one GitHub issue.
+      - If an open unassigned slot exists, read it and all comments with
+        `gh issue view <number> --comments`. Check its claims and acceptance
+        criteria against the current default branch and related issues and
+        PRs, then decide whether it is still valid.
+        - If it is valid, keep it unless your candidate is clearly more
+          impactful or important. Refresh its title prefix and latest verdict
+          even when you keep the existing candidate.
+        - If it is invalid and you have a candidate, replace it with the
+          candidate and record a valid verdict.
+        - If it is invalid and you have no candidate, record an invalid
+          verdict, then close it with
+          `gh issue close <number> --reason "not planned"`.
+      - If no open slot exists and you have a candidate, create exactly one
+        GitHub issue.
+    - Every issue title you create or update MUST start with exactly one
+      `[kelos-fake-strategist] ` prefix.
+    - Every issue body you create or update MUST contain exactly one section
+      in this format:
+      ```
+      ## Latest verdict
+      - Status: `VALID` or `INVALID`
+      - Checked at: `<UTC RFC3339 timestamp>`
+      - Evidence: <concise current evidence with relevant issue or PR links>
+      ```
+      Replace this section on each assessment; do not append verdict history.
     - Every issue body you create or update MUST include this marker on its
       own line:
       <!-- kelos-taskspawner=kelos-fake-strategist -->
-    - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`
-      to update the unassigned slot, or `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`
-      to create the first slot.
+    - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+      for a verdict-only refresh or before closing an invalid slot. Preserve all
+      existing labels in these cases.
+    - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+    - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
     - Do NOT create PRs. Only create or update this issue slot
     - Prefer well-researched issues with clear proposals over broad, vague suggestions
 
@@ -97,4 +119,4 @@ spec:
     - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
     - Keep changes minimal and focused
     - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
-    - If after reviewing existing issues you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output
+    - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the autonomous discovery issue-slot prompts for Kelos, Agora, and Kanon so every managed issue:

- starts its title with the owning TaskSpawner name in brackets;
- is revalidated against the current repository and related work before it is retained;
- records one replaceable `Latest verdict` section with status, timestamp, and evidence; and
- is replaced or closed when its tracked problem is no longer valid.

Verdict-only refreshes and invalid-slot closure preserve existing labels. The
prompts add `triage-accepted` only when replacing the tracked candidate or
creating a new slot, so scheduled refreshes cannot undo a maintainer's triage
decision.

The manual fake-strategist Task and the self-development READMEs now follow the same contract.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation: `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
