### PR TITLE
Show runtime status in Session web chat

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -247,9 +247,10 @@ request number. Codex Sessions also show reported context use, weekly limit
 remaining, and cumulative input and output tokens. Less important status-bar
 items are omitted as the terminal narrows. The model is the same
 runtime-reported value persisted in `status.model`. Web chat is served by the
-optional shared `kelos-session-server`; it shows connection status separately
-from working, waiting-for-input, and interrupting progress, including elapsed
-time for active work. Both clients use the same event stream and provider
+optional shared `kelos-session-server`; it shows the same live runtime details
+beneath its composer. It shows connection status separately from working,
+waiting-for-input, and interrupting progress, including elapsed time for active
+work. Both clients use the same event stream and provider
 conversation. Both clients can stream agent and tool activity, answer
 user-input requests, and interrupt active work without ending the provider
 conversation.

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -112,6 +112,7 @@ function resetHarness() {
     progress: new TestNode('div'),
     progressLabel: new TestNode('span'),
     progressElapsed: new TestNode('span'),
+    runtimeStatus: new TestNode('div'),
     sidebar: new TestNode('aside'),
     welcome: null,
   };
@@ -133,6 +134,7 @@ function resetHarness() {
     activeTurnStartedAt: 0,
     waitingForInput: false,
     interrupting: false,
+    runtimeStatus: null,
     progressTimer: null,
     replayingHistory: false,
     pinHistoryToBottom: false,
@@ -283,6 +285,53 @@ function testSessionProgressElapsedFormatting() {
   assert.equal(formatSessionProgressElapsed(59000), '59s');
   assert.equal(formatSessionProgressElapsed(60000), '1m 00s');
   assert.equal(formatSessionProgressElapsed(7389000), '2h 03m 09s');
+}
+
+function testRuntimeStatusLifecycle() {
+  resetHarness();
+  const view = createSessionView();
+  activateSessionView(view);
+  assert.equal(elements.runtimeStatus.hidden, true);
+
+  handleEvent({
+    type: 'runtime.status',
+    runtime: {
+      sessionName: 'fix-cli-connect',
+      agentType: 'codex',
+      model: 'gpt-5.6-sol',
+      effort: 'xhigh',
+      workingDir: '/home/agent/workspace/repo',
+      homeDir: '/home/agent',
+      branch: 'main',
+      usage: {
+        inputTokens: 15900000,
+        outputTokens: 59100,
+        contextTokens: 90960,
+        contextWindow: 200000,
+      },
+      weeklyLimit: {usedPercent: 52},
+    },
+  });
+
+  const expected = 'fix-cli-connect · codex · gpt-5.6-sol xhigh · ~/workspace/repo · main · Context 42% used · weekly 48% left · 15.9M in · 59.1K out';
+  assert.equal(elements.runtimeStatus.hidden, false);
+  assert.equal(elements.runtimeStatus.textContent, expected);
+  assert.equal(elements.runtimeStatus.title, expected);
+  assert.equal(view.runtimeStatus, state.runtimeStatus);
+
+  saveCurrentSessionView();
+  activateSessionView(createSessionView());
+  assert.equal(elements.runtimeStatus.hidden, true);
+  activateSessionView(view);
+  assert.equal(elements.runtimeStatus.textContent, expected);
+
+  resetCurrentSessionView();
+  assert.equal(elements.runtimeStatus.hidden, true);
+  assert.equal(state.runtimeStatus, null);
+}
+
+function testRuntimeStatusTreatsOmittedContextTokensAsZero() {
+  assert.equal(sessionRuntimeContextUsedPercent({contextWindow: 200000}), 0);
 }
 
 function testSessionResetClearsPromptDraft() {
@@ -445,6 +494,8 @@ testSessionViewReset();
 testSessionProgressLifecycle();
 testSessionProgressSurvivesCachedViewSwitch();
 testSessionProgressElapsedFormatting();
+testRuntimeStatusLifecycle();
+testRuntimeStatusTreatsOmittedContextTokensAsZero();
 testSessionResetClearsPromptDraft();
 testHistoryReplayCompletion();
 testReselectRefreshesStatusPlaceholder();

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -26,6 +26,7 @@ const elements = {
   input: document.querySelector('#message-input'),
   send: document.querySelector('#send-message'),
   composerHint: document.querySelector('#composer-hint'),
+  runtimeStatus: document.querySelector('#session-runtime-status'),
   progress: document.querySelector('#session-progress'),
   progressLabel: document.querySelector('#session-progress-label'),
   progressElapsed: document.querySelector('#session-progress-elapsed'),
@@ -90,6 +91,7 @@ const state = {
   activeTurnStartedAt: 0,
   waitingForInput: false,
   interrupting: false,
+  runtimeStatus: null,
   progressTimer: null,
   replayingHistory: false,
   pinHistoryToBottom: false,
@@ -172,6 +174,7 @@ function createSessionView() {
     activeTurnStartedAt: 0,
     waitingForInput: false,
     interrupting: false,
+    runtimeStatus: null,
     replayingHistory: false,
     pinHistoryToBottom: false,
     fileChangesDirty: false,
@@ -199,6 +202,7 @@ function saveCurrentSessionView() {
   view.activeTurnStartedAt = state.activeTurnStartedAt;
   view.waitingForInput = state.waitingForInput;
   view.interrupting = state.interrupting;
+  view.runtimeStatus = state.runtimeStatus;
   view.replayingHistory = state.replayingHistory;
   view.pinHistoryToBottom = state.pinHistoryToBottom;
   view.fileChangesDirty = state.fileChangesDirty;
@@ -225,6 +229,7 @@ function activateSessionView(view) {
   state.activeTurnStartedAt = view.activeTurnStartedAt;
   state.waitingForInput = view.waitingForInput;
   state.interrupting = view.interrupting;
+  state.runtimeStatus = view.runtimeStatus;
   state.replayingHistory = view.replayingHistory;
   state.pinHistoryToBottom = view.pinHistoryToBottom;
   state.fileChangesDirty = view.fileChangesDirty;
@@ -236,6 +241,7 @@ function activateSessionView(view) {
   updateFileChangesHeader();
   if (!hasChanges) renderFileChanges();
   refreshSessionProgress();
+  renderRuntimeStatus();
 }
 
 function cachedSessionView(session) {
@@ -269,6 +275,7 @@ function resetCurrentSessionView() {
   state.activeTurnStartedAt = 0;
   state.waitingForInput = false;
   state.interrupting = false;
+  state.runtimeStatus = null;
   state.replayingHistory = true;
   state.pinHistoryToBottom = true;
   state.fileChangesDirty = false;
@@ -292,9 +299,11 @@ function resetCurrentSessionView() {
     view.activeTurnStartedAt = 0;
     view.waitingForInput = false;
     view.interrupting = false;
+    view.runtimeStatus = null;
     view.pinHistoryToBottom = true;
   }
   refreshSessionProgress();
+  renderRuntimeStatus();
 }
 
 function formatSessionProgressElapsed(elapsedMilliseconds) {
@@ -341,6 +350,72 @@ function refreshSessionProgress() {
   if (state.activeTurn) {
     state.progressTimer = window.setInterval(() => renderSessionProgress(), 1000);
   }
+}
+
+function sessionRuntimePath(workingDir = '', homeDir = '') {
+  const home = homeDir.replace(/\/$/, '');
+  if (!home) return workingDir;
+  if (workingDir === home) return '~';
+  if (workingDir.startsWith(`${home}/`)) return `~/${workingDir.slice(home.length + 1)}`;
+  return workingDir;
+}
+
+function sessionRuntimeContextUsedPercent(usage) {
+  const baselineTokens = 12000;
+  if (usage.contextWindow <= baselineTokens) return 100;
+  const effectiveWindow = usage.contextWindow - baselineTokens;
+  const used = Math.max(0, (Number(usage.contextTokens) || 0) - baselineTokens);
+  return Math.min(100, Math.round(used * 100 / effectiveWindow));
+}
+
+function formatSessionRuntimeTokens(value) {
+  const tokens = Math.max(0, Number(value) || 0);
+  if (tokens < 1000) return String(tokens);
+  let scaled = tokens / 1000;
+  let suffix = 'K';
+  if (tokens >= 1e12) {
+    scaled = tokens / 1e12;
+    suffix = 'T';
+  } else if (tokens >= 1e9) {
+    scaled = tokens / 1e9;
+    suffix = 'B';
+  } else if (tokens >= 1e6) {
+    scaled = tokens / 1e6;
+    suffix = 'M';
+  }
+  const decimals = scaled < 10 ? 2 : scaled < 100 ? 1 : 0;
+  return `${Number(scaled.toFixed(decimals))}${suffix}`;
+}
+
+function sessionRuntimeStatusText(status) {
+  if (!status) return '';
+  const parts = [];
+  const add = value => { if (value) parts.push(value); };
+  add(status.sessionName);
+  add(status.agentType);
+  add(`${status.model || ''} ${status.effort || ''}`.trim());
+  add(sessionRuntimePath(status.workingDir, status.homeDir));
+  add(status.branch);
+  if (status.pullRequestNumber > 0) add(`PR #${status.pullRequestNumber}`);
+  if (status.usage?.contextWindow > 0) {
+    add(`Context ${sessionRuntimeContextUsedPercent(status.usage)}% used`);
+  }
+  if (status.weeklyLimit) {
+    const remaining = 100 - Math.min(100, Math.max(0, status.weeklyLimit.usedPercent));
+    add(`weekly ${remaining}% left`);
+  }
+  if (status.usage) {
+    add(`${formatSessionRuntimeTokens(status.usage.inputTokens)} in`);
+    add(`${formatSessionRuntimeTokens(status.usage.outputTokens)} out`);
+  }
+  return parts.join(' · ');
+}
+
+function renderRuntimeStatus() {
+  const text = sessionRuntimeStatusText(state.runtimeStatus);
+  elements.runtimeStatus.textContent = text;
+  elements.runtimeStatus.title = text;
+  elements.runtimeStatus.hidden = !text;
 }
 
 function savePromptDraft(session) {
@@ -2208,6 +2283,11 @@ function handleEvent(event) {
       break;
     case 'history.end':
       finishHistoryReplay();
+      break;
+    case 'runtime.status':
+      state.runtimeStatus = event.runtime || null;
+      if (state.currentView) state.currentView.runtimeStatus = state.runtimeStatus;
+      renderRuntimeStatus();
       break;
     case 'runtime.recovered':
       renderRecovery(event);

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -88,6 +88,7 @@
           <textarea id="message-input" rows="1" placeholder="Choose a ready session to start chatting" aria-label="Message" disabled></textarea>
           <button class="send-button" id="send-message" type="submit" aria-label="Send message" data-action="send" disabled>↑</button>
         </form>
+        <div class="session-runtime-status" id="session-runtime-status" role="status" aria-live="polite" hidden></div>
         <div class="composer-hint" id="composer-hint">Enter to send · Shift+Enter for a new line</div>
       </footer>
     </main>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -260,6 +260,7 @@ button { color: inherit; }
 .send-button { flex: 0 0 auto; width: 36px; height: 36px; border: 0; border-radius: 11px; background: var(--accent); color: white; font-size: 20px; font-weight: 500; cursor: pointer; }
 .send-button[data-action="interrupt"] { background: var(--warning); font-size: 11px; }
 .send-button:disabled { background: #c8ceca; cursor: default; }
+.session-runtime-status { padding-top: 8px; overflow: hidden; color: var(--muted); font: 10px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
 .composer-hint { padding-top: 7px; text-align: center; color: var(--faint); font-size: 9.5px; }
 .primary-button, .secondary-button { padding: 10px 15px; border-radius: 10px; font-size: 12px; font-weight: 750; cursor: pointer; }
 .primary-button { border: 1px solid var(--accent); background: var(--accent); color: white; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The Session runtime already streams live model, workspace, Git, context, rate-limit, and token usage details to connected clients. The terminal client displayed those details, but the Session web chat discarded the `runtime.status` events.

This PR adds a compact runtime status row beneath the web composer. It formats the same details as the terminal client, keeps the status isolated in each cached Session view, and clears it when a Session is reset. The user-facing reference now documents the behavior.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This uses the existing WebSocket event stream and does not add an API field, CRD change, or polling endpoint.

Validation:

- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
The Session web chat now shows live model, workspace, Git, context, rate-limit, and token usage details beneath the composer.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show live runtime status in Session web chat, matching the terminal status bar. Adds a compact row under the composer with model, workspace, Git, context %, weekly limit, and token usage.

- **New Features**
  - Renders `runtime.status` WebSocket events; no new API or polling.
  - Formats: model/effort, `~`-expanded path, branch/PR, context used % (12k token baseline; missing = 0), weekly % left, and input/output tokens (K/M/B/T).
  - Status is per cached Session view, restored on view switch, and cleared on reset; uses `role="status"` and `aria-live="polite"`.
  - Docs updated and tests added for lifecycle and formatting.

<sup>Written for commit 3b7b5cf521828873d61ea2260c7acaf40dfba411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

