### PR TITLE
Report runtime status from Claude Code and OpenCode Sessions

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -244,10 +244,11 @@ waiting-for-input, and interrupting progress with elapsed time. After a
 completed turn, both interactive and plain terminal output show a `Worked for
 ...` separator when the duration is known. A separate status bar beneath the
 composer shows the Session name, agent type, model and effort when available,
-working directory, git branch, and associated pull request number. Codex
-Sessions also show reported context use, weekly limit remaining, and cumulative
-input and output tokens. Less important status-bar items are omitted as the
-terminal narrows. The model is the same runtime-reported value persisted in
+working directory, git branch, and associated pull request number. Sessions
+also show reported context use and cumulative input and output tokens once the
+agent reports usage; Codex Sessions additionally show weekly limit remaining.
+Less important status-bar items are omitted as the terminal narrows. The
+model is the same runtime-reported value persisted in
 `status.model`. Web chat is served by the optional shared
 `kelos-session-server`; it shows the same live runtime details beneath its
 composer. It shows connection status separately from working, waiting-for-input,

--- a/internal/sessionruntime/claude.go
+++ b/internal/sessionruntime/claude.go
@@ -57,6 +57,14 @@ type ClaudeProvider struct {
 	blockText         map[int]*strings.Builder
 	interrupted       bool
 
+	statusMu sync.Mutex
+	model    string
+	usage    *RuntimeUsage
+	// countedMessages holds assistant message IDs whose usage was already added
+	// to the totals; Claude Code repeats a message's usage on every content-block
+	// event for that message.
+	countedMessages map[string]struct{}
+
 	sessionMu sync.Mutex
 	sessionID string
 	done      chan struct{}
@@ -159,6 +167,7 @@ func (p *ClaudeProvider) RunTurn(ctx context.Context, prompt string, sink EventS
 	p.blockText = map[int]*strings.Builder{}
 	p.interrupted = false
 	p.activeMu.Unlock()
+	p.emitRuntimeStatus(sink)
 	defer func() {
 		interactionCancel()
 		p.activeMu.Lock()
@@ -365,15 +374,18 @@ func newProviderScanner(reader io.Reader) *bufio.Scanner {
 
 func (p *ClaudeProvider) handleClaudeLine(line []byte, sink EventSink) (*claudeTurnResult, error) {
 	var envelope struct {
-		Type           string          `json:"type"`
-		Subtype        string          `json:"subtype"`
-		IsError        bool            `json:"is_error"`
-		Result         string          `json:"result"`
-		StopReason     string          `json:"stop_reason"`
-		TerminalReason string          `json:"terminal_reason"`
-		SessionID      string          `json:"session_id"`
-		Event          json.RawMessage `json:"event"`
-		Message        json.RawMessage `json:"message"`
+		Type           string                      `json:"type"`
+		Subtype        string                      `json:"subtype"`
+		IsError        bool                        `json:"is_error"`
+		Result         string                      `json:"result"`
+		StopReason     string                      `json:"stop_reason"`
+		TerminalReason string                      `json:"terminal_reason"`
+		SessionID      string                      `json:"session_id"`
+		Model          string                      `json:"model"`
+		Usage          *claudeUsage                `json:"usage"`
+		ModelUsage     map[string]claudeModelUsage `json:"modelUsage"`
+		Event          json.RawMessage             `json:"event"`
+		Message        json.RawMessage             `json:"message"`
 	}
 	if err := json.Unmarshal(line, &envelope); err != nil {
 		return nil, fmt.Errorf("decoding Claude Code event: %w", err)
@@ -382,6 +394,16 @@ func (p *ClaudeProvider) handleClaudeLine(line []byte, sink EventSink) (*claudeT
 		p.sessionMu.Lock()
 		p.sessionID = envelope.SessionID
 		p.sessionMu.Unlock()
+	}
+	switch envelope.Type {
+	case "system":
+		if envelope.Subtype == "init" {
+			p.updateClaudeModel(envelope.Model, sink)
+		}
+	case "assistant":
+		p.recordClaudeUsage(envelope.Message, sink)
+	case "result":
+		p.recordClaudeResultUsage(envelope.Usage, envelope.ModelUsage, sink)
 	}
 	if sink == nil && envelope.Type != "result" {
 		return nil, nil
@@ -412,6 +434,143 @@ func (p *ClaudeProvider) handleClaudeLine(line []byte, sink EventSink) (*claudeT
 		return result, nil
 	}
 	return nil, nil
+}
+
+type claudeModelUsage struct {
+	ContextWindow int64 `json:"contextWindow"`
+}
+
+type claudeUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+}
+
+// updateClaudeModel records the model reported by Claude Code. The init event
+// can arrive before any turn is active, so state is stored even without a sink.
+func (p *ClaudeProvider) updateClaudeModel(model string, sink EventSink) {
+	if model == "" {
+		return
+	}
+	p.statusMu.Lock()
+	changed := p.model != model
+	p.model = model
+	p.statusMu.Unlock()
+	if changed && sink != nil {
+		p.emitRuntimeStatus(sink)
+	}
+}
+
+// recordClaudeUsage accumulates token usage from one assistant message event.
+// This keeps totals moving while a turn runs; each result event then replaces
+// them with Claude Code's authoritative session totals.
+func (p *ClaudeProvider) recordClaudeUsage(raw json.RawMessage, sink EventSink) {
+	var message struct {
+		ID    string       `json:"id"`
+		Model string       `json:"model"`
+		Usage *claudeUsage `json:"usage"`
+	}
+	if json.Unmarshal(raw, &message) != nil {
+		return
+	}
+	changed := false
+	p.statusMu.Lock()
+	if message.Model != "" && message.Model != p.model {
+		p.model = message.Model
+		changed = true
+	}
+	if message.Usage != nil {
+		input := message.Usage.InputTokens + message.Usage.CacheCreationInputTokens + message.Usage.CacheReadInputTokens
+		output := message.Usage.OutputTokens
+		if p.usage == nil {
+			p.usage = &RuntimeUsage{}
+		}
+		if message.ID != "" {
+			if _, counted := p.countedMessages[message.ID]; !counted {
+				if p.countedMessages == nil {
+					p.countedMessages = map[string]struct{}{}
+				}
+				p.countedMessages[message.ID] = struct{}{}
+				p.usage.InputTokens += input
+				p.usage.OutputTokens += output
+				p.usage.TotalTokens += input + output
+				changed = true
+			}
+		}
+		if context := input + output; p.usage.ContextTokens != context {
+			p.usage.ContextTokens = context
+			changed = true
+		}
+	}
+	p.statusMu.Unlock()
+	if changed && sink != nil {
+		p.emitRuntimeStatus(sink)
+	}
+}
+
+// recordClaudeResultUsage replaces the running totals with a result event's
+// usage and stores the context window from its per-model usage. Claude Code
+// reports session-cumulative usage on result events, covering subagent and
+// internal API calls that never appear as assistant events in the stream, so
+// the result totals correct any drift in the per-message accumulation.
+func (p *ClaudeProvider) recordClaudeResultUsage(usage *claudeUsage, models map[string]claudeModelUsage, sink EventSink) {
+	changed := false
+	p.statusMu.Lock()
+	if usage != nil {
+		input := usage.InputTokens + usage.CacheCreationInputTokens + usage.CacheReadInputTokens
+		output := usage.OutputTokens
+		// Claude Code emits zeroed usage on synthetic result events; those must
+		// not wipe the totals.
+		if input > 0 || output > 0 {
+			if p.usage == nil {
+				p.usage = &RuntimeUsage{}
+			}
+			if p.usage.InputTokens != input || p.usage.OutputTokens != output || p.usage.TotalTokens != input+output {
+				p.usage.InputTokens = input
+				p.usage.OutputTokens = output
+				p.usage.TotalTokens = input + output
+				changed = true
+			}
+		}
+	}
+	window := models[p.model].ContextWindow
+	if window == 0 {
+		for _, modelUsage := range models {
+			window = max(window, modelUsage.ContextWindow)
+		}
+	}
+	if window > 0 {
+		if p.usage == nil {
+			p.usage = &RuntimeUsage{}
+		}
+		if p.usage.ContextWindow != window {
+			p.usage.ContextWindow = window
+			changed = true
+		}
+	}
+	p.statusMu.Unlock()
+	if changed && sink != nil {
+		p.emitRuntimeStatus(sink)
+	}
+}
+
+func (p *ClaudeProvider) emitRuntimeStatus(sink EventSink) {
+	status := p.runtimeStatusSnapshot()
+	if !status.empty() {
+		sink.Emit(Event{Type: EventRuntimeStatus, Runtime: &status})
+	}
+}
+
+func (p *ClaudeProvider) runtimeStatusSnapshot() RuntimeStatus {
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+	status := RuntimeStatus{Model: p.model, Effort: p.config.Effort}
+	if p.usage != nil {
+		usage := *p.usage
+		status.Usage = &usage
+	}
+	return status
 }
 
 func (p *ClaudeProvider) handleControlRequest(line []byte) {

--- a/internal/sessionruntime/claude_test.go
+++ b/internal/sessionruntime/claude_test.go
@@ -80,6 +80,68 @@ func TestClaudeProviderEmitsMessageWithoutStreaming(t *testing.T) {
 	}
 }
 
+// TestClaudeProviderRuntimeStatusMapping verifies that the model, token usage,
+// and context window reported by Claude Code become runtime status updates,
+// that repeated per-block usage for one assistant message is counted once, and
+// that a result event's session-cumulative usage replaces the per-message sums
+// (it also covers API calls that never appear as assistant events).
+func TestClaudeProviderRuntimeStatusMapping(t *testing.T) {
+	provider := &ClaudeProvider{config: ProviderConfig{Effort: "high"}}
+	sink := newOpenCodeTestSink(nil)
+
+	// The init event arrives before any turn is active, so it has no sink.
+	if _, err := provider.handleClaudeLine([]byte(`{"type":"system","subtype":"init","model":"claude-opus-4-6","session_id":"ses-1"}`), nil); err != nil {
+		t.Fatalf("handleClaudeLine() error = %v", err)
+	}
+
+	lines := []string{
+		`{"type":"assistant","message":{"id":"msg-1","model":"claude-opus-4-6","usage":{"input_tokens":10,"cache_creation_input_tokens":40,"cache_read_input_tokens":50,"output_tokens":5},"content":[]}}`,
+		`{"type":"assistant","message":{"id":"msg-1","model":"claude-opus-4-6","usage":{"input_tokens":10,"cache_creation_input_tokens":40,"cache_read_input_tokens":50,"output_tokens":5},"content":[]}}`,
+		`{"type":"assistant","message":{"id":"msg-2","model":"claude-opus-4-6","usage":{"input_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":100,"output_tokens":10},"content":[]}}`,
+		`{"type":"result","subtype":"success","usage":{"input_tokens":40,"cache_creation_input_tokens":60,"cache_read_input_tokens":200,"output_tokens":25},"modelUsage":{"claude-opus-4-6":{"contextWindow":200000}}}`,
+	}
+	for _, line := range lines {
+		if _, err := provider.handleClaudeLine([]byte(line), sink); err != nil {
+			t.Fatalf("handleClaudeLine(%s) error = %v", line, err)
+		}
+	}
+
+	events := sink.snapshot()
+	if len(events) != 3 {
+		t.Fatalf("runtime status events = %#v", events)
+	}
+	for _, event := range events {
+		if event.Type != EventRuntimeStatus || event.Runtime == nil {
+			t.Fatalf("runtime status event = %#v", event)
+		}
+	}
+	// The per-message sums (220 in, 15 out) provide live updates mid-turn.
+	live := events[1].Runtime
+	if live.Usage == nil || live.Usage.InputTokens != 220 || live.Usage.OutputTokens != 15 {
+		t.Fatalf("Claude mid-turn runtime status = %#v", live)
+	}
+	// The result event's cumulative usage exceeds the visible message sums and
+	// replaces them.
+	status := events[2].Runtime
+	if status.Model != "claude-opus-4-6" ||
+		status.Effort != "high" ||
+		status.Usage == nil ||
+		status.Usage.InputTokens != 300 ||
+		status.Usage.OutputTokens != 25 ||
+		status.Usage.TotalTokens != 325 ||
+		status.Usage.ContextTokens != 130 ||
+		status.Usage.ContextWindow != 200000 {
+		t.Fatalf("Claude runtime status = %#v", status)
+	}
+
+	server := NewServer(Config{AgentType: "claude-code"}, NewJournal(), provider)
+	t.Cleanup(func() { server.journal.Close() })
+	initial := server.runtimeStatusSnapshot()
+	if initial.Model != "claude-opus-4-6" || initial.Usage == nil || initial.Usage.TotalTokens != 325 {
+		t.Fatalf("initial server runtime status = %#v", initial)
+	}
+}
+
 // TestClaudeProviderStreamingSuppressesAssembledMessage verifies that once text
 // deltas have streamed (and been closed per block), the assembled assistant
 // message does not re-emit the same text as duplicate assistant.message events.

--- a/internal/sessionruntime/opencode.go
+++ b/internal/sessionruntime/opencode.go
@@ -62,6 +62,17 @@ type openCodePart struct {
 		Output string `json:"output"`
 		Error  string `json:"error"`
 	} `json:"state"`
+	Tokens *openCodePartTokens `json:"tokens"`
+}
+
+type openCodePartTokens struct {
+	Input     int64 `json:"input"`
+	Output    int64 `json:"output"`
+	Reasoning int64 `json:"reasoning"`
+	Cache     struct {
+		Read  int64 `json:"read"`
+		Write int64 `json:"write"`
+	} `json:"cache"`
 }
 
 // OpenCodeProvider owns one OpenCode server session and its event stream.
@@ -78,6 +89,14 @@ type OpenCodeProvider struct {
 	doneOnce      sync.Once
 	errMu         sync.Mutex
 	terminalErr   error
+
+	statusMu sync.Mutex
+	model    string
+	usage    *RuntimeUsage
+	// countedSteps holds step-finish part IDs whose usage was already added to
+	// the totals, since a part can be republished on later updates.
+	countedSteps   map[string]struct{}
+	contextWindows map[string]int64
 
 	sessionMu sync.RWMutex
 	sessionID string
@@ -178,7 +197,45 @@ func (p *OpenCodeProvider) initialize(ctx context.Context) error {
 	if err := p.startEventStream(ctx); err != nil {
 		return err
 	}
-	return p.openSession(ctx)
+	if err := p.openSession(ctx); err != nil {
+		return err
+	}
+	// Context windows only enrich the runtime status display, so a failed
+	// lookup must not block the session.
+	p.loadContextWindows(ctx)
+	return nil
+}
+
+// loadContextWindows caches each available model's context limit so runtime
+// status can report context use as a fraction of the window.
+func (p *OpenCodeProvider) loadContextWindows(ctx context.Context) {
+	var config struct {
+		Providers []struct {
+			ID     string `json:"id"`
+			Models map[string]struct {
+				Limit struct {
+					Context int64 `json:"context"`
+				} `json:"limit"`
+			} `json:"models"`
+		} `json:"providers"`
+	}
+	if p.client.doJSON(ctx, http.MethodGet, "/config/providers", true, nil, &config) != nil {
+		return
+	}
+	windows := map[string]int64{}
+	for _, provider := range config.Providers {
+		for id, model := range provider.Models {
+			if model.Limit.Context > 0 {
+				windows[provider.ID+"/"+id] = model.Limit.Context
+			}
+		}
+	}
+	if len(windows) == 0 {
+		return
+	}
+	p.statusMu.Lock()
+	p.contextWindows = windows
+	p.statusMu.Unlock()
 }
 
 func (p *OpenCodeProvider) waitForHealth(ctx context.Context) error {
@@ -347,6 +404,7 @@ func (p *OpenCodeProvider) RunTurn(ctx context.Context, prompt string, sink Even
 	p.questions = map[string]struct{}{}
 	p.permissions = map[string]struct{}{}
 	p.activeMu.Unlock()
+	p.emitRuntimeStatus(sink)
 	defer func() {
 		interactionCancel()
 		p.activeMu.Lock()
@@ -506,23 +564,48 @@ func (p *OpenCodeProvider) handleEvent(data []byte) {
 func (p *OpenCodeProvider) handleMessageUpdated(raw json.RawMessage) {
 	var properties struct {
 		Info struct {
-			ID        string          `json:"id"`
-			SessionID string          `json:"sessionID"`
-			Role      string          `json:"role"`
-			Error     json.RawMessage `json:"error"`
+			ID         string          `json:"id"`
+			SessionID  string          `json:"sessionID"`
+			Role       string          `json:"role"`
+			ProviderID string          `json:"providerID"`
+			ModelID    string          `json:"modelID"`
+			Error      json.RawMessage `json:"error"`
 		} `json:"info"`
 	}
 	if json.Unmarshal(raw, &properties) != nil || properties.Info.SessionID != p.currentSessionID() {
 		return
 	}
 	p.activeMu.Lock()
-	defer p.activeMu.Unlock()
-	if p.activeSink == nil {
+	sink := p.activeSink
+	if sink == nil {
+		p.activeMu.Unlock()
 		return
 	}
 	p.messageRoles[properties.Info.ID] = properties.Info.Role
 	if message := openCodeErrorText(properties.Info.Error); message != "" {
 		p.activeError = message
+	}
+	p.activeMu.Unlock()
+	if properties.Info.Role == "assistant" {
+		p.updateOpenCodeModel(properties.Info.ProviderID, properties.Info.ModelID, sink)
+	}
+}
+
+// updateOpenCodeModel records the model reported on an assistant message.
+func (p *OpenCodeProvider) updateOpenCodeModel(providerID, modelID string, sink EventSink) {
+	if modelID == "" {
+		return
+	}
+	model := modelID
+	if providerID != "" {
+		model = providerID + "/" + modelID
+	}
+	p.statusMu.Lock()
+	changed := p.model != model
+	p.model = model
+	p.statusMu.Unlock()
+	if changed {
+		p.emitRuntimeStatus(sink)
 	}
 }
 
@@ -564,6 +647,68 @@ func (p *OpenCodeProvider) handlePartUpdated(raw json.RawMessage) {
 	for _, event := range toolEvents {
 		sink.Emit(event)
 	}
+	if part.Type == "step-finish" || part.Type == "step_finish" {
+		p.recordOpenCodeStepUsage(part.ID, part.Tokens, sink)
+	}
+}
+
+// recordOpenCodeStepUsage accumulates token usage from one step-finish part.
+// OpenCode reports each step's usage separately, so the step totals sum to the
+// session totals and the latest step reflects current context use. Its input
+// field excludes cache tokens and its output field excludes reasoning tokens,
+// so both are added back to count all tokens the model read and generated.
+func (p *OpenCodeProvider) recordOpenCodeStepUsage(partID string, tokens *openCodePartTokens, sink EventSink) {
+	if tokens == nil {
+		return
+	}
+	input := tokens.Input + tokens.Cache.Read + tokens.Cache.Write
+	output := tokens.Output + tokens.Reasoning
+	changed := false
+	p.statusMu.Lock()
+	if p.usage == nil {
+		p.usage = &RuntimeUsage{}
+	}
+	if partID != "" {
+		if _, counted := p.countedSteps[partID]; !counted {
+			if p.countedSteps == nil {
+				p.countedSteps = map[string]struct{}{}
+			}
+			p.countedSteps[partID] = struct{}{}
+			p.usage.InputTokens += input
+			p.usage.OutputTokens += output
+			p.usage.TotalTokens += input + output
+			changed = true
+		}
+	}
+	if context := input + output; p.usage.ContextTokens != context {
+		p.usage.ContextTokens = context
+		changed = true
+	}
+	p.statusMu.Unlock()
+	if changed {
+		p.emitRuntimeStatus(sink)
+	}
+}
+
+func (p *OpenCodeProvider) emitRuntimeStatus(sink EventSink) {
+	status := p.runtimeStatusSnapshot()
+	if !status.empty() {
+		sink.Emit(Event{Type: EventRuntimeStatus, Runtime: &status})
+	}
+}
+
+func (p *OpenCodeProvider) runtimeStatusSnapshot() RuntimeStatus {
+	p.statusMu.Lock()
+	defer p.statusMu.Unlock()
+	status := RuntimeStatus{Model: p.model, Effort: p.config.Effort}
+	if p.usage != nil {
+		usage := *p.usage
+		if window, ok := p.contextWindows[p.model]; ok {
+			usage.ContextWindow = window
+		}
+		status.Usage = &usage
+	}
+	return status
 }
 
 func (p *OpenCodeProvider) handlePartDelta(raw json.RawMessage) {

--- a/internal/sessionruntime/opencode_test.go
+++ b/internal/sessionruntime/opencode_test.go
@@ -73,6 +73,7 @@ func TestOpenCodeProviderStreamsOrderedEvents(t *testing.T) {
 		t.Fatal("OpenCode permission was not approved")
 	}
 	want := []Event{
+		{Type: EventRuntimeStatus, Runtime: &RuntimeStatus{Effort: "high"}},
 		{Type: EventAssistantDelta, Text: "hello"},
 		{Type: EventToolStarted, ToolID: "tool-1", ToolName: "bash", Status: "running"},
 		{Type: EventToolCompleted, ToolID: "tool-1", ToolName: "bash", Output: "ok\n", Status: "completed"},
@@ -121,6 +122,69 @@ func TestOpenCodeProviderAnswersQuestion(t *testing.T) {
 	fake.emit("session.idle", map[string]string{"sessionID": fake.sessionID})
 	if err := receiveOpenCodeResult(t, turnDone); err != nil {
 		t.Fatalf("RunTurn() error = %v", err)
+	}
+}
+
+// TestOpenCodeProviderRuntimeStatusMapping verifies that the model reported on
+// assistant messages and the per-step token usage become runtime status
+// updates, that a republished step-finish part is counted once, that reasoning
+// tokens count toward output, and that the context window comes from the
+// server's provider configuration.
+func TestOpenCodeProviderRuntimeStatusMapping(t *testing.T) {
+	fake := newFakeOpenCodeServer(t)
+	provider := newTestOpenCodeProvider(t, fake, ProviderConfig{
+		WorkingDir: t.TempDir(),
+		StateDir:   t.TempDir(),
+		Effort:     "high",
+	})
+	sink := newOpenCodeTestSink(nil)
+	turnDone := make(chan error, 1)
+	go func() { turnDone <- provider.RunTurn(t.Context(), "hello", sink) }()
+	receiveOpenCodePrompt(t, fake.prompts)
+
+	fake.emit("session.status", map[string]any{"sessionID": fake.sessionID, "status": map[string]string{"type": "busy"}})
+	fake.emit("message.updated", map[string]any{"info": map[string]string{
+		"id": "message-1", "sessionID": fake.sessionID, "role": "assistant",
+		"providerID": "anthropic", "modelID": "claude-opus-4-6",
+	}})
+	step1 := map[string]any{
+		"id": "step-1", "messageID": "message-1", "sessionID": fake.sessionID, "type": "step-finish",
+		"tokens": map[string]any{"input": 100, "output": 20, "cache": map[string]any{"read": 1000, "write": 50}},
+	}
+	fake.emit("message.part.updated", map[string]any{"part": step1})
+	fake.emit("message.part.updated", map[string]any{"part": step1})
+	fake.emit("message.part.updated", map[string]any{"part": map[string]any{
+		"id": "step-2", "messageID": "message-1", "sessionID": fake.sessionID, "type": "step-finish",
+		"tokens": map[string]any{"input": 200, "output": 30, "reasoning": 70, "cache": map[string]any{"read": 1100, "write": 0}},
+	}})
+	fake.emit("session.idle", map[string]string{"sessionID": fake.sessionID})
+	if err := receiveOpenCodeResult(t, turnDone); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	var statuses []Event
+	for _, event := range sink.snapshot() {
+		if event.Type == EventRuntimeStatus {
+			statuses = append(statuses, event)
+		}
+	}
+	if len(statuses) != 4 || statuses[3].Runtime == nil {
+		t.Fatalf("runtime status events = %#v", statuses)
+	}
+	status := statuses[3].Runtime
+	if status.Model != "anthropic/claude-opus-4-6" ||
+		status.Effort != "high" ||
+		status.Usage == nil ||
+		status.Usage.InputTokens != 2450 ||
+		status.Usage.OutputTokens != 120 ||
+		status.Usage.TotalTokens != 2570 ||
+		status.Usage.ContextTokens != 1400 ||
+		status.Usage.ContextWindow != 200000 {
+		t.Fatalf("OpenCode runtime status = %#v", status)
+	}
+	snapshot := provider.runtimeStatusSnapshot()
+	if snapshot.Model != "anthropic/claude-opus-4-6" || snapshot.Usage == nil || snapshot.Usage.ContextWindow != 200000 {
+		t.Fatalf("OpenCode runtime status snapshot = %#v", snapshot)
 	}
 }
 
@@ -260,6 +324,14 @@ func (f *fakeOpenCodeServer) serveHTTP(response http.ResponseWriter, request *ht
 	switch {
 	case request.Method == http.MethodGet && request.URL.Path == "/event":
 		f.serveEvents(response, request)
+	case request.Method == http.MethodGet && request.URL.Path == "/config/providers":
+		f.requireDirectory(request)
+		writeOpenCodeJSON(response, map[string]any{"providers": []map[string]any{{
+			"id": "anthropic",
+			"models": map[string]any{
+				"claude-opus-4-6": map[string]any{"limit": map[string]any{"context": 200000}},
+			},
+		}}})
 	case request.Method == http.MethodPost && request.URL.Path == "/session":
 		f.requireDirectory(request)
 		var body map[string]any


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Only the Codex provider emitted `runtime.status` events, so the session status bar (terminal and web) and `status.model` showed the model, cumulative token usage, and context use for Codex Sessions only; claude-code and opencode Sessions displayed just the static basics.

This brings both providers to parity with Codex:

- **Claude Code**: records the model from the `system`/`init` event and from assistant messages, accumulates input/output tokens from assistant message usage for live mid-turn updates (deduplicated by message ID, since usage repeats on every content-block event of a message), reconciles totals from each result event's session-cumulative `usage` (authoritative — it also covers subagent and internal API calls that never appear as assistant events in the stream), derives context use from the latest message's usage, and reads the context window from the result event's `modelUsage`.
- **OpenCode**: records the model (`provider/model`) from assistant `message.updated` events, sums token usage from `step-finish` parts (deduplicated by part ID) including cache and reasoning tokens (OpenCode reports `tokens.input` without cache tokens and `tokens.output` without reasoning tokens, so both are added back), derives context use from the latest step, and resolves context windows once at startup from the server's `/config/providers` model limits (best-effort; a failed lookup only omits the context percentage).

Both providers now implement `runtimeStatusSnapshot()`, so the server seeds their status at construction and they emit it at each turn start, matching the Codex flow. As a result `status.model` is also populated with the actual runtime model for claude-code and opencode Sessions after the first turn.

Docs are updated: context use and token counts are no longer documented as Codex-only; weekly limit remaining stays Codex-only because neither Claude Code stream-json nor the OpenCode server API exposes rate-limit data.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The weekly limit segment intentionally remains Codex-only; the status bar simply hides it when absent.
- Token-accounting semantics were verified against the pinned agent versions: Claude Code 2.1.223 (result events carry process-cumulative `usage`/`modelUsage` aggregated across all API calls) and OpenCode 1.18.11 (`getUsage` computes `output` as `outputTokens - reasoningTokens` and `input` without cache tokens).
- `TestOpenCodeProviderStreamsOrderedEvents` gained a leading `runtime.status` event in its expected sequence because OpenCode now emits status at turn start, as Codex already did.
- New tests: `TestClaudeProviderRuntimeStatusMapping` (including result-usage reconciliation exceeding the visible assistant-message sums) and `TestOpenCodeProviderRuntimeStatusMapping` (including a nonzero-reasoning step), mirroring the existing `TestCodexRuntimeStatusMapping`; the fake OpenCode server now serves `/config/providers`.

#### Does this PR introduce a user-facing change?

```release-note
claude-code and opencode Sessions now report the runtime model, cumulative input/output tokens, and context use in the session status bar and `status.model`, matching codex Sessions. Weekly limit remaining is still reported by codex Sessions only.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)