### PR TITLE
Show session activity time

### DIFF
--- a/internal/sessionruntime/session_status_publisher.go
+++ b/internal/sessionruntime/session_status_publisher.go
@@ -63,9 +63,16 @@ func NewSessionStatusPublisher(client clientv1alpha2.SessionInterface, sessionNa
 			Message:            message,
 		})
 		activityTime := session.Status.LastActivityTime
-		if activityTime == nil || (previousActive != nil && previousActive.Status != metav1.ConditionUnknown && previousActive.Status != conditionStatus) {
+		activeStateChanged := previousActive != nil && previousActive.Status != metav1.ConditionUnknown &&
+			(previousActive.Status != conditionStatus || previousActive.Reason != reason)
+		if activityTime == nil || activeStateChanged {
 			if previousActive != nil && previousActive.Status != metav1.ConditionUnknown && previousActive.Status == conditionStatus {
-				activityTime = &previousActive.LastTransitionTime
+				if previousActive.Reason == reason {
+					activityTime = &previousActive.LastTransitionTime
+				} else {
+					now := metav1.Now()
+					activityTime = &now
+				}
 			} else if active := apiMeta.FindStatusCondition(conditions, kelos.SessionConditionActive); active != nil {
 				activityTime = &active.LastTransitionTime
 			}

--- a/internal/sessionruntime/session_status_publisher_test.go
+++ b/internal/sessionruntime/session_status_publisher_test.go
@@ -95,37 +95,70 @@ func TestSessionStatusPublisherPatchesLiveSession(t *testing.T) {
 }
 
 func TestSessionStatusPublisherUpdatesActivityTimeOnStateChange(t *testing.T) {
-	const sessionName = "chat"
-	podUID := types.UID("live-pod")
-	lastActivityTime := metav1.NewTime(time.Now().UTC().Truncate(time.Second).Add(-time.Hour))
-	clientset := clientfake.NewSimpleClientset(&kelos.Session{
-		ObjectMeta: metav1.ObjectMeta{Name: sessionName, Namespace: "default"},
-		Status: kelos.SessionStatus{
-			Phase:            kelos.SessionPhaseReady,
-			PodUID:           podUID,
-			LastActivityTime: &lastActivityTime,
-			Conditions: []metav1.Condition{{
-				Type:               kelos.SessionConditionActive,
-				Status:             metav1.ConditionTrue,
-				Reason:             "TurnActive",
-				LastTransitionTime: lastActivityTime,
-			}},
+	tests := []struct {
+		name           string
+		currentStatus  metav1.ConditionStatus
+		currentReason  string
+		observedStatus ObservedSessionStatus
+	}{
+		{
+			name:          "turn finishes",
+			currentStatus: metav1.ConditionTrue,
+			currentReason: "TurnActive",
 		},
-	})
-	publisher, err := NewSessionStatusPublisher(clientset.ApiV1alpha2().Sessions("default"), sessionName, podUID)
-	if err != nil {
-		t.Fatal(err)
+		{
+			name:          "input requested",
+			currentStatus: metav1.ConditionTrue,
+			currentReason: "TurnActive",
+			observedStatus: ObservedSessionStatus{
+				Active:          true,
+				WaitingForInput: true,
+			},
+		},
+		{
+			name:          "input resolved",
+			currentStatus: metav1.ConditionTrue,
+			currentReason: "WaitingForInput",
+			observedStatus: ObservedSessionStatus{
+				Active: true,
+			},
+		},
 	}
-	if err := publisher(context.Background(), ObservedSessionStatus{Active: false}); err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const sessionName = "chat"
+			podUID := types.UID("live-pod")
+			lastActivityTime := metav1.NewTime(time.Now().UTC().Truncate(time.Second).Add(-time.Hour))
+			clientset := clientfake.NewSimpleClientset(&kelos.Session{
+				ObjectMeta: metav1.ObjectMeta{Name: sessionName, Namespace: "default"},
+				Status: kelos.SessionStatus{
+					Phase:            kelos.SessionPhaseReady,
+					PodUID:           podUID,
+					LastActivityTime: &lastActivityTime,
+					Conditions: []metav1.Condition{{
+						Type:               kelos.SessionConditionActive,
+						Status:             tt.currentStatus,
+						Reason:             tt.currentReason,
+						LastTransitionTime: lastActivityTime,
+					}},
+				},
+			})
+			publisher, err := NewSessionStatusPublisher(clientset.ApiV1alpha2().Sessions("default"), sessionName, podUID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := publisher(context.Background(), tt.observedStatus); err != nil {
+				t.Fatal(err)
+			}
 
-	got, err := clientset.ApiV1alpha2().Sessions("default").Get(context.Background(), sessionName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Status.LastActivityTime == nil || !got.Status.LastActivityTime.After(lastActivityTime.Time) {
-		t.Fatalf("Session lastActivityTime = %v, want after %v", got.Status.LastActivityTime, lastActivityTime)
+			got, err := clientset.ApiV1alpha2().Sessions("default").Get(context.Background(), sessionName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status.LastActivityTime == nil || !got.Status.LastActivityTime.After(lastActivityTime.Time) {
+				t.Fatalf("Session lastActivityTime = %v, want after %v", got.Status.LastActivityTime, lastActivityTime)
+			}
+		})
 	}
 }
 

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -402,8 +402,8 @@ function testReselectRefreshesStatusPlaceholder() {
 function testSessionTimestampFormatting() {
   const now = Date.parse('2026-07-21T12:00:00Z');
   const active = {active: true, lastActivityAt: '2026-07-21T11:52:00Z'};
-  assert.equal(formatSessionRecency(active, true, now), 'Now');
-  assert.equal(formatSessionRecency(active, false, now), 'Active now');
+  assert.equal(formatSessionRecency(active, true, now), '8m');
+  assert.equal(formatSessionRecency(active, false, now), 'Last active 8 minutes ago');
 
   const idle = {active: false, lastActivityAt: '2026-07-21T11:52:00Z', createdAt: '2026-07-20T12:00:00Z'};
   assert.equal(formatSessionRecency(idle, true, now), '8m');

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -472,7 +472,6 @@ function sessionTimestamp(session) {
 }
 
 function formatSessionRecency(session, compact = false, now = Date.now()) {
-  if (session.active === true) return compact ? 'Now' : 'Active now';
   const timestamp = sessionTimestamp(session);
   if (!timestamp) return '';
   const elapsed = Math.max(0, now - timestamp.date.getTime());
@@ -513,7 +512,7 @@ function createSessionTimestamp(session, compact, className) {
   element.dateTime = timestamp.date.toISOString();
   element.textContent = label;
   const exact = new Intl.DateTimeFormat(undefined, {dateStyle: 'medium', timeStyle: 'long'}).format(timestamp.date);
-  const exactLabel = `${session.active === true && timestamp.activity ? 'Active since' : timestamp.activity ? 'Last active' : 'Created'} ${exact}`;
+  const exactLabel = `${timestamp.activity ? 'Last active' : 'Created'} ${exact}`;
   element.title = exactLabel;
   element.setAttribute('aria-label', exactLabel);
   return element;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Session sidebar now shows the actual activity timestamp used to order Sessions instead of displaying `Now` for every active Session.

Session activity time also advances when the runtime enters or leaves `WaitingForInput`. Previously, these transitions only changed the `Active` condition reason, so Kubernetes preserved the condition transition time and the Session was not reordered when an agent asked a question.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `make test TEST_FLAGS=-run=SessionStatusPublisher`
- `make test TEST_FLAGS=-run=TestApplicationSessionHistoryBehavior`

A full `make test` run was also attempted. Two unrelated `internal/controller` entrypoint tests failed because the Codex test environment contained persistent Codex configuration and skill-link state; the changed packages passed.

#### Does this PR introduce a user-facing change?

```release-note
Session timestamps now show actual activity recency and update when Sessions request or resolve user input.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real session activity timestamps in the sidebar and update them when agents request or resolve user input, fixing incorrect “Now” labels and session ordering.

- **Bug Fixes**
  - Update last activity when the Active condition status or reason changes, including transitions to/from WaitingForInput, so sorting reflects true recency.
  - Replace “Now”/“Active now” with elapsed labels (e.g., “8m”, “Last active 8 minutes ago”) and use “Last active …” in tooltips.
  - Extend tests to cover state transitions and new timestamp formatting.

<sup>Written for commit ddc5eb7dfa45ea6567e09cd4b11fb337f63ad611. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

