### PR TITLE
Place Session composer gap above input

### DIFF
--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -407,9 +407,9 @@ func (m *sessionTUIModel) View() string {
 	}
 	footer := m.footerView()
 	if m.activeView == "" {
-		return "\n" + footer
+		return footer
 	}
-	return m.activeView + "\n\n" + footer
+	return m.activeView + "\n" + footer
 }
 
 func (m *sessionTUIModel) readEvent() tea.Cmd {
@@ -1155,7 +1155,7 @@ func (m *sessionTUIModel) footerHeight() int {
 }
 
 func (m *sessionTUIModel) footerView() string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 5)
 	if progress := m.progressView(); progress != "" {
 		parts = append(parts, progress)
 	}
@@ -1163,7 +1163,7 @@ func (m *sessionTUIModel) footerView() string {
 	if queue != "" {
 		parts = append(parts, queue)
 	}
-	parts = append(parts, m.composerView(), m.statusBarView())
+	parts = append(parts, "", m.composerView(), m.statusBarView())
 	return strings.Join(parts, "\n")
 }
 

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -100,6 +100,25 @@ func TestSessionTUIComposerUsesFullWidthPadding(t *testing.T) {
 	}
 }
 
+func TestSessionTUIComposerGapFollowsProgress(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.Update(tea.WindowSizeMsg{Width: 40, Height: 8})
+	model.ready = true
+	model.connectionStatus = ""
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1"})
+
+	lines := strings.Split(stripSessionTUIANSI(model.View()), "\n")
+	if progress := strings.TrimSpace(lines[0]); !strings.HasPrefix(progress, "• Working (") {
+		t.Fatalf("first footer row = %q, want working progress", progress)
+	}
+	if gap := lines[1]; gap != "" {
+		t.Fatalf("row above composer = %q, want an unstyled blank row", gap)
+	}
+	if prompt := strings.TrimSpace(lines[3]); prompt != ">" {
+		t.Fatalf("composer prompt row = %q, want >", prompt)
+	}
+}
+
 func TestSessionTUIStatusBarShowsRuntimeAndWorkspaceDetails(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	model.Update(tea.WindowSizeMsg{Width: 180, Height: 12})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Moves the existing Session terminal UI composer gap so it renders immediately above the input block. During active work, the blank row now separates the progress or queued-turn display from the composer instead of appearing above the entire footer.

Adds a unit test that verifies the progress row, blank gap, and composer remain in the intended order.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make test TEST_FLAGS='-run TestSessionTUI'`
- `make verify`

The full `make test` target was also attempted. It currently fails in two unrelated `internal/controller` tests: `TestCodexEntrypointUsesPersistentSessionHome` and the Codex case of `TestAgentEntrypointsPreserveSkillReferenceFiles`.

#### Does this PR introduce a user-facing change?

```release-note
`kelos session connect` now separates progress and queued status output from the input block with a blank line.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Session TUI blank gap to render directly above the input composer, separating progress/queue from the composer for clearer `kelos session connect` output.

- **Bug Fixes**
  - Insert a blank line before the composer in `footerView()` to place the gap directly above input.
  - Normalize spacing in `View()` by removing the extra leading newline and reducing double newlines to single.
  - Add `TestSessionTUIComposerGapFollowsProgress` to verify progress → blank gap → composer order.

<sup>Written for commit 058349227709e0467b17798298179bfbaf3848f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

