### PR TITLE
Add Session turn duration separator

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -240,18 +240,22 @@ Use `kelos session connect NAME` for terminal chat. In an interactive terminal,
 press Enter to send a message, Ctrl+J to insert a newline, and Ctrl+C or Esc to
 interrupt an active turn. Ctrl+C exits the terminal client when no turn is
 active. The terminal client shows live connecting, reconnecting, working,
-waiting-for-input, and interrupting progress with elapsed time. A separate
-status bar beneath the composer shows the Session name, agent type, model and
-effort when available, working directory, git branch, and associated pull
-request number. Codex Sessions also show reported context use, weekly limit
-remaining, and cumulative input and output tokens. Less important status-bar
-items are omitted as the terminal narrows. The model is the same
-runtime-reported value persisted in `status.model`. Web chat is served by the
-optional shared `kelos-session-server`; it shows the same live runtime details
-beneath its composer. It shows connection status separately from working,
-waiting-for-input, and interrupting progress, including elapsed time for active
-work. Both clients use the same event stream and provider
-conversation. Both clients can stream agent and tool activity, answer
+waiting-for-input, and interrupting progress with elapsed time. After a
+completed turn, both interactive and plain terminal output show a `Worked for
+...` separator when the duration is known. A separate status bar beneath the
+composer shows the Session name, agent type, model and effort when available,
+working directory, git branch, and associated pull request number. Codex
+Sessions also show reported context use, weekly limit remaining, and cumulative
+input and output tokens. Less important status-bar items are omitted as the
+terminal narrows. The model is the same runtime-reported value persisted in
+`status.model`. Web chat is served by the optional shared
+`kelos-session-server`; it shows the same live runtime details beneath its
+composer. It shows connection status separately from working, waiting-for-input,
+and interrupting progress, including elapsed time for active work, and adds the
+duration to its separator after a completed turn. Duration labels are omitted
+from retained history that does not contain event timestamps and from turns
+interrupted by runtime recovery. Both clients use the same event stream and
+provider conversation. Both clients can stream agent and tool activity, answer
 user-input requests, and interrupt active work without ending the provider
 conversation.
 

--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kelos-dev/kelos/internal/sessionruntime"
 	"golang.org/x/term"
@@ -87,6 +88,10 @@ func (f sessionTerminalFormatter) status(status string) string {
 
 func (f sessionTerminalFormatter) muted(text string) string {
 	return f.style(sessionANSIDim, text)
+}
+
+func (f sessionTerminalFormatter) turnSeparator(elapsed time.Duration, width int) string {
+	return f.muted(formatSessionTurnSeparator(elapsed, width))
 }
 
 func (f sessionTerminalFormatter) warning(text string) string {
@@ -169,6 +174,12 @@ func sessionTerminalDiagnosticsUseTUI(input io.Reader, output, diagnostics io.Wr
 }
 
 func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Writer, decoder *json.Decoder, encoder *json.Encoder, color bool) error {
+	return runSessionPlainTerminalWithWidth(ctx, input, output, decoder, encoder, color, func() int {
+		return sessionPlainTerminalWidth(output)
+	})
+}
+
+func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, output io.Writer, decoder *json.Decoder, encoder *json.Encoder, color bool, terminalWidth func() int) error {
 	var writeMu sync.Mutex
 	write := func(format string, args ...any) {
 		writeMu.Lock()
@@ -179,16 +190,32 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 	done := make(chan error, 1)
 	go func() {
 		streaming := false
+		replayingHistory := true
+		recoveryActive := false
+		activeTurnID := ""
+		var activeTurnStarted time.Time
 		for {
 			var event sessionruntime.Event
 			if err := decoder.Decode(&event); err != nil {
 				done <- err
 				return
 			}
+			recoveredCompletion := sessionTerminalRecoveredCompletion(recoveryActive, event)
+			if recoveryActive && !sessionTerminalRuntimeRecoveryEvent(event) {
+				recoveryActive = false
+			}
 			switch event.Type {
+			case sessionruntime.EventHistoryStart:
+				replayingHistory = true
+				if event.Reset {
+					activeTurnID = ""
+					activeTurnStarted = time.Time{}
+				}
 			case sessionruntime.EventHistoryEnd:
+				replayingHistory = false
 				write("\n%s\n\n", formatter.muted("Connected. Type a message, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
 			case sessionruntime.EventRuntimeRecovered:
+				recoveryActive = true
 				if streaming {
 					write("\n")
 					streaming = false
@@ -203,6 +230,11 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 				if color {
 					write("\n")
 				}
+			case sessionruntime.EventTurnStarted:
+				if activeTurnID != event.TurnID || activeTurnStarted.IsZero() {
+					activeTurnStarted = sessionTerminalTurnStartedAt(event, time.Now(), replayingHistory)
+				}
+				activeTurnID = event.TurnID
 			case sessionruntime.EventAssistantDelta:
 				if !streaming {
 					write("%s", formatter.assistantPrefix())
@@ -259,7 +291,13 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 				if event.Status == "interrupted" {
 					write("%s\n", formatter.warning("Turn interrupted."))
 				}
-				write("\n")
+				if elapsed, ok := sessionTerminalTurnElapsed(activeTurnID, activeTurnStarted, event, time.Now(), replayingHistory, recoveredCompletion); ok {
+					write("%s\n\n", formatter.turnSeparator(elapsed, terminalWidth()))
+					activeTurnID = ""
+					activeTurnStarted = time.Time{}
+				} else {
+					write("\n")
+				}
 			case sessionruntime.EventError:
 				if streaming {
 					write("\n")
@@ -312,6 +350,60 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 			}
 		}
 	}
+}
+
+func sessionPlainTerminalWidth(output io.Writer) int {
+	file, ok := output.(*os.File)
+	if !ok {
+		return sessionTUIDefaultWidth
+	}
+	width, _, err := term.GetSize(int(file.Fd()))
+	if err != nil || width <= 0 {
+		return sessionTUIDefaultWidth
+	}
+	return width
+}
+
+func sessionTerminalEventTime(event sessionruntime.Event, fallback time.Time) time.Time {
+	if event.Timestamp != nil {
+		return *event.Timestamp
+	}
+	return fallback
+}
+
+func sessionTerminalTurnStartedAt(event sessionruntime.Event, fallback time.Time, replayingHistory bool) time.Time {
+	if event.Timestamp != nil {
+		return *event.Timestamp
+	}
+	if replayingHistory {
+		return time.Time{}
+	}
+	return fallback
+}
+
+func sessionTerminalRecoveredCompletion(recoveryActive bool, event sessionruntime.Event) bool {
+	return recoveryActive && event.Type == sessionruntime.EventTurnCompleted && event.Status == "interrupted"
+}
+
+func sessionTerminalRuntimeRecoveryEvent(event sessionruntime.Event) bool {
+	return event.Type == sessionruntime.EventRuntimeRecovered ||
+		(event.Type == sessionruntime.EventInputResolved && event.Status == "cancelled") ||
+		(event.Type == sessionruntime.EventTurnCompleted && event.Status == "interrupted")
+}
+
+func sessionTerminalTurnElapsed(activeTurnID string, started time.Time, event sessionruntime.Event, fallback time.Time, replayingHistory, recoveredCompletion bool) (time.Duration, bool) {
+	if started.IsZero() || recoveredCompletion || (replayingHistory && event.Timestamp == nil) || (event.TurnID != "" && activeTurnID != "" && event.TurnID != activeTurnID) {
+		return 0, false
+	}
+	elapsed := sessionTerminalEventTime(event, fallback).Sub(started)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return elapsed, true
+}
+
+func formatSessionTurnSeparator(elapsed time.Duration, width int) string {
+	return formatSessionTurnSeparatorText(formatSessionTUIElapsed(elapsed), width)
 }
 
 func sessionTerminalRequest(line string) sessionruntime.ClientRequest {

--- a/internal/cli/session_terminal_test.go
+++ b/internal/cli/session_terminal_test.go
@@ -111,6 +111,151 @@ func TestSessionTerminalSeparatesStreamedTextBlocks(t *testing.T) {
 	}
 }
 
+func TestSessionTerminalRendersTurnDurationSeparator(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(5*time.Minute + 19*time.Second)
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryEnd},
+		{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt},
+		{Type: sessionruntime.EventAssistantMessage, Text: "First reply"},
+		{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Timestamp: &completedAt},
+		{Type: sessionruntime.EventUserMessage, Text: "Second question"},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	var requests bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, &requests, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got := output.String()
+	separator := formatSessionTurnSeparator(5*time.Minute+19*time.Second, sessionTUIDefaultWidth)
+	if !strings.Contains(got, separator+"\n") {
+		t.Fatalf("terminal output = %q, want separator %q", got, separator)
+	}
+	if replyAt, separatorAt, questionAt := strings.Index(got, "First reply"), strings.Index(got, separator), strings.Index(got, "Second question"); replyAt < 0 || separatorAt < replyAt || questionAt < separatorAt {
+		t.Fatalf("terminal output order = %q, want separator between turns", got)
+	}
+}
+
+func TestSessionPlainTerminalUsesCurrentWidthForTurnSeparator(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryEnd},
+		{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt},
+		{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Timestamp: timePointer(startedAt.Add(time.Second))},
+		{Type: sessionruntime.EventTurnStarted, TurnID: "turn-2", Timestamp: timePointer(startedAt.Add(2 * time.Second))},
+		{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-2", Timestamp: timePointer(startedAt.Add(3 * time.Second))},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	widths := []int{36, 52}
+	widthIndex := 0
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionPlainTerminalWithWidth(ctx, input, &output, json.NewDecoder(&events), json.NewEncoder(io.Discard), false, func() int {
+		width := widths[widthIndex]
+		widthIndex++
+		return width
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotWidths []int
+	for _, line := range strings.Split(output.String(), "\n") {
+		if strings.HasPrefix(line, "─ Worked for") {
+			gotWidths = append(gotWidths, len([]rune(line)))
+		}
+	}
+	if !reflect.DeepEqual(gotWidths, widths) {
+		t.Fatalf("turn separator widths = %v, want %v", gotWidths, widths)
+	}
+}
+
+func TestSessionPlainTerminalOmitsUnknownHistoryDuration(t *testing.T) {
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryStart},
+		{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1"},
+		{Type: sessionruntime.EventAssistantMessage, Text: "Historical reply"},
+		{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1"},
+		{Type: sessionruntime.EventHistoryEnd},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, io.Discard, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); strings.Contains(got, "Worked for") {
+		t.Fatalf("terminal output = %q, want unknown history duration omitted", got)
+	}
+}
+
+func TestSessionPlainTerminalOmitsRuntimeRecoveryDuration(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryStart},
+		{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt},
+		{Type: sessionruntime.EventRuntimeRecovered, Text: "Session runtime restarted"},
+		{Type: sessionruntime.EventInputResolved, TurnID: "turn-1", InputID: "input-1", Status: "cancelled"},
+		{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Status: "interrupted", Timestamp: timePointer(startedAt.Add(time.Hour))},
+		{Type: sessionruntime.EventHistoryEnd},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, io.Discard, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); strings.Contains(got, "Worked for") {
+		t.Fatalf("terminal output = %q, want runtime recovery duration omitted", got)
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}
+
 func TestSessionTerminalFormatterUsesANSIStyles(t *testing.T) {
 	formatter := sessionTerminalFormatter{color: true}
 	if got, want := formatter.userMessage("hello"), "\x1b[7m  hello  \x1b[0m"; got != want {

--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -55,6 +55,7 @@ const (
 	sessionTUIBlockError
 	sessionTUIBlockInput
 	sessionTUIBlockDiff
+	sessionTUIBlockTurnSeparator
 )
 
 type sessionTUIBlock struct {
@@ -133,6 +134,8 @@ type sessionTUIModel struct {
 	width              int
 	height             int
 	ready              bool
+	replayingHistory   bool
+	recoveryActive     bool
 	turnActive         bool
 	streamingAt        int
 	connectionStatus   string
@@ -230,6 +233,7 @@ func newSessionTUIModel(events *json.Decoder, requests *json.Encoder, output io.
 		height:             sessionTUIDefaultHeight,
 		connectionStatus:   sessionTerminalStatusConnecting,
 		connectionStarted:  now(),
+		replayingHistory:   true,
 		historyAt:          -1,
 		streamingAt:        -1,
 		printHistory:       func(rendered string) tea.Cmd { return tea.Println(rendered) },
@@ -476,11 +480,17 @@ func (m *sessionTUIModel) nextInput() {
 
 func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUICommands {
 	var commands sessionTUICommands
+	recoveredCompletion := sessionTerminalRecoveredCompletion(m.recoveryActive, event)
+	if m.recoveryActive && !sessionTerminalRuntimeRecoveryEvent(event) {
+		m.recoveryActive = false
+	}
 	switch event.Type {
 	case sessionruntime.EventHistoryStart:
+		m.replayingHistory = true
 		if event.Reset {
 			m.turnActive = false
 			m.activeTurnID = ""
+			m.activeTurnStarted = time.Time{}
 			m.waitingForInput = false
 			m.turnInterrupting = false
 		}
@@ -489,11 +499,13 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 			m.runtimeStatus = *event.Runtime
 		}
 	case sessionruntime.EventHistoryEnd:
+		m.replayingHistory = false
 		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Ctrl+C quits when idle. Use /answer INPUT QUESTION VALUE or /quit.")
 		m.ready = true
 		m.connectionStatus = ""
 		commands.ui = tea.Batch(m.input.Focus(), m.scheduleProgress())
 	case sessionruntime.EventRuntimeRecovered:
+		m.recoveryActive = true
 		m.appendBlock(sessionTUIBlockWarning, event.Text)
 	case sessionTerminalEventDiagnostic:
 		if event.Text != "" {
@@ -520,10 +532,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		m.turnActive = true
 		m.acceptQueuedTurn(event.TurnID)
 		if m.activeTurnID != event.TurnID {
-			m.activeTurnStarted = m.now()
-			if event.Timestamp != nil {
-				m.activeTurnStarted = *event.Timestamp
-			}
+			m.activeTurnStarted = sessionTerminalTurnStartedAt(event, m.now(), m.replayingHistory)
 		}
 		m.activeTurnID = event.TurnID
 		m.waitingForInput = false
@@ -571,13 +580,18 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		m.turnActive = false
 		m.acceptQueuedTurn(event.TurnID)
 		m.finishStreaming()
+		elapsed, hasElapsed := sessionTerminalTurnElapsed(m.activeTurnID, m.activeTurnStarted, event, m.now(), m.replayingHistory, recoveredCompletion)
 		if event.TurnID == "" || event.TurnID == m.activeTurnID {
 			m.activeTurnID = ""
+			m.activeTurnStarted = time.Time{}
 			m.waitingForInput = false
 			m.turnInterrupting = false
 		}
 		if event.Status == "interrupted" {
 			m.appendBlock(sessionTUIBlockWarning, "Turn interrupted.")
+		}
+		if hasElapsed {
+			m.appendBlock(sessionTUIBlockTurnSeparator, formatSessionTUIElapsed(elapsed))
 		}
 	case sessionruntime.EventError:
 		m.finishStreaming()
@@ -934,6 +948,8 @@ func (m *sessionTUIModel) renderBlock(block sessionTUIBlock) string {
 		return m.renderIndentedBlock(text, 0, m.styles.inputHeading)
 	case sessionTUIBlockDiff:
 		return m.renderDiff(text)
+	case sessionTUIBlockTurnSeparator:
+		return m.styles.muted.Render(formatSessionTurnSeparatorText(text, m.width))
 	default:
 		return ""
 	}
@@ -1386,6 +1402,13 @@ func formatSessionTUIElapsed(elapsed time.Duration) string {
 		return fmt.Sprintf("%dm %02ds", seconds/60, seconds%60)
 	}
 	return fmt.Sprintf("%dh %02dm %02ds", seconds/(60*60), (seconds/60)%60, seconds%60)
+}
+
+func formatSessionTurnSeparatorText(elapsed string, width int) string {
+	width = max(1, width)
+	label := "─ Worked for " + elapsed + " "
+	label = truncateSessionTUIStatus(label, width)
+	return label + strings.Repeat("─", max(0, width-lipgloss.Width(label)))
 }
 
 func truncateSessionTUIProgress(text string, width int) string {

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -417,6 +417,64 @@ func TestSessionTUIShowsTurnProgressUntilCompletion(t *testing.T) {
 	if progress := model.progressView(); progress != "" {
 		t.Fatalf("completed progress = %q, want empty", progress)
 	}
+	if transcript := stripSessionTUIANSI(model.renderTranscript()); !strings.Contains(transcript, "─ Worked for 1m 05s ─") {
+		t.Fatalf("completed transcript = %q, want live fallback duration", transcript)
+	}
+}
+
+func TestSessionTUIRendersTurnDurationSeparator(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.Update(tea.WindowSizeMsg{Width: 48, Height: 12})
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(5*time.Minute + 19*time.Second)
+
+	model.applyEvent(sessionruntime.Event{
+		Type:      sessionruntime.EventTurnStarted,
+		TurnID:    "turn-1",
+		Timestamp: &startedAt,
+	})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventAssistantMessage, Text: "First reply"})
+	model.applyEvent(sessionruntime.Event{
+		Type:      sessionruntime.EventTurnCompleted,
+		TurnID:    "turn-1",
+		Timestamp: &completedAt,
+	})
+
+	lines := strings.Split(stripSessionTUIANSI(model.renderTranscript()), "\n")
+	separator := lines[len(lines)-1]
+	if !strings.HasPrefix(separator, "─ Worked for 5m 19s ─") {
+		t.Fatalf("turn separator = %q, want worked duration", separator)
+	}
+	assertSessionTUIBlockWidth(t, separator, 48)
+}
+
+func TestSessionTUIOmitsUnknownHistoryDuration(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventAssistantMessage, Text: "Historical reply"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
+
+	if transcript := stripSessionTUIANSI(model.renderTranscript()); strings.Contains(transcript, "Worked for") {
+		t.Fatalf("historical transcript = %q, want unknown duration omitted", transcript)
+	}
+}
+
+func TestSessionTUIOmitsRuntimeRecoveryDuration(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(time.Hour)
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryStart})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventRuntimeRecovered, Text: "Session runtime restarted"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventInputResolved, TurnID: "turn-1", InputID: "input-1", Status: "cancelled"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Status: "interrupted", Timestamp: &completedAt})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
+
+	if transcript := stripSessionTUIANSI(model.renderTranscript()); strings.Contains(transcript, "Worked for") {
+		t.Fatalf("historical transcript = %q, want runtime recovery duration omitted", transcript)
+	}
 }
 
 func TestSessionTUIRestoresTurnProgressFromHistoryTimestamp(t *testing.T) {

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -137,6 +137,7 @@ function resetHarness() {
     runtimeStatus: null,
     progressTimer: null,
     replayingHistory: false,
+    runtimeRecoveryActive: false,
     pinHistoryToBottom: false,
     fileChangesDirty: false,
   };
@@ -334,6 +335,54 @@ function testRuntimeStatusTreatsOmittedContextTokensAsZero() {
   assert.equal(sessionRuntimeContextUsedPercent({contextWindow: 200000}), 0);
 }
 
+function testTurnDividerShowsDuration() {
+  resetHarness();
+  handleEvent({type: 'turn.started', turnId: 'turn-1', timestamp: '2026-08-08T12:00:00Z'});
+  handleEvent({type: 'turn.completed', turnId: 'turn-1', status: 'completed', timestamp: '2026-08-08T12:05:19Z'});
+
+  const divider = elements.messages.querySelector('.turn-divider');
+  assert.equal(divider.textContent, 'Worked for 5m 19s');
+}
+
+function testUntimestampedHistoryDividerOmitsDuration() {
+  resetHarness();
+  handleEvent({type: 'history.start'});
+  handleEvent({type: 'turn.started', turnId: 'turn-1'});
+  handleEvent({type: 'turn.completed', turnId: 'turn-1', status: 'completed'});
+
+  const divider = elements.messages.querySelector('.turn-divider');
+  assert.equal(divider.textContent, '');
+}
+
+function testUntimestampedLiveTurnUsesLocalDuration() {
+  resetHarness();
+  const originalNow = Date.now;
+  let now = Date.parse('2026-08-08T12:00:00Z');
+  Date.now = () => now;
+  try {
+    handleEvent({type: 'turn.started', turnId: 'turn-1'});
+    now += 65_000;
+    handleEvent({type: 'turn.completed', turnId: 'turn-1', status: 'completed'});
+  } finally {
+    Date.now = originalNow;
+  }
+
+  const divider = elements.messages.querySelector('.turn-divider');
+  assert.equal(divider.textContent, 'Worked for 1m 05s');
+}
+
+function testRuntimeRecoveryDividerOmitsDuration() {
+  resetHarness();
+  handleEvent({type: 'history.start'});
+  handleEvent({type: 'turn.started', turnId: 'turn-1', timestamp: '2026-08-08T12:00:00Z'});
+  handleEvent({type: 'runtime.recovered', text: 'Session runtime restarted'});
+  handleEvent({type: 'input.resolved', turnId: 'turn-1', inputId: 'input-1', status: 'cancelled'});
+  handleEvent({type: 'turn.completed', turnId: 'turn-1', status: 'interrupted', timestamp: '2026-08-08T13:00:00Z'});
+
+  const divider = elements.messages.querySelector('.turn-divider');
+  assert.equal(divider.textContent, '');
+}
+
 function testSessionResetClearsPromptDraft() {
   resetHarness();
   const session = {namespace: 'default', name: 'one', uid: 'uid-one', phase: 'Ready'};
@@ -496,6 +545,10 @@ testSessionProgressSurvivesCachedViewSwitch();
 testSessionProgressElapsedFormatting();
 testRuntimeStatusLifecycle();
 testRuntimeStatusTreatsOmittedContextTokensAsZero();
+testTurnDividerShowsDuration();
+testUntimestampedHistoryDividerOmitsDuration();
+testUntimestampedLiveTurnUsesLocalDuration();
+testRuntimeRecoveryDividerOmitsDuration();
 testSessionResetClearsPromptDraft();
 testHistoryReplayCompletion();
 testReselectRefreshesStatusPlaceholder();

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -94,6 +94,7 @@ const state = {
   runtimeStatus: null,
   progressTimer: null,
   replayingHistory: false,
+  runtimeRecoveryActive: false,
   pinHistoryToBottom: false,
   fileChangesDirty: false,
   defaultNamespace: 'default',
@@ -176,6 +177,7 @@ function createSessionView() {
     interrupting: false,
     runtimeStatus: null,
     replayingHistory: false,
+    runtimeRecoveryActive: false,
     pinHistoryToBottom: false,
     fileChangesDirty: false,
     historyLoaded: false,
@@ -204,6 +206,7 @@ function saveCurrentSessionView() {
   view.interrupting = state.interrupting;
   view.runtimeStatus = state.runtimeStatus;
   view.replayingHistory = state.replayingHistory;
+  view.runtimeRecoveryActive = state.runtimeRecoveryActive;
   view.pinHistoryToBottom = state.pinHistoryToBottom;
   view.fileChangesDirty = state.fileChangesDirty;
 }
@@ -231,6 +234,7 @@ function activateSessionView(view) {
   state.interrupting = view.interrupting;
   state.runtimeStatus = view.runtimeStatus;
   state.replayingHistory = view.replayingHistory;
+  state.runtimeRecoveryActive = view.runtimeRecoveryActive;
   state.pinHistoryToBottom = view.pinHistoryToBottom;
   state.fileChangesDirty = view.fileChangesDirty;
   const hasChanges = view.changes.hasChildNodes();
@@ -277,6 +281,7 @@ function resetCurrentSessionView() {
   state.interrupting = false;
   state.runtimeStatus = null;
   state.replayingHistory = true;
+  state.runtimeRecoveryActive = false;
   state.pinHistoryToBottom = true;
   state.fileChangesDirty = false;
   elements.messages.replaceChildren();
@@ -300,6 +305,7 @@ function resetCurrentSessionView() {
     view.waitingForInput = false;
     view.interrupting = false;
     view.runtimeStatus = null;
+    view.runtimeRecoveryActive = false;
     view.pinHistoryToBottom = true;
   }
   refreshSessionProgress();
@@ -2273,6 +2279,8 @@ function finishHistoryReplay() {
 
 function handleEvent(event) {
   if (event.id) state.lastEventID = Math.max(state.lastEventID, event.id);
+  const recoveredCompletion = state.runtimeRecoveryActive && event.type === 'turn.completed' && event.status === 'interrupted';
+  if (state.runtimeRecoveryActive && !isRuntimeRecoveryEvent(event)) state.runtimeRecoveryActive = false;
   switch (event.type) {
     case 'history.start':
       if (event.reset || (state.currentView?.journalID && state.currentView.journalID !== event.journalId)) {
@@ -2290,6 +2298,7 @@ function handleEvent(event) {
       renderRuntimeStatus();
       break;
     case 'runtime.recovered':
+      state.runtimeRecoveryActive = true;
       renderRecovery(event);
       break;
     case 'user.message':
@@ -2299,7 +2308,7 @@ function handleEvent(event) {
       endAssistantSegment(event.turnId);
       if (!state.activeTurn || state.activeTurnID !== event.turnId) {
         const timestamp = Date.parse(event.timestamp || '');
-        state.activeTurnStartedAt = Number.isNaN(timestamp) ? Date.now() : timestamp;
+        state.activeTurnStartedAt = Number.isNaN(timestamp) ? (state.replayingHistory ? 0 : Date.now()) : timestamp;
       }
       state.activeTurn = true;
       state.activeTurnID = event.turnId || '';
@@ -2345,7 +2354,7 @@ function handleEvent(event) {
       break;
     case 'turn.completed':
       endAssistantSegment(event.turnId);
-      renderTurnEnd(event);
+      renderTurnEnd(event, recoveredCompletion);
       break;
     case 'error':
       endAssistantSegment(event.turnId);
@@ -2883,7 +2892,13 @@ function renderRecovery(event) {
   scrollToBottom();
 }
 
-function renderTurnEnd(event) {
+function renderTurnEnd(event, recoveredCompletion = false) {
+  const completedAt = Date.parse(event.timestamp || '');
+  const matchingTurn = !event.turnId || !state.activeTurnID || event.turnId === state.activeTurnID;
+  const completedTimeKnown = !Number.isNaN(completedAt) || !state.replayingHistory;
+  const elapsed = state.activeTurnStartedAt > 0 && matchingTurn && completedTimeKnown && !recoveredCompletion
+    ? Math.max(0, (Number.isNaN(completedAt) ? Date.now() : completedAt) - state.activeTurnStartedAt)
+    : null;
   state.activeTurn = false;
   state.activeTurnID = '';
   state.activeTurnStartedAt = 0;
@@ -2895,8 +2910,15 @@ function renderTurnEnd(event) {
   if (event.status === 'interrupted') showToast('Active work interrupted');
   const divider = document.createElement('div');
   divider.className = 'turn-divider';
+  if (elapsed !== null) divider.textContent = `Worked for ${formatSessionProgressElapsed(elapsed)}`;
   elements.messages.append(divider);
   scrollToBottom();
+}
+
+function isRuntimeRecoveryEvent(event) {
+  return event.type === 'runtime.recovered'
+    || (event.type === 'input.resolved' && event.status === 'cancelled')
+    || (event.type === 'turn.completed' && event.status === 'interrupted');
 }
 
 function scrollToBottom(smooth = true) {

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -240,7 +240,12 @@ button { color: inherit; }
 .diff-line.metadata { color: var(--muted); }
 .error-card { padding: 12px 14px; border-color: rgba(167,63,63,.25); background: #fff6f6; color: var(--danger); font-size: 12px; line-height: 1.5; }
 .recovery-card { padding: 12px 14px; border-color: rgba(197,138,62,.3); background: #fff9ef; color: #8a5b1f; font-size: 12px; line-height: 1.5; }
-.turn-divider { height: 1px; margin: 2px 0 22px 40px; background: linear-gradient(90deg,var(--line),transparent); }
+.turn-divider { margin: 2px 0 22px 40px; color: var(--faint); font-size: 10px; line-height: 1; white-space: nowrap; }
+.turn-divider:empty { height: 1px; background: linear-gradient(90deg,var(--line),transparent); }
+.turn-divider:not(:empty) { display: flex; align-items: center; gap: 8px; }
+.turn-divider:not(:empty)::before, .turn-divider:not(:empty)::after { height: 1px; background: var(--line); content: ""; }
+.turn-divider:not(:empty)::before { flex: 0 0 10px; }
+.turn-divider:not(:empty)::after { flex: 1; }
 .composer-wrap { padding: 12px max(24px, calc((100% - 850px) / 2)) 19px; background: linear-gradient(transparent, var(--canvas) 20%); }
 .session-progress { display: flex; align-items: center; gap: 5px; min-height: 18px; margin: 0 4px 7px; color: var(--muted); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; }
 .session-progress[hidden] { display: none; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a Codex-style separator after each completed Session turn so users can see how long the turn took in both `kelos session connect` and the `kelos-session-server` web UI.

The clients derive elapsed time from the existing server-stamped `turn.started` and `turn.completed` events. The terminal separator follows the current terminal width, while the web UI adds the duration to its existing turn divider. History replay and journal resets use the same timing behavior without changing the Session protocol.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with:

- `make verify`
- `make build WHAT=cmd/kelos`
- `make build WHAT=cmd/kelos-session-server`
- `make test TEST_FLAGS=-run=TestSession`
- `make test TEST_FLAGS=-run=TestApplication`

A full `make test` run passed the changed Session and CLI packages but remains red on two unrelated, reproducible Codex entrypoint fixture tests in `internal/controller`:

- `TestCodexEntrypointUsesPersistentSessionHome`
- `TestAgentEntrypointsPreserveSkillReferenceFiles/codex`

#### Does this PR introduce a user-facing change?

```release-note
Add a turn separator with elapsed duration to the Session terminal and web UI.
```
