### PR TITLE
Bound Session workload names

### DIFF
--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -51,8 +51,10 @@ const (
 	sessionNameAnnotation             = "kelos.dev/session-name"
 	sessionPluginChecksumAnnotation   = "kelos.dev/plugin-content-checksum"
 	sessionTokenFingerprintAnnotation = "kelos.dev/github-token-mint-fingerprint"
-	idleResumeAcknowledgementGrace    = 5 * time.Second
-	idleResumeRequestTimeout          = 10 * time.Minute
+	// ControllerRevision names append a hyphen and up to 10 hash characters and are used as Pod label values.
+	sessionWorkloadNameMaxLength   = 52
+	idleResumeAcknowledgementGrace = 5 * time.Second
+	idleResumeRequestTimeout       = 10 * time.Minute
 )
 
 // SessionReconciler reconciles a Session object.
@@ -1854,7 +1856,7 @@ func buildSessionService(session *kelos.Session) *corev1.Service {
 }
 
 func sessionWorkloadName(session *kelos.Session) string {
-	return truncateResourceName("session-" + session.Name)
+	return truncateResourceNameTo("session-"+session.Name, sessionWorkloadNameMaxLength)
 }
 
 func sessionSelectorLabels(session *kelos.Session) map[string]string {

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -1866,15 +1866,29 @@ func TestSessionGitHubTokenSecretNameBoundsLongNames(t *testing.T) {
 	}
 }
 
-func TestSessionWorkloadNameBoundsLongNames(t *testing.T) {
+func TestSessionWorkloadNameBoundsStatefulSetRevisionLabel(t *testing.T) {
 	t.Parallel()
-	session := testSession(strings.Repeat("a", 253), "codex")
-	name := sessionWorkloadName(session)
-	if len(name) > 63 {
-		t.Fatalf("Session workload name length = %d, want at most 63", len(name))
+	if got := sessionWorkloadName(testSession("chat", "codex")); got != "session-chat" {
+		t.Fatalf("Session workload name = %q, want %q", got, "session-chat")
 	}
-	if name != sessionWorkloadName(session) {
-		t.Fatal("Session workload name is not deterministic")
+
+	for _, sessionName := range []string{
+		"open-actions-workers-issue-comment-bbc08c8a77c3",
+		strings.Repeat("a", 253),
+	} {
+		session := testSession(sessionName, "codex")
+		name := sessionWorkloadName(session)
+		if len(name) > sessionWorkloadNameMaxLength {
+			t.Fatalf("Session workload name length = %d, want at most %d", len(name), sessionWorkloadNameMaxLength)
+		}
+		if name != sessionWorkloadName(session) {
+			t.Fatal("Session workload name is not deterministic")
+		}
+	}
+
+	if sessionWorkloadName(testSession(strings.Repeat("a", 253), "codex")) ==
+		sessionWorkloadName(testSession(strings.Repeat("b", 253), "codex")) {
+		t.Fatal("different Session names produced the same workload name")
 	}
 }
 

--- a/internal/controller/workerpool_controller.go
+++ b/internal/controller/workerpool_controller.go
@@ -1838,11 +1838,15 @@ func poolWorkerCredentialsSecretName(pool *kelos.WorkerPool) string {
 }
 
 func truncateResourceName(name string) string {
-	if len(name) <= 63 {
+	return truncateResourceNameTo(name, 63)
+}
+
+func truncateResourceNameTo(name string, maxLength int) string {
+	if len(name) <= maxLength {
 		return name
 	}
 	sum := sha1.Sum([]byte(name))
 	suffix := hex.EncodeToString(sum[:])[:8]
-	maxPrefixLen := 63 - len(suffix) - 1
+	maxPrefixLen := maxLength - len(suffix) - 1
 	return name[:maxPrefixLen] + "-" + suffix
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Bounds generated Session StatefulSet and governing Service names to 52 characters while preserving the established `session-<name>` identity. Names within that bound remain unchanged; longer names use the existing stable hash suffix.

Kubernetes appends a hyphen and an up-to-10-character revision hash to a StatefulSet name and stores the result in a Pod label limited to 63 characters. The generic 63-character resource-name bound did not reserve space for that suffix, so Pods for long Session names failed validation.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make test TEST_FLAGS='-run TestSession'`
- `make verify`

Existing Session workload and workspace PVC names within the safe bound remain unchanged. Only names that could exceed StatefulSet-generated label limits are shortened.

#### Does this PR introduce a user-facing change?

```release-note
Session workload names retain the `session-` prefix and are now truncated to 52 characters when necessary, reserving room for StatefulSet revision hashes and preventing Pod label validation failures.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound Session workload names to prevent Kubernetes label overflows while keeping the `session-` prefix. StatefulSets, Services, and Pods now use a truncated `session-<name>` (max 52 chars) so `controller-revision-hash` labels stay within limits.

- **Bug Fixes**
  - Enforce `sessionWorkloadNameMaxLength=52` via `truncateResourceNameTo` to leave room for the 10-char revision hash.
  - Updated selectors and tests for determinism, bounds, and collision checks.

- **Migration**
  - No migration. Existing names remain; new names may be truncated if too long.

<sup>Written for commit 483d055cc0ca565abe3fd15d050a6af29c02eeaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


