### PR TITLE
Add full spawner fleet for kelos-dev/open-actions

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -111,6 +111,12 @@ func TestSelfDevelopmentRoleAgentConfigsDoNotDuplicateBaseSkills(t *testing.T) {
 		{dir: "self-development/kanon", file: "kanon-fake-user.yaml"},
 		{dir: "self-development/kanon", file: "kanon-planner.yaml"},
 		{dir: "self-development/kanon", file: "kanon-reviewer.yaml"},
+		{dir: "self-development/open-actions", file: "agentconfig.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-api-reviewer.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-strategist.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-user.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-planner.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-reviewer.yaml"},
 	}
 
 	for _, tt := range files {
@@ -168,6 +174,17 @@ func TestSelfDevelopmentSpawnersUseBaseAgent(t *testing.T) {
 		{dir: "self-development/kanon", file: "kanon-squash-commits.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "kanon-dev-agent"}}},
 		{dir: "self-development/kanon", file: "kanon-triage.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "kanon-dev-agent"}}},
 		{dir: "self-development/kanon", file: "kanon-workers.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-api-reviewer.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-api-reviewer-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-config-update.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "kelos-dev-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-fake-strategist.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-fake-strategist-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-fake-user.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-fake-user-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-planner.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-planner-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-pr-responder.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-reviewer.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-reviewer-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-self-update.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "kelos-dev-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-squash-commits.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-dev-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-triage.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}, {Name: "open-actions-dev-agent"}}},
+		{dir: "self-development/open-actions", file: "open-actions-workers.yaml", refs: []kelos.AgentConfigReference{{Name: "base-agent"}}},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -215,6 +232,15 @@ func TestDevelopmentTaskSpawnersIgnoreDisruptions(t *testing.T) {
 		{dir: "self-development/kanon", file: "kanon-self-update.yaml"},
 		{dir: "self-development/kanon", file: "kanon-squash-commits.yaml"},
 		{dir: "self-development/kanon", file: "kanon-triage.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-api-reviewer.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-config-update.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-strategist.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-user.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-planner.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-reviewer.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-self-update.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-squash-commits.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-triage.yaml"},
 	}
 
 	for _, tt := range tests {
@@ -241,6 +267,8 @@ func TestDevelopmentSessionSpawnersUsePersistentWorkspace(t *testing.T) {
 		{dir: "self-development/agora", file: "agora-pr-responder.yaml"},
 		{dir: "self-development/kanon", file: "kanon-workers.yaml"},
 		{dir: "self-development/kanon", file: "kanon-pr-responder.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-workers.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-pr-responder.yaml"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -286,6 +314,7 @@ func TestDevelopmentSessionSpawnersMatchPickUpOnly(t *testing.T) {
 		{dir: "self-development", file: "kelos-workers.yaml"},
 		{dir: "self-development/agora", file: "agora-workers.yaml"},
 		{dir: "self-development/kanon", file: "kanon-workers.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-workers.yaml"},
 	}
 
 	for _, tt := range spawners {
@@ -358,6 +387,7 @@ func TestDevelopmentSessionSpawnersUseIssueBranches(t *testing.T) {
 		{dir: "self-development", file: "kelos-workers.yaml", want: "kelos-task-42"},
 		{dir: "self-development/agora", file: "agora-workers.yaml", want: "agora-task-42"},
 		{dir: "self-development/kanon", file: "kanon-workers.yaml", want: "kanon-task-42"},
+		{dir: "self-development/open-actions", file: "open-actions-workers.yaml", want: "open-actions-task-42"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -408,6 +438,7 @@ func TestDevelopmentPRResponderSessionSpawnersMatchPickUpOnPullRequests(t *testi
 		{dir: "self-development", file: "kelos-pr-responder.yaml"},
 		{dir: "self-development/agora", file: "agora-pr-responder.yaml"},
 		{dir: "self-development/kanon", file: "kanon-pr-responder.yaml"},
+		{dir: "self-development/open-actions", file: "open-actions-pr-responder.yaml"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -463,6 +494,12 @@ func TestDevelopmentCommandPatternsMatchCommandLines(t *testing.T) {
 		{dir: "self-development/kanon", file: "kanon-reviewer.yaml", command: "/kelos review"},
 		{dir: "self-development/kanon", file: "kanon-pr-responder.yaml", command: "/kelos pick-up"},
 		{dir: "self-development/kanon", file: "kanon-squash-commits.yaml", command: "/kelos squash-commits"},
+		{dir: "self-development/open-actions", file: "open-actions-workers.yaml", command: "/kelos pick-up"},
+		{dir: "self-development/open-actions", file: "open-actions-planner.yaml", command: "/kelos plan"},
+		{dir: "self-development/open-actions", file: "open-actions-reviewer.yaml", command: "/kelos review"},
+		{dir: "self-development/open-actions", file: "open-actions-api-reviewer.yaml", command: "/kelos api-review"},
+		{dir: "self-development/open-actions", file: "open-actions-pr-responder.yaml", command: "/kelos pick-up"},
+		{dir: "self-development/open-actions", file: "open-actions-squash-commits.yaml", command: "/kelos squash-commits"},
 	}
 
 	for _, tt := range tests {
@@ -579,6 +616,20 @@ func TestReviewersUseStickyPRComments(t *testing.T) {
 			marker:         "<!-- agora-reviewer:sticky-review -->",
 			templatePrefix: "Format the PR comment body as:",
 		},
+		{
+			dir:            "self-development/open-actions",
+			file:           "open-actions-reviewer.yaml",
+			repository:     "kelos-dev/open-actions",
+			marker:         "<!-- open-actions-reviewer:sticky-review -->",
+			templatePrefix: "Format the PR comment body as:",
+		},
+		{
+			dir:            "self-development/open-actions",
+			file:           "open-actions-api-reviewer.yaml",
+			repository:     "kelos-dev/open-actions",
+			marker:         "<!-- open-actions-api-reviewer:sticky-review -->",
+			templatePrefix: "Format the PR comment body as:",
+		},
 	}
 
 	forbidden := []string{
@@ -677,8 +728,10 @@ func TestDevelopmentReviewersUseReviewSkills(t *testing.T) {
 		{dir: "self-development", file: "kelos-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
 		{dir: "self-development/agora", file: "agora-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
 		{dir: "self-development/kanon", file: "kanon-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
+		{dir: "self-development/open-actions", file: "open-actions-reviewer.yaml", workflow: "Use the `review-all` skill with `origin/main` as the base"},
 		{dir: "self-development", file: "kelos-api-reviewer.yaml", workflow: "Use the `api-review` skill for the review analysis"},
 		{dir: "self-development", file: "kelos-glm-api-reviewer.yaml", workflow: "Use the `api-review` skill for the review analysis"},
+		{dir: "self-development/open-actions", file: "open-actions-api-reviewer.yaml", workflow: "Use the `api-review` skill for the review analysis"},
 	}
 
 	for _, tt := range tests {
@@ -770,6 +823,16 @@ func TestAgoraReviewerTriggerableByBot(t *testing.T) {
 	assertReviewerTriggerableByBot(t, "self-development/agora", "agora-reviewer.yaml", "kelos-dev/agora", "/kelos review")
 }
 
+func TestOpenActionsReviewerTriggerableByBot(t *testing.T) {
+	t.Parallel()
+	assertReviewerTriggerableByBot(t, "self-development/open-actions", "open-actions-reviewer.yaml", "kelos-dev/open-actions", "/kelos review")
+}
+
+func TestOpenActionsAPIReviewerTriggerableByBot(t *testing.T) {
+	t.Parallel()
+	assertReviewerTriggerableByBot(t, "self-development/open-actions", "open-actions-api-reviewer.yaml", "kelos-dev/open-actions", "/kelos api-review")
+}
+
 func TestAgoraIssueCreatorsUseTriageAcceptedLabel(t *testing.T) {
 	t.Parallel()
 
@@ -817,6 +880,9 @@ func TestStickyIssueSlotCommands(t *testing.T) {
 		{dir: "self-development/kanon", file: "kanon-fake-strategist.yaml", marker: "kanon-fake-strategist"},
 		{dir: "self-development/kanon", file: "kanon-fake-user.yaml", marker: "kanon-fake-user"},
 		{dir: "self-development/kanon", file: "kanon-self-update.yaml", marker: "kanon-self-update"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-strategist.yaml", marker: "open-actions-fake-strategist"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-user.yaml", marker: "open-actions-fake-user"},
+		{dir: "self-development/open-actions", file: "open-actions-self-update.yaml", marker: "open-actions-self-update"},
 	}
 
 	for _, tt := range tests {
@@ -962,6 +1028,17 @@ func TestDevelopmentSpawnersSetExpectedEffort(t *testing.T) {
 		{dir: "self-development/kanon", file: "kanon-config-update.yaml", effort: "xhigh"},
 		{dir: "self-development/kanon", file: "kanon-fake-user.yaml", effort: "medium"},
 		{dir: "self-development/kanon", file: "kanon-squash-commits.yaml", effort: "medium"},
+		{dir: "self-development/open-actions", file: "open-actions-workers.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-planner.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-reviewer.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-api-reviewer.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-self-update.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-strategist.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-triage.yaml", effort: "high"},
+		{dir: "self-development/open-actions", file: "open-actions-pr-responder.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-config-update.yaml", effort: "xhigh"},
+		{dir: "self-development/open-actions", file: "open-actions-fake-user.yaml", effort: "medium"},
+		{dir: "self-development/open-actions", file: "open-actions-squash-commits.yaml", effort: "medium"},
 	}
 
 	for _, tt := range tests {

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -9,9 +9,10 @@ repository while keeping the configuration in this repo.
 The nested [`kanon/`](kanon/README.md) directory does the same for the sibling
 [`kelos-dev/kanon`](https://github.com/kelos-dev/kanon) repository.
 
-The nested [`open-actions/`](open-actions/README.md) directory provides
-general and Kubernetes API reviewers for
-[`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions).
+The nested [`open-actions/`](open-actions/README.md) directory does the same
+for the sibling
+[`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions)
+repository.
 
 [`cs`](cs) creates persistent interactive Codex environments for developing
 Kelos with the same Workspace, credentials, model, effort, and Git identity as
@@ -28,8 +29,8 @@ directory and its nested Agora, Kanon, and Open Actions directories references
 and installs all skills from that repository through `spec.skills`.
 Tasks and TaskSpawners add a second role-specific AgentConfig when they need
 local identity, conventions, or workflow instructions. The issue and PR
-pick-up SessionSpawners for Kelos, Agora, and Kanon, plus Sessions created with
-`cs`, use only `base-agent`.
+pick-up SessionSpawners for Kelos, Agora, Kanon, and Open Actions, plus
+Sessions created with `cs`, use only `base-agent`.
 
 Apply the shared AgentConfig before deploying any self-development resource:
 
@@ -654,7 +655,7 @@ To adapt these examples for your own repository:
 The key pattern in these examples is webhook-triggered handoff plus runtime re-validation:
 
 1. GitHub delivers an `issue_comment`, `issues`, or `pull_request_review` webhook
-2. The matching TaskSpawner creates a Task, while the issue and PR pick-up spawners for Kelos, Agora, and Kanon create Sessions
+2. The matching TaskSpawner creates a Task, while the issue and PR pick-up spawners for Kelos, Agora, Kanon, and Open Actions create Sessions
 3. The agent re-reads the latest issue or PR state with `gh` before acting, so asynchronous label updates are respected
 4. If the agent needs human input, it posts a plain-English status comment describing what happened
 5. An exact `/kelos pick-up` command creates a Session for an open issue or PR; explicit commands or relabel events retrigger the other matching automation

--- a/self-development/open-actions/README.md
+++ b/self-development/open-actions/README.md
@@ -1,45 +1,481 @@
-# Open Actions Reviewers
+# Open Actions Development Orchestration Patterns
 
-This directory configures on-demand code and Kubernetes API reviewers for
-[`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions). The
-reviewers are read-only: they inspect pull requests or issues and publish
-feedback without modifying repository files or branches.
+This directory contains the orchestration patterns that drive autonomous
+development of [`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions)
+— a Kubernetes-native, self-hosted control plane that plans, schedules, and
+executes a supported subset of GitHub Actions workflows in the team's own
+cluster.
 
-Both TaskSpawners use the `open-actions-agent` Workspace from
-[`../workspaces.yaml`](../workspaces.yaml) and the shared `base-agent`
-AgentConfig from [`../base-agent.yaml`](../base-agent.yaml). The Workspace
-references the `kelos-agent-credentials` Secret, which must contain the Kelos
-GitHub App credentials so reviews are published by `kelos-bot[bot]`.
+It mirrors [`self-development/`](../), which does the same for this repository
+(`kelos-dev/kelos`). The configs live here, in the kelos repository, but the
+webhook filters and Workspaces target `kelos-dev/open-actions`, so the agents
+they spawn operate on the Open Actions repository.
+
+## How It Works
+
+Every spawner references the root [`base-agent`](../base-agent.yaml) for shared
+instructions and skills. The issue and PR pick-up SessionSpawners reference
+only `base-agent`. The remaining TaskSpawners add repository- or role-specific
+instructions where needed: triage and squash-commits share `agentconfig.yaml`
+(`open-actions-dev-agent`), while the planner, the two reviewers, fake-user,
+and fake-strategist define their own AgentConfig inline.
+
+Autonomous discovery agents that publish GitHub issues maintain at most one
+open `generated-by-kelos` issue slot per TaskSpawner. Its title starts with the
+TaskSpawner name in brackets, and its body includes both a
+`kelos-taskspawner=<name>` marker and one replaceable `Latest verdict` section.
+Each run checks whether an unassigned slot is still valid against the current
+repository before retaining, replacing, or closing it. Assigned issues and PRs
+are treated as ongoing human or agent work and are not updated by autonomous
+discovery jobs. This cap does not apply to follow-up issues created while a
+worker or PR responder is handling an explicitly requested issue or PR.
+
+The two SessionSpawners operate on the Open Actions repository through the
+`open-actions-session-agent` Workspace, which uses the personal Session token.
+Seven TaskSpawners use the `open-actions-agent` Workspace. The two
+meta-maintenance spawners (`open-actions-config-update`,
+`open-actions-self-update`) are different: the files they maintain
+(`self-development/open-actions/*`) live in *this* repository, so they use the
+`kelos-agent` Workspace and the `kelos-dev-agent` role AgentConfig from
+`self-development/`, and they read Open Actions' activity cross-repo with
+`gh ... --repo kelos-dev/open-actions`.
 
 ## Spawners
 
-| Spawner | Trigger | Agent | Scope |
+| Spawner | Trigger | Agent | Description |
 |---|---|---|---|
-| **open-actions-reviewer** | PR comment or review `/kelos review` | Codex | General correctness, tests, security, and project conventions |
-| **open-actions-api-reviewer** | Issue/PR comment or review `/kelos api-review` | Codex | Kubernetes API design, compatibility, schemas, and documentation |
+| **open-actions-workers** | Webhook: issue comment `/kelos pick-up` | Codex | Creates durable Sessions for issue work, including PR creation or updates |
+| **open-actions-planner** | Webhook: issue comment `/kelos plan` | Codex | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
+| **open-actions-reviewer** | Webhook: PR comment or review `/kelos review` | Codex | Reviews PRs on demand — analyzes code, checks conventions, and updates a sticky review comment |
+| **open-actions-api-reviewer** | Webhook: issue/PR comment or review `/kelos api-review` | Codex | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
+| **open-actions-pr-responder** | Webhook: PR review/comment with `/kelos pick-up` | Codex | Creates durable Sessions for PR review feedback on the existing branch |
+| **open-actions-triage** | Webhook: issue opened/reopened (untriaged) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
+| **open-actions-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user and maintains one unassigned issue slot for the highest-impact problem found |
+| **open-actions-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integrations, and API extensions while maintaining one unassigned strategic issue slot |
+| **open-actions-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent Open Actions PR feedback and creates or updates unassigned configuration PRs accordingly |
+| **open-actions-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes the `self-development/open-actions/` prompts, configs, and README while maintaining one unassigned improvement issue slot |
+| **open-actions-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Codex | Rebases and squashes PR branch commits into a single clean commit |
 
-The general reviewer creates or updates one sticky pull request comment. The
-API reviewer does the same for pull requests and posts a normal comment for
-issue-based design proposals. Each trigger accepts commands from `gjkim42`;
-comments from `kelos-bot[bot]` are also accepted for automated handoffs.
+> **Not ported from `self-development/`:** `kelos-image-update` (Open Actions
+> builds its own controller and runner images in-repo; there are no
+> coding-agent Dockerfiles to bump).
 
-The review prompts use Open Actions' Makefile targets and treat CRD types,
-generated schemas, samples, labels, annotations, flags, configuration, and
-webhook contracts as user-facing API surfaces. API reviews also check
-`docs/api-design.md` and the repository's schema tests.
-
-## Deploy
-
-Apply the shared prerequisites once:
+Apply the shared Workspaces and root `base-agent` first, then the whole
+directory. The directory includes `agentconfig.yaml`, which defines the
+`open-actions-dev-agent` role instructions referenced by the triage and
+squash-commits spawners:
 
 ```bash
-kubectl apply -f self-development/base-agent.yaml
 kubectl apply -f self-development/workspaces.yaml
+kubectl apply -f self-development/session-workspaces.yaml
+kubectl apply -f self-development/base-agent.yaml
+kubectl apply -f self-development/open-actions/
 ```
 
-Apply the reviewers:
+The per-spawner `kubectl apply` commands below are for deploying or updating an
+individual spawner after `base-agent` is installed.
 
+### open-actions-workers.yaml
+
+Picks up open GitHub issues when a maintainer posts `/kelos pick-up` and
+creates a durable Session to fix them.
+
+| | |
+|---|---|
+| **Trigger** | GitHub `issue_comment` webhook with `/kelos pick-up` |
+| **Agent** | Codex |
+| **Storage** | 10 Gi PVC |
+
+**Key features:**
+- Automatically checks for existing PRs and updates them incrementally
+- Self-reviews PRs before requesting human review
+- Ensures CI passes before completion
+- Requires a `/kelos pick-up` comment to pick up an issue (maintainer approval gate)
+- Hands off finished PRs to `/kelos review`, or `/kelos api-review` when the diff touches `api/`
+- Keeps the workspace across Session follow-ups and pod restarts
+- Supports routine follow-ups through the Session's web or terminal clients
+- May create separate follow-up issues for out-of-scope discoveries; those
+  follow-ups are exempt from autonomous discovery issue slot caps
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-workers.yaml
+```
+
+### open-actions-planner.yaml
+
+Reacts to `/kelos plan` comments on open issues. Investigates the issue,
+inspects the codebase, and posts a structured implementation plan — advisory
+only, no code changes. For issues that touch CRD types or another user-facing
+surface (controller flags, the webhook contract, the supported workflow
+subset), the plan must resolve naming, shape, and backward compatibility up
+front.
+
+| | |
+|---|---|
+| **Trigger** | GitHub `issue_comment` webhook with `/kelos plan` |
+| **Agent** | Codex |
+| **Concurrency** | 2 |
+
+**Handoff flow:**
+1. `/kelos plan` — requests or refreshes an implementation plan
+2. `/kelos pick-up` — maintainer hands off to workers when ready
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-planner.yaml
+```
+
+### open-actions-reviewer.yaml
+
+Reviews open pull requests on demand when a maintainer posts `/kelos review` or
+when an Open Actions worker posts `/kelos review` after pushing a generated PR
+and confirming CI passes.
+
+| | |
+|---|---|
+| **Trigger** | GitHub PR comment or review webhook with `/kelos review` from a maintainer or worker handoff (`kelos-bot[bot]`) |
+| **Agent** | Codex |
+| **Concurrency** | 3 |
+
+**Key features:**
+- Uses the `review-all` skill to reconcile two independent reviews of the same diff
+- Reads the full diff and surrounding context to understand changes
+- Checks correctness, tests, project conventions, security, and code quality
+- Flags obvious CRD permanence risks and defers the deep API checklist to `/kelos api-review`
+- Creates or updates a single sticky PR comment with the structured review result
+- Read-only agent — does not push code, modify files, or run local validation
+
+**Deploy:**
 ```bash
 kubectl apply -f self-development/open-actions/open-actions-reviewer.yaml
+```
+
+### open-actions-api-reviewer.yaml
+
+Reviews issues and pull requests for Kubernetes API design conventions,
+compatibility, and best practices when a maintainer posts `/kelos api-review`
+or when an Open Actions worker hands off a generated API PR.
+
+| | |
+|---|---|
+| **Trigger** | GitHub issue/PR comment or review webhook with `/kelos api-review` from a maintainer or worker handoff (`kelos-bot[bot]`) |
+| **Agent** | Codex |
+| **Concurrency** | 3 |
+
+**Key features:**
+- Uses the `api-review` skill for API design analysis and verdicts
+- Works on both issues (API design proposals) and pull requests (API implementation review)
+- Treats CRD types, generated schemas, samples, labels, annotations, flags,
+  configuration, and webhook contracts as user-facing API surfaces
+- For PRs: creates or updates a single sticky PR comment with structured API review feedback
+- For issues: posts a structured comment with API design guidance
+- Read-only agent — does not push code or modify files
+
+**Deploy:**
+```bash
 kubectl apply -f self-development/open-actions/open-actions-api-reviewer.yaml
 ```
+
+### open-actions-pr-responder.yaml
+
+Picks up open GitHub pull requests when a reviewer requests changes with
+`/kelos pick-up`.
+
+| | |
+|---|---|
+| **Trigger** | GitHub PR comment with `/kelos pick-up`, or a PR review whose body contains `/kelos pick-up` |
+| **Agent** | Codex |
+| **Storage** | 10 Gi PVC |
+
+**Key features:**
+- Reuses the existing PR branch instead of starting over
+- Reads review comments and PR conversation before making incremental changes
+- Lets the maintainer stay on the PR page for the common review-feedback loop
+- Requires a `/kelos pick-up` PR comment or review body to be picked up
+- Keeps the workspace across Session follow-ups and pod restarts
+- Supports routine follow-ups through the Session's web or terminal clients
+- May create separate follow-up issues for out-of-scope discoveries; those
+  follow-ups are exempt from autonomous discovery issue slot caps
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-pr-responder.yaml
+```
+
+### open-actions-triage.yaml
+
+Triages newly opened (and certain reopened) GitHub issues.
+
+| | |
+|---|---|
+| **Trigger** | GitHub issue opened (no `triage-accepted`), or reopened with `needs-actor` |
+| **Agent** | Codex |
+| **Concurrency** | 8 |
+
+**For each issue, the agent:**
+1. Classifies with exactly one `kind/*` label (`kind/bug`, `kind/feature`, `kind/api`, `kind/docs`). `kind/api` covers any change to a user-facing surface — CRD fields, generated CRD schemas, controller flags, the webhook contract, or the supported workflow subset.
+2. Checks if the issue has already been fixed by a merged PR or recent commit
+3. Checks if the issue references outdated CRD fields, flags, or workflow behaviors
+4. Detects duplicate issues
+5. Assesses priority (`priority/important-soon`, `priority/important-longterm`, `priority/backlog`)
+6. Recommends an actor — assigns `actor/kelos` if the issue has clear scope and verifiable criteria, otherwise `actor/human`. `kind/api` issues always get `actor/human` and are **not** marked `triage-accepted`, because user-facing surface changes must be reviewed with a maintainer first.
+
+Posts a single triage comment and adds `triage-accepted` to prevent re-triage.
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-triage.yaml
+```
+
+### open-actions-fake-user.yaml
+
+Runs daily to test the developer experience as if you were a new user.
+
+| | |
+|---|---|
+| **Trigger** | Cron `0 9 * * *` (daily at 09:00 UTC) |
+| **Agent** | Codex |
+| **Concurrency** | 1 |
+
+Each run picks one focus area:
+- **Documentation & Onboarding** — follow the installation instructions, check the documented workflow subset
+- **Developer Experience** — build and test, review error messages and status conditions, exercise operator workflows
+- **Examples & Use Cases** — verify `config/samples/` manifests, identify missing examples
+
+Creates or updates the single unassigned `open-actions-fake-user` issue slot
+for the highest-impact problem found. If that issue is assigned, the run treats
+it as ongoing and exits without editing it or creating another issue.
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-fake-user.yaml
+```
+
+### open-actions-fake-strategist.yaml
+
+Runs every 12 hours to strategically explore new ways to use and improve Open
+Actions.
+
+| | |
+|---|---|
+| **Trigger** | Cron `0 */12 * * *` (every 12 hours) |
+| **Agent** | Codex |
+| **Concurrency** | 1 |
+
+Each run picks one focus area:
+- **New Use Cases** — explore teams and CI workloads that could benefit from self-hosted, high-volume workflow execution
+- **Integration Opportunities** — identify source integrations and Kubernetes-toolchain integrations Open Actions could support
+- **New CRDs & API Extensions** — propose extensions to the supported workflow subset, existing CRDs, or new controller capabilities
+
+Creates or updates the single unassigned `open-actions-fake-strategist` issue
+slot for the highest-impact actionable insight. If that issue is assigned, the
+run treats it as ongoing and exits without editing it or creating another issue.
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-fake-strategist.yaml
+```
+
+### open-actions-config-update.yaml
+
+Runs daily to update the Open Actions agent configuration based on patterns
+found in Open Actions' PR reviews.
+
+| | |
+|---|---|
+| **Trigger** | Cron `0 18 * * *` (daily at 18:00 UTC) |
+| **Agent** | Codex |
+| **Workspace** | `kelos-agent` (edits `self-development/open-actions/` in this repo) |
+| **Concurrency** | 1 |
+
+Reviews recent `kelos-dev/open-actions` PRs and their review comments to
+identify recurring feedback patterns, then updates the configuration under
+`self-development/open-actions/` (the shared role instructions in
+`agentconfig.yaml` or a specific TaskSpawner prompt). Opens a PR against this
+repository using `/kind cleanup` and `release-note: NONE`, since it only
+touches `self-development/open-actions/`. Skips uncertain or contradictory
+feedback, and skips an existing configuration PR when it has assignees.
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-config-update.yaml
+```
+
+### open-actions-self-update.yaml
+
+Runs daily to review and improve the `self-development/open-actions/` workflow
+files themselves.
+
+| | |
+|---|---|
+| **Trigger** | Cron `0 6 * * *` (daily at 06:00 UTC) |
+| **Agent** | Codex |
+| **Workspace** | `kelos-agent` (reasons about `self-development/open-actions/` in this repo) |
+| **Concurrency** | 1 |
+
+Each run picks one focus area: **Prompt Tuning**, **Configuration Alignment**, or **Workflow Completeness**.
+
+Creates or updates the single unassigned `open-actions-self-update` issue slot
+for the highest-impact actionable improvement. If that issue is assigned, the
+run treats it as ongoing and exits without editing it or creating another
+issue.
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-self-update.yaml
+```
+
+### open-actions-squash-commits.yaml
+
+Rebases and squashes PR branch commits into a single clean commit when a
+maintainer posts `/kelos squash-commits`.
+
+| | |
+|---|---|
+| **Trigger** | GitHub PR comment webhook with `/kelos squash-commits` |
+| **Agent** | Codex |
+| **Concurrency** | 1 |
+
+**Key features:**
+- Rebases the PR branch on `origin/main` and squashes all commits after the merge base into one
+- Amends the squashed commit message based on the linked issue and PR description when needed
+- Force-pushes with `--force-with-lease`
+- Adds `kelos/needs-input` to the linked issue to signal the PR is ready for re-review
+- Does not start new development work or modify source code
+
+**Deploy:**
+```bash
+kubectl apply -f self-development/open-actions/open-actions-squash-commits.yaml
+```
+
+## Prerequisites
+
+These spawners are applied to the same cluster that runs `self-development/`.
+Before deploying them, set up the following.
+
+### 1. Workspaces
+
+Three Workspaces are referenced:
+
+- **`open-actions-session-agent`** — points at the Open Actions repository and
+  is used only by `open-actions-workers` and `open-actions-pr-responder`. It is
+  defined in [`session-workspaces.yaml`](../session-workspaces.yaml) and
+  references the `personal-github-token` Secret.
+
+- **`open-actions-agent`** — points at the Open Actions repository and is used
+  by the seven TaskSpawners that operate directly on Open Actions. It is
+  defined in [`workspaces.yaml`](../workspaces.yaml) and references the
+  `kelos-agent-credentials` Secret, which must contain the Kelos GitHub App
+  credentials so reviews and comments are published by `kelos-bot[bot]`.
+
+- **`kelos-agent`** — points at this repository (`kelos-dev/kelos`). Used by
+  `open-actions-config-update` and `open-actions-self-update`, which edit the
+  `self-development/open-actions/` files that live here. It is also defined in
+  [`workspaces.yaml`](../workspaces.yaml) and references the
+  `kelos-agent-credentials` Secret.
+
+### 2. Repository labels
+
+The Open Actions repository starts with only the default GitHub labels. Create
+the labels these spawners rely on (run once, against
+`kelos-dev/open-actions`):
+
+```bash
+REPO=kelos-dev/open-actions
+gh label create generated-by-kelos --repo "$REPO" --color 1d76db --force
+for l in kind/bug kind/feature kind/api kind/docs; do
+  gh label create "$l" --repo "$REPO" --color 0e8a16 --force
+done
+for l in priority/important-soon priority/important-longterm priority/backlog; do
+  gh label create "$l" --repo "$REPO" --color fbca04 --force
+done
+for l in actor/kelos actor/human; do
+  gh label create "$l" --repo "$REPO" --color 5319e7 --force
+done
+for l in triage-accepted needs-actor needs-kind needs-priority needs-triage kelos/needs-input; do
+  gh label create "$l" --repo "$REPO" --color c5def5 --force
+done
+```
+
+- `generated-by-kelos` marks bot-created PRs and issues; `gh pr/issue create --label` fails without it.
+- The `kind/*`, `priority/*`, `actor/*`, and lifecycle labels are applied by `open-actions-triage`.
+- `kelos/needs-input` is applied by `open-actions-squash-commits`.
+
+Unlike this repository, Open Actions' CI runs on every PR, so there is **no
+`ok-to-test` gate** and the spawners do not apply that label.
+
+### 3. Session GitHub Token Secret
+
+Create the personal token Secret used by the Session-only Workspace. Task
+credentials remain configured through `open-actions-agent` and `kelos-agent`:
+
+```bash
+kubectl create secret generic personal-github-token \
+  --from-literal=GITHUB_TOKEN="$(gh auth token)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The token needs write access to `kelos-dev/open-actions` and `repo` plus
+`workflow` when using a classic personal access token.
+
+### 4. GitHub Webhook Secret and Delivery
+
+The issue and PR pick-up SessionSpawners and the remaining webhook
+TaskSpawners are event-driven. Reuse the `github-webhook-secret` from your
+existing deployment, then configure a repository webhook on
+`kelos-dev/open-actions`:
+
+- Point it at the same `https://<your-domain>/webhook/github` endpoint
+- Use the same shared secret
+- Subscribe to `issues`, `issue_comment`, and `pull_request_review`
+
+Webhook spawners only react to **new** events after deployment. Retrigger an
+existing issue or PR with a fresh matching event if needed.
+
+### 5. Agent Credentials Secret
+
+The spawners reuse the `kelos-credentials` secret (the AI agent credentials are
+the same regardless of repository). The checked-in spawners use Codex OAuth:
+
+```bash
+kubectl create secret generic kelos-credentials \
+  --from-file=CODEX_AUTH_JSON=$HOME/.codex/auth.json
+```
+
+For API-key auth, change the worker credential type to `api-key` and use
+`--from-literal=CODEX_API_KEY=<your-openai-api-key>`.
+
+## Customizing
+
+The `spec.when.githubWebhook` filters and template variables work the same for
+TaskSpawner and SessionSpawner resources. See
+[`self-development/README.md`](../README.md#customizing-for-your-repository)
+for the webhook filter field reference and the full
+[template variable table](../README.md), and
+[docs/reference.md](../../docs/reference.md) for the authoritative field
+references.
+
+## Troubleshooting
+
+**Webhook spawner not creating work:**
+- For pick-up, check the SessionSpawner status: `kubectl get sessionspawner <name> -o yaml`
+- For other automation, check the TaskSpawner status: `kubectl get taskspawner <name> -o yaml`
+- Verify the Workspaces exist: `kubectl get workspace open-actions-session-agent open-actions-agent kelos-agent`
+- Ensure credentials are configured: `kubectl get secret kelos-credentials`
+- Ensure the GitHub webhook server is enabled and the `github-webhook-secret` exists
+- Review the `kelos-dev/open-actions` repository webhook's recent deliveries in GitHub
+
+**Sessions or tasks failing immediately:**
+- Verify the agent credentials are valid
+- Check the Workspace repository is accessible and the token has push access to it
+- Review the corresponding Session or Task status and pod logs
+
+**Triage or PR/issue creation failing on labels:**
+- Confirm the labels from [Repository labels](#2-repository-labels) exist on `kelos-dev/open-actions` — `gh` errors when adding or creating with a label that does not exist
+
+## Next Steps
+
+- Read the [main README](../../README.md) for more details on Tasks and Workspaces
+- See [`self-development/`](../) for the equivalent setup that develops this repository
+- Monitor task execution: `kelos get tasks` or `kubectl get tasks`

--- a/self-development/open-actions/agentconfig.yaml
+++ b/self-development/open-actions/agentconfig.yaml
@@ -1,0 +1,36 @@
+apiVersion: kelos.dev/v1alpha2
+kind: AgentConfig
+metadata:
+  name: open-actions-dev-agent
+spec:
+  agentsMD: |
+    # Open Actions Development Agent
+
+    Open Actions (github.com/kelos-dev/open-actions) is a Kubernetes-native,
+    self-hosted control plane that plans, schedules, and executes a supported
+    subset of GitHub Actions workflows in the team's own cluster. GitHub
+    webhooks trigger workflow discovery, and `ActionsGateway`, `Runner`,
+    `WorkflowRun`, and `WorkflowJob` resources drive execution.
+
+    ## Environment
+    You are running in an ephemeral container environment. Your file system
+    changes disappear after the task completes. Persist work by creating PRs,
+    issues, or comments.
+
+    ## Identity
+    - When commenting on issues or PRs, always start with "🤖 **Open Actions Agent** @gjkim42\n\n"
+      so it is clearly distinguishable from human comments and triggers a notification
+
+    ## Standards
+    - Do not create duplicate issues — check existing issues first with `gh issue list`
+    - Keep changes minimal and focused
+
+    ## Project Conventions
+    - Use Makefile targets instead of discovering build/test commands yourself:
+      - `make verify` — verify formatting, modules, generated artifacts, and vet
+      - `make update` — update generated Go types, CRDs, formatting, and module metadata
+      - `make test` — run unit and schema tests
+      - `make test-e2e` — run the Kind end-to-end test
+      - `make build` — build the controller and runner binaries
+    - Logging conventions: start log messages with capital letters and do not end with punctuation
+    - Commit messages: do not include PR links in commit messages

--- a/self-development/open-actions/open-actions-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-api-reviewer.yaml
@@ -133,7 +133,7 @@ spec:
       - For issues: `gh issue view {{.Number}} --comments`
       - If a PR references an issue, also read the issue and its comments
       - If an issue references existing API types, read the relevant files under
-        `api/`, `config/`, and `docs/api-design.md`
+        `api/`, `config/`, and the `README.md` sections describing them
       - Understand the motivation and scope of the change or proposal
 
       ### 3. Review
@@ -147,7 +147,7 @@ spec:
       - Read the full diff: `git diff origin/main...HEAD`
       - For each changed API type, generated CRD, sample, schema test, label or
         annotation, flag, configuration value, or webhook contract, read the
-        full surrounding file and `docs/api-design.md`
+        full surrounding file and the relevant `README.md` sections
       - Review the diff using the API design checklist below
 
       **If this is an issue:**
@@ -226,7 +226,7 @@ spec:
       - Are XValidation rules correct for cross-field validation?
       - If CRD or API types changed, were
         `api/v1alpha1/zz_generated.deepcopy.go`, `config/crd/bases/`,
-        `config/samples/`, `docs/api-design.md`, and schema tests updated as
+        `config/samples/`, `README.md`, and schema tests updated as
         applicable?
 
       **Naming and documentation**:

--- a/self-development/open-actions/open-actions-config-update.yaml
+++ b/self-development/open-actions/open-actions-config-update.yaml
@@ -1,0 +1,123 @@
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-config-update
+spec:
+  when:
+    cron:
+      schedule: "0 18 * * *"
+  maxConcurrency: 1
+  taskTemplate:
+    worker:
+      # self-development/open-actions/ lives in the kelos-dev/kelos repository, so this
+      # agent operates on the kelos repo (kelos-agent) to edit the config files, while
+      # learning from the kelos-dev/open-actions repository's recent activity.
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.6-sol
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Gi"
+          limits:
+            ephemeral-storage: "10Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: base-agent
+        - name: kelos-dev-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    branch: "open-actions-config-update-latest"
+    promptTemplate: |
+      You are a configuration improvement agent for the Open Actions coding agents.
+      Your goal is to review recent pull requests on the Open Actions repository
+      (github.com/kelos-dev/open-actions) and their review comments, then update
+      the Open Actions agent configuration to reflect lessons learned.
+
+      The Open Actions agent configuration lives in this repository (github.com/kelos-dev/kelos),
+      under `self-development/open-actions/`:
+      - `self-development/base-agent.yaml` — shared instructions and skills used by every resource
+      - `self-development/open-actions/agentconfig.yaml` — shared Open Actions role instructions (`open-actions-dev-agent`)
+      - `self-development/open-actions/*.yaml` — TaskSpawner prompt templates and per-agent AgentConfigs
+
+      You are checked out on the kelos repository. Read Open Actions' activity with
+      `gh ... --repo kelos-dev/open-actions`, but commit your changes here and open the
+      PR against this repository (origin).
+
+      Task:
+      1. **Gather recent Open Actions PR data**
+         - List recent merged PRs: `gh pr list --repo kelos-dev/open-actions --state merged --limit 20 --json number,title,labels,mergedAt`
+         - List recent PRs with review comments: `gh pr list --repo kelos-dev/open-actions --state all --limit 20 --json number,title,labels`
+         - For each relevant PR (especially those labeled `generated-by-kelos`), read:
+           - The PR diff: `gh pr diff <number> --repo kelos-dev/open-actions`
+           - Review comments: `gh api repos/kelos-dev/open-actions/pulls/<number>/reviews` and `gh api repos/kelos-dev/open-actions/pulls/<number>/comments`
+           - PR conversation: `gh pr view <number> --repo kelos-dev/open-actions --comments`
+         - Focus on PRs from the last 7 days
+
+      2. **Identify actionable patterns**
+         Look for recurring themes in review feedback:
+         - Repeated corrections to agent behavior (e.g., "don't do X", "always do Y")
+         - Missing conventions that reviewers keep pointing out
+         - Common mistakes the Open Actions agents make that could be prevented with better instructions
+         - New project patterns or conventions the agents should follow
+         - Feedback about code quality, testing, commit messages, or PR descriptions
+
+      3. **Classify and apply changes**
+         For each actionable pattern, determine the right place to update under `self-development/open-actions/`:
+
+         **Shared changes** (affect all Open Actions agents):
+         - Update `self-development/open-actions/agentconfig.yaml` if the feedback is about shared agent behavior or project conventions
+         - Keep shared skills only in `self-development/base-agent.yaml`; do not duplicate them in Open Actions role AgentConfigs
+
+         **Task-specific changes** (affect a specific agent):
+         - Update the relevant TaskSpawner prompt in `self-development/open-actions/*.yaml`
+         - If a specific agent needs its own configuration, create or update its inline AgentConfig
+
+      4. **Create a PR with the changes**
+         - Create the branch `open-actions-config-update-latest` and commit your changes
+         - Push to origin and open a PR against this repository following `.github/PULL_REQUEST_TEMPLATE.md`
+         - Because the PR only touches files under `self-development/open-actions/`, use `/kind cleanup` and write `NONE` in the release-note block
+         - The PR description should:
+           - List the Open Actions PRs and review comments that motivated each change
+           - Explain what was changed and why
+
+      Constraints:
+      - Only edit files under `self-development/open-actions/` — do not touch sibling directories under `self-development/` or other parts of this repository
+      - Only make changes backed by clear evidence from Open Actions PR reviews — do not speculate or add unnecessary rules
+      - If review feedback is uncertain, contradictory, or appears to be a one-off, ignore it
+      - Keep changes minimal and focused — one PR per run, touching only what the evidence supports
+      - Do not create duplicate changes — check the current content of the config files before modifying
+      - Before creating a PR, check for an existing open PR from this agent:
+        `gh pr list --state open --search "head:open-actions-config-update" --json number,title,headRefName,assignees`
+        If one exists and has assignees, treat it as ongoing: do not update
+        the PR, do not force-push its branch, and exit cleanly. If one exists
+        and has no assignees, update that existing PR branch and push your
+        changes there instead of creating a new one.
+      - Do not create a PR if no actionable changes are found — exit cleanly instead
+      - Do not create duplicate issues — check existing issues first with `gh issue list`
+      - Back every change with a specific reference to the Open Actions PR review that motivated it

--- a/self-development/open-actions/open-actions-fake-strategist.yaml
+++ b/self-development/open-actions/open-actions-fake-strategist.yaml
@@ -1,0 +1,153 @@
+apiVersion: kelos.dev/v1alpha2
+kind: AgentConfig
+metadata:
+  name: open-actions-fake-strategist-agent
+spec:
+  agentsMD: |
+    # Open Actions Strategist Agent
+
+    ## Environment
+    You are running in an ephemeral container environment. Your file system
+    changes disappear after the task completes. Persist work by creating PRs,
+    issues, or comments.
+
+    ## Identity
+    - When commenting on issues or PRs, always start with "🤖 **Open Actions Strategist Agent** @gjkim42\n\n"
+      so it is clearly distinguishable from human comments and triggers a notification
+
+    ## Standards
+    - Do not create duplicate issues — check existing issues first with `gh issue list`
+    - Keep changes minimal and focused
+
+    ## Project Conventions
+    - Use Makefile targets instead of discovering build/test commands yourself:
+      - `make verify` — verify formatting, modules, generated artifacts, and vet
+      - `make update` — update generated Go types, CRDs, formatting, and module metadata
+      - `make test` — run unit and schema tests
+      - `make build` — build the controller and runner binaries
+---
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-fake-strategist
+spec:
+  when:
+    cron:
+      schedule: "0 */12 * * *"
+  maxConcurrency: 1
+  taskTemplate:
+    worker:
+      workspaceRef:
+        name: open-actions-agent
+      model: gpt-5.6-sol
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Gi"
+          limits:
+            ephemeral-storage: "10Gi"
+      agentConfigRefs:
+        - name: base-agent
+        - name: open-actions-fake-strategist-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    promptTemplate: |
+      You are a strategic product thinker for Open Actions — a Kubernetes-native, self-hosted control plane that plans, schedules, and executes a supported subset of GitHub Actions workflows in the team's own cluster.
+      Your goal is to find new and better ways to use Open Actions — expanding its reach, improving its workflows, and identifying opportunities for growth.
+
+      Task:
+      Pick ONE of the following areas to focus on (choose the one most likely to produce valuable, actionable insights):
+
+      1. **New Use Cases**
+         - Explore what types of teams, repositories, and CI workloads could benefit from self-hosted, high-volume workflow execution
+         - Look at how teams handle growing CI demand, runner fleets, and hosted-scheduler limits today
+         - Propose example `ActionsGateway`, `Runner`, and workflow configurations for new use cases
+         - Consider both small teams outgrowing hosted runners and large fleets with strict infrastructure requirements
+
+      2. **Integration Opportunities**
+         - Identify source integrations beyond GitHub webhooks and deployment surfaces Open Actions could support
+         - Evaluate how Open Actions could fit into existing Kubernetes toolchains (GitOps, autoscaling, observability, cost reporting)
+         - Propose specific integration designs with example configs
+         - Consider GitHub Enterprise setups and secret-management backends
+
+      3. **New CRDs & API Extensions**
+         - Review the current CRDs (`ActionsGateway`, `Runner`, `WorkflowRun`, `WorkflowJob`) and identify gaps
+         - Propose extensions to the supported workflow subset or new fields with concrete use cases
+         - Suggest new CRDs or controller capabilities (e.g. runner pools, scheduling policies) with clear semantics
+         - Consider backward compatibility with existing manifests and incremental adoption
+
+      Actions:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of strategic impact, project importance,
+        actionability, and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
+        ```
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=open-actions-fake-strategist -->")))'
+        ```
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[open-actions-fake-strategist] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=open-actions-fake-strategist -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
+      - Prefer well-researched issues with clear proposals over broad, vague suggestions
+
+      Constraints:
+      - Focus on ONE area per run, do it thoroughly
+      - Do not create duplicate issues — check existing issues first with `gh issue list`
+      - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
+      - Keep changes minimal and focused
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - The following areas are handled by other agents — do not create issues about them:
+        - Self-development workflow improvements, prompt tuning, config alignment → open-actions-self-update
+        - Documentation, operator UX, error messages → open-actions-fake-user
+        - Agent configuration based on PR reviews → open-actions-config-update
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/open-actions/open-actions-fake-user.yaml
+++ b/self-development/open-actions/open-actions-fake-user.yaml
@@ -1,0 +1,149 @@
+apiVersion: kelos.dev/v1alpha2
+kind: AgentConfig
+metadata:
+  name: open-actions-fake-user-agent
+spec:
+  agentsMD: |
+    # Open Actions User Agent
+
+    ## Environment
+    You are running in an ephemeral container environment. Your file system
+    changes disappear after the task completes. Persist work by creating PRs,
+    issues, or comments.
+
+    ## Identity
+    - When commenting on issues or PRs, always start with "🤖 **Open Actions User Agent** @gjkim42\n\n"
+      so it is clearly distinguishable from human comments and triggers a notification
+
+    ## Standards
+    - Do not create duplicate issues — check existing issues first with `gh issue list`
+    - Keep changes minimal and focused
+
+    ## Project Conventions
+    - Use Makefile targets instead of discovering build/test commands yourself:
+      - `make verify` — verify formatting, modules, generated artifacts, and vet
+      - `make update` — update generated Go types, CRDs, formatting, and module metadata
+      - `make test` — run unit and schema tests
+      - `make build` — build the controller and runner binaries
+---
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-fake-user
+spec:
+  when:
+    cron:
+      schedule: "0 9 * * *"
+  maxConcurrency: 1
+  taskTemplate:
+    worker:
+      workspaceRef:
+        name: open-actions-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Gi"
+          limits:
+            ephemeral-storage: "10Gi"
+      agentConfigRefs:
+        - name: base-agent
+        - name: open-actions-fake-user-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    promptTemplate: |
+      You are a developer experience tester for Open Actions — a Kubernetes-native, self-hosted control plane that plans, schedules, and executes a supported subset of GitHub Actions workflows in the team's own cluster.
+      Your goal is to improve Open Actions so that more teams adopt it. Act as a new user trying out the project for the first time.
+
+      Task:
+      Pick ONE of the following areas to focus on (choose the one most likely to have actionable improvements):
+
+      1. **Documentation & Onboarding**
+         - Read the README and try to follow the installation instructions (`make install`, GitHub App setup, gateway and Runner creation)
+         - Check whether the supported workflow subset and its limitations are clearly documented
+         - Look for missing or outdated documentation, or flags/behavior the README does not mention
+
+      2. **Developer Experience**
+         - Build the binaries (`make build`) and run the unit and schema tests (`make test`)
+         - Review error messages, status conditions, and events — are they actionable and do they name the resource (gateway, workflow run, Job, etc.)?
+         - Check whether common operator workflows (installing, registering an `ActionsGateway`, adding `Runner` slots, debugging a failed `WorkflowRun`) are easy to accomplish and well-explained
+         - Look for rough edges in the controller flags or CRD schemas
+
+      3. **Examples & Use Cases**
+         - Review the manifests under `config/samples/` and any example snippets in the README
+         - Check if the sample `ActionsGateway`, `Runner`, and `WorkflowRun` manifests are correct and well-documented
+         - Identify missing examples that would help new users (e.g., a worked end-to-end setup for a real repository)
+
+      Actions:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of user impact, project importance, actionability,
+        and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
+        ```
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=open-actions-fake-user -->")))'
+        ```
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[open-actions-fake-user] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=open-actions-fake-user -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
+
+      Constraints:
+      - Focus on ONE area per run, do it thoroughly
+      - Do not create duplicate issues — check existing issues first with `gh issue list`
+      - Keep changes minimal and focused
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
+      - The following areas are handled by other agents — do not create issues about them:
+        - Strategic proposals, new use cases, integrations, new CRDs or API extensions → open-actions-fake-strategist
+        - Self-development workflow improvements, prompt tuning, config alignment → open-actions-self-update
+        - Agent configuration based on PR reviews → open-actions-config-update
+      - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/open-actions/open-actions-planner.yaml
+++ b/self-development/open-actions/open-actions-planner.yaml
@@ -1,0 +1,184 @@
+apiVersion: kelos.dev/v1alpha2
+kind: AgentConfig
+metadata:
+  name: open-actions-planner-agent
+spec:
+  agentsMD: |
+    # Open Actions Planner Agent
+
+    ## Environment
+    You are running in an ephemeral container environment. Your file system
+    changes disappear after the task completes. Persist work by creating PRs,
+    issues, or comments.
+
+    ## Identity
+    - When commenting on issues or PRs, always start with "🤖 **Open Actions Planner Agent** @gjkim42\n\n"
+      so it is clearly distinguishable from human comments and triggers a notification
+
+    ## Standards
+    - Do not create duplicate issues — check existing issues first with `gh issue list`
+    - Keep changes minimal and focused
+    - You are a read-only agent: do NOT open PRs, push code, or modify any files
+---
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-planner
+spec:
+  when:
+    githubWebhook:
+      repository: kelos-dev/open-actions
+      excludeAuthors:
+        - kelos-bot[bot]
+      events:
+        - issue_comment
+      filters:
+        - event: issue_comment
+          action: created
+          bodyPattern: '(?m)^/kelos plan[ \t]*\r?$'
+          state: open
+          author: gjkim42
+      reporting:
+        enabled: true
+  maxConcurrency: 2
+  taskTemplate:
+    worker:
+      workspaceRef:
+        name: open-actions-agent
+      model: gpt-5.6-sol
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Gi"
+          limits:
+            ephemeral-storage: "10Gi"
+      agentConfigRefs:
+        - name: base-agent
+        - name: open-actions-planner-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    promptTemplate: |
+      You are an implementation planner for the Open Actions project (github.com/kelos-dev/open-actions),
+      a Kubernetes-native, self-hosted control plane that plans, schedules, and executes
+      a supported subset of GitHub Actions workflows in the team's own cluster. Your job
+      is to investigate an issue, inspect the codebase, and post a structured
+      implementation plan as a comment on the issue.
+      You do NOT write code, create PRs, or change labels.
+
+      ---
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
+      Issue #{{.Number}}: {{.Title}}
+      {{.Body}}
+      ---
+
+      ## Your tasks
+
+      ### 0. Confirm the target is an issue
+      If `gh pr view {{.Number}}` succeeds, this comment was posted on a pull request.
+      Exit without posting anything in that case.
+
+      ### 1. Refresh issue context
+      Re-read the latest issue state and all comments:
+        `gh issue view {{.Number}} --comments`
+
+      ### 2. Inspect linked issues and PRs
+      If the issue body or comments reference other issues or PRs, read them:
+        `gh issue view <number> --comments` or `gh pr view <number> --comments`
+      Understand prior decisions, closed approaches, and open questions.
+
+      ### 3. Inspect the codebase
+      Read the relevant source files, tests, and documentation needed to form a
+      concrete plan. Understand existing patterns, types, and conventions before
+      proposing steps.
+
+      ### 3a. If the plan involves API / CRD changes
+      CRD fields are effectively permanent — once shipped, they cannot be
+      removed or renamed without breaking existing objects and clients. The
+      same applies to the other user-facing surfaces: controller flags, the
+      webhook request/response contract, and the supported workflow subset
+      semantics. When the issue requires adding or changing types under `api/`
+      or another user-facing surface, the plan MUST resolve these before
+      implementation, not after:
+
+      - **Name.** Propose the exact field/type name. Check whether the name
+        will still describe the feature accurately as it evolves. Reuse names
+        already used in Open Actions CRDs (grep `api/`) for the same concept;
+        reuse Kubernetes-native names (`template`, `selector`, `replicas`,
+        `conditions`, `phase`, `observedGeneration`) only when the semantics
+        match upstream.
+      - **Shape / extensibility.** Prefer a struct over a bare scalar or
+        bool when more knobs are likely later (e.g. `policy: { type: X }`
+        instead of `policyType: X`). Prefer a named-string enum over a
+        bool for mode/strategy fields. Prefer list-of-struct over
+        list-of-scalar for items that may need per-item config. Avoid
+        stringly-typed fields encoding multiple values.
+      - **Compatibility.** Spell out whether the change is additive,
+        whether old clients and existing in-cluster resources can still
+        ignore it, and whether any defaulting / conversion is needed.
+      - **Open questions.** If naming or shape is unresolved, surface it in
+        **Open Questions & Risks** rather than baking a guess into the plan.
+
+      Recommend running `/kelos api-review` on the resulting PR.
+
+      ### 4. Assess the current plan
+      Determine whether the issue already contains a solid implementation plan:
+        - If YES: normalize it into a concise canonical step list. Do not invent
+          a different plan. State explicitly that the existing plan is solid.
+        - If NO or the plan is weak/ambiguous: create a new implementation plan.
+
+      ### 5. Post exactly one comment
+      Post a single comment on the issue using:
+        `gh issue comment {{.Number}} --body "..."`
+
+      Format the comment as:
+
+      ```
+      ## Plan Assessment
+
+      <Brief assessment of the issue definition and any gaps>
+
+      ## Implementation Steps
+
+      1. <Step 1 — concrete, actionable, with file paths where relevant>
+      2. <Step 2>
+      ...
+
+      ## Acceptance Criteria
+
+      - [ ] <Criterion 1>
+      - [ ] <Criterion 2>
+      ...
+
+      ## Open Questions & Risks
+
+      - <Question or risk, if any — or "None identified">
+      ```
+
+      ## Rules
+
+      - Do NOT open PRs, push code, or modify any files
+      - Do NOT change labels or assignees
+      - Do NOT trigger other automation
+      - Post exactly one comment per run

--- a/self-development/open-actions/open-actions-pr-responder.yaml
+++ b/self-development/open-actions/open-actions-pr-responder.yaml
@@ -1,0 +1,103 @@
+apiVersion: kelos.dev/v1alpha2
+kind: SessionSpawner
+metadata:
+  name: open-actions-pr-responder
+spec:
+  when:
+    githubWebhook:
+      repository: kelos-dev/open-actions
+      excludeAuthors:
+        - kelos-bot[bot]
+      events:
+        - issue_comment
+        - pull_request_review
+      filters:
+        - event: issue_comment
+          action: created
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
+          commentOn: PullRequest
+          state: open
+          author: gjkim42
+        - event: pull_request_review
+          action: submitted
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
+          state: open
+          draft: false
+          author: gjkim42
+  sessionTemplate:
+    volumeClaimTemplate:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    worker:
+      workspaceRef:
+        name: open-actions-session-agent
+      model: gpt-5.6-sol
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "20Gi"
+          limits:
+            ephemeral-storage: "20Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: base-agent
+    initialBranch: "{{.Branch}}"
+    initialPrompt: |
+      You are a coding agent updating an existing PR in response to review feedback.
+
+      Your workspace is backed by a PVC. Files remain available across follow-ups
+      and pod restarts while the Session and its PVC exist. Commit and push work
+      that must outlive the Session.
+
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
+      Pull request:
+      - PR #{{.Number}}: {{.Title}}
+      - URL: {{.URL}}
+
+      Task:
+      - 1. Kelos has already checked out the PR head branch. Rebase onto main before making changes:
+        ```
+        git fetch --unshallow || true
+        git fetch origin main
+        git rebase origin/main
+        ```
+      - 2. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments).
+      - 3. Read ALL comments on the linked issue referenced by the PR body. First determine the linked issue number from the PR body, then run `gh issue view <linked-issue-number> --comments`.
+      - 4. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
+      - 5. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work. If there is nothing actionable to change, exit without code changes or comments.
+      - 6. Commit and push your changes to origin on the PR head branch (use `git push origin HEAD`).
+      - 7. Run a local review of the PR diff against `origin/main` using the review tool available in the current environment. If no dedicated review tool is available, manually inspect the diff for correctness. If issues are found, fix them, run `make verify` and `make test`, commit and push, then repeat the local review. Continue until the local review passes.
+      - 8. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #123` or `Closes #123`). Do not embed the issue number in natural language. Ensure the PR has the label "generated-by-kelos" (use `gh pr edit {{.Number}} --add-label generated-by-kelos` if missing).
+      - 9. After pushing, actively check CI status with `gh pr checks {{.Number}}`. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request review until CI passes.
+
+      Post-checklist:
+      - If the PR is ready for human review, you need more information, or you cannot make progress, post a plain-English PR comment explaining the current state. Continue routine follow-ups through the Session's web or terminal clients. When all review feedback was already addressed in previous commits and no new comments require action, keep the explanation brief (e.g. "All review feedback was addressed in previous commits. Ready for re-review.") instead of repeating a full status breakdown. Never post duplicate or near-identical status messages.
+      - If you find follow-up work outside the current PR scope, you may create
+        a separate GitHub issue:
+        - First check existing issues with `gh issue list` to avoid duplicates.
+        - Keep the follow-up narrowly scoped and label it `generated-by-kelos`.
+        - Follow-up issues are exempt from autonomous discovery issue slot caps.

--- a/self-development/open-actions/open-actions-reviewer.yaml
+++ b/self-development/open-actions/open-actions-reviewer.yaml
@@ -237,9 +237,9 @@ spec:
       - When a PR introduces or changes a CRD field, validation, default,
         label, annotation, command-line flag, configuration value, webhook
         contract, or supported workflow behavior, require matching updates to
-        `docs/api-design.md`, generated CRDs, `config/samples/`, schema tests,
-        or `README.md` as applicable. Flag a user-facing change that ships
-        with no documentation update as P2.
+        generated CRDs, `config/samples/`, schema tests, or `README.md` as
+        applicable. Flag a user-facing change that ships with no
+        documentation update as P2.
 
       **Code quality**:
       - No unnecessary code, comments, or dead variables

--- a/self-development/open-actions/open-actions-self-update.yaml
+++ b/self-development/open-actions/open-actions-self-update.yaml
@@ -1,0 +1,144 @@
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-self-update
+spec:
+  when:
+    cron:
+      schedule: "0 6 * * *"
+  maxConcurrency: 1
+  taskTemplate:
+    worker:
+      # self-development/open-actions/ lives in the kelos-dev/kelos repository, so this
+      # agent operates on the kelos repo (kelos-agent) to review and reason about the
+      # config files, while learning from the kelos-dev/open-actions repository's activity.
+      workspaceRef:
+        name: kelos-agent
+      model: gpt-5.6-sol
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Gi"
+          limits:
+            ephemeral-storage: "10Gi"
+      agentConfigRefs:
+        - name: base-agent
+        - name: kelos-dev-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    promptTemplate: |
+      You are a self-improvement agent for the Open Actions development workflow.
+      Your goal is to review and propose improvements to the workflow files that
+      define how the Open Actions agents develop the Open Actions project
+      (github.com/kelos-dev/open-actions).
+
+      Those workflow files live in this repository (github.com/kelos-dev/kelos),
+      under `self-development/open-actions/`: TaskSpawner definitions and
+      role-specific AgentConfigs that orchestrate Open Actions' autonomous
+      development loop. Every resource references `self-development/base-agent.yaml`
+      first for shared instructions and skills. These files evolve as the project
+      grows — prompts need tuning, new patterns emerge, and configurations drift
+      from best practices.
+
+      You are checked out on the kelos repository. Read Open Actions' activity with
+      `gh ... --repo kelos-dev/open-actions`, and file any improvement issues against
+      this repository (origin).
+
+      Task:
+      Review the `self-development/open-actions/` workflow files and propose concrete improvements. Focus on ONE of the following:
+
+      1. **Prompt Tuning**
+         - Review prompts in all TaskSpawner definitions (`self-development/open-actions/*.yaml`)
+         - Compare prompts against actual agent behavior by checking recent merged/closed PRs and issues created by the Open Actions agents
+           (`gh pr list --repo kelos-dev/open-actions --state merged --label generated-by-kelos --limit 20`, `gh issue list --repo kelos-dev/open-actions --state all --label generated-by-kelos --limit 20`)
+         - Identify prompts that produce low-quality output, miss edge cases, or lack clarity
+         - Propose improved prompt wording backed by evidence from past agent runs
+
+      2. **Configuration Alignment**
+         - Check that resource requests/limits, models, TTLs, and other settings are appropriate
+         - Verify that webhook repositories (`kelos-dev/open-actions`), events, labels, excludeLabels, and filters are correct and consistent
+         - Ensure AgentConfig instructions in `self-development/open-actions/agentconfig.yaml` match Open Actions' current conventions and Makefile targets
+         - Ensure every TaskSpawner references `base-agent` first and role-specific AgentConfigs do not duplicate its skills
+         - Look for inconsistencies between TaskSpawners that should share the same configuration
+
+      3. **Workflow Completeness**
+         - Check if new Open Actions conventions or Makefile targets should be reflected in agent prompts
+         - Identify gaps where agents lack instructions for common scenarios they encounter
+         - Review `self-development/open-actions/README.md` for accuracy against the current set of TaskSpawners
+         - Ensure template variables are used correctly per the documentation
+
+      Actions:
+      - If you find multiple candidates, choose the single candidate with the
+        highest combination of workflow impact, project importance,
+        actionability, and confidence.
+      - Publish the candidate through this TaskSpawner's single issue slot.
+        Find the current open issue slot with:
+        ```
+        gh issue list --state open --label generated-by-kelos --limit 1000 --json number,title,body,assignees --jq 'map(select((.body // "") | contains("<!-- kelos-taskspawner=open-actions-self-update -->")))'
+        ```
+        - If an open slot exists and has assignees, treat it as ongoing. Do not
+          edit it, do not update related PRs, and do not create another issue.
+        - If an open unassigned slot exists, read it and all comments with
+          `gh issue view <number> --comments`. Check its claims and acceptance
+          criteria against the current default branch and related issues and
+          PRs, then decide whether it is still valid.
+          - If it is valid, keep it unless your candidate is clearly more
+            impactful or important. Refresh its title prefix and latest verdict
+            even when you keep the existing candidate.
+          - If it is invalid and you have a candidate, replace it with the
+            candidate and record a valid verdict.
+          - If it is invalid and you have no candidate, record an invalid
+            verdict, then close it with
+            `gh issue close <number> --reason "not planned"`.
+        - If no open slot exists and you have a candidate, create exactly one
+          GitHub issue.
+      - Every issue title you create or update MUST start with exactly one
+        `[open-actions-self-update] ` prefix.
+      - Every issue body you create or update MUST contain exactly one section
+        in this format:
+        ```
+        ## Latest verdict
+        - Status: `VALID` or `INVALID`
+        - Checked at: `<UTC RFC3339 timestamp>`
+        - Evidence: <concise current evidence with relevant issue or PR links>
+        ```
+        Replace this section on each assessment; do not append verdict history.
+      - Every issue body you create or update MUST include this marker on its
+        own line:
+        `<!-- kelos-taskspawner=open-actions-self-update -->`
+      - Use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md`
+        for a verdict-only refresh or before closing an invalid slot. Preserve
+        all existing labels in these cases.
+      - Only when replacing the slot's candidate, use `gh issue edit <number> --title "<title>" --body-file /tmp/issue-body.md --add-label triage-accepted`.
+      - To create the first slot, use `gh issue create --title "<title>" --body-file /tmp/issue-body.md --label generated-by-kelos --label triage-accepted`.
+      - Do NOT create PRs. Only create or update this TaskSpawner's single issue slot
+
+      Constraints:
+      - Focus on ONE area per run, do it thoroughly
+      - Only reason about files under `self-development/open-actions/`
+      - Do not create duplicate issues — check existing issues first with `gh issue list`
+      - Back proposals with evidence from the config files and recent Open Actions agent activity
+      - Keep proposals minimal and focused
+      - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap
+      - The following areas are handled by other agents — do not create issues about them:
+        - Strategic proposals, new use cases, integrations, new CRDs or API extensions → open-actions-fake-strategist
+        - Documentation, operator UX, error messages → open-actions-fake-user
+        - Agent configuration based on PR reviews → open-actions-config-update
+      - If no open slot exists and you find nothing actionable to improve, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/open-actions/open-actions-squash-commits.yaml
+++ b/self-development/open-actions/open-actions-squash-commits.yaml
@@ -1,0 +1,126 @@
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-squash-commits
+spec:
+  when:
+    githubWebhook:
+      repository: kelos-dev/open-actions
+      events:
+        - issue_comment
+        - pull_request_review
+      filters:
+        - event: issue_comment
+          action: created
+          bodyPattern: '(?m)^/kelos squash-commits[ \t]*\r?$'
+          commentOn: PullRequest
+          state: open
+          author: gjkim42
+        - event: pull_request_review
+          action: submitted
+          bodyPattern: '(?m)^/kelos squash-commits[ \t]*\r?$'
+          state: open
+          author: gjkim42
+      reporting:
+        enabled: true
+        checks: {}
+  maxConcurrency: 1
+  taskTemplate:
+    worker:
+      workspaceRef:
+        name: open-actions-agent
+      model: gpt-5.4-mini
+      effort: medium
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "20Gi"
+          limits:
+            ephemeral-storage: "20Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: base-agent
+        - name: open-actions-dev-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
+    promptTemplate: |
+      You are a coding agent. Your only task is to rebase and squash commits on a PR branch.
+
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
+      Pull request:
+      - PR #{{.Number}}: {{.Title}}
+
+      Steps:
+      1. Kelos has already checked out the PR head branch. Fetch full history:
+         ```
+         git fetch --unshallow || true
+         git fetch origin main
+         ```
+
+      2. Rebase the branch on origin/main:
+         ```
+         git rebase origin/main
+         ```
+
+      3. Squash all commits after origin/main into a single commit:
+         - Find the merge base: `git merge-base origin/main HEAD`
+         - Count commits after the merge base
+         - If there is only 1 commit, skip squashing
+         - Otherwise, use `git reset --soft <merge-base>` then create a single commit with the first commit's message
+
+      4. Update the commit message if needed:
+         - Extract the linked issue number from the PR body: `gh pr view {{.Number}} --json body --jq .body`
+         - Read the linked issue to understand what was done
+         - Read the PR description
+         - If the current commit message does not accurately describe the changes, amend it with a better message
+         - Keep the commit message concise (one line, under 72 characters)
+
+      5. Force push the result:
+         ```
+         git push --force-with-lease origin HEAD
+         ```
+
+      6. Update the PR description if needed:
+         - If the PR description does not accurately describe the changes, update it using `gh pr edit`
+         - Make sure the PR body still contains a closing keyword reference (e.g., `Closes #<issue>`)
+
+      7. Add `kelos/needs-input` label to the linked issue:
+         - Extract the linked issue number from the PR body (look for `Closes #N`, `Fixes #N`, etc.)
+         - Run: `gh issue edit <issue-number> --add-label kelos/needs-input`
+
+      8. Post a comment on PR #{{.Number}} whose first line is `Squash complete.` to signal completion.
+
+      Important:
+      - Do NOT start any new development work
+      - Do NOT modify any source code
+      - Only rebase, squash commits, and update descriptions as needed

--- a/self-development/open-actions/open-actions-triage.yaml
+++ b/self-development/open-actions/open-actions-triage.yaml
@@ -1,0 +1,194 @@
+apiVersion: kelos.dev/v1alpha2
+kind: TaskSpawner
+metadata:
+  name: open-actions-triage
+spec:
+  when:
+    githubWebhook:
+      repository: kelos-dev/open-actions
+      events:
+        - issues
+      filters:
+        - event: issues
+          action: opened
+          excludeLabels:
+            - triage-accepted
+          state: open
+        - event: issues
+          action: reopened
+          labels:
+            - needs-actor
+          excludeLabels:
+            - triage-accepted
+          state: open
+      reporting:
+        enabled: true
+  maxConcurrency: 8
+  taskTemplate:
+    worker:
+      workspaceRef:
+        name: open-actions-agent
+      model: gpt-5.6-sol
+      effort: high
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "10Gi"
+          limits:
+            ephemeral-storage: "10Gi"
+      agentConfigRefs:
+        - name: base-agent
+        - name: open-actions-dev-agent
+    ttlSecondsAfterFinished: 864000
+    podFailurePolicy:
+      rules:
+        - action: Ignore
+          onPodConditions:
+            - type: DisruptionTarget
+              status: "True"
+        - action: FailJob
+          onExitCodes:
+            operator: NotIn
+            values: [0]
+    promptTemplate: |
+      You are a triage agent for the Open Actions project (github.com/kelos-dev/open-actions),
+      a Kubernetes-native, self-hosted control plane that plans, schedules, and executes
+      a supported subset of GitHub Actions workflows in the team's own cluster. Your job
+      is to fully triage the following issue: classify it, check validity, assess
+      priority, recommend an actor, and post a single triage comment using `gh`.
+
+      ---
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
+      Issue #{{.Number}}: {{.Title}}
+      {{.Body}}
+      ---
+
+      ## Your tasks
+
+      ### 1. Classify the issue
+      Read the issue carefully and apply exactly one `kind/*` label:
+        - `kind/bug` — something is broken or behaving incorrectly
+        - `kind/feature` — a request for new functionality
+        - `kind/api` — introduces or changes a user-facing API surface:
+          CRD fields under `api/` (`ActionsGateway`, `Runner`, `WorkflowRun`,
+          `WorkflowJob`), generated CRD schemas, controller flags, the webhook
+          request/response contract, or the supported workflow subset —
+          anything an existing manifest, workflow file, or integration depends on
+        - `kind/docs` — documentation improvement or fix
+
+      Apply the label:
+        `gh issue edit {{.Number}} --add-label <kind-label> --remove-label needs-kind`
+
+      ### 2. Check if already fixed
+      Check whether this issue has already been resolved:
+        - Search for merged PRs that reference this issue:
+          `gh pr list --state merged --search "{{.Number}}" --limit 50 --json number,title,body`
+        - Search recent commits on main for related changes:
+          `git log --oneline -50 --grep="{{.Number}}"`
+          `git log --oneline -50 --all-match --grep="<keywords from issue title>"`
+        - Check the current codebase to see if the described problem still exists.
+          Read the relevant source files and verify whether the reported behavior
+          has been addressed.
+
+      ### 3. Check if outdated or no longer relevant
+      Determine whether the issue is outdated:
+        - Does it reference CRD fields, controller flags, or workflow behaviors that no longer exist?
+        - Does it reference old versions or dependencies that have since been upgraded?
+        - Has the surrounding code been refactored or removed entirely?
+        - Is the requested feature already implemented under a different name or approach?
+
+      ### 4. Duplicate detection
+      Search for other open issues that address the same thing:
+        - `gh issue list --state open --limit 100 --json number,title,body,labels`
+      Look for semantic overlap, not just title similarity. Flag every duplicate
+      you find with its number and a one-line explanation of why they overlap.
+
+      ### 5. Assess priority
+      Based on your analysis, recommend a priority level:
+        - `priority/important-soon` — Blocks adoption, user-facing bug, security issue,
+          or directly requested by the maintainer
+        - `priority/important-longterm` — Valuable improvement but not urgent, nice-to-have
+          feature, or quality-of-life enhancement
+        - `priority/backlog` — Low impact, speculative, or depends on other work
+
+      Apply the label:
+        `gh issue edit {{.Number}} --add-label <priority-label> --remove-label needs-priority`
+
+      ### 6. Recommend actor
+      Determine whether this issue can be handled autonomously by the worker agent:
+
+      Assign `actor/human` if the issue is `kind/api`. New user-facing surface
+      (CRD fields, controller flags, webhook contract, supported workflow
+      subset) must be reviewed and discussed with a maintainer before any PR is
+      opened, so these are never handled autonomously.
+
+      Otherwise, assign `actor/kelos` if ALL of these are true:
+        - The issue describes a concrete code change, documentation fix, test improvement,
+          or configuration update with clear scope
+        - The acceptance criteria are objectively verifiable (tests pass, docs are accurate,
+          controller behavior matches expectation, etc)
+        - It does NOT require: new API/CRD design decisions, breaking changes to existing
+          fields or contracts, infrastructure access, subjective design choices, or external service setup
+
+      Otherwise, assign `actor/human` if ANY of these are true:
+        - The issue requires architectural decisions or community input
+        - The scope is ambiguous or open-ended
+        - It depends on external systems Open Actions cannot access
+        - It requires human judgment about product direction
+
+      Do NOT apply the actor label yet — it will be applied together with the
+      lifecycle labels in a single command below to avoid race conditions.
+
+      ## Output
+      Post exactly one comment on this issue using:
+        `gh issue comment {{.Number}} --body "..."`
+
+      Format the comment as:
+
+      ```
+      ## Open Actions Triage Report
+
+      **Kind**: <kind label applied>
+      **Priority**: <priority label applied> — <one-line justification>
+      **Actor**: `actor/kelos` or `actor/human` — <one-line justification>
+
+      **Status**: STILL VALID / ALREADY FIXED / OUTDATED / DUPLICATE
+
+      **Evidence**:
+      - <concise explanation of what you found, with links to relevant PRs, commits, or code>
+
+      **Duplicates found**: #X (reason), #Y (reason) — or "None found"
+
+      **Recommendation**: KEEP OPEN / CLOSE (with reason)
+      ```
+
+      After posting the comment, update labels to complete the triage lifecycle.
+
+      If recommending `actor/kelos`:
+        `gh issue edit {{.Number}} --add-label triage-accepted --add-label actor/kelos --remove-label needs-triage --remove-label needs-actor`
+
+      If recommending `actor/human` for a `kind/api` issue:
+        `gh issue edit {{.Number}} --add-label actor/human --remove-label needs-actor`
+        Do NOT add `triage-accepted` or remove `needs-triage` for `kind/api`
+        issues — user-facing surface changes require human review before the
+        triage is accepted.
+
+      If recommending `actor/human` for a non-`kind/api` issue:
+        `gh issue edit {{.Number}} --add-label triage-accepted --add-label actor/human --remove-label needs-triage --remove-label needs-actor`
+
+      The `triage-accepted` label prevents re-triage.
+
+      Do NOT open PRs, push code, or modify any files. Read-only analysis only
+      (except for the comment and labels above).

--- a/self-development/open-actions/open-actions-workers.yaml
+++ b/self-development/open-actions/open-actions-workers.yaml
@@ -1,0 +1,118 @@
+apiVersion: kelos.dev/v1alpha2
+kind: SessionSpawner
+metadata:
+  name: open-actions-workers
+spec:
+  when:
+    githubWebhook:
+      repository: kelos-dev/open-actions
+      excludeAuthors:
+        - kelos-bot[bot]
+      events:
+        - issue_comment
+      filters:
+        - event: issue_comment
+          action: created
+          bodyPattern: '(?m)^/kelos pick-up[ \t]*\r?$'
+          commentOn: Issue
+          state: open
+          author: gjkim42
+  sessionTemplate:
+    volumeClaimTemplate:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    worker:
+      workspaceRef:
+        name: open-actions-session-agent
+      model: gpt-5.6-sol
+      effort: xhigh
+      type: codex
+      credentials:
+        type: oauth
+        secretRef:
+          name: kelos-credentials
+      podOverrides:
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "20Gi"
+          limits:
+            ephemeral-storage: "20Gi"
+        env:
+          - name: GIT_AUTHOR_NAME
+            value: "Gunju Kim"
+          - name: GIT_AUTHOR_EMAIL
+            value: "gjkim042@gmail.com"
+          - name: GIT_COMMITTER_NAME
+            value: "Gunju Kim"
+          - name: GIT_COMMITTER_EMAIL
+            value: "gjkim042@gmail.com"
+      agentConfigRefs:
+        - name: base-agent
+    initialBranch: "open-actions-task-{{.Number}}"
+    initialPrompt: |
+      You are a coding agent. You either
+      - create a PR to fix the issue
+      - update an existing PR to fix the issue
+      - comment on the issue or the PR if you cannot fix it
+
+      Your workspace is backed by a PVC. Files remain available across follow-ups
+      and pod restarts while the Session and its PVC exist. Commit and push work
+      that must outlive the Session.
+
+      Webhook:
+      - Event: {{.Event}}
+      - Action: {{.Action}}
+      - Sender: {{.Sender}}
+      - URL: {{.URL}}
+
+      Task:
+      - 0. Refresh the latest issue state:
+        - Re-read the issue and all comments: `gh issue view {{.Number}} --comments`
+      - 1. Set up your working branch. Run this exactly:
+        ```
+        git fetch --unshallow || true; git fetch origin main; git rebase origin/main
+        ```
+      - 2. Check if a PR already exists for branch open-actions-task-{{.Number}}.
+
+      If a PR already exists:
+      - 3a. Read ALL review comments and conversation on the PR (gh pr view, gh api for review comments).
+        - Also read ALL comments on the linked issue (gh issue view {{.Number}} --comments), not just the PR.
+      - 4a. Read the existing diff (git diff main...HEAD) to understand what has already been done. Do NOT start over or rewrite from scratch.
+      - 5a. Make only the incremental changes needed to address review feedback or remaining issues. Preserve existing work.
+      - 6a. Commit and push your changes to origin open-actions-task-{{.Number}}.
+      - 7a. Run a local review of the PR diff against `origin/main` using the review tool available in the current environment. If no dedicated review tool is available, manually inspect the diff for correctness. If issues are found, fix them, run `make verify` and `make test`, commit and push, then repeat the local review. Continue until the local review passes.
+      - 8a. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #{{.Number}}` or `Closes #{{.Number}}`). Do not embed the issue number in natural language. Ensure the PR has the label "generated-by-kelos" (use `gh pr edit open-actions-task-{{.Number}} --add-label generated-by-kelos` if missing).
+      - 9a. After pushing, actively check CI status with `gh pr checks`. If any checks fail, investigate the failures, fix them, commit and push, then check again.
+      - 10a. If the branch has more than one commit (`[ "$(git rev-list --count origin/main..HEAD)" -gt 1 ]`), squash all commits on the branch into a single commit before requesting external review. Use `git reset --soft $(git merge-base HEAD origin/main)` followed by `git commit` and `git push --force-with-lease origin open-actions-task-{{.Number}}`. Do not use `git rebase -i` — interactive commands are not supported. Skip the squash and force-push entirely if the branch is already a single commit, to avoid an unnecessary CI re-run.
+      - 11a. After the squash + force-push (if any), actively check CI status with `gh pr checks` again. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request external review until CI passes. Then request a review by posting a comment on the PR — `/kelos api-review` if `git diff origin/main...HEAD --name-only` includes any path under `api/` (CRD types, kubebuilder markers, generated CRD YAML), otherwise `/kelos review`. Use `gh pr comment open-actions-task-{{.Number}} --body "/kelos api-review"` (or `--body "/kelos review"`). The dedicated reviewer agents will post their findings asynchronously as a sticky PR comment.
+
+      If no PR exists:
+      - 3b. Investigate the issue #{{.Number}}.
+        - Read ALL comments on the issue (gh issue view {{.Number}} --comments), including maintainer feedback and linked issues/PRs.
+        - If previous PRs for this issue were closed, read their reviews to understand why before choosing your approach.
+        - Search the codebase for existing constants, types, and patterns before creating new ones. Do not duplicate definitions.
+        - Only implement what the issue explicitly asks for. If you discover related improvements, create separate issues for them.
+      - 4b. Create a commit that fixes the issue.
+      - 5b. Push your branch to origin open-actions-task-{{.Number}}.
+      - 6b. Create a PR with the label "generated-by-kelos" (use `gh pr create --label generated-by-kelos`).
+      - 7b. Run a local review of your diff against `origin/main` using the review tool available in the current environment. If no dedicated review tool is available, manually inspect the diff for correctness. If issues are found, fix them, run `make verify` and `make test`, commit and push, then repeat the local review. Continue until the local review passes.
+      - 8b. Update the PR title and description to reflect the final diff. The PR body MUST contain a standard closing keyword reference on its own line (e.g., `Fixes #{{.Number}}` or `Closes #{{.Number}}`). Do not embed the issue number in natural language.
+      - 9b. After pushing, actively check CI status with `gh pr checks`. If any checks fail, investigate the failures, fix them, commit and push, then check again.
+      - 10b. If the branch has more than one commit (`[ "$(git rev-list --count origin/main..HEAD)" -gt 1 ]`), squash all commits on the branch into a single commit before requesting external review. Use `git reset --soft $(git merge-base HEAD origin/main)` followed by `git commit` and `git push --force-with-lease origin open-actions-task-{{.Number}}`. Do not use `git rebase -i` — interactive commands are not supported. Skip the squash and force-push entirely if the branch is already a single commit, to avoid an unnecessary CI re-run.
+      - 11b. After the squash + force-push (if any), actively check CI status with `gh pr checks` again. If any checks fail, investigate the failures, fix them, commit and push, then check again. Do not request external review until CI passes. Then request a review by posting a comment on the PR — `/kelos api-review` if `git diff origin/main...HEAD --name-only` includes any path under `api/` (CRD types, kubebuilder markers, generated CRD YAML), otherwise `/kelos review`. Use `gh pr comment open-actions-task-{{.Number}} --body "/kelos api-review"` (or `--body "/kelos review"`). The dedicated reviewer agents will post their findings asynchronously as a sticky PR comment.
+
+      Post-checklist:
+      - Post a plain-English status comment on the issue (`gh issue comment {{.Number}} --body "..."`) for any of the following situations, explaining what happened:
+        - The PR is ready for review.
+        - You commented on the issue or the PR for more information.
+        - You cannot make any progress on the issue, explain why.
+      - If you find follow-up work outside the current issue scope, you may
+        create a separate GitHub issue:
+        - First check existing issues with `gh issue list` to avoid duplicates.
+        - Keep the follow-up narrowly scoped and label it `generated-by-kelos`.
+        - Follow-up issues are exempt from autonomous discovery issue slot caps.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Ports the remaining self-development spawners to `self-development/open-actions/`, which so far only had the general and API reviewers. Following the `kanon/` layout, this adds:

- **SessionSpawners**: `open-actions-workers` (issue pick-up) and `open-actions-pr-responder` (PR pick-up), both on the existing `open-actions-session-agent` Workspace with a 10 Gi PVC.
- **Webhook TaskSpawners**: `open-actions-planner` (`/kelos plan`), `open-actions-triage` (issue opened/reopened), and `open-actions-squash-commits` (`/kelos squash-commits`).
- **Cron TaskSpawners**: `open-actions-fake-user`, `open-actions-fake-strategist`, and the two meta-maintenance spawners `open-actions-config-update` / `open-actions-self-update`, which run on the `kelos-agent` Workspace because the files they maintain live in this repository.
- `agentconfig.yaml` defining the shared `open-actions-dev-agent` role instructions used by triage and squash-commits.

Prompts are adapted to Open Actions specifics: the worker hands off to `/kelos api-review` when the diff touches `api/`, triage/planner treat CRD fields, controller flags, the webhook contract, and the supported workflow subset as user-facing API surface, and file references point at paths that exist in that repository (`api/v1alpha1/`, `config/samples/`, `README.md`).

The manifest test suite in `internal/examples/self_development_test.go` is extended to cover the whole directory (agentConfig refs, pod failure policy, PVC settings, webhook filters and command patterns, sticky comment flow, issue slot commands, and effort), including the two pre-existing reviewer spawners that were not covered before. The READMEs are updated to document the fleet, its prerequisites (repository labels, webhook delivery), and the directory's new scope.

The `Apply Open Actions self-development resources` step in `deploy-dev.yaml` already applies the whole directory, so no workflow change is needed.

Not ported: `kelos-image-update` (Open Actions builds its own controller and runner images in-repo; there are no coding-agent Dockerfiles to bump).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Before the new spawners can act on `kelos-dev/open-actions`, the repository needs one-time setup documented in `self-development/open-actions/README.md`: the custom labels (`generated-by-kelos`, `kind/*`, `priority/*`, `actor/*`, lifecycle labels — the repo currently has only GitHub defaults) and a repository webhook subscribed to `issues`, `issue_comment`, and `pull_request_review`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the full spawner fleet for `kelos-dev/open-actions` to automate triage, planning, worker/PR sessions, squash-commits, and maintenance. Reviewer prompts now read API details from `README.md`; tests cover the entire directory. No workflow changes.

- **New Features**
  - Session spawners: workers + PR responder on `open-actions-session-agent` (10Gi PVC).
  - Webhook/cron spawners: planner (`/kelos plan`), triage, squash-commits; fake-user, fake-strategist, config-update, self-update.
  - Shared `open-actions-dev-agent` for triage and squash-commits; workers hand off to `/kelos api-review` when `api/` changes.
  - `config-update` and `self-update` run on `kelos-agent` to edit this repo’s config while learning from `kelos-dev/open-actions`.

- **Migration**
  - One-time setup in `self-development/open-actions/README.md`: add required labels and a webhook for `issues`, `issue_comment`, and `pull_request_review`.

<sup>Written for commit b169c1a230e2b2a270a53a59e876e98780f8210c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

