### PR TITLE
Increase self-development ephemeral storage

### DIFF
--- a/self-development/agora/agora-config-update.yaml
+++ b/self-development/agora/agora-config-update.yaml
@@ -26,9 +26,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -53,9 +53,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: agora-fake-strategist-agent

--- a/self-development/agora/agora-fake-user.yaml
+++ b/self-development/agora/agora-fake-user.yaml
@@ -53,9 +53,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: agora-fake-user-agent

--- a/self-development/agora/agora-planner.yaml
+++ b/self-development/agora/agora-planner.yaml
@@ -58,9 +58,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: agora-planner-agent

--- a/self-development/agora/agora-pr-responder.yaml
+++ b/self-development/agora/agora-pr-responder.yaml
@@ -46,9 +46,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/agora/agora-reviewer.yaml
+++ b/self-development/agora/agora-reviewer.yaml
@@ -77,9 +77,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: agora-reviewer-agent

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -26,9 +26,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent

--- a/self-development/agora/agora-squash-commits.yaml
+++ b/self-development/agora/agora-squash-commits.yaml
@@ -41,9 +41,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/agora/agora-triage.yaml
+++ b/self-development/agora/agora-triage.yaml
@@ -40,9 +40,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: agora-dev-agent

--- a/self-development/agora/agora-workers.yaml
+++ b/self-development/agora/agora-workers.yaml
@@ -39,9 +39,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kanon/kanon-config-update.yaml
+++ b/self-development/kanon/kanon-config-update.yaml
@@ -26,9 +26,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -51,9 +51,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kanon-fake-strategist-agent

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -51,9 +51,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kanon-fake-user-agent

--- a/self-development/kanon/kanon-planner.yaml
+++ b/self-development/kanon/kanon-planner.yaml
@@ -57,9 +57,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kanon-planner-agent

--- a/self-development/kanon/kanon-pr-responder.yaml
+++ b/self-development/kanon/kanon-pr-responder.yaml
@@ -46,9 +46,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kanon/kanon-reviewer.yaml
+++ b/self-development/kanon/kanon-reviewer.yaml
@@ -77,9 +77,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kanon-reviewer-agent

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -26,9 +26,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent

--- a/self-development/kanon/kanon-squash-commits.yaml
+++ b/self-development/kanon/kanon-squash-commits.yaml
@@ -41,9 +41,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kanon/kanon-triage.yaml
+++ b/self-development/kanon/kanon-triage.yaml
@@ -40,9 +40,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kanon-dev-agent

--- a/self-development/kanon/kanon-workers.yaml
+++ b/self-development/kanon/kanon-workers.yaml
@@ -39,9 +39,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -79,9 +79,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-api-reviewer-agent

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -23,9 +23,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -55,9 +55,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-fake-strategist-agent

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -55,9 +55,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-fake-user-agent

--- a/self-development/kelos-glm-api-reviewer.yaml
+++ b/self-development/kelos-glm-api-reviewer.yaml
@@ -82,9 +82,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-glm-api-reviewer-agent

--- a/self-development/kelos-glm-reviewer.yaml
+++ b/self-development/kelos-glm-reviewer.yaml
@@ -83,9 +83,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-glm-reviewer-agent

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -44,9 +44,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -57,9 +57,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-planner-agent

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -46,9 +46,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -80,9 +80,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-reviewer-agent

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -55,9 +55,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-self-update-agent

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -41,9 +41,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -40,9 +40,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
           limits:
-            ephemeral-storage: "2Gi"
+            ephemeral-storage: "10Gi"
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -102,9 +102,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
         env:
           - name: GIT_AUTHOR_NAME
             value: "Gunju Kim"

--- a/self-development/open-actions/open-actions-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-api-reviewer.yaml
@@ -78,9 +78,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-api-reviewer-agent

--- a/self-development/open-actions/open-actions-reviewer.yaml
+++ b/self-development/open-actions/open-actions-reviewer.yaml
@@ -80,9 +80,9 @@ spec:
           requests:
             cpu: "250m"
             memory: "512Mi"
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
           limits:
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "20Gi"
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-reviewer-agent

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -23,9 +23,9 @@ spec:
         requests:
           cpu: "250m"
           memory: "512Mi"
-          ephemeral-storage: "2Gi"
+          ephemeral-storage: "10Gi"
         limits:
-          ephemeral-storage: "2Gi"
+          ephemeral-storage: "10Gi"
   ttlSecondsAfterFinished: 864000
   podFailurePolicy:
     rules:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Increases ephemeral-storage requests and limits across all self-development
worker configurations:

- 2Gi profiles become 10Gi
- 4Gi profiles become 20Gi

The matching limits are raised with the requests so every Pod specification
remains valid. This gives autonomous agent workloads more room for workspace
data, writable container layers, and logs after observed Tasks were evicted
for crossing the previous 2Gi limit.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The change covers 37 manifests under `self-development/`.
- Persistent-volume requests remain unchanged.
- Validation: `GOCACHE=/tmp/kelos-go-build-cache make verify`
- Validation: `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase ephemeral-storage for all self-development workers to reduce evictions and give agents more workspace headroom. 2Gi profiles now request/limit 10Gi; 4Gi profiles now request/limit 20Gi.

- **Migration**
  - Ensure cluster nodes and any Kubernetes `ResourceQuota`/`LimitRange` allow 10Gi/20Gi ephemeral-storage.
  - Persistent volumes are unchanged.

<sup>Written for commit b6c488766a94e34766415ba6b53d0de49cb23777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

