### PR TITLE
Keep Session status within phone viewport

### DIFF
--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -659,6 +659,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"phone safe-area padding":    `env(safe-area-inset-bottom)`,
 		"non-zooming form fields":    `.composer textarea, .yaml-panel textarea, .form-grid input`,
 		"phone-sized dialog":         `max-height: calc(100dvh - 16px`,
+		"shrinking composer content": `.composer-wrap { min-width: 0;`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session styles are missing %s: %s", description, expected)

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -250,7 +250,7 @@ button { color: inherit; }
 .turn-divider:not(:empty)::before, .turn-divider:not(:empty)::after { height: 1px; background: var(--line); content: ""; }
 .turn-divider:not(:empty)::before { flex: 0 0 10px; }
 .turn-divider:not(:empty)::after { flex: 1; }
-.composer-wrap { padding: 12px max(24px, calc((100% - 850px) / 2)) 19px; background: linear-gradient(transparent, var(--canvas) 20%); }
+.composer-wrap { min-width: 0; padding: 12px max(24px, calc((100% - 850px) / 2)) 19px; background: linear-gradient(transparent, var(--canvas) 20%); }
 .session-progress { display: flex; align-items: center; gap: 5px; min-height: 18px; margin: 0 4px 7px; color: var(--muted); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; }
 .session-progress[hidden] { display: none; }
 .session-progress-dot { color: var(--accent-2); animation: pulse 1.1s infinite; }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Session server's runtime status is rendered as one non-wrapping line beneath the composer. Because the composer footer kept its automatic minimum width as a grid item, that status line could widen the entire application beyond a phone viewport before its ellipsis styling took effect.

This change allows the composer footer to shrink within the Session layout, keeping the page at the viewport width while the existing runtime-status ellipsis clips the additional details. It also extends the phone-layout contract test to cover the width constraint.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `make test` — `internal/sessionserver` passes; the full target still reports the unrelated existing `TestCodexEntrypointUsesPersistentSessionHome` and Codex `TestAgentEntrypointsPreserveSkillReferenceFiles` failures in `internal/controller`
- Browser layout reproduction at a 320 px viewport: the representative runtime status widened the document to 794 px before the fix and remains within 320 px with this change

#### Does this PR introduce a user-facing change?

```release-note
Fixed the Session web interface expanding beyond phone viewports when runtime status is displayed.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Session UI overflowing on phones when the runtime status line is long. The layout now stays within the viewport by allowing the composer footer to shrink.

- **Bug Fixes**
  - Set `.composer-wrap { min-width: 0; }` so the status line truncates without expanding the grid.
  - Extended the phone-layout contract test to assert the shrinking composer rule.

<sup>Written for commit 705cd796eafb3ff043707fd290d39afb212ee8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

