### PR TITLE
Paginate Session terminal history

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -239,7 +239,9 @@ metadata, conversation, or persistent-volume data.
 Use `kelos session connect NAME` for terminal chat. In an interactive terminal,
 press Enter to send a message, Ctrl+J to insert a newline, and Ctrl+C or Esc to
 interrupt an active turn. Ctrl+C exits the terminal client when no turn is
-active. The terminal client shows live connecting, reconnecting, working,
+active. The terminal initially loads a bounded page of recent transcript items.
+Use `/history` or Page Up to load the previous page.
+The terminal client shows live connecting, reconnecting, working,
 waiting-for-input, and interrupting progress with elapsed time. After a
 completed turn, both interactive and plain terminal output show a `Worked for
 ...` separator when the duration is known. A separate status bar beneath the

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -433,6 +433,7 @@ func connectSessionWithDependencies(
 	}()
 
 	var lastEventID int64
+	var historyLastEventID int64
 	var journalID string
 	connectedBefore := false
 	pendingRequests := make([]pendingSessionRequest, 0)
@@ -478,6 +479,8 @@ func connectSessionWithDependencies(
 			Since:         lastEventID,
 			JournalID:     journalID,
 			HistoryBounds: true,
+			HistoryItems:  sessionruntime.DefaultHistoryItemLimit,
+			HistoryBytes:  sessionruntime.DefaultHistoryByteLimit,
 		}); err != nil {
 			stream.Close()
 			if diagnosticWriter != nil {
@@ -558,13 +561,17 @@ func connectSessionWithDependencies(
 				if event.RequestID != "" {
 					pendingRequests = removePendingSessionRequest(pendingRequests, event.RequestID)
 				}
-				if event.Type == sessionruntime.EventHistoryStart {
+				if event.Type == sessionruntime.EventHistoryStart && !event.HistoryPage {
 					journalID = event.JournalID
+					historyLastEventID = event.LastEventID
 					if event.Reset {
 						lastEventID = 0
 					}
 				}
-				if event.Type == sessionruntime.EventHistoryEnd {
+				if event.Type == sessionruntime.EventHistoryEnd && !event.HistoryPage {
+					if historyLastEventID > lastEventID {
+						lastEventID = historyLastEventID
+					}
 					if announceReconnect {
 						reportSessionTerminalDiagnostic(diagnostics, sessionTerminalStatusConnected, "Reconnected to Session runtime")
 						announceReconnect = false

--- a/internal/cli/session_reconnect_test.go
+++ b/internal/cli/session_reconnect_test.go
@@ -53,10 +53,10 @@ func TestSessionTerminalReconnectsToReplacementPod(t *testing.T) {
 						t.Error(err)
 						return
 					}
-					if subscribe.Type != "subscribe" || subscribe.Since != 0 || subscribe.JournalID != "" || !subscribe.HistoryBounds {
+					if subscribe.Type != "subscribe" || subscribe.Since != 0 || subscribe.JournalID != "" || !subscribe.HistoryBounds || subscribe.HistoryItems != sessionruntime.DefaultHistoryItemLimit || subscribe.HistoryBytes != sessionruntime.DefaultHistoryByteLimit {
 						t.Errorf("first subscribe = %#v", subscribe)
 					}
-					_ = encoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, JournalID: "journal-1"})
+					_ = encoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, JournalID: "journal-1", LastEventID: 10})
 					_ = encoder.Encode(sessionruntime.Event{ID: 1, Type: sessionruntime.EventTurnStarted, TurnID: "turn-1", Status: "running"})
 					_ = encoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
 					close(firstConnected)
@@ -80,7 +80,7 @@ func TestSessionTerminalReconnectsToReplacementPod(t *testing.T) {
 						t.Error(err)
 						return
 					}
-					if subscribe.Type != "subscribe" || subscribe.Since != 1 || subscribe.JournalID != "journal-1" || !subscribe.HistoryBounds {
+					if subscribe.Type != "subscribe" || subscribe.Since != 10 || subscribe.JournalID != "journal-1" || !subscribe.HistoryBounds || subscribe.HistoryItems != sessionruntime.DefaultHistoryItemLimit || subscribe.HistoryBytes != sessionruntime.DefaultHistoryByteLimit {
 						t.Errorf("replacement subscribe = %#v", subscribe)
 					}
 					_ = encoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, JournalID: "journal-2", Reset: true})

--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kelos-dev/kelos/internal/sessionruntime"
 	"golang.org/x/term"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const (
@@ -36,6 +37,11 @@ const (
 
 type sessionTerminalFormatter struct {
 	color bool
+}
+
+type sessionPlainAssistantState struct {
+	streaming bool
+	lineOpen  bool
 }
 
 func (f sessionTerminalFormatter) style(style, text string) string {
@@ -181,6 +187,12 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 
 func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, output io.Writer, decoder *json.Decoder, encoder *json.Encoder, color bool, terminalWidth func() int) error {
 	var writeMu sync.Mutex
+	var historyMu sync.Mutex
+	historyCursor := ""
+	pendingHistoryCursor := ""
+	historyLoading := false
+	historyRequestID := ""
+	initialHistorySeen := false
 	write := func(format string, args ...any) {
 		writeMu.Lock()
 		defer writeMu.Unlock()
@@ -189,8 +201,20 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 	formatter := sessionTerminalFormatter{color: color}
 	done := make(chan error, 1)
 	go func() {
-		streaming := false
+		liveAssistant := sessionPlainAssistantState{}
+		pageAssistant := sessionPlainAssistantState{}
+		closeAssistantLine := func(assistant *sessionPlainAssistantState) {
+			if assistant.lineOpen {
+				write("\n")
+				assistant.lineOpen = false
+			}
+		}
+		finishAssistant := func(assistant *sessionPlainAssistantState) {
+			closeAssistantLine(assistant)
+			assistant.streaming = false
+		}
 		replayingHistory := true
+		historyPageReading := false
 		recoveryActive := false
 		activeTurnID := ""
 		var activeTurnStarted time.Time
@@ -200,67 +224,129 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				done <- err
 				return
 			}
-			recoveredCompletion := sessionTerminalRecoveredCompletion(recoveryActive, event)
-			if recoveryActive && !sessionTerminalRuntimeRecoveryEvent(event) {
-				recoveryActive = false
+			if historyPageReading && event.Type == sessionruntime.EventHistoryStart && !event.HistoryPage {
+				finishAssistant(&pageAssistant)
+				historyPageReading = false
+				historyMu.Lock()
+				pendingHistoryCursor = ""
+				historyLoading = false
+				historyRequestID = ""
+				historyMu.Unlock()
+			}
+			pageEvent := historyPageReading || (event.Type == sessionruntime.EventHistoryStart && event.HistoryPage)
+			assistant := &liveAssistant
+			if pageEvent {
+				assistant = &pageAssistant
+			}
+			recoveredCompletion := false
+			if !pageEvent {
+				recoveredCompletion = sessionTerminalRecoveredCompletion(recoveryActive, event)
+				if recoveryActive && !sessionTerminalRuntimeRecoveryEvent(event) {
+					recoveryActive = false
+				}
 			}
 			switch event.Type {
 			case sessionruntime.EventHistoryStart:
 				replayingHistory = true
+				historyMu.Lock()
+				if event.HistoryPage {
+					pendingHistoryCursor = event.HistoryCursor
+				} else if event.Reset || !initialHistorySeen {
+					historyCursor = event.HistoryCursor
+				}
+				if !event.HistoryPage {
+					initialHistorySeen = true
+				}
+				historyMu.Unlock()
 				if event.Reset {
+					finishAssistant(&liveAssistant)
 					activeTurnID = ""
 					activeTurnStarted = time.Time{}
 				}
+				if event.HistoryPage {
+					closeAssistantLine(&liveAssistant)
+					pageAssistant = sessionPlainAssistantState{}
+					historyPageReading = true
+					write("\n%s\n", formatter.muted("Earlier Session history:"))
+				}
 			case sessionruntime.EventHistoryEnd:
 				replayingHistory = false
-				write("\n%s\n\n", formatter.muted("Connected. Type a message, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
-			case sessionruntime.EventRuntimeRecovered:
-				recoveryActive = true
-				if streaming {
+				if event.HistoryPage {
+					finishAssistant(&pageAssistant)
+					historyMu.Lock()
+					historyCursor = pendingHistoryCursor
+					pendingHistoryCursor = ""
+					if event.RequestID == historyRequestID {
+						historyLoading = false
+						historyRequestID = ""
+					}
+					historyMu.Unlock()
+					historyPageReading = false
 					write("\n")
-					streaming = false
+					continue
 				}
+				if event.HistoryState != nil {
+					activeTurnID = event.HistoryState.ActiveTurnID
+					activeTurnStarted = time.Time{}
+					if event.HistoryState.ActiveTurnStarted != nil {
+						activeTurnStarted = *event.HistoryState.ActiveTurnStarted
+					}
+				}
+				closeAssistantLine(&liveAssistant)
+				liveAssistant.streaming = liveAssistant.streaming && activeTurnID != ""
+				if event.HistoryState != nil && len(event.HistoryState.QueuedTurns) > 0 {
+					write("\n%s\n", formatter.muted("Queued messages:"))
+					for _, turn := range event.HistoryState.QueuedTurns {
+						write("%s\n", formatter.userMessage(turn.Text))
+					}
+				}
+				historyMu.Lock()
+				hasEarlierHistory := historyCursor != ""
+				historyMu.Unlock()
+				if hasEarlierHistory {
+					write("\n%s\n", formatter.muted("Earlier Session history is available. Use /history to load the previous page."))
+				}
+				write("\n%s\n\n", formatter.muted("Connected. Type a message, /history, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
+			case sessionruntime.EventRuntimeRecovered:
+				if !pageEvent {
+					recoveryActive = true
+				}
+				finishAssistant(assistant)
 				write("%s\n", formatter.warning(event.Text))
 			case sessionruntime.EventUserMessage:
-				if streaming {
-					write("\n")
-					streaming = false
-				}
+				finishAssistant(assistant)
 				write("%s\n", formatter.userMessage(event.Text))
 				if color {
 					write("\n")
 				}
 			case sessionruntime.EventTurnStarted:
+				if pageEvent {
+					continue
+				}
 				if activeTurnID != event.TurnID || activeTurnStarted.IsZero() {
 					activeTurnStarted = sessionTerminalTurnStartedAt(event, time.Now(), replayingHistory)
 				}
 				activeTurnID = event.TurnID
 			case sessionruntime.EventAssistantDelta:
-				if !streaming {
+				if !assistant.lineOpen {
 					write("%s", formatter.assistantPrefix())
-					streaming = true
+					assistant.lineOpen = true
 				}
+				assistant.streaming = true
 				write("%s", event.Text)
 			case sessionruntime.EventAssistantMessage:
-				if streaming {
-					write("\n")
-					streaming = false
+				if assistant.streaming {
+					finishAssistant(assistant)
 				} else if event.Text != "" {
 					write("%s%s\n", formatter.assistantPrefix(), event.Text)
 				}
 			case sessionruntime.EventToolStarted:
-				if streaming {
-					write("\n")
-					streaming = false
-				}
+				finishAssistant(assistant)
 				write("%s\n", formatter.tool(event.ToolName))
 			case sessionruntime.EventToolCompleted:
 				write("%s\n", formatter.toolStatus(event.Status))
 			case sessionruntime.EventInputRequested:
-				if streaming {
-					write("\n")
-					streaming = false
-				}
+				finishAssistant(assistant)
 				write("\n%s\n", formatter.inputHeading(fmt.Sprintf("Input %s requested:", event.InputID)))
 				for _, question := range event.Questions {
 					write("  %s — %s\n", formatter.accent(question.ID), question.Question)
@@ -272,22 +358,13 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 			case sessionruntime.EventInputResolved:
 				write("\nInput %s %s.\n", event.InputID, formatter.status(event.Status))
 			case sessionruntime.EventTurnInterrupting:
-				if streaming {
-					write("\n")
-					streaming = false
-				}
+				finishAssistant(assistant)
 				write("\n%s\n", formatter.warning("Interrupting active work…"))
 			case sessionruntime.EventFileDiff:
-				if streaming {
-					write("\n")
-					streaming = false
-				}
+				finishAssistant(assistant)
 				write("\n%s\n%s\n", formatter.accent("--- file changes ---"), formatter.diff(event.Diff))
 			case sessionruntime.EventTurnCompleted:
-				if streaming {
-					write("\n")
-					streaming = false
-				}
+				finishAssistant(assistant)
 				if event.Status == "interrupted" {
 					write("%s\n", formatter.warning("Turn interrupted."))
 				}
@@ -299,10 +376,14 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 					write("\n")
 				}
 			case sessionruntime.EventError:
-				if streaming {
-					write("\n")
-					streaming = false
+				finishAssistant(assistant)
+				historyMu.Lock()
+				if event.RequestID != "" && event.RequestID == historyRequestID {
+					historyLoading = false
+					historyRequestID = ""
+					pendingHistoryCursor = ""
 				}
+				historyMu.Unlock()
 				write("%s\n", formatter.error("error: "+event.Text))
 			}
 		}
@@ -340,6 +421,28 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 			}
 			if line == "/quit" || line == "/exit" {
 				return nil
+			}
+			if strings.TrimSpace(line) == "/history" {
+				historyMu.Lock()
+				if historyLoading {
+					historyMu.Unlock()
+					write("%s\n", formatter.muted("Session history is already loading."))
+					continue
+				}
+				cursor := historyCursor
+				if cursor == "" {
+					historyMu.Unlock()
+					write("%s\n", formatter.muted("All retained Session history is loaded."))
+					continue
+				}
+				requestID := string(uuid.NewUUID())
+				historyLoading = true
+				historyRequestID = requestID
+				historyMu.Unlock()
+				if err := encoder.Encode(sessionruntime.ClientRequest{Type: "history", RequestID: requestID, HistoryCursor: cursor}); err != nil {
+					return err
+				}
+				continue
 			}
 			request := sessionTerminalRequest(line)
 			if request.Type == "" {

--- a/internal/cli/session_terminal_test.go
+++ b/internal/cli/session_terminal_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,7 +19,7 @@ func TestSessionTerminalRendersANSIEvents(t *testing.T) {
 	var events bytes.Buffer
 	encoder := json.NewEncoder(&events)
 	for _, event := range []sessionruntime.Event{
-		{Type: sessionruntime.EventHistoryEnd},
+		{Type: sessionruntime.EventHistoryEnd, HistoryState: &sessionruntime.HistoryState{QueuedTurns: []sessionruntime.HistoryQueuedTurn{{TurnID: "turn-2", Text: "queued"}}}},
 		{Type: sessionruntime.EventRuntimeRecovered, Text: "Session runtime restarted"},
 		{Type: sessionruntime.EventUserMessage, Text: "hello"},
 		{Type: sessionruntime.EventAssistantDelta, Text: "working"},
@@ -53,6 +55,7 @@ func TestSessionTerminalRendersANSIEvents(t *testing.T) {
 	got := output.String()
 	for _, want := range []string{
 		"\x1b[7m  hello  \x1b[0m",
+		"\x1b[7m  queued  \x1b[0m",
 		"\x1b[1m\x1b[33mSession runtime restarted\x1b[0m",
 		"\x1b[1m\x1b[36m↳ shell\x1b[0m",
 		"\x1b[32mcompleted\x1b[0m",
@@ -111,6 +114,123 @@ func TestSessionTerminalSeparatesStreamedTextBlocks(t *testing.T) {
 	}
 }
 
+func TestSessionPlainTerminalIsolatesHistoryPagesFromLiveStream(t *testing.T) {
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryStart, HistoryLimited: true, HistoryCursor: "cursor-1"},
+		{Type: sessionruntime.EventAssistantDelta, Text: "projected response"},
+		{Type: sessionruntime.EventHistoryEnd, HistoryState: &sessionruntime.HistoryState{ActiveTurnID: "turn-1"}},
+		{Type: sessionruntime.EventAssistantMessage, Text: "projected response"},
+		{Type: sessionruntime.EventAssistantDelta, Text: "live response"},
+		{Type: sessionruntime.EventHistoryStart, RequestID: "history-1", HistoryPage: true},
+		{Type: sessionruntime.EventAssistantMessage, Text: "earlier response"},
+		{Type: sessionruntime.EventHistoryEnd, RequestID: "history-1", HistoryPage: true},
+		{Type: sessionruntime.EventAssistantMessage, Text: "live response"},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, io.Discard, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got := output.String()
+	for _, response := range []string{"projected response", "live response", "earlier response"} {
+		if count := strings.Count(got, response); count != 1 {
+			t.Fatalf("terminal output contains %q %d times, want 1: %q", response, count, got)
+		}
+	}
+	if !strings.Contains(got, "Earlier Session history is available. Use /history to load the previous page.") {
+		t.Fatalf("terminal output = %q, want limited history notice", got)
+	}
+}
+
+func TestSessionPlainTerminalIgnoresDuplicateHistoryRequests(t *testing.T) {
+	input, inputWriter := io.Pipe()
+	events, eventsWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	defer events.Close()
+	defer eventsWriter.Close()
+
+	var output synchronizedBuffer
+	var requests synchronizedBuffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- runSessionPlainTerminalWithWidth(ctx, input, &output, json.NewDecoder(events), json.NewEncoder(&requests), false, func() int {
+			return sessionTUIDefaultWidth
+		})
+	}()
+
+	eventEncoder := json.NewEncoder(eventsWriter)
+	if err := eventEncoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, HistoryLimited: true, HistoryCursor: "cursor-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := eventEncoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd}); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionTerminalOutput(t, &output, "Connected.")
+	if _, err := io.WriteString(inputWriter, "/history\n/history\n"); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionTerminalOutput(t, &output, "Session history is already loading.")
+	var firstRequest sessionruntime.ClientRequest
+	if err := json.NewDecoder(strings.NewReader(requests.String())).Decode(&firstRequest); err != nil {
+		t.Fatal(err)
+	}
+	if firstRequest.Type != "history" || firstRequest.RequestID == "" || firstRequest.HistoryCursor != "cursor-1" {
+		t.Fatalf("first history request = %#v", firstRequest)
+	}
+	if err := eventEncoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, RequestID: firstRequest.RequestID, HistoryPage: true, HistoryCursor: "cursor-2"}); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionTerminalOutput(t, &output, "Earlier Session history:")
+	outputLength := len(output.String())
+	if err := eventEncoder.Encode(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd, RequestID: firstRequest.RequestID, HistoryPage: true}); err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionTerminalOutputLength(t, &output, outputLength+1)
+	if _, err := io.WriteString(inputWriter, "/history\n/quit\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(requests.String()))
+	var requestsSent []sessionruntime.ClientRequest
+	for {
+		var request sessionruntime.ClientRequest
+		if err := decoder.Decode(&request); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		requestsSent = append(requestsSent, request)
+	}
+	if len(requestsSent) != 2 {
+		t.Fatalf("history requests = %#v, want two requests", requestsSent)
+	}
+	if !reflect.DeepEqual(requestsSent[0], firstRequest) {
+		t.Fatalf("first history request = %#v, want %#v", requestsSent[0], firstRequest)
+	}
+	request := requestsSent[1]
+	if request.Type != "history" || request.RequestID == "" || request.RequestID == firstRequest.RequestID || request.HistoryCursor != "cursor-2" {
+		t.Fatalf("second history request = %#v", request)
+	}
+}
+
 func TestSessionTerminalRendersTurnDurationSeparator(t *testing.T) {
 	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
 	completedAt := startedAt.Add(5*time.Minute + 19*time.Second)
@@ -146,6 +266,36 @@ func TestSessionTerminalRendersTurnDurationSeparator(t *testing.T) {
 	}
 	if replyAt, separatorAt, questionAt := strings.Index(got, "First reply"), strings.Index(got, separator), strings.Index(got, "Second question"); replyAt < 0 || separatorAt < replyAt || questionAt < separatorAt {
 		t.Fatalf("terminal output order = %q, want separator between turns", got)
+	}
+}
+
+func TestSessionPlainTerminalContinuesProjectedTurnDuration(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(2*time.Hour + 3*time.Minute)
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryEnd, HistoryState: &sessionruntime.HistoryState{ActiveTurnID: "turn-1", ActiveTurnStarted: &startedAt}},
+		{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Timestamp: &completedAt},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, io.Discard, false); err != nil {
+		t.Fatal(err)
+	}
+
+	separator := formatSessionTurnSeparator(completedAt.Sub(startedAt), sessionTUIDefaultWidth)
+	if got := output.String(); !strings.Contains(got, separator) {
+		t.Fatalf("terminal output = %q, want separator %q", got, separator)
 	}
 }
 
@@ -326,5 +476,44 @@ func TestSessionTerminalDoesNotUseTUIForDumbTerminal(t *testing.T) {
 	}
 	if !sessionTerminalSupportsTUI("xterm-256color") {
 		t.Fatal("sessionTerminalSupportsTUI(xterm-256color) = false, want true")
+	}
+}
+
+type synchronizedBuffer struct {
+	mu sync.Mutex
+	bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(value []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.Write(value)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.String()
+}
+
+func waitForSessionTerminalOutput(t *testing.T, output *synchronizedBuffer, text string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for !strings.Contains(output.String(), text) {
+		if time.Now().After(deadline) {
+			t.Fatalf("terminal output = %q, want %q", output.String(), text)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func waitForSessionTerminalOutputLength(t *testing.T, output *synchronizedBuffer, length int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for len(output.String()) < length {
+		if time.Now().After(deadline) {
+			t.Fatalf("terminal output has %d bytes, want at least %d", len(output.String()), length)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -21,6 +21,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/kelos-dev/kelos/internal/sessionruntime"
 	"github.com/muesli/termenv"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const (
@@ -156,6 +157,17 @@ type sessionTUIModel struct {
 	historyWrites      []sessionTUIHistoryWrite
 	historyWriting     bool
 	nextHistoryID      uint64
+	hideNextHistory    bool
+	historyHiddenUntil int
+	historyCursor      string
+	historyNoticeAt    int
+	historyPageLoading bool
+	historyPageReading bool
+	historyPageCursor  string
+	historyPageEvents  []sessionruntime.Event
+	historyRequestID   string
+	historyPageStarted time.Time
+	historyAllReported bool
 	printHistory       func(string) tea.Cmd
 	waitForTermination tea.Cmd
 	now                func() time.Time
@@ -236,6 +248,7 @@ func newSessionTUIModel(events *json.Decoder, requests *json.Encoder, output io.
 		replayingHistory:   true,
 		historyAt:          -1,
 		streamingAt:        -1,
+		historyNoticeAt:    -1,
 		printHistory:       func(rendered string) tea.Cmd { return tea.Println(rendered) },
 		waitForTermination: waitForTermination,
 		now:                now,
@@ -374,6 +387,11 @@ func (m *sessionTUIModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.submitInput()
 			}
 			return m, nil
+		case tea.KeyPgUp:
+			if m.ready && m.input.Value() == "" {
+				return m, m.requestOlderHistory()
+			}
+			return m, nil
 		case tea.KeyCtrlJ:
 			if m.ready {
 				m.input.SetHeight(min(m.input.Height()+1, m.composerMaxHeight()))
@@ -429,6 +447,11 @@ func (m *sessionTUIModel) submitInput() tea.Cmd {
 	if line == "/quit" || line == "/exit" {
 		return m.quit()
 	}
+	if strings.TrimSpace(line) == "/history" {
+		m.input.Reset()
+		m.resizeComposer()
+		return m.requestOlderHistory()
+	}
 	request := sessionTerminalRequest(line)
 	if request.Type == "" {
 		m.input.Reset()
@@ -480,14 +503,41 @@ func (m *sessionTUIModel) nextInput() {
 
 func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUICommands {
 	var commands sessionTUICommands
+	if m.historyPageReading {
+		if event.Type == sessionruntime.EventHistoryEnd && event.HistoryPage {
+			return m.finishOlderHistoryPage()
+		}
+		if event.Type == sessionTerminalEventDiagnostic || (event.Type == sessionruntime.EventHistoryStart && !event.HistoryPage) {
+			m.cancelOlderHistoryPage()
+		} else {
+			m.historyPageEvents = append(m.historyPageEvents, event)
+			return commands
+		}
+	}
 	recoveredCompletion := sessionTerminalRecoveredCompletion(m.recoveryActive, event)
 	if m.recoveryActive && !sessionTerminalRuntimeRecoveryEvent(event) {
 		m.recoveryActive = false
 	}
 	switch event.Type {
 	case sessionruntime.EventHistoryStart:
+		if event.HistoryPage {
+			m.historyPageLoading = true
+			m.historyPageReading = true
+			m.historyPageCursor = event.HistoryCursor
+			m.historyPageEvents = nil
+			return commands
+		}
 		m.replayingHistory = true
+		if event.Reset || !m.ready {
+			m.historyCursor = event.HistoryCursor
+			m.historyAllReported = false
+		}
+		if event.HistoryLimited {
+			m.historyNoticeAt = len(m.blocks)
+			m.appendBlock(sessionTUIBlockNotice, "Earlier Session history is available. Use /history or Page Up to load the previous page.")
+		}
 		if event.Reset {
+			m.cancelOlderHistoryPage()
 			m.turnActive = false
 			m.activeTurnID = ""
 			m.activeTurnStarted = time.Time{}
@@ -500,7 +550,11 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		}
 	case sessionruntime.EventHistoryEnd:
 		m.replayingHistory = false
-		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Ctrl+C quits when idle. Use /answer INPUT QUESTION VALUE or /quit.")
+		m.applyHistoryState(event.HistoryState)
+		// A terminal-height transcript in both the managed view and native scrollback
+		// makes Bubble Tea move the smaller footer to the top when the copy is removed.
+		m.hideNextHistory = !m.ready
+		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Ctrl+C quits when idle. Use /history or Page Up for earlier history, /answer INPUT QUESTION VALUE, or /quit.")
 		m.ready = true
 		m.connectionStatus = ""
 		commands.ui = tea.Batch(m.input.Focus(), m.scheduleProgress())
@@ -513,6 +567,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		}
 		switch event.Status {
 		case sessionTerminalStatusConnecting, sessionTerminalStatusReconnecting:
+			m.cancelOlderHistoryPage()
 			if m.connectionStatus != event.Status {
 				m.connectionStarted = m.now()
 			}
@@ -595,6 +650,9 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		}
 	case sessionruntime.EventError:
 		m.finishStreaming()
+		if event.RequestID != "" && event.RequestID == m.historyRequestID {
+			m.cancelOlderHistoryPage()
+		}
 		if event.Status == "rejected" {
 			m.turnInterrupting = false
 		}
@@ -609,6 +667,131 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		m.refreshActiveView()
 	}
 	return commands
+}
+
+func (m *sessionTUIModel) applyHistoryState(state *sessionruntime.HistoryState) {
+	if state == nil {
+		return
+	}
+	m.queuedTurns = make(map[string]string, len(state.QueuedTurns))
+	m.queuedTurnOrder = make([]string, 0, len(state.QueuedTurns))
+	for _, turn := range state.QueuedTurns {
+		m.queuedTurns[turn.TurnID] = turn.Text
+		m.queuedTurnOrder = append(m.queuedTurnOrder, turn.TurnID)
+	}
+	m.activeTurnID = state.ActiveTurnID
+	m.turnActive = state.ActiveTurnID != ""
+	if state.ActiveTurnStarted != nil {
+		m.activeTurnStarted = *state.ActiveTurnStarted
+	} else if m.turnActive {
+		m.activeTurnStarted = m.now()
+	}
+	m.waitingForInput = state.WaitingForInput
+	m.turnInterrupting = state.TurnInterrupting
+}
+
+func (m *sessionTUIModel) requestOlderHistory() tea.Cmd {
+	if m.historyPageLoading {
+		return nil
+	}
+	if m.historyCursor == "" {
+		if m.historyAllReported {
+			return nil
+		}
+		m.historyAllReported = true
+		m.appendBlock(sessionTUIBlockNotice, "All retained Session history is loaded.")
+		command := m.queueReadyBlocks()
+		m.refreshActiveView()
+		return command
+	}
+	requestID := string(uuid.NewUUID())
+	if err := m.requests.Encode(sessionruntime.ClientRequest{
+		Type:          "history",
+		RequestID:     requestID,
+		HistoryCursor: m.historyCursor,
+	}); err != nil {
+		m.err = err
+		return m.quit()
+	}
+	m.historyPageLoading = true
+	m.historyRequestID = requestID
+	m.historyPageStarted = m.now()
+	return m.scheduleProgress()
+}
+
+func (m *sessionTUIModel) finishOlderHistoryPage() sessionTUICommands {
+	blocks := m.replayHistoryPage(m.historyPageEvents)
+	m.historyCursor = m.historyPageCursor
+	m.historyAllReported = m.historyCursor == ""
+	m.historyPageLoading = false
+	m.historyPageReading = false
+	m.historyPageCursor = ""
+	m.historyPageEvents = nil
+	m.historyRequestID = ""
+
+	noticeChanged := false
+	if m.historyCursor == "" && m.historyNoticeAt >= 0 && m.historyNoticeAt < len(m.blocks) {
+		m.blocks[m.historyNoticeAt].text = "All retained Session history is loaded."
+		m.blocks[m.historyNoticeAt].dirty = true
+		noticeChanged = true
+	}
+	command := m.prependHistoryBlocks(blocks)
+	if len(blocks) == 0 && noticeChanged {
+		m.reflowGeneration++
+		command = m.queueHistoryReflow(m.reflowGeneration)
+	}
+	m.refreshActiveView()
+	return sessionTUICommands{history: command}
+}
+
+func (m *sessionTUIModel) cancelOlderHistoryPage() {
+	m.historyPageLoading = false
+	m.historyPageReading = false
+	m.historyPageCursor = ""
+	m.historyPageEvents = nil
+	m.historyRequestID = ""
+}
+
+func (m *sessionTUIModel) replayHistoryPage(events []sessionruntime.Event) []sessionTUIBlock {
+	replay := &sessionTUIModel{
+		styles:          m.styles,
+		queuedTurns:     make(map[string]string),
+		toolNames:       make(map[string]string),
+		width:           m.width,
+		height:          m.height,
+		streamingAt:     -1,
+		historyNoticeAt: -1,
+		now:             m.now,
+	}
+	for _, event := range events {
+		replay.applyEvent(event)
+	}
+	replay.finishStreaming()
+	return replay.blocks
+}
+
+func (m *sessionTUIModel) prependHistoryBlocks(blocks []sessionTUIBlock) tea.Cmd {
+	if len(blocks) == 0 {
+		return nil
+	}
+	count := len(blocks)
+	m.blocks = append(blocks, m.blocks...)
+	if m.streamingAt >= 0 {
+		m.streamingAt += count
+	}
+	if m.historyNoticeAt >= 0 {
+		m.historyNoticeAt += count
+	}
+	m.committed += count
+	m.historyQueued += count
+	for index := range m.historyWrites {
+		if m.historyWrites[index].commitEnd > 0 {
+			m.historyWrites[index].commitEnd += count
+		}
+	}
+	m.invalidateTranscript()
+	m.reflowGeneration++
+	return m.queueHistoryReflow(m.reflowGeneration)
 }
 
 func (m *sessionTUIModel) scheduleRefresh() tea.Cmd {
@@ -634,7 +817,7 @@ func (m *sessionTUIModel) scheduleProgress() tea.Cmd {
 func (m *sessionTUIModel) progressVisible() bool {
 	connecting := m.connectionStatus == sessionTerminalStatusReconnecting ||
 		(m.connectionStatus == sessionTerminalStatusConnecting && !m.ready)
-	return connecting || m.activeTurnID != ""
+	return connecting || m.historyPageLoading || m.activeTurnID != ""
 }
 
 func (m *sessionTUIModel) canInterruptTurn() bool {
@@ -836,6 +1019,10 @@ func (m *sessionTUIModel) queueReadyBlocks() tea.Cmd {
 		rendered:  m.renderBlockRange(m.historyQueued, end),
 		commitEnd: end,
 	})
+	if m.hideNextHistory {
+		m.historyHiddenUntil = end
+		m.hideNextHistory = false
+	}
 	m.historyQueued = end
 	return m.startHistoryWrite()
 }
@@ -893,6 +1080,9 @@ func (m *sessionTUIModel) completeHistoryWrite(write sessionTUIHistoryWrite) {
 	if write.commitEnd > m.committed {
 		m.committed = write.commitEnd
 	}
+	if m.committed >= m.historyHiddenUntil {
+		m.historyHiddenUntil = 0
+	}
 	m.refreshActiveView()
 }
 
@@ -905,7 +1095,8 @@ func (m *sessionTUIModel) popHistoryWrite() {
 }
 
 func (m *sessionTUIModel) refreshActiveView() {
-	m.activeView = m.renderBlockRange(m.committed, len(m.blocks))
+	start := max(m.committed, m.historyHiddenUntil)
+	m.activeView = m.renderBlockRange(start, len(m.blocks))
 }
 
 func (m *sessionTUIModel) quit() tea.Cmd {
@@ -1372,6 +1563,9 @@ func (m *sessionTUIModel) progressView() string {
 	case m.connectionStatus == sessionTerminalStatusConnecting && !m.ready:
 		label = "Connecting"
 		started = m.connectionStarted
+	case m.historyPageLoading:
+		label = "Loading history"
+		started = m.historyPageStarted
 	case m.turnInterrupting:
 		label = "Interrupting"
 	case m.waitingForInput:

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -610,6 +610,151 @@ func TestSessionTUIBatchesLoadedHistory(t *testing.T) {
 	}
 }
 
+func TestSessionTUIKeepsPendingInitialHistoryOutOfManagedView(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.resize(40, 8)
+	writes := captureAsynchronousSessionTUIHistory(model)
+	question := strings.Repeat("long history line\n", 10)
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, Text: question})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventAssistantMessage, Text: "loaded answer"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
+
+	if len(*writes) != 1 || !strings.Contains((*writes)[0], "long history line") {
+		t.Fatalf("initial history write = %q", *writes)
+	}
+	view := stripSessionTUIANSI(model.View())
+	if strings.Contains(view, "long history line") || strings.Contains(view, "loaded answer") {
+		t.Fatalf("pending initial history remains in managed view: %q", view)
+	}
+	if lines := strings.Count(view, "\n") + 1; lines > model.footerHeight()+1 {
+		t.Fatalf("managed view has %d lines, want only footer height %d: %q", lines, model.footerHeight(), view)
+	}
+	if model.historyHiddenUntil != len(model.blocks) {
+		t.Fatalf("hidden history boundary = %d, want %d", model.historyHiddenUntil, len(model.blocks))
+	}
+
+	model.finishHistoryWrite(model.historyWrites[0].id)
+	if model.historyHiddenUntil != 0 || model.committed != len(model.blocks) {
+		t.Fatalf("completed history state = hidden %d committed %d, want hidden 0 committed %d", model.historyHiddenUntil, model.committed, len(model.blocks))
+	}
+}
+
+func TestSessionTUIReportsLimitedHistory(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	history := captureSessionTUIHistory(model)
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, HistoryLimited: true, HistoryCursor: "cursor-1"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
+
+	if len(*history) != 1 {
+		t.Fatalf("history was committed in %d batches, want 1: %q", len(*history), *history)
+	}
+	if got := stripSessionTUIANSI((*history)[0]); !strings.Contains(got, "/history or Page Up") {
+		t.Fatalf("limited history notice = %q", got)
+	}
+}
+
+func TestSessionTUILoadsAndPrependsOlderHistoryPage(t *testing.T) {
+	model, requests := newSessionTUITestModel()
+	history := captureSessionTUIHistory(model)
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, HistoryLimited: true, HistoryCursor: "cursor-1"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "recent question"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-2"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventAssistantMessage, TurnID: "turn-2", Text: "recent answer"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-2", Status: "completed"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
+
+	model.input.SetValue("/history")
+	model.submitInput()
+	var request sessionruntime.ClientRequest
+	if err := json.NewDecoder(requests).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Type != "history" || request.RequestID == "" || request.HistoryCursor != "cursor-1" {
+		t.Fatalf("history request = %#v", request)
+	}
+	if !model.historyPageLoading || !strings.Contains(stripSessionTUIANSI(model.progressView()), "Loading history") {
+		t.Fatalf("history request did not enter loading state: loading=%t progress=%q", model.historyPageLoading, stripSessionTUIANSI(model.progressView()))
+	}
+
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, HistoryPage: true, RequestID: request.RequestID})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-1", Text: "earlier question"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventAssistantMessage, TurnID: "turn-1", Text: "earlier answer"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Status: "completed"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd, HistoryPage: true, RequestID: request.RequestID})
+
+	if len(*history) != 2 {
+		t.Fatalf("history writes = %d, want initial write and replay: %q", len(*history), *history)
+	}
+	replayed := (*history)[1]
+	if !strings.HasPrefix(replayed, sessionTUIClearHistory) {
+		t.Fatalf("older history replay = %q, want terminal history reset", replayed)
+	}
+	view := stripSessionTUIANSI(replayed)
+	for _, want := range []string{"earlier question", "earlier answer", "recent question", "recent answer", "All retained Session history is loaded"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("older history replay = %q, want %q", view, want)
+		}
+	}
+	if strings.Index(view, "earlier question") > strings.Index(view, "recent question") {
+		t.Fatalf("older history was not prepended: %q", view)
+	}
+	if model.historyCursor != "" || model.historyPageLoading || model.historyPageReading {
+		t.Fatalf("history page state was not completed: cursor=%q loading=%t reading=%t", model.historyCursor, model.historyPageLoading, model.historyPageReading)
+	}
+}
+
+func TestSessionTUIAppliesStateFromProjectedHistory(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, Text: "active request"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventInputRequested, InputID: "input-1", Questions: []sessionruntime.InputQuestion{{ID: "confirm", Question: "Continue?"}}})
+	model.applyEvent(sessionruntime.Event{
+		Type: sessionruntime.EventHistoryEnd,
+		HistoryState: &sessionruntime.HistoryState{
+			ActiveTurnID:      "turn-2",
+			ActiveTurnStarted: &startedAt,
+			WaitingForInput:   true,
+			QueuedTurns: []sessionruntime.HistoryQueuedTurn{
+				{TurnID: "turn-3", Text: "queued request"},
+			},
+		},
+	})
+
+	if !model.turnActive || model.activeTurnID != "turn-2" || !model.activeTurnStarted.Equal(startedAt) || !model.waitingForInput {
+		t.Fatalf("active state = active %t ID %q started %v waiting %t", model.turnActive, model.activeTurnID, model.activeTurnStarted, model.waitingForInput)
+	}
+	if len(model.queuedTurnOrder) != 1 || model.queuedTurns["turn-3"] != "queued request" {
+		t.Fatalf("queued state = order %#v turns %#v", model.queuedTurnOrder, model.queuedTurns)
+	}
+	if transcript := stripSessionTUIANSI(model.renderTranscript()); !strings.Contains(transcript, "active request") || !strings.Contains(transcript, "Continue?") {
+		t.Fatalf("projected transcript = %q", transcript)
+	}
+}
+
+func TestSessionTUICancelsPartialHistoryPageOnReconnect(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, HistoryLimited: true, HistoryCursor: "cursor-1"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
+	model.historyPageLoading = true
+	model.historyRequestID = "history-1"
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart, HistoryPage: true, RequestID: "history-1", HistoryCursor: "cursor-2"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-1", Text: "partial page"})
+
+	model.applyEvent(sessionruntime.Event{Type: sessionTerminalEventDiagnostic, Status: sessionTerminalStatusReconnecting})
+
+	if model.historyPageLoading || model.historyPageReading || len(model.historyPageEvents) != 0 {
+		t.Fatalf("partial history page was not discarded: loading=%t reading=%t events=%#v", model.historyPageLoading, model.historyPageReading, model.historyPageEvents)
+	}
+	if model.historyCursor != "cursor-1" {
+		t.Fatalf("history cursor = %q, want retry cursor", model.historyCursor)
+	}
+	if strings.Contains(model.renderTranscript(), "partial page") {
+		t.Fatalf("partial history page was rendered: %q", stripSessionTUIANSI(model.renderTranscript()))
+	}
+}
+
 func TestSessionTUICoalescesAssistantDeltaRefreshes(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	model.ready = true

--- a/internal/sessionruntime/history.go
+++ b/internal/sessionruntime/history.go
@@ -1,0 +1,443 @@
+package sessionruntime
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+)
+
+const (
+	maxHistoryItemLimit       = 100
+	maxHistoryByteLimit       = 1024 * 1024
+	maxHistoryMessageBytes    = 32 * 1024
+	maxHistoryToolOutputBytes = 8 * 1024
+	maxHistoryDiffBytes       = 32 * 1024
+	maxHistoryNoticeBytes     = 8 * 1024
+	maxHistoryIdentifierBytes = 1024
+	maxHistoryQuestions       = 5
+	maxHistoryOptions         = 10
+
+	historyTruncationMarker = "\n… history item truncated …\n"
+)
+
+type historyItem struct {
+	events       []Event
+	firstEventID int64
+	lastEventID  int64
+}
+
+type historyTurn struct {
+	user            *Event
+	userEventID     int64
+	started         bool
+	activityEventID int64
+	startedAt       *time.Time
+	completed       bool
+	interrupting    bool
+}
+
+type historyAssistant struct {
+	event        Event
+	text         *historyTextBuffer
+	finalText    string
+	firstEventID int64
+	lastEventID  int64
+}
+
+type historyPendingEvent struct {
+	event        Event
+	firstEventID int64
+}
+
+// projectHistory converts provider event streams into replayable display items
+// and separates live conversation state from transcript page boundaries.
+func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
+	events := make([]Event, len(source))
+	copy(events, source)
+	for index := range events {
+		if events[index].ID <= 0 {
+			events[index].ID = int64(index + 1)
+		}
+	}
+
+	turns := make(map[string]*historyTurn)
+	pendingInputs := make(map[string]Event)
+	for index := range events {
+		event := events[index]
+		if event.TurnID != "" {
+			turn := turns[event.TurnID]
+			if turn == nil {
+				turn = &historyTurn{}
+				turns[event.TurnID] = turn
+			}
+			switch event.Type {
+			case EventUserMessage:
+				copy := event
+				turn.user = &copy
+				turn.userEventID = event.ID
+			case EventTurnStarted:
+				turn.started = true
+				turn.startedAt = event.Timestamp
+			case EventTurnInterrupting:
+				turn.interrupting = true
+			case EventTurnCompleted:
+				turn.completed = true
+				turn.interrupting = false
+			}
+			if event.Type != EventUserMessage && event.Type != EventTurnCompleted {
+				turn.activityEventID = event.ID
+				if turn.startedAt == nil {
+					turn.startedAt = event.Timestamp
+				}
+			}
+		}
+		switch event.Type {
+		case EventInputRequested:
+			if event.InputID != "" {
+				pendingInputs[event.InputID] = event
+			}
+		case EventInputResolved:
+			delete(pendingInputs, event.InputID)
+		}
+	}
+
+	state := HistoryState{}
+	queued := make([]HistoryQueuedTurn, 0)
+	queuedEventIDs := make(map[string]int64)
+	var activeEventID int64
+	for turnID, turn := range turns {
+		if turn.activityEventID > 0 && !turn.completed && turn.activityEventID >= activeEventID {
+			state.ActiveTurnID = turnID
+			state.ActiveTurnStarted = turn.startedAt
+			state.TurnInterrupting = turn.interrupting
+			activeEventID = turn.activityEventID
+		}
+		if turn.user != nil && !turn.started && turn.activityEventID == 0 && !turn.completed {
+			queued = append(queued, HistoryQueuedTurn{TurnID: turnID, Text: boundedHistoryText(turn.user.Text, maxHistoryMessageBytes)})
+			queuedEventIDs[turnID] = turn.userEventID
+		}
+	}
+	sort.Slice(queued, func(i, j int) bool {
+		return queuedEventIDs[queued[i].TurnID] < queuedEventIDs[queued[j].TurnID]
+	})
+	state.QueuedTurns = queued
+	state.WaitingForInput = len(pendingInputs) > 0
+
+	queuedTurnIDs := make(map[string]struct{}, len(queued))
+	for _, turn := range queued {
+		queuedTurnIDs[turn.TurnID] = struct{}{}
+	}
+
+	items := make([]historyItem, 0)
+	assistants := make(map[string]historyAssistant)
+	tools := make(map[string]historyPendingEvent)
+	inputs := make(map[string]historyPendingEvent)
+	addItem := func(firstEventID, lastEventID int64, itemEvents ...Event) {
+		if len(itemEvents) == 0 {
+			return
+		}
+		items = append(items, historyItem{
+			events:       itemEvents,
+			firstEventID: firstEventID,
+			lastEventID:  lastEventID,
+		})
+	}
+	flushAssistant := func(turnID string, keepStreaming bool) {
+		assistant, exists := assistants[turnID]
+		if !exists {
+			return
+		}
+		assistant.event.Type = EventAssistantMessage
+		if keepStreaming && turnID == state.ActiveTurnID {
+			assistant.event.Type = EventAssistantDelta
+		}
+		assistant.event.Text = assistant.finalText
+		if assistant.event.Text == "" && assistant.text != nil {
+			assistant.event.Text = assistant.text.String()
+		}
+		addItem(assistant.firstEventID, assistant.lastEventID, normalizedHistoryEvent(assistant.event))
+		delete(assistants, turnID)
+	}
+
+	for _, event := range events {
+		if _, queued := queuedTurnIDs[event.TurnID]; queued {
+			continue
+		}
+		if event.Type != EventAssistantDelta && event.Type != EventAssistantMessage {
+			flushAssistant(event.TurnID, false)
+		}
+
+		switch event.Type {
+		case EventUserMessage:
+			event.Text = boundedHistoryText(event.Text, maxHistoryMessageBytes)
+			addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+		case EventAssistantDelta:
+			assistant := assistants[event.TurnID]
+			if assistant.firstEventID == 0 {
+				assistant.firstEventID = event.ID
+				assistant.event = event
+				assistant.text = newHistoryTextBuffer(maxHistoryMessageBytes)
+			}
+			assistant.lastEventID = event.ID
+			assistant.event.ID = event.ID
+			assistant.text.WriteString(event.Text)
+			assistants[event.TurnID] = assistant
+		case EventAssistantMessage:
+			assistant, exists := assistants[event.TurnID]
+			if exists {
+				if event.Text != "" {
+					assistant.finalText = boundedHistoryText(event.Text, maxHistoryMessageBytes)
+				}
+				assistant.event.ID = event.ID
+				assistant.lastEventID = event.ID
+				assistants[event.TurnID] = assistant
+				flushAssistant(event.TurnID, false)
+				continue
+			}
+			if event.Text != "" {
+				event.Text = boundedHistoryText(event.Text, maxHistoryMessageBytes)
+				addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+			}
+		case EventToolStarted:
+			if event.ToolID == "" {
+				addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+				continue
+			}
+			tools[historyToolKey(event)] = historyPendingEvent{event: event, firstEventID: event.ID}
+		case EventToolCompleted:
+			completion := normalizedHistoryEvent(event)
+			completion.Output = boundedHistoryText(completion.Output, maxHistoryToolOutputBytes)
+			toolKey := historyToolKey(event)
+			started, exists := tools[toolKey]
+			if !exists {
+				start := normalizedHistoryEvent(Event{
+					ID:       event.ID,
+					Type:     EventToolStarted,
+					ToolID:   event.ToolID,
+					ToolName: event.ToolName,
+					Status:   "running",
+				})
+				addItem(event.ID, event.ID, start, completion)
+				continue
+			}
+			addItem(started.firstEventID, event.ID, normalizedHistoryEvent(started.event), completion)
+			delete(tools, toolKey)
+		case EventInputRequested:
+			if _, pending := pendingInputs[event.InputID]; !pending {
+				inputs[event.InputID] = historyPendingEvent{event: event, firstEventID: event.ID}
+			}
+		case EventInputResolved:
+			resolved := normalizedHistoryEvent(event)
+			requested, exists := inputs[event.InputID]
+			if !exists {
+				addItem(event.ID, event.ID, resolved)
+				continue
+			}
+			addItem(requested.firstEventID, event.ID, normalizedHistoryEvent(requested.event), resolved)
+			delete(inputs, event.InputID)
+		case EventFileDiff:
+			event.Diff = boundedHistoryText(event.Diff, maxHistoryDiffBytes)
+			addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+		case EventRuntimeRecovered, EventError, EventTurnInterrupting:
+			event.Text = boundedHistoryText(event.Text, maxHistoryNoticeBytes)
+			addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+		case EventTurnCompleted:
+			if event.Status == "interrupted" {
+				addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+			}
+		}
+	}
+	for turnID := range assistants {
+		flushAssistant(turnID, true)
+	}
+	for _, tool := range tools {
+		addItem(tool.firstEventID, tool.firstEventID, normalizedHistoryEvent(tool.event))
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].firstEventID == items[j].firstEventID {
+			return items[i].lastEventID < items[j].lastEventID
+		}
+		return items[i].firstEventID < items[j].firstEventID
+	})
+
+	essential := make([]Event, 0, len(pendingInputs))
+	for _, event := range pendingInputs {
+		pending := normalizedHistoryEvent(event)
+		pending.InputID = event.InputID
+		pending.Questions = event.Questions
+		essential = append(essential, pending)
+	}
+	sort.Slice(essential, func(i, j int) bool { return essential[i].ID < essential[j].ID })
+	return items, state, essential
+}
+
+func historyToolKey(event Event) string {
+	return event.TurnID + "\x00" + event.ToolID
+}
+
+type historyTextBuffer struct {
+	maxBytes  int
+	head      []byte
+	tail      []byte
+	truncated bool
+}
+
+func newHistoryTextBuffer(maxBytes int) *historyTextBuffer {
+	return &historyTextBuffer{maxBytes: maxBytes}
+}
+
+func (b *historyTextBuffer) WriteString(value string) {
+	if value == "" || b.maxBytes <= 0 {
+		return
+	}
+	if b.truncated {
+		b.appendTail([]byte(value))
+		return
+	}
+	if len(b.head)+len(value) <= b.maxBytes {
+		b.head = append(b.head, value...)
+		return
+	}
+
+	headLimit, _ := b.limits()
+	retained := b.head
+	retainedHeadBytes := min(headLimit, len(retained))
+	b.head = append([]byte(nil), retained[:retainedHeadBytes]...)
+	valueHeadBytes := min(headLimit-len(b.head), len(value))
+	b.head = append(b.head, value[:valueHeadBytes]...)
+	b.truncated = true
+	b.appendTail(retained[retainedHeadBytes:])
+	b.appendTail([]byte(value[valueHeadBytes:]))
+}
+
+func (b *historyTextBuffer) String() string {
+	if !b.truncated {
+		return string(b.head)
+	}
+	return string(validUTF8Prefix(b.head)) + historyTruncationMarker + string(validUTF8Suffix(b.tail))
+}
+
+func (b *historyTextBuffer) limits() (int, int) {
+	available := max(0, b.maxBytes-len(historyTruncationMarker))
+	head := available / 2
+	return head, available - head
+}
+
+func (b *historyTextBuffer) appendTail(value []byte) {
+	_, tailLimit := b.limits()
+	if tailLimit == 0 {
+		return
+	}
+	if len(value) >= tailLimit {
+		b.tail = append(b.tail[:0], value[len(value)-tailLimit:]...)
+		return
+	}
+	overflow := len(b.tail) + len(value) - tailLimit
+	if overflow > 0 {
+		copy(b.tail, b.tail[overflow:])
+		b.tail = b.tail[:len(b.tail)-overflow]
+	}
+	b.tail = append(b.tail, value...)
+}
+
+// historyItemsPage returns at least one eligible item so every page advances,
+// even when that item alone exceeds the requested byte limit.
+func historyItemsPage(items []historyItem, beforeEventID int64, itemLimit, byteLimit int) ([]Event, int64) {
+	eligible := make([]historyItem, 0, len(items))
+	for _, item := range items {
+		if beforeEventID == 0 || item.firstEventID < beforeEventID {
+			eligible = append(eligible, item)
+		}
+	}
+	if len(eligible) == 0 || itemLimit <= 0 || byteLimit <= 0 {
+		return nil, 0
+	}
+
+	start := len(eligible)
+	bytes := 0
+	for start > 0 && len(eligible)-start < itemLimit {
+		itemBytes := historyItemWireBytes(eligible[start-1])
+		if start < len(eligible) && bytes+itemBytes > byteLimit {
+			break
+		}
+		start--
+		bytes += itemBytes
+	}
+
+	page := make([]Event, 0)
+	for _, item := range eligible[start:] {
+		page = append(page, item.events...)
+	}
+	if start == 0 {
+		return page, 0
+	}
+	return page, eligible[start].firstEventID
+}
+
+func historyItemWireBytes(item historyItem) int {
+	size := 0
+	for _, event := range item.events {
+		encoded, _ := json.Marshal(event)
+		size += len(encoded) + 1
+	}
+	return size
+}
+
+func normalizedHistoryEvent(event Event) Event {
+	event.Timestamp = nil
+	event.RequestID = ""
+	event.TurnID = ""
+	event.FirstEventID = 0
+	event.LastEventID = 0
+	event.JournalID = ""
+	event.Reset = false
+	event.HistoryLimited = false
+	event.HistoryPage = false
+	event.HistoryCursor = ""
+	event.HistoryState = nil
+	event.Runtime = nil
+	event.ToolID = boundedHistoryText(event.ToolID, maxHistoryIdentifierBytes)
+	event.ToolName = boundedHistoryText(event.ToolName, maxHistoryIdentifierBytes)
+	event.InputID = boundedHistoryText(event.InputID, maxHistoryIdentifierBytes)
+	event.Status = boundedHistoryText(event.Status, maxHistoryIdentifierBytes)
+	event.Questions = boundedHistoryQuestions(event.Questions)
+	return event
+}
+
+func boundedHistoryQuestions(questions []InputQuestion) []InputQuestion {
+	if len(questions) > maxHistoryQuestions {
+		questions = questions[:maxHistoryQuestions]
+	}
+	bounded := make([]InputQuestion, len(questions))
+	for index, question := range questions {
+		bounded[index] = question
+		bounded[index].ID = boundedHistoryText(question.ID, maxHistoryIdentifierBytes)
+		bounded[index].Header = boundedHistoryText(question.Header, 512)
+		bounded[index].Question = boundedHistoryText(question.Question, 4*1024)
+		options := question.Options
+		if len(options) > maxHistoryOptions {
+			options = options[:maxHistoryOptions]
+		}
+		bounded[index].Options = make([]InputOption, len(options))
+		for optionIndex, option := range options {
+			bounded[index].Options[optionIndex] = InputOption{
+				Label:       boundedHistoryText(option.Label, 512),
+				Description: boundedHistoryText(option.Description, 512),
+			}
+		}
+	}
+	return bounded
+}
+
+func boundedHistoryText(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	available := max(0, maxBytes-len(historyTruncationMarker))
+	headBytes := available / 2
+	tailBytes := available - headBytes
+	head := validUTF8Prefix([]byte(value[:headBytes]))
+	tail := validUTF8Suffix([]byte(value[len(value)-tailBytes:]))
+	return string(head) + historyTruncationMarker + string(tail)
+}

--- a/internal/sessionruntime/history_test.go
+++ b/internal/sessionruntime/history_test.go
@@ -1,0 +1,164 @@
+package sessionruntime
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	events := []Event{
+		{ID: 1, Type: EventUserMessage, TurnID: "turn-1", Text: "first request"},
+		{ID: 2, Type: EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt, Status: "running"},
+		{ID: 3, Type: EventAssistantDelta, TurnID: "turn-1", Text: "Claude "},
+		{ID: 4, Type: EventAssistantDelta, TurnID: "turn-1", Text: "answer"},
+		{ID: 5, Type: EventAssistantMessage, TurnID: "turn-1", Text: "Claude answer"},
+		{ID: 6, Type: EventToolStarted, TurnID: "turn-1", ToolID: "tool-1", ToolName: "shell", Status: "running"},
+		{ID: 7, Type: EventToolCompleted, TurnID: "turn-1", ToolID: "tool-1", ToolName: "shell", Output: strings.Repeat("output", 2*maxHistoryToolOutputBytes), Status: "completed"},
+		{ID: 8, Type: EventInputRequested, TurnID: "turn-1", InputID: "input-1", Questions: []InputQuestion{{ID: "choice", Question: "Choose"}}, Status: "pending"},
+		{ID: 9, Type: EventInputResolved, InputID: "input-1", Status: "answered"},
+		{ID: 10, Type: EventTurnCompleted, TurnID: "turn-1", Status: "completed"},
+		{ID: 11, Type: EventUserMessage, TurnID: "turn-2", Text: "active request"},
+		{ID: 12, Type: EventTurnStarted, TurnID: "turn-2", Timestamp: &startedAt, Status: "running"},
+		{ID: 13, Type: EventAssistantDelta, TurnID: "turn-2", Text: "Open"},
+		{ID: 14, Type: EventAssistantDelta, TurnID: "turn-2", Text: "Code answer"},
+		{ID: 15, Type: EventInputRequested, TurnID: "turn-2", InputID: "input-2", Questions: []InputQuestion{{ID: "confirm", Question: "Continue?"}}, Status: "pending"},
+		{ID: 16, Type: EventUserMessage, TurnID: "turn-3", Text: "queued first"},
+		{ID: 17, Type: EventUserMessage, TurnID: "turn-4", Text: "queued second"},
+	}
+
+	items, state, essential := projectHistory(events)
+	if state.ActiveTurnID != "turn-2" || state.ActiveTurnStarted == nil || !state.ActiveTurnStarted.Equal(startedAt) {
+		t.Fatalf("history state = %#v, want active turn-2", state)
+	}
+	if !state.WaitingForInput || state.TurnInterrupting {
+		t.Fatalf("history state = %#v, want waiting active turn", state)
+	}
+	if len(state.QueuedTurns) != 2 || state.QueuedTurns[0].TurnID != "turn-3" || state.QueuedTurns[1].TurnID != "turn-4" {
+		t.Fatalf("queued turns = %#v", state.QueuedTurns)
+	}
+	if len(essential) != 1 || essential[0].Type != EventInputRequested || essential[0].InputID != "input-2" || essential[0].TurnID != "" {
+		t.Fatalf("essential history events = %#v", essential)
+	}
+
+	projected, cursor := historyItemsPage(items, 0, 100, maxHistoryByteLimit)
+	if cursor != 0 {
+		t.Fatalf("history cursor = %d, want all items", cursor)
+	}
+	assertEventTypes(t, projected,
+		EventUserMessage,
+		EventAssistantMessage,
+		EventToolStarted,
+		EventToolCompleted,
+		EventInputRequested,
+		EventInputResolved,
+		EventUserMessage,
+		EventAssistantMessage,
+	)
+	for _, event := range projected {
+		if event.TurnID != "" || event.RequestID != "" {
+			t.Fatalf("projected event retains transient state: %#v", event)
+		}
+	}
+	if projected[1].Text != "Claude answer" || projected[7].Text != "OpenCode answer" {
+		t.Fatalf("assistant messages = %q, %q", projected[1].Text, projected[7].Text)
+	}
+	if len(projected[3].Output) > maxHistoryToolOutputBytes || !strings.Contains(projected[3].Output, historyTruncationMarker) {
+		t.Fatalf("tool output preview has %d bytes", len(projected[3].Output))
+	}
+}
+
+func TestHistoryItemsPageHonorsItemAndByteLimits(t *testing.T) {
+	events := make([]Event, 0, 5)
+	for id := int64(1); id <= 5; id++ {
+		events = append(events, Event{ID: id, Type: EventUserMessage, Text: strings.Repeat(string(rune('a'+id)), 256)})
+	}
+	items, _, _ := projectHistory(events)
+
+	page, cursor := historyItemsPage(items, 0, 2, maxHistoryByteLimit)
+	assertHistoryEventIDs(t, page, 4, 5)
+	if cursor != 4 {
+		t.Fatalf("history cursor = %d, want 4", cursor)
+	}
+	page, cursor = historyItemsPage(items, cursor, 2, maxHistoryByteLimit)
+	assertHistoryEventIDs(t, page, 2, 3)
+	if cursor != 2 {
+		t.Fatalf("history cursor = %d, want 2", cursor)
+	}
+	page, cursor = historyItemsPage(items, cursor, 2, maxHistoryByteLimit)
+	assertHistoryEventIDs(t, page, 1)
+	if cursor != 0 {
+		t.Fatalf("history cursor = %d, want end of history", cursor)
+	}
+
+	page, cursor = historyItemsPage(items, 0, len(items), historyItemWireBytes(items[len(items)-1]))
+	assertHistoryEventIDs(t, page, 5)
+	if cursor != 5 {
+		t.Fatalf("byte-limited history cursor = %d, want 5", cursor)
+	}
+}
+
+func TestProjectHistoryKeepsActiveAssistantStreaming(t *testing.T) {
+	items, state, _ := projectHistory([]Event{
+		{ID: 1, Type: EventUserMessage, TurnID: "turn-1", Text: "request"},
+		{ID: 2, Type: EventTurnStarted, TurnID: "turn-1", Status: "running"},
+		{ID: 3, Type: EventAssistantDelta, TurnID: "turn-1", Text: "partial "},
+		{ID: 4, Type: EventAssistantDelta, TurnID: "turn-1", Text: "answer"},
+	})
+	if state.ActiveTurnID != "turn-1" {
+		t.Fatalf("active turn = %q, want turn-1", state.ActiveTurnID)
+	}
+	page, cursor := historyItemsPage(items, 0, DefaultHistoryItemLimit, DefaultHistoryByteLimit)
+	if cursor != 0 {
+		t.Fatalf("history cursor = %d, want all items", cursor)
+	}
+	assertEventTypes(t, page, EventUserMessage, EventAssistantDelta)
+	if page[1].Text != "partial answer" {
+		t.Fatalf("active assistant text = %q", page[1].Text)
+	}
+}
+
+func TestProjectHistoryBoundsLargeMessages(t *testing.T) {
+	items, _, _ := projectHistory([]Event{{
+		ID:   1,
+		Type: EventAssistantMessage,
+		Text: strings.Repeat("界", maxHistoryMessageBytes),
+	}})
+	page, cursor := historyItemsPage(items, 0, DefaultHistoryItemLimit, DefaultHistoryByteLimit)
+	if cursor != 0 || len(page) != 1 {
+		t.Fatalf("history page = %#v, cursor %d", page, cursor)
+	}
+	if len(page[0].Text) > maxHistoryMessageBytes || !strings.Contains(page[0].Text, historyTruncationMarker) || !utf8.ValidString(page[0].Text) {
+		t.Fatalf("message preview is not a bounded UTF-8 string")
+	}
+}
+
+func TestProjectHistoryBoundsQueuedMessages(t *testing.T) {
+	_, state, _ := projectHistory([]Event{{
+		ID:     1,
+		Type:   EventUserMessage,
+		TurnID: "turn-1",
+		Text:   strings.Repeat("界", maxHistoryMessageBytes),
+	}})
+	if len(state.QueuedTurns) != 1 {
+		t.Fatalf("queued turns = %#v, want one turn", state.QueuedTurns)
+	}
+	text := state.QueuedTurns[0].Text
+	if len(text) > maxHistoryMessageBytes || !strings.Contains(text, historyTruncationMarker) || !utf8.ValidString(text) {
+		t.Fatalf("queued message preview is not a bounded UTF-8 string")
+	}
+}
+
+func assertHistoryEventIDs(t *testing.T, events []Event, want ...int64) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("history events = %#v, want IDs %v", events, want)
+	}
+	for index, event := range events {
+		if event.ID != want[index] {
+			t.Fatalf("history events = %#v, want IDs %v", events, want)
+		}
+	}
+}

--- a/internal/sessionruntime/journal.go
+++ b/internal/sessionruntime/journal.go
@@ -355,6 +355,22 @@ func (j *Journal) Snapshot() []Event {
 	return append([]Event(nil), j.events[j.firstEvent:]...)
 }
 
+// SnapshotWithBounds returns the retained events and their current journal identity.
+func (j *Journal) SnapshotWithBounds() (HistoryBounds, []Event) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	firstEventID := j.nextID
+	lastEventID := j.nextID - 1
+	if j.firstEvent < len(j.events) {
+		firstEventID = j.events[j.firstEvent].ID
+	}
+	return HistoryBounds{
+		FirstEventID: firstEventID,
+		LastEventID:  lastEventID,
+		JournalID:    j.journalID,
+	}, append([]Event(nil), j.events[j.firstEvent:]...)
+}
+
 // Failed is closed if durable journal writes fail.
 func (j *Journal) Failed() <-chan struct{} {
 	return j.failure

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -23,6 +23,9 @@ const (
 	EventFileDiff         = "file.diff"
 	EventTurnCompleted    = "turn.completed"
 	EventError            = "error"
+
+	DefaultHistoryItemLimit = 20
+	DefaultHistoryByteLimit = 128 * 1024
 )
 
 // Event is one conversation event exposed through the shared Session control interface.
@@ -30,22 +33,41 @@ type Event struct {
 	ID   int64  `json:"id,omitempty"`
 	Type string `json:"type"`
 	// Timestamp records when a durable conversation event was first appended.
-	Timestamp    *time.Time      `json:"timestamp,omitempty"`
-	RequestID    string          `json:"requestId,omitempty"`
-	TurnID       string          `json:"turnId,omitempty"`
-	Text         string          `json:"text,omitempty"`
-	ToolID       string          `json:"toolId,omitempty"`
-	ToolName     string          `json:"toolName,omitempty"`
-	Output       string          `json:"output,omitempty"`
-	Status       string          `json:"status,omitempty"`
-	InputID      string          `json:"inputId,omitempty"`
-	Questions    []InputQuestion `json:"questions,omitempty"`
-	Diff         string          `json:"diff,omitempty"`
-	FirstEventID int64           `json:"firstEventId,omitempty"`
-	LastEventID  int64           `json:"lastEventId,omitempty"`
-	JournalID    string          `json:"journalId,omitempty"`
-	Reset        bool            `json:"reset,omitempty"`
-	Runtime      *RuntimeStatus  `json:"runtime,omitempty"`
+	Timestamp      *time.Time      `json:"timestamp,omitempty"`
+	RequestID      string          `json:"requestId,omitempty"`
+	TurnID         string          `json:"turnId,omitempty"`
+	Text           string          `json:"text,omitempty"`
+	ToolID         string          `json:"toolId,omitempty"`
+	ToolName       string          `json:"toolName,omitempty"`
+	Output         string          `json:"output,omitempty"`
+	Status         string          `json:"status,omitempty"`
+	InputID        string          `json:"inputId,omitempty"`
+	Questions      []InputQuestion `json:"questions,omitempty"`
+	Diff           string          `json:"diff,omitempty"`
+	FirstEventID   int64           `json:"firstEventId,omitempty"`
+	LastEventID    int64           `json:"lastEventId,omitempty"`
+	JournalID      string          `json:"journalId,omitempty"`
+	Reset          bool            `json:"reset,omitempty"`
+	HistoryLimited bool            `json:"historyLimited,omitempty"`
+	HistoryPage    bool            `json:"historyPage,omitempty"`
+	HistoryCursor  string          `json:"historyCursor,omitempty"`
+	HistoryState   *HistoryState   `json:"historyState,omitempty"`
+	Runtime        *RuntimeStatus  `json:"runtime,omitempty"`
+}
+
+// HistoryState describes conversation state that is independent of transcript paging.
+type HistoryState struct {
+	ActiveTurnID      string              `json:"activeTurnId,omitempty"`
+	ActiveTurnStarted *time.Time          `json:"activeTurnStarted,omitempty"`
+	TurnInterrupting  bool                `json:"turnInterrupting,omitempty"`
+	WaitingForInput   bool                `json:"waitingForInput,omitempty"`
+	QueuedTurns       []HistoryQueuedTurn `json:"queuedTurns,omitempty"`
+}
+
+// HistoryQueuedTurn describes one user message waiting to run.
+type HistoryQueuedTurn struct {
+	TurnID string `json:"turnId"`
+	Text   string `json:"text"`
 }
 
 // RuntimeStatus describes the current Session and workspace for connected clients.
@@ -83,6 +105,9 @@ type ClientRequest struct {
 	Since         int64               `json:"since,omitempty"`
 	JournalID     string              `json:"journalId,omitempty"`
 	HistoryBounds bool                `json:"historyBounds,omitempty"`
+	HistoryItems  int                 `json:"historyItems,omitempty"`
+	HistoryBytes  int                 `json:"historyBytes,omitempty"`
+	HistoryCursor string              `json:"historyCursor,omitempty"`
 	Text          string              `json:"text,omitempty"`
 	InputID       string              `json:"inputId,omitempty"`
 	Answers       map[string][]string `json:"answers,omitempty"`

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -3,6 +3,7 @@ package sessionruntime
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -848,6 +849,7 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 	defer cancel()
 
 	out := make(chan Event, 512)
+	var writeMu sync.Mutex
 	writerDone := make(chan error, 1)
 	go func() {
 		encoder := json.NewEncoder(connection)
@@ -872,7 +874,7 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			subscriptionCancel()
 		}
 	}()
-	subscribe := func(since int64, journalID string, includeHistoryBounds bool) {
+	subscribe := func(since int64, journalID string, includeHistoryBounds bool, historyItems, historyBytes int) {
 		if subscriptionCancel != nil {
 			return
 		}
@@ -885,6 +887,25 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			bounds, retained, stream, overflow, stop = s.journal.SubscribeWithBounds(since, journalID)
 		} else {
 			retained, stream, overflow, stop = s.journal.Subscribe(since)
+		}
+		historyCursor := ""
+		var historyState *HistoryState
+		if includeHistoryBounds && historyItems > 0 && historyBytes > 0 && (since == 0 || bounds.Reset) {
+			historyItems = min(historyItems, maxHistoryItemLimit)
+			historyBytes = min(historyBytes, maxHistoryByteLimit)
+			items, state, essential := projectHistory(retained)
+			var beforeEventID int64
+			retained, beforeEventID = historyItemsPage(items, 0, historyItems, historyBytes)
+			retained = append(retained, essential...)
+			historyState = &state
+			if beforeEventID > 0 {
+				historyCursor = encodeHistoryCursor(sessionHistoryCursor{
+					JournalID:     bounds.JournalID,
+					BeforeEventID: beforeEventID,
+					ItemLimit:     historyItems,
+					ByteLimit:     historyBytes,
+				})
+			}
 		}
 		statusStream, stopStatus := s.subscribeRuntimeStatus()
 		subscriptionCancel = func() {
@@ -907,11 +928,13 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			}
 		}
 		if includeHistoryBounds && !enqueue(Event{
-			Type:         EventHistoryStart,
-			FirstEventID: bounds.FirstEventID,
-			LastEventID:  bounds.LastEventID,
-			JournalID:    bounds.JournalID,
-			Reset:        bounds.Reset,
+			Type:           EventHistoryStart,
+			FirstEventID:   bounds.FirstEventID,
+			LastEventID:    bounds.LastEventID,
+			JournalID:      bounds.JournalID,
+			Reset:          bounds.Reset,
+			HistoryLimited: historyCursor != "",
+			HistoryCursor:  historyCursor,
 		}) {
 			return
 		}
@@ -925,7 +948,7 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 				return
 			}
 		}
-		if !enqueue(Event{Type: EventHistoryEnd}) {
+		if !enqueue(Event{Type: EventHistoryEnd, HistoryState: historyState}) {
 			return
 		}
 		go func() {
@@ -941,14 +964,20 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 						disconnect()
 						return
 					}
-					if !sendLiveEvent(connectionCtx, out, overflow, event, disconnect) {
+					writeMu.Lock()
+					sent := sendLiveEvent(connectionCtx, out, overflow, event, disconnect)
+					writeMu.Unlock()
+					if !sent {
 						return
 					}
 				case status, ok := <-statusStream:
 					if !ok {
 						return
 					}
-					if !sendLiveEvent(connectionCtx, out, overflow, Event{Type: EventRuntimeStatus, Runtime: &status}, disconnect) {
+					writeMu.Lock()
+					sent := sendLiveEvent(connectionCtx, out, overflow, Event{Type: EventRuntimeStatus, Runtime: &status}, disconnect)
+					writeMu.Unlock()
+					if !sent {
 						return
 					}
 				}
@@ -969,19 +998,31 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 		}
 		switch request.Type {
 		case "subscribe":
-			subscribe(request.Since, request.JournalID, request.HistoryBounds)
+			subscribe(request.Since, request.JournalID, request.HistoryBounds, request.HistoryItems, request.HistoryBytes)
+		case "history":
+			start, retained, err := s.loadHistoryPage(request.RequestID, request.HistoryCursor)
+			if err != nil {
+				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
+				continue
+			}
+			writeMu.Lock()
+			sent := sendHistoryPage(connectionCtx, out, start, retained)
+			writeMu.Unlock()
+			if !sent {
+				return
+			}
 		case "message":
-			subscribe(0, "", false)
+			subscribe(0, "", false, 0, 0)
 			if err := s.submitMessage(request.Text, request.RequestID); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
 			}
 		case "input":
-			subscribe(0, "", false)
+			subscribe(0, "", false, 0, 0)
 			if err := s.resolveInput(request.InputID, request.Answers, request.Cancel, request.RequestID); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
 			}
 		case "interrupt":
-			subscribe(0, "", false)
+			subscribe(0, "", false, 0, 0)
 			if err := s.interruptTurn(connectionCtx, request.RequestID); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
 			}
@@ -989,6 +1030,79 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			out <- Event{Type: EventError, RequestID: request.RequestID, Text: fmt.Sprintf("unsupported client request type %q", request.Type), Status: "rejected"}
 		}
 	}
+}
+
+type sessionHistoryCursor struct {
+	JournalID     string `json:"journalId"`
+	BeforeEventID int64  `json:"beforeEventId"`
+	ItemLimit     int    `json:"itemLimit"`
+	ByteLimit     int    `json:"byteLimit"`
+}
+
+func encodeHistoryCursor(cursor sessionHistoryCursor) string {
+	encoded, _ := json.Marshal(cursor)
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func decodeHistoryCursor(value string) (sessionHistoryCursor, error) {
+	encoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return sessionHistoryCursor{}, errors.New("invalid Session history cursor")
+	}
+	var cursor sessionHistoryCursor
+	if err := json.Unmarshal(encoded, &cursor); err != nil ||
+		cursor.JournalID == "" || cursor.BeforeEventID <= 0 ||
+		cursor.ItemLimit <= 0 || cursor.ItemLimit > maxHistoryItemLimit ||
+		cursor.ByteLimit <= 0 || cursor.ByteLimit > maxHistoryByteLimit {
+		return sessionHistoryCursor{}, errors.New("invalid Session history cursor")
+	}
+	return cursor, nil
+}
+
+func (s *Server) loadHistoryPage(requestID, value string) (Event, []Event, error) {
+	cursor, err := decodeHistoryCursor(value)
+	if err != nil {
+		return Event{}, nil, err
+	}
+	bounds, events := s.journal.SnapshotWithBounds()
+	if bounds.JournalID != cursor.JournalID {
+		return Event{}, nil, errors.New("Session history cursor expired; reconnect to reload history")
+	}
+	items, _, _ := projectHistory(events)
+	retained, beforeEventID := historyItemsPage(items, cursor.BeforeEventID, cursor.ItemLimit, cursor.ByteLimit)
+	nextCursor := ""
+	if beforeEventID > 0 {
+		cursor.BeforeEventID = beforeEventID
+		nextCursor = encodeHistoryCursor(cursor)
+	}
+	return Event{
+		Type:           EventHistoryStart,
+		RequestID:      requestID,
+		JournalID:      bounds.JournalID,
+		HistoryPage:    true,
+		HistoryLimited: nextCursor != "",
+		HistoryCursor:  nextCursor,
+	}, retained, nil
+}
+
+func sendHistoryPage(ctx context.Context, out chan<- Event, start Event, events []Event) bool {
+	send := func(event Event) bool {
+		select {
+		case out <- event:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	if !send(start) {
+		return false
+	}
+	for _, event := range events {
+		if !send(event) {
+			return false
+		}
+	}
+	return send(Event{Type: EventHistoryEnd, RequestID: start.RequestID, HistoryPage: true})
 }
 
 func sendLiveEvent(ctx context.Context, out chan<- Event, overflow <-chan struct{}, event Event, disconnect func()) bool {

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -1479,6 +1479,191 @@ func TestServerResetsHistoryForReplacedJournalWithOverlappingIDs(t *testing.T) {
 	}
 }
 
+func TestServerPagesProjectedHistoryItems(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	for _, event := range []Event{
+		{Type: EventUserMessage, TurnID: "turn-1", Text: "first"},
+		{Type: EventTurnStarted, TurnID: "turn-1", Status: "running"},
+		{Type: EventAssistantDelta, TurnID: "turn-1", Text: "first "},
+		{Type: EventAssistantDelta, TurnID: "turn-1", Text: "answer"},
+		{Type: EventAssistantMessage, TurnID: "turn-1", Text: "first answer"},
+		{Type: EventTurnCompleted, TurnID: "turn-1", Status: "completed"},
+		{Type: EventUserMessage, TurnID: "turn-2", Text: "second"},
+		{Type: EventTurnStarted, TurnID: "turn-2", Status: "running"},
+		{Type: EventAssistantMessage, TurnID: "turn-2", Text: "second answer"},
+		{Type: EventTurnCompleted, TurnID: "turn-2", Status: "completed"},
+	} {
+		if err := journal.Append(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	server := &Server{journal: journal}
+	serverConnection, clientConnection := net.Pipe()
+	defer clientConnection.Close()
+	go server.handleConnection(t.Context(), serverConnection)
+	if err := json.NewEncoder(clientConnection).Encode(ClientRequest{
+		Type:          "subscribe",
+		HistoryBounds: true,
+		HistoryItems:  2,
+		HistoryBytes:  DefaultHistoryByteLimit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	decoder := json.NewDecoder(clientConnection)
+	var start Event
+	if err := decoder.Decode(&start); err != nil {
+		t.Fatal(err)
+	}
+	if start.Type != EventHistoryStart || !start.HistoryLimited || start.HistoryCursor == "" {
+		t.Fatalf("history start = %#v, want limited history", start)
+	}
+
+	var retained []Event
+	var end Event
+	for {
+		var event Event
+		if err := decoder.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Type == EventHistoryEnd {
+			end = event
+			break
+		}
+		retained = append(retained, event)
+	}
+	wantIDs := []int64{7, 9}
+	if len(retained) != len(wantIDs) {
+		t.Fatalf("retained events = %#v, want IDs %v", retained, wantIDs)
+	}
+	for index, event := range retained {
+		if event.ID != wantIDs[index] {
+			t.Fatalf("retained event IDs = %#v, want %v", retained, wantIDs)
+		}
+		if event.TurnID != "" {
+			t.Fatalf("projected event retains turn state: %#v", retained)
+		}
+	}
+	assertEventTypes(t, retained, EventUserMessage, EventAssistantMessage)
+	if end.HistoryState == nil {
+		t.Fatalf("history end = %#v, want state snapshot", end)
+	}
+
+	if err := json.NewEncoder(clientConnection).Encode(ClientRequest{
+		Type:          "history",
+		RequestID:     "history-1",
+		HistoryCursor: start.HistoryCursor,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var pageStart Event
+	if err := decoder.Decode(&pageStart); err != nil {
+		t.Fatal(err)
+	}
+	if pageStart.Type != EventHistoryStart || !pageStart.HistoryPage || pageStart.RequestID != "history-1" || pageStart.HistoryCursor != "" {
+		t.Fatalf("older history start = %#v", pageStart)
+	}
+	retained = nil
+	for {
+		var event Event
+		if err := decoder.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Type == EventHistoryEnd {
+			if !event.HistoryPage || event.RequestID != "history-1" {
+				t.Fatalf("older history end = %#v", event)
+			}
+			break
+		}
+		retained = append(retained, event)
+	}
+	wantIDs = []int64{1, 5}
+	if len(retained) != len(wantIDs) {
+		t.Fatalf("older retained events = %#v, want IDs %v", retained, wantIDs)
+	}
+	for index, event := range retained {
+		if event.ID != wantIDs[index] || event.TurnID != "" {
+			t.Fatalf("older retained events = %#v, want projected IDs %v", retained, wantIDs)
+		}
+	}
+	assertEventTypes(t, retained, EventUserMessage, EventAssistantMessage)
+}
+
+func TestServerPreservesStateOutsideProjectedHistoryPage(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	queuedText := strings.Repeat("queued ", maxHistoryMessageBytes)
+	for _, event := range []Event{
+		{Type: EventUserMessage, TurnID: "turn-1", Text: "active request"},
+		{Type: EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt, Status: "running"},
+		{Type: EventAssistantDelta, TurnID: "turn-1", Text: "partial answer"},
+		{Type: EventInputRequested, TurnID: "turn-1", InputID: "input-1", Questions: []InputQuestion{{ID: "confirm", Question: "Continue?"}}, Status: "pending"},
+		{Type: EventUserMessage, TurnID: "turn-2", Text: queuedText},
+	} {
+		if err := journal.Append(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	server := &Server{journal: journal}
+	serverConnection, clientConnection := net.Pipe()
+	defer clientConnection.Close()
+	go server.handleConnection(t.Context(), serverConnection)
+	if err := json.NewEncoder(clientConnection).Encode(ClientRequest{
+		Type:          "subscribe",
+		HistoryBounds: true,
+		HistoryItems:  1,
+		HistoryBytes:  DefaultHistoryByteLimit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	decoder := json.NewDecoder(clientConnection)
+	var start Event
+	if err := decoder.Decode(&start); err != nil {
+		t.Fatal(err)
+	}
+	if start.Type != EventHistoryStart || !start.HistoryLimited || start.HistoryCursor == "" {
+		t.Fatalf("history start = %#v, want limited history", start)
+	}
+	var retained []Event
+	var end Event
+	for {
+		var event Event
+		if err := decoder.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Type == EventHistoryEnd {
+			end = event
+			break
+		}
+		retained = append(retained, event)
+	}
+	assertEventTypes(t, retained, EventAssistantMessage, EventInputRequested)
+	if retained[0].Text != "partial answer" || retained[0].TurnID != "" {
+		t.Fatalf("projected assistant message = %#v", retained[0])
+	}
+	if retained[1].InputID != "input-1" || retained[1].TurnID != "" || len(retained[1].Questions) != 1 || retained[1].Questions[0].Question != "Continue?" {
+		t.Fatalf("pending input = %#v", retained[1])
+	}
+	if end.HistoryState == nil {
+		t.Fatalf("history end = %#v, want state snapshot", end)
+	}
+	state := end.HistoryState
+	if state.ActiveTurnID != "turn-1" || state.ActiveTurnStarted == nil || !state.ActiveTurnStarted.Equal(startedAt) || !state.WaitingForInput {
+		t.Fatalf("history state = %#v, want active turn waiting for input", state)
+	}
+	if len(state.QueuedTurns) != 1 || state.QueuedTurns[0].TurnID != "turn-2" {
+		t.Fatalf("queued turns = %#v, want turn-2", state.QueuedTurns)
+	}
+	if text := state.QueuedTurns[0].Text; len(text) > maxHistoryMessageBytes || !strings.Contains(text, historyTruncationMarker) {
+		t.Fatalf("queued message preview has %d bytes", len(text))
+	}
+}
+
 func TestServerStreamsRuntimeStatusOutsideConversationHistory(t *testing.T) {
 	journal := NewJournal()
 	defer journal.Close()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kelos session connect` replayed every retained provider event into terminal scrollback. A small number of turns could still contain large delta streams, tool outputs, or file diffs, so turn-count pagination did not make connection cost predictable.

This PR pages provider-neutral transcript items under item and serialized-byte budgets. The shared Session runtime projects Claude Code, Codex, and OpenCode events into self-contained user messages, assistant messages, tool calls, input requests, and file-diff previews. The terminal loads a bounded recent page and lets users prepend older pages with `/history` or Page Up.

Active-turn, pending-input, and queued-message state is sent separately from transcript pages. This keeps the terminal actionable even when the events that established that state are outside the loaded page. The reconnect client advances to the journal snapshot high-water mark after projected history, avoiding duplicate or omitted live replay.

The TUI also writes initial history to native scrollback without pinning the composer to the top when the transcript is long.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The terminal requests up to 20 transcript items and 128 KiB per page. Large messages, queued-message previews, tool outputs, and file diffs are rendered under per-item bounds. Opaque cursors include the journal identity, item boundary, and page budgets so cursors from replaced runtimes are rejected.

Pending input details and bounded queued-message previews are delivered independently of the transcript page. Older clients that do not request projected history retain the raw event replay protocol.

Tests cover Claude/Codex finalized messages, OpenCode delta aggregation, in-progress streaming, tool and input pairing, item and byte limits, state restoration, older-page retrieval, reconnect high-water tracking, plain-terminal stream/page isolation and request deduplication, chronological TUI prepending, and reconnect cancellation.

Validation:

- `make test`
- `make verify`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
`kelos session connect` now loads bounded recent transcript items and lets users page backward with `/history` or Page Up.
```
