### PR TITLE
Allow Session interruption while draining

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -260,7 +260,11 @@ from retained history that does not contain event timestamps and from turns
 interrupted by runtime recovery. Both clients use the same event stream and
 provider conversation. Both clients can stream agent and tool activity, answer
 user-input requests, and interrupt active work without ending the provider
-conversation.
+conversation. Kelos first asks the provider to interrupt gracefully, including
+while the runtime is draining. If the request fails or the turn does not finish
+within 10 seconds, Kelos marks the turn interrupted and restarts the provider.
+Clients reconnect to the retained conversation after a provider restart, and
+queued prompts accepted before the restart resume in their original order.
 
 Completed tool output is retained with Session history up to 512 KiB per tool
 result. Larger results keep their beginning and end around an

--- a/internal/sessionruntime/journal.go
+++ b/internal/sessionruntime/journal.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -34,10 +35,12 @@ type Journal struct {
 	path        string
 	file        *os.File
 	journalID   string
-	failure     chan struct{}
-	failureErr  error
-	failureOnce sync.Once
-	closed      bool
+	// pendingTurns keeps accepted prompts durable after they leave replay history.
+	pendingTurns map[string]Event
+	failure      chan struct{}
+	failureErr   error
+	failureOnce  sync.Once
+	closed       bool
 }
 
 type journalSubscriber struct {
@@ -60,17 +63,22 @@ func NewJournal() *Journal {
 
 func newJournal(maxEvents int) *Journal {
 	return &Journal{
-		maxEvents:   maxEvents,
-		nextID:      1,
-		journalID:   uuid.New().String(),
-		subscribers: map[int]*journalSubscriber{},
-		failure:     make(chan struct{}),
+		maxEvents:    maxEvents,
+		nextID:       1,
+		journalID:    uuid.New().String(),
+		pendingTurns: map[string]Event{},
+		subscribers:  map[int]*journalSubscriber{},
+		failure:      make(chan struct{}),
 	}
 }
 
 // OpenJournal opens or creates a durable event journal.
 func OpenJournal(path string) (*Journal, error) {
-	journal := newJournal(maxRetainedEvents)
+	return openJournal(path, maxRetainedEvents)
+}
+
+func openJournal(path string, maxEvents int) (*Journal, error) {
+	journal := newJournal(maxEvents)
 	journal.path = path
 	_, statErr := os.Stat(path)
 	journalExisted := statErr == nil
@@ -209,6 +217,7 @@ func (j *Journal) load() (string, bool, error) {
 			event.JournalID = ""
 		}
 		j.nextID = event.ID + 1
+		j.updatePendingTurns(event)
 		j.appendRetained(event)
 		offset += int64(len(line))
 		total++
@@ -216,7 +225,7 @@ func (j *Journal) load() (string, bool, error) {
 			break
 		}
 	}
-	return journalID, total > j.maxEvents, nil
+	return journalID, total > len(j.recoveryEvents()), nil
 }
 
 // Append records and broadcasts one event after writing it to durable storage.
@@ -254,6 +263,7 @@ func (j *Journal) Append(event Event) error {
 		}
 	}
 	j.nextID++
+	j.updatePendingTurns(event)
 	compacted := j.appendRetained(event)
 	if compacted && j.file != nil {
 		if err := j.rewrite(); err != nil {
@@ -271,6 +281,33 @@ func (j *Journal) Append(event Event) error {
 		}
 	}
 	return nil
+}
+
+func (j *Journal) updatePendingTurns(event Event) {
+	if event.TurnID == "" {
+		return
+	}
+	switch event.Type {
+	case EventUserMessage:
+		j.pendingTurns[event.TurnID] = event
+	case EventTurnStarted, EventTurnCompleted:
+		delete(j.pendingTurns, event.TurnID)
+	}
+}
+
+func (j *Journal) recoveryEvents() []Event {
+	events := append([]Event(nil), j.events[j.firstEvent:]...)
+	retained := make(map[int64]struct{}, len(events))
+	for _, event := range events {
+		retained[event.ID] = struct{}{}
+	}
+	for _, event := range j.pendingTurns {
+		if _, exists := retained[event.ID]; !exists {
+			events = append(events, event)
+		}
+	}
+	sort.Slice(events, func(i, k int) bool { return events[i].ID < events[k].ID })
+	return events
 }
 
 func (j *Journal) appendRetained(event Event) bool {
@@ -305,7 +342,7 @@ func (j *Journal) rewrite() error {
 		return fmt.Errorf("securing compacted Session event journal: %w", err)
 	}
 	writer := bufio.NewWriter(temporary)
-	for _, event := range j.events[j.firstEvent:] {
+	for _, event := range j.recoveryEvents() {
 		persistedEvent := event
 		persistedEvent.JournalID = j.journalID
 		encoded, err := json.Marshal(persistedEvent)
@@ -353,6 +390,12 @@ func (j *Journal) Snapshot() []Event {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	return append([]Event(nil), j.events[j.firstEvent:]...)
+}
+
+func (j *Journal) snapshotForRecovery() []Event {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.recoveryEvents()
 }
 
 // SnapshotWithBounds returns the retained events and their current journal identity.

--- a/internal/sessionruntime/journal_test.go
+++ b/internal/sessionruntime/journal_test.go
@@ -84,6 +84,78 @@ func TestJournalPersistsEventsAndRecoversInterruptedTurn(t *testing.T) {
 	}
 }
 
+func TestJournalRecoveryHandlesEventsWithoutTurnIDs(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	for _, event := range []Event{
+		{Type: EventUserMessage, Text: "message without a turn"},
+		{Type: EventTurnCompleted, Status: "completed"},
+		{Type: EventInputRequested, InputID: "input-1", Status: "pending"},
+	} {
+		if err := journal.Append(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	recovery, err := recoverJournal(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recovery.queuedTurns) != 0 {
+		t.Fatalf("recovered queued turns = %#v", recovery.queuedTurns)
+	}
+	events := journal.Snapshot()
+	assertEventTypes(t, events,
+		EventUserMessage,
+		EventTurnCompleted,
+		EventInputRequested,
+		EventRuntimeRecovered,
+		EventInputResolved,
+	)
+	if resolved := events[len(events)-1]; resolved.InputID != "input-1" || resolved.TurnID != "" || resolved.Status != "cancelled" {
+		t.Fatalf("recovered input resolution = %#v", resolved)
+	}
+}
+
+func TestJournalCompactionPreservesQueuedTurnForRecovery(t *testing.T) {
+	path := filepath.Join(t.TempDir(), journalFileName)
+	journal, err := openJournal(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendEvent := func(event Event) {
+		t.Helper()
+		if err := journal.Append(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	appendEvent(Event{Type: EventUserMessage, TurnID: "turn-1", Text: "active work"})
+	appendEvent(Event{Type: EventTurnStarted, TurnID: "turn-1", Status: "running"})
+	appendEvent(Event{Type: EventUserMessage, TurnID: "turn-2", Text: "queued work"})
+	for i := 0; i < 3; i++ {
+		appendEvent(Event{Type: EventAssistantDelta, TurnID: "turn-1", Text: fmt.Sprintf("event-%d", i+1)})
+	}
+	for _, event := range journal.Snapshot() {
+		if event.TurnID == "turn-2" {
+			t.Fatalf("queued turn remained in replay history after compaction: %#v", event)
+		}
+	}
+	journal.Close()
+
+	reopened, err := openJournal(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	recovery, err := recoverJournal(reopened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recovery.queuedTurns) != 1 || recovery.queuedTurns[0].id != "turn-2" || recovery.queuedTurns[0].text != "queued work" {
+		t.Fatalf("recovered queued turns = %#v", recovery.queuedTurns)
+	}
+}
+
 func TestJournalIdentityPersistsUntilJournalIsReplaced(t *testing.T) {
 	path := filepath.Join(t.TempDir(), journalFileName)
 	journal, err := OpenJournal(path)

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -32,6 +32,7 @@ const (
 	journalFileName                     = "events.jsonl"
 	activityPublishedFile               = "activity-published"
 	initializedFile                     = "initialized"
+	defaultInterruptTimeout             = 10 * time.Second
 	defaultSessionStatusPublishInterval = 30 * time.Second
 	defaultSessionStatusRetryInterval   = 2 * time.Second
 )
@@ -84,9 +85,11 @@ type pendingInputResult struct {
 
 // Server owns one provider process, event stream, and local client socket.
 type Server struct {
-	config   Config
-	journal  *Journal
-	provider Provider
+	config            Config
+	journal           *Journal
+	provider          Provider
+	providerCloseOnce sync.Once
+	providerCloseErr  error
 
 	submitMu      sync.Mutex
 	appendMessage func(Event) error
@@ -107,8 +110,15 @@ type Server struct {
 	updateRequest      *sessionupdate.Request
 	idleDrainRequest   *sessionupdate.Request
 	updateReport       chan struct{}
+	interruptMu        sync.Mutex
 	activeMu           sync.Mutex
 	activeTurn         string
+	activeTurnCancel   context.CancelCauseFunc
+	activeTurnDone     chan struct{}
+	providerStopping   atomic.Bool
+	providerStopOnce   sync.Once
+	providerStop       chan struct{}
+	interruptTimeout   time.Duration
 	pendingInputCount  atomic.Int64
 
 	runtimeStatusMu             sync.RWMutex
@@ -143,6 +153,8 @@ func NewServer(config Config, journal *Journal, provider Provider) *Server {
 		pendingInputs:                map[string]*pendingInput{},
 		workspaceStatusRefreshes:     make(chan struct{}, 1),
 		sessionStatusPublishWakeups:  make(chan struct{}, 1),
+		providerStop:                 make(chan struct{}),
+		interruptTimeout:             defaultInterruptTimeout,
 		sessionStatusPublishInterval: defaultSessionStatusPublishInterval,
 		sessionStatusRetryInterval:   defaultSessionStatusRetryInterval,
 	}
@@ -217,9 +229,12 @@ func Run(ctx context.Context, config Config) error {
 	}
 	server.nextTurnID.Store(recovery.nextTurnID)
 	server.nextInputID.Store(recovery.nextInputID)
-	// Journal recovery marks any interrupted turn complete, so every recovered turn
-	// is finished; a republished idle status may settle up to the highest of them.
-	server.completedTurnID.Store(recovery.nextTurnID)
+	server.completedTurnID.Store(recovery.completedTurnID)
+	if err := server.restoreTurns(recovery.queuedTurns); err != nil {
+		_ = provider.Close()
+		journal.Close()
+		return err
+	}
 	if server.activityMarkerPath != "" {
 		settledTurnID, err := loadSettledTurnID(server.activityMarkerPath)
 		if err != nil {
@@ -230,7 +245,7 @@ func Run(ctx context.Context, config Config) error {
 		server.settledTurnID.Store(settledTurnID)
 	}
 	// Republish activity when the journal holds locally accepted turns that were
-	// never durably settled to a published idle status. This covers both
+	// never durably settled to a published idle status. This covers queued or
 	// interrupted turns and turns that completed while their ordered Active status
 	// publications were still retrying: a container restart drops the in-memory
 	// publish queue, so without this a surviving idle-drain request could be
@@ -301,7 +316,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	serveCtx, cancelServe := context.WithCancel(ctx)
 	defer cancelServe()
 	defer func() {
-		_ = s.provider.Close()
+		_ = s.closeProvider()
 		s.journal.Close()
 		_ = os.Remove(s.config.SocketPath)
 	}()
@@ -384,13 +399,28 @@ func (s *Server) runTurns(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-s.providerStop:
+			return
 		case turn := <-s.turns:
 			select {
 			case <-turn.accepted:
 			case <-ctx.Done():
 				return
+			case <-s.providerStop:
+				// Leave accepted but unstarted work queued for journal recovery.
+				s.turns <- turn
+				return
+			}
+			if s.providerStopping.Load() {
+				// Leave accepted but unstarted work queued for journal recovery.
+				s.turns <- turn
+				return
 			}
 			s.runTurn(ctx, turn)
+			// Keep the next queued turn out of reach of an interrupt call that is
+			// still settling after this turn returned.
+			s.interruptMu.Lock()
+			s.interruptMu.Unlock()
 		}
 	}
 }
@@ -652,46 +682,64 @@ func (s *Server) runSessionStatusPublishes(ctx context.Context) {
 
 func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 	defer s.requestWorkspaceStatusRefresh()
-	defer s.finishTurn()
+	turnCtx, cancelTurn := context.WithCancelCause(ctx)
+	turnDone := make(chan struct{})
 	s.activeMu.Lock()
 	s.activeTurn = turn.id
+	s.activeTurnCancel = cancelTurn
+	s.activeTurnDone = turnDone
 	s.activeMu.Unlock()
 	s.requestSessionStatusPublish()
 	defer func() {
+		cancelTurn(nil)
 		s.activeMu.Lock()
 		if s.activeTurn == turn.id {
 			s.activeTurn = ""
+			s.activeTurnCancel = nil
+			s.activeTurnDone = nil
 		}
 		s.activeMu.Unlock()
 		// Advance the completed-turn high-water mark before requesting the idle
 		// publication so that publication carries a snapshot reflecting this turn.
 		s.markTurnCompleted(turn.id)
 		s.requestSessionStatusPublish()
+		s.finishTurn()
+		close(turnDone)
 	}()
 
 	if err := s.journal.Append(Event{Type: EventTurnStarted, TurnID: turn.id, Status: "running"}); err != nil {
 		return
 	}
 	sink := &turnSink{server: s, turnID: turn.id}
-	err := s.provider.RunTurn(ctx, turn.text, sink)
+	result := make(chan error, 1)
+	go func() {
+		result <- s.provider.RunTurn(turnCtx, turn.text, sink)
+	}()
+	var err error
+	select {
+	case err = <-result:
+	case <-turnCtx.Done():
+		err = context.Cause(turnCtx)
+	}
 	if s.config.AgentType == "claude-code" || s.config.AgentType == "opencode" {
-		if diff := workspaceDiff(ctx, s.config.WorkingDir); diff != "" {
+		if diff := workspaceDiff(turnCtx, s.config.WorkingDir); diff != "" {
 			sink.Emit(Event{Type: EventFileDiff, Diff: diff})
 		}
 	}
-	if errors.Is(err, ErrTurnInterrupted) {
-		sink.Emit(Event{Type: EventTurnCompleted, Status: "interrupted"})
+	sink.stop()
+	if errors.Is(err, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted) {
+		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "interrupted"})
 		return
 	}
 	if err != nil {
-		if ctx.Err() != nil {
+		if turnCtx.Err() != nil {
 			return
 		}
-		sink.Emit(Event{Type: EventError, Text: err.Error(), Status: "failed"})
-		sink.Emit(Event{Type: EventTurnCompleted, Status: "failed"})
+		_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: err.Error(), Status: "failed"})
+		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "failed"})
 		return
 	}
-	sink.Emit(Event{Type: EventTurnCompleted, Status: "completed"})
+	_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "completed"})
 }
 
 func workspaceDiff(ctx context.Context, workingDir string) string {
@@ -720,6 +768,9 @@ func (s *Server) submitMessage(text, requestID string) error {
 	if s.updateRequest != nil {
 		return errors.New("Session runtime is draining for an update; retry after it reconnects")
 	}
+	if s.providerStopping.Load() {
+		return errors.New("Session provider is restarting; retry after it reconnects")
+	}
 	if err := s.journal.Err(); err != nil {
 		return fmt.Errorf("recording Session message: %w", err)
 	}
@@ -743,24 +794,34 @@ func (s *Server) submitMessage(text, requestID string) error {
 }
 
 type journalRecovery struct {
-	nextTurnID  int64
-	nextInputID int64
+	nextTurnID      int64
+	nextInputID     int64
+	completedTurnID int64
+	queuedTurns     []turnRequest
+}
+
+type journalTurnRecovery struct {
+	id        string
+	text      string
+	started   bool
+	completed bool
 }
 
 // hasUnsettledActivity reports whether the journal holds locally accepted turns
 // beyond the given durably-settled high-water mark. nextTurnID is the highest
-// turn ID observed in the journal, so any turn — interrupted or completed — whose
-// idle status was never durably published leaves nextTurnID above settledTurnID.
+// turn ID observed in the journal, so any queued, interrupted, or completed turn
+// whose idle status was never durably published leaves nextTurnID above
+// settledTurnID.
 func (r journalRecovery) hasUnsettledActivity(settledTurnID int64) bool {
 	return r.nextTurnID > settledTurnID
 }
 
 func recoverJournal(journal *Journal) (journalRecovery, error) {
-	events := journal.Snapshot()
+	events := journal.snapshotForRecovery()
 	if len(events) == 0 {
 		return journalRecovery{}, nil
 	}
-	turns := map[string]bool{}
+	turns := map[string]*journalTurnRecovery{}
 	turnOrder := make([]string, 0)
 	inputs := map[string]string{}
 	inputOrder := make([]string, 0)
@@ -772,16 +833,30 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 		if value := numericEventID(event.InputID, "input-"); value > recovery.nextInputID {
 			recovery.nextInputID = value
 		}
-		if event.TurnID != "" && event.Type != EventTurnCompleted {
+		var turn *journalTurnRecovery
+		if event.TurnID != "" {
 			if _, exists := turns[event.TurnID]; !exists {
 				turnOrder = append(turnOrder, event.TurnID)
+				turns[event.TurnID] = &journalTurnRecovery{id: event.TurnID}
 			}
-			turns[event.TurnID] = true
+			turn = turns[event.TurnID]
 		}
 		switch event.Type {
+		case EventUserMessage:
+			if turn != nil {
+				turn.text = event.Text
+			}
 		case EventTurnCompleted:
-			delete(turns, event.TurnID)
+			if turn != nil {
+				turn.completed = true
+			}
+			if value := numericEventID(event.TurnID, "turn-"); value > recovery.completedTurnID {
+				recovery.completedTurnID = value
+			}
 		case EventInputRequested:
+			if turn != nil {
+				turn.started = true
+			}
 			if event.InputID != "" {
 				if _, exists := inputs[event.InputID]; !exists {
 					inputOrder = append(inputOrder, event.InputID)
@@ -790,10 +865,18 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 			}
 		case EventInputResolved:
 			delete(inputs, event.InputID)
+		default:
+			if turn != nil {
+				turn.started = true
+			}
 		}
 	}
 	message := "Session runtime restarted"
-	if len(turns) > 0 || len(inputs) > 0 {
+	interruptedWork := len(inputs) > 0
+	for _, turn := range turns {
+		interruptedWork = interruptedWork || (!turn.completed && turn.started)
+	}
+	if interruptedWork {
 		message += "; unfinished work was interrupted"
 	}
 	if err := journal.Append(Event{Type: EventRuntimeRecovered, Text: message, Status: "recovered"}); err != nil {
@@ -807,13 +890,37 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 		}
 	}
 	for _, turnID := range turnOrder {
-		if turns[turnID] {
-			if err := journal.Append(Event{Type: EventTurnCompleted, TurnID: turnID, Status: "interrupted"}); err != nil {
-				return recovery, fmt.Errorf("recording recovered Session turn: %w", err)
-			}
+		turn := turns[turnID]
+		if turn.completed {
+			continue
+		}
+		if !turn.started {
+			accepted := make(chan struct{})
+			close(accepted)
+			recovery.queuedTurns = append(recovery.queuedTurns, turnRequest{id: turn.id, text: turn.text, accepted: accepted})
+			continue
+		}
+		if err := journal.Append(Event{Type: EventTurnCompleted, TurnID: turnID, Status: "interrupted"}); err != nil {
+			return recovery, fmt.Errorf("recording recovered Session turn: %w", err)
+		}
+		if value := numericEventID(turnID, "turn-"); value > recovery.completedTurnID {
+			recovery.completedTurnID = value
 		}
 	}
 	return recovery, nil
+}
+
+func (s *Server) restoreTurns(turns []turnRequest) error {
+	if len(turns) > cap(s.turns) {
+		return fmt.Errorf("restoring %d queued Session turns: queue capacity is %d", len(turns), cap(s.turns))
+	}
+	s.submitMu.Lock()
+	defer s.submitMu.Unlock()
+	for _, turn := range turns {
+		s.turns <- turn
+		s.outstanding++
+	}
+	return nil
 }
 
 func numericEventID(value, prefix string) int64 {
@@ -827,20 +934,91 @@ func numericEventID(value, prefix string) int64 {
 	return number
 }
 
-func (s *Server) interruptTurn(ctx context.Context, requestID string) error {
+func (s *Server) interruptTurn(runtimeCtx context.Context, requestID string) error {
 	s.activeMu.Lock()
 	turnID := s.activeTurn
+	turnCancel := s.activeTurnCancel
+	turnDone := s.activeTurnDone
 	s.activeMu.Unlock()
 	if turnID == "" {
 		return ErrNoActiveTurn
 	}
+	s.interruptMu.Lock()
+	defer s.interruptMu.Unlock()
+	s.activeMu.Lock()
+	activeTurn := s.activeTurn
+	s.activeMu.Unlock()
+	if activeTurn != turnID {
+		return nil
+	}
 	if err := s.journal.Append(Event{Type: EventTurnInterrupting, RequestID: requestID, TurnID: turnID, Status: "interrupting"}); err != nil {
 		return fmt.Errorf("recording Session interruption: %w", err)
 	}
-	if err := s.provider.Interrupt(ctx); err != nil {
-		return err
+	interruptCtx, cancel := context.WithTimeout(runtimeCtx, s.interruptTimeout)
+	defer cancel()
+	interruptResult := make(chan error, 1)
+	go func() {
+		interruptResult <- s.provider.Interrupt(interruptCtx)
+	}()
+	select {
+	case err := <-interruptResult:
+		if err != nil && !errors.Is(err, ErrNoActiveTurn) {
+			if runtimeCtx.Err() != nil {
+				return runtimeCtx.Err()
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				log.Printf("Session provider interruption timed out turnID=%s", turnID)
+			} else {
+				log.Printf("Session provider interruption failed; stopping provider turnID=%s error=%v", turnID, err)
+			}
+			return s.stopInterruptedTurn(turnID, turnCancel, turnDone)
+		}
+	case <-interruptCtx.Done():
+		if runtimeCtx.Err() != nil {
+			return runtimeCtx.Err()
+		}
+		log.Printf("Session provider interruption timed out turnID=%s", turnID)
+		return s.stopInterruptedTurn(turnID, turnCancel, turnDone)
 	}
+	select {
+	case <-turnDone:
+		return nil
+	case <-interruptCtx.Done():
+		if runtimeCtx.Err() != nil {
+			return runtimeCtx.Err()
+		}
+		log.Printf("Session provider interruption timed out turnID=%s", turnID)
+		return s.stopInterruptedTurn(turnID, turnCancel, turnDone)
+	}
+}
+
+func (s *Server) stopInterruptedTurn(turnID string, cancel context.CancelCauseFunc, done <-chan struct{}) error {
+	if cancel == nil || done == nil {
+		return errors.New("Session active turn cannot be stopped")
+	}
+	s.activeMu.Lock()
+	if s.activeTurn != "" && s.activeTurn != turnID {
+		s.activeMu.Unlock()
+		return nil
+	}
+	s.activeMu.Unlock()
+	s.submitMu.Lock()
+	s.providerStopping.Store(true)
+	s.providerStopOnce.Do(func() { close(s.providerStop) })
+	s.submitMu.Unlock()
+	cancel(ErrTurnInterrupted)
+	if err := s.closeProvider(); err != nil {
+		log.Printf("Unable to restart Session provider after forced interruption error=%v", err)
+	}
+	<-done
 	return nil
+}
+
+func (s *Server) closeProvider() error {
+	s.providerCloseOnce.Do(func() {
+		s.providerCloseErr = s.provider.Close()
+	})
+	return s.providerCloseErr
 }
 
 func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
@@ -1023,7 +1201,7 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			}
 		case "interrupt":
 			subscribe(0, "", false, 0, 0)
-			if err := s.interruptTurn(connectionCtx, request.RequestID); err != nil {
+			if err := s.interruptTurn(ctx, request.RequestID); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
 			}
 		default:
@@ -1118,11 +1296,18 @@ func sendLiveEvent(ctx context.Context, out chan<- Event, overflow <-chan struct
 }
 
 type turnSink struct {
-	server *Server
-	turnID string
+	server  *Server
+	turnID  string
+	mu      sync.Mutex
+	stopped bool
 }
 
 func (s *turnSink) Emit(event Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return
+	}
 	if event.Type == EventRuntimeStatus && event.Runtime != nil {
 		s.server.updateProviderRuntimeStatus(*event.Runtime)
 		return
@@ -1136,7 +1321,19 @@ func (s *turnSink) Emit(event Event) {
 	_ = s.server.journal.Append(event)
 }
 
+func (s *turnSink) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+}
+
 func (s *turnSink) RequestInput(ctx context.Context, request InputRequest) (map[string][]string, error) {
+	s.mu.Lock()
+	stopped := s.stopped
+	s.mu.Unlock()
+	if stopped {
+		return nil, ErrInputCancelled
+	}
 	if request.ID == "" {
 		request.ID = fmt.Sprintf("input-%d", s.server.nextInputID.Add(1))
 	}

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -73,6 +73,102 @@ type interruptProvider struct {
 	closeOnce   sync.Once
 }
 
+type stuckInterruptProvider struct {
+	started                chan struct{}
+	interruptCalled        chan struct{}
+	runStopped             chan struct{}
+	done                   chan struct{}
+	acknowledge            bool
+	ignoreInterruptContext bool
+	interruptErr           error
+	startOnce              sync.Once
+	interruptOnce          sync.Once
+	closeOnce              sync.Once
+}
+
+type turnCompletionRaceProvider struct {
+	mu              sync.Mutex
+	runCount        int
+	firstStarted    chan struct{}
+	secondStarted   chan struct{}
+	finishFirst     chan struct{}
+	interruptCalled chan struct{}
+	finishInterrupt chan struct{}
+	done            chan struct{}
+	interruptOnce   sync.Once
+	closeOnce       sync.Once
+}
+
+func (p *turnCompletionRaceProvider) RunTurn(ctx context.Context, _ string, _ EventSink) error {
+	p.mu.Lock()
+	p.runCount++
+	runCount := p.runCount
+	p.mu.Unlock()
+	switch runCount {
+	case 1:
+		close(p.firstStarted)
+		select {
+		case <-p.finishFirst:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case 2:
+		close(p.secondStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	default:
+		return errors.New("unexpected provider turn")
+	}
+}
+
+func (p *turnCompletionRaceProvider) Interrupt(ctx context.Context) error {
+	p.interruptOnce.Do(func() { close(p.interruptCalled) })
+	select {
+	case <-p.finishInterrupt:
+		return ErrNoActiveTurn
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *turnCompletionRaceProvider) Done() <-chan struct{} { return p.done }
+func (p *turnCompletionRaceProvider) Close() error {
+	p.closeOnce.Do(func() { close(p.done) })
+	return nil
+}
+
+func (p *stuckInterruptProvider) RunTurn(ctx context.Context, _ string, _ EventSink) error {
+	p.startOnce.Do(func() { close(p.started) })
+	<-p.runStopped
+	return ctx.Err()
+}
+
+func (p *stuckInterruptProvider) Interrupt(ctx context.Context) error {
+	p.interruptOnce.Do(func() { close(p.interruptCalled) })
+	if p.interruptErr != nil {
+		return p.interruptErr
+	}
+	if p.acknowledge {
+		return nil
+	}
+	if p.ignoreInterruptContext {
+		<-p.done
+		return errors.New("provider stopped")
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (p *stuckInterruptProvider) Done() <-chan struct{} { return p.done }
+func (p *stuckInterruptProvider) Close() error {
+	p.closeOnce.Do(func() {
+		close(p.runStopped)
+		close(p.done)
+	})
+	return nil
+}
+
 func (p *interruptProvider) RunTurn(context.Context, string, EventSink) error {
 	p.startOnce.Do(func() { close(p.started) })
 	<-p.interrupted
@@ -855,6 +951,348 @@ func TestServerInterruptsActiveTurn(t *testing.T) {
 	cancel()
 	if err := <-serveDone; err != nil {
 		t.Fatalf("Serve() error = %v", err)
+	}
+}
+
+func TestServerGracefullyInterruptsDrainingTurn(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	provider := &interruptProvider{
+		started:     make(chan struct{}),
+		interrupted: make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+	defer provider.Close()
+	server := NewServer(Config{PodUID: types.UID("pod-uid")}, journal, provider)
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(ctx)
+		close(runDone)
+	}()
+	if err := server.submitMessage("work", "request-work"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("provider turn did not start")
+	}
+	podUID := server.config.PodUID
+	request := sessionupdate.NewRequest(podUID, "desired-revision")
+	encoded, err := sessionupdate.Encode(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.observeSessionUpdate(&kelos.Session{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{sessionupdate.RequestAnnotation: encoded},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.interruptTurn(t.Context(), "request-interrupt"); err != nil {
+		t.Fatalf("interruptTurn() error = %v", err)
+	}
+	select {
+	case <-provider.interrupted:
+	default:
+		t.Fatal("draining interruption did not call the provider")
+	}
+	select {
+	case <-provider.done:
+		t.Fatal("graceful draining interruption recycled the provider")
+	default:
+	}
+	report, _ := server.sessionDrainReports()
+	if report == nil || report.Phase != sessionupdate.PhaseDrained {
+		t.Fatalf("runtime update report = %#v, want Drained", report)
+	}
+	cancel()
+	<-runDone
+}
+
+func TestServerForcesStuckInterruptAfterTimeout(t *testing.T) {
+	for _, test := range []struct {
+		name                   string
+		acknowledge            bool
+		ignoreInterruptContext bool
+		interruptErr           error
+	}{
+		{name: "interrupt request does not return"},
+		{name: "interrupt request ignores cancellation", ignoreInterruptContext: true},
+		{name: "interrupt request fails", interruptErr: errors.New("interrupt failed")},
+		{name: "turn does not finish after interrupt", acknowledge: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, provider, turnDone := startStuckInterruptServer(t, test.acknowledge)
+			provider.ignoreInterruptContext = test.ignoreInterruptContext
+			provider.interruptErr = test.interruptErr
+			server.interruptTimeout = 20 * time.Millisecond
+			if err := server.interruptTurn(t.Context(), "request-interrupt"); err != nil {
+				t.Fatalf("interruptTurn() error = %v", err)
+			}
+			assertStuckTurnInterrupted(t, server, provider, turnDone)
+			select {
+			case <-provider.interruptCalled:
+			default:
+				t.Fatal("provider interrupt was not attempted before timeout recovery")
+			}
+		})
+	}
+}
+
+func TestServerCompletesAcceptedInterruptAfterClientDisconnect(t *testing.T) {
+	server, provider, turnDone := startStuckInterruptServer(t, false)
+	server.interruptTimeout = 20 * time.Millisecond
+	serverConnection, clientConnection := net.Pipe()
+	connectionDone := make(chan struct{})
+	go func() {
+		server.handleConnection(t.Context(), serverConnection)
+		close(connectionDone)
+	}()
+	if err := json.NewEncoder(clientConnection).Encode(ClientRequest{Type: "interrupt", RequestID: "request-interrupt"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-provider.interruptCalled:
+	case <-time.After(time.Second):
+		t.Fatal("provider interrupt was not attempted")
+	}
+	if err := clientConnection.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertStuckTurnInterrupted(t, server, provider, turnDone)
+	select {
+	case <-connectionDone:
+	case <-time.After(time.Second):
+		t.Fatal("disconnected client handler did not finish")
+	}
+}
+
+func TestServerCancelsInterruptWhenRuntimeStops(t *testing.T) {
+	server, provider, _ := startStuckInterruptServer(t, false)
+	defer provider.Close()
+	server.interruptTimeout = time.Second
+	runtimeCtx, cancelRuntime := context.WithCancel(context.Background())
+	interruptDone := make(chan error, 1)
+	go func() {
+		interruptDone <- server.interruptTurn(runtimeCtx, "request-interrupt")
+	}()
+	select {
+	case <-provider.interruptCalled:
+	case <-time.After(time.Second):
+		t.Fatal("provider interrupt was not attempted")
+	}
+	cancelRuntime()
+	select {
+	case err := <-interruptDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("interruptTurn() error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runtime shutdown did not cancel provider interruption")
+	}
+	select {
+	case <-provider.done:
+		t.Fatal("runtime cancellation forced provider recovery")
+	default:
+	}
+}
+
+func TestServerDoesNotInterruptNextTurnWhenCompletionRacesWithInterrupt(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	provider := &turnCompletionRaceProvider{
+		firstStarted:    make(chan struct{}),
+		secondStarted:   make(chan struct{}),
+		finishFirst:     make(chan struct{}),
+		interruptCalled: make(chan struct{}),
+		finishInterrupt: make(chan struct{}),
+		done:            make(chan struct{}),
+	}
+	defer provider.Close()
+	server := NewServer(Config{}, journal, provider)
+	if err := server.submitMessage("first", "request-first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.submitMessage("second", "request-second"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(ctx)
+		close(runDone)
+	}()
+	select {
+	case <-provider.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first provider turn did not start")
+	}
+	interruptDone := make(chan error, 1)
+	go func() {
+		interruptDone <- server.interruptTurn(t.Context(), "request-interrupt")
+	}()
+	select {
+	case <-provider.interruptCalled:
+	case <-time.After(time.Second):
+		t.Fatal("provider interrupt was not attempted")
+	}
+	close(provider.finishFirst)
+	select {
+	case <-provider.secondStarted:
+		t.Fatal("second turn started while the first turn interruption was still pending")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(provider.finishInterrupt)
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("interruptTurn() error = %v", err)
+	}
+	select {
+	case <-provider.secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second provider turn did not start after interruption settled")
+	}
+	cancel()
+	<-runDone
+}
+
+func TestServerPreservesQueuedTurnAcrossForcedProviderRestart(t *testing.T) {
+	server, provider, turnDone := startStuckInterruptServer(t, false)
+	server.interruptTimeout = 20 * time.Millisecond
+	if err := server.submitMessage("queued work", "request-queued"); err != nil {
+		t.Fatal(err)
+	}
+	podUID := server.config.PodUID
+	request := sessionupdate.NewRequest(podUID, "desired-revision")
+	encoded, err := sessionupdate.Encode(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.observeSessionUpdate(&kelos.Session{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{sessionupdate.RequestAnnotation: encoded},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.interruptTurn(t.Context(), "request-interrupt"); err != nil {
+		t.Fatalf("interruptTurn() error = %v", err)
+	}
+	assertStuckTurnInterrupted(t, server, provider, turnDone)
+	if report, _ := server.sessionDrainReports(); report == nil || report.Phase != sessionupdate.PhaseDraining {
+		t.Fatalf("runtime update report = %#v, want Draining while queued work remains", report)
+	}
+
+	recovery, err := recoverJournal(server.journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recovery.queuedTurns) != 1 || recovery.queuedTurns[0].id != "turn-2" || recovery.queuedTurns[0].text != "queued work" {
+		t.Fatalf("recovered queued turns = %#v", recovery.queuedTurns)
+	}
+	restartedProvider := &fakeProvider{}
+	restarted := NewServer(Config{}, server.journal, restartedProvider)
+	if err := restarted.restoreTurns(recovery.queuedTurns); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		restarted.runTurns(ctx)
+		close(runDone)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		restartedProvider.mu.Lock()
+		prompts := append([]string(nil), restartedProvider.prompts...)
+		restartedProvider.mu.Unlock()
+		if reflect.DeepEqual(prompts, []string{"queued work"}) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("provider prompts = %v, want queued work", prompts)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-runDone
+}
+
+func TestServerStopsAcceptingAndDispatchingTurnsWhileProviderRestarts(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	provider := &fakeProvider{}
+	server := NewServer(Config{}, journal, provider)
+	accepted := make(chan struct{})
+	close(accepted)
+	server.turns <- turnRequest{id: "turn-1", text: "queued work", accepted: accepted}
+	server.providerStopping.Store(true)
+
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(t.Context())
+		close(runDone)
+	}()
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("turn dispatcher did not stop")
+	}
+	if len(server.turns) != 1 {
+		t.Fatalf("queued turns = %d, want 1", len(server.turns))
+	}
+	if err := server.submitMessage("late work", "request-late"); err == nil || !strings.Contains(err.Error(), "restarting") {
+		t.Fatalf("submitMessage() error = %v, want provider restart rejection", err)
+	}
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.prompts) != 0 {
+		t.Fatalf("provider prompts = %v, want none", provider.prompts)
+	}
+}
+
+func startStuckInterruptServer(t *testing.T, acknowledge bool) (*Server, *stuckInterruptProvider, <-chan struct{}) {
+	t.Helper()
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &stuckInterruptProvider{
+		started:         make(chan struct{}),
+		interruptCalled: make(chan struct{}),
+		runStopped:      make(chan struct{}),
+		done:            make(chan struct{}),
+		acknowledge:     acknowledge,
+	}
+	server := NewServer(Config{PodUID: types.UID("pod-uid")}, journal, provider)
+	if err := server.submitMessage("work", "request-work"); err != nil {
+		t.Fatal(err)
+	}
+	turnDone := make(chan struct{})
+	go func() {
+		server.runTurns(t.Context())
+		close(turnDone)
+	}()
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("provider turn did not start")
+	}
+	return server, provider, turnDone
+}
+
+func assertStuckTurnInterrupted(t *testing.T, server *Server, provider *stuckInterruptProvider, turnDone <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-turnDone:
+	case <-time.After(time.Second):
+		t.Fatal("forced interruption did not finish the turn")
+	}
+	select {
+	case <-provider.done:
+	default:
+		t.Fatal("stuck provider was not closed")
+	}
+	events := server.journal.Snapshot()
+	assertEventTypes(t, events, EventTurnInterrupting, EventTurnCompleted)
+	if completion := events[len(events)-1]; completion.Type != EventTurnCompleted || completion.Status != "interrupted" {
+		t.Fatalf("turn completion = %#v, want interrupted", completion)
 	}
 }
 

--- a/internal/sessionruntime/update.go
+++ b/internal/sessionruntime/update.go
@@ -203,7 +203,7 @@ func encodeDrainReport(report *sessionupdate.Report) (any, error) {
 // sessionDrainReports returns the acknowledgement for each pending drain request
 // (runtime update and idle drain), or nil for a request that is not pending.
 //
-// A runtime-update report is Drained once no turn is in flight: the Pod is
+// A runtime-update report is Drained once no accepted turn remains: the Pod is
 // replaced and recovers from the journal, so an unpublished activity transition
 // is not lost.
 //

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -618,8 +618,9 @@ func TestSessionComposerAllowsMultilinePromptsOnTouchDevices(t *testing.T) {
 	javascript := string(source)
 	for description, expected := range map[string]string{
 		"touch device detection":  `window.matchMedia('(pointer: coarse)').matches`,
-		"touch composer hint":     "? `Tap ↑ to ${action} · Return for a new line`",
-		"desktop composer hint":   ": `Enter to ${action} · Shift+Enter for a new line`;",
+		"touch composer hint":     "? `Tap ${actionSymbol} to ${action} · Return for a new line`",
+		"desktop composer hint":   "`Enter to ${action} · Shift+Enter for a new line`",
+		"disabled interrupt hint": "`Click ${actionSymbol} to interrupt`",
 		"desktop-only Enter send": `!event.isComposing && !usesTouchComposer()`,
 	} {
 		if !strings.Contains(javascript, expected) {

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -138,18 +138,21 @@ global.document = {
 };
 
 let bottomAnchors;
+let interruptRequests;
 let socketConnections;
 let progressTimers;
 let toasts;
 
 global.window = {
   clearInterval: (timer) => progressTimers.delete(timer),
+  matchMedia: () => ({matches: false}),
   setInterval: (callback) => {
     const timer = progressTimers.size + 1;
     progressTimers.set(timer, callback);
     return timer;
   },
 };
+global.WebSocket = {OPEN: 1};
 
 function resetHarness() {
   global.elements = {
@@ -158,7 +161,9 @@ function resetHarness() {
     changesList: new TestNode('div'),
     changesCount: new TestNode('span'),
     changesSummary: new TestNode('span'),
+    composerHint: new TestNode('span'),
     input: new TestNode('textarea'),
+    send: new TestNode('button'),
     progress: new TestNode('div'),
     progressLabel: new TestNode('span'),
     progressElapsed: new TestNode('span'),
@@ -200,6 +205,7 @@ function resetHarness() {
     fileChangesDirty: false,
   };
   bottomAnchors = 0;
+  interruptRequests = 0;
   socketConnections = 0;
   progressTimers = new Map();
   toasts = [];
@@ -226,6 +232,7 @@ global.acceptQueuedMessage = () => {};
 global.renderInputRequest = () => {};
 global.resolveInputCard = () => {};
 global.scrollToBottom = () => {};
+global.interruptActiveTurn = () => { interruptRequests++; };
 global.showToast = (message) => { toasts.push(message); };
 
 const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
@@ -242,6 +249,7 @@ vm.runInThisContext(applicationSlice('function sessionKey', 'function savePrompt
 vm.runInThisContext(applicationSlice('function savePromptDraft', 'function providerLabel'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function parseSessionTimestamp', 'function safeHTTPURL'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function selectSession', 'function renderHeader'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function usesTouchComposer', 'function closeSocket'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function ensureConversation', 'function trimURLSuffix'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function completedAssistantText', 'function handleEvent'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function handleEvent', 'function renderUser'), {filename: 'app.js'});
@@ -249,6 +257,7 @@ vm.runInThisContext(applicationSlice('function renderUser', 'function renderTool
 vm.runInThisContext(applicationSlice('function renderTool', 'function renderInputRequest'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function renderDiff', 'function setActiveView'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function renderError', 'function scrollToBottom'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function submitComposer', "elements.composer.addEventListener('submit'"), {filename: 'app.js'});
 
 function testSessionViewSaveAndRestore() {
   resetHarness();
@@ -331,6 +340,39 @@ function testSessionProgressLifecycle() {
   handleEvent({type: 'turn.completed', turnId: 'turn-1', status: 'completed'});
   assert.equal(elements.progress.hidden, true);
   assert.equal(state.progressTimer, null);
+}
+
+function testComposerInterruptsWhileInputIsDisabled() {
+  resetHarness();
+  const sent = [];
+  state.socket = {
+    readyState: WebSocket.OPEN,
+    send: (message) => sent.push(message),
+  };
+  state.activeTurn = true;
+  elements.input.disabled = true;
+  elements.input.value = 'preserved draft';
+
+  updateComposerAction();
+
+  assert.equal(elements.send.dataset.action, 'interrupt');
+  assert.equal(elements.send.attributes.get('aria-label'), 'Interrupt active work');
+  assert.equal(elements.send.disabled, false);
+  assert.equal(elements.composerHint.textContent, 'Click ■ to interrupt');
+  assert.equal(elements.input.value, 'preserved draft');
+  window.matchMedia = () => ({matches: true});
+  updateComposerAction();
+  assert.equal(elements.composerHint.textContent, 'Tap ■ to interrupt · Return for a new line');
+  window.matchMedia = () => ({matches: false});
+
+  submitComposer();
+  assert.equal(interruptRequests, 1);
+  assert.deepEqual(sent, []);
+  assert.equal(elements.input.value, 'preserved draft');
+
+  state.interrupting = true;
+  updateComposerAction();
+  assert.equal(elements.send.disabled, true);
 }
 
 function testSessionProgressSurvivesCachedViewSwitch() {
@@ -713,6 +755,7 @@ function testHistoryToolCompletionRendersOutputWithoutStart() {
 testSessionViewSaveAndRestore();
 testSessionViewReset();
 testSessionProgressLifecycle();
+testComposerInterruptsWhileInputIsDisabled();
 testSessionProgressSurvivesCachedViewSwitch();
 testSessionProgressElapsedFormatting();
 testRuntimeStatusLifecycle();

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -1555,18 +1555,25 @@ function usesTouchComposer() {
   return window.matchMedia('(pointer: coarse)').matches;
 }
 
+function composerInterruptAction() {
+  return state.activeTurn && (elements.input.disabled || !elements.input.value.trim());
+}
+
 function updateComposerAction() {
   const connected = state.socket && state.socket.readyState === WebSocket.OPEN;
-  const interrupt = state.activeTurn && !elements.input.value.trim();
-  const action = state.activeTurn ? 'queue' : 'send';
+  const interrupt = composerInterruptAction();
+  const action = interrupt ? 'interrupt' : (state.activeTurn ? 'queue' : 'send');
+  const actionSymbol = interrupt ? '■' : '↑';
   elements.send.dataset.action = interrupt ? 'interrupt' : 'send';
-  elements.send.textContent = interrupt ? '■' : '↑';
+  elements.send.textContent = actionSymbol;
   elements.send.setAttribute('aria-label', interrupt ? 'Interrupt active work' : 'Send message');
   elements.send.title = interrupt ? 'Interrupt active work' : 'Send message';
-  elements.send.disabled = !connected || elements.input.disabled || (interrupt && state.interrupting);
+  elements.send.disabled = !connected || (interrupt ? state.interrupting : elements.input.disabled);
   elements.composerHint.textContent = usesTouchComposer()
-    ? `Tap ↑ to ${action} · Return for a new line`
-    : `Enter to ${action} · Shift+Enter for a new line`;
+    ? `Tap ${actionSymbol} to ${action} · Return for a new line`
+    : (interrupt && elements.input.disabled
+      ? `Click ${actionSymbol} to interrupt`
+      : `Enter to ${action} · Shift+Enter for a new line`);
 }
 
 function closeSocket() {
@@ -3161,16 +3168,20 @@ function scheduleBottomAnchor() {
   });
 }
 
-elements.composer.addEventListener('submit', event => {
-  event.preventDefault();
+function submitComposer() {
   const text = elements.input.value.trim();
   if (!state.socket || state.socket.readyState !== WebSocket.OPEN) return;
-  if (text) {
+  if (composerInterruptAction()) {
+    interruptActiveTurn();
+  } else if (text) {
     state.socket.send(JSON.stringify({type: 'message', text}));
     clearPromptDraft(state.selected);
-  } else if (state.activeTurn) {
-    interruptActiveTurn();
   }
+}
+
+elements.composer.addEventListener('submit', event => {
+  event.preventDefault();
+  submitComposer();
 });
 
 elements.input.addEventListener('keydown', event => {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Keeps the Session web chat Stop action available while the composer is disabled during draining. The action preserves any unsent draft and submits an interrupt instead of attempting to queue the draft. The composer hint reflects the Stop action on desktop and touch devices.

Uses the same graceful-first interruption lifecycle for every active turn, including while the runtime is draining. Kelos asks the provider to interrupt and keeps the provider conversation when the turn finishes successfully.

The accepted interruption is owned by the Session runtime rather than the requesting client connection. If the provider interruption fails or the turn does not finish within 10 seconds, Kelos cancels the turn and recycles the provider without depending on a blocked provider call. Accepted queued prompts remain pending and resume in order after the provider restarts, so a runtime update remains `Draining` until all accepted work finishes.

Adds browser behavior coverage for disabled input with a preserved draft, graceful provider interruption while draining, client disconnect after Stop, provider errors and timeouts, blocked provider calls, and queued-turn recovery across a forced provider restart.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `env -u CODEX_HOME -u CODEX_AUTH_JSON -u KELOS_PLUGIN_DIR make test`

The environment variables are removed locally so Codex entrypoint fixtures do not inherit this development Session credentials, persistent home, or plugin directory.

#### Does this PR introduce a user-facing change?

```release-note
Session interruption remains available while draining, attempts graceful provider interruption first, and recovers stalled interruptions after 10 seconds.
```