### PR TITLE
Support file attachments in Sessions

### DIFF
--- a/cmd/kelos-session-runtime/main.go
+++ b/cmd/kelos-session-runtime/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -55,7 +56,7 @@ func main() {
 		return
 	}
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: kelos-session-runtime <serve|health|client>")
+		fmt.Fprintln(os.Stderr, "Usage: kelos-session-runtime <serve|health|client|attachment>")
 		os.Exit(2)
 	}
 
@@ -66,8 +67,63 @@ func main() {
 		runHealth()
 	case "client":
 		runClient()
+	case "attachment":
+		runAttachment()
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %q\n", os.Args[1])
+		os.Exit(2)
+	}
+}
+
+func runAttachment() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: kelos-session-runtime attachment <put|get>")
+		os.Exit(2)
+	}
+	store, err := sessionruntime.NewAttachmentStore(envOrDefault("KELOS_SESSION_STATE_DIR", sessionruntime.DefaultStateDir))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Creating Session attachment store failed: %v\n", err)
+		os.Exit(1)
+	}
+	switch os.Args[2] {
+	case "put":
+		flags := flag.NewFlagSet("attachment put", flag.ExitOnError)
+		name := flags.String("name", "", "Original attachment file name")
+		_ = flags.Parse(os.Args[3:])
+		if *name == "" {
+			fmt.Fprintln(os.Stderr, "Attachment name must not be empty")
+			os.Exit(2)
+		}
+		attachment, err := store.Put(*name, os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Storing Session attachment failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := json.NewEncoder(os.Stdout).Encode(attachment); err != nil {
+			fmt.Fprintf(os.Stderr, "Writing Session attachment metadata failed: %v\n", err)
+			os.Exit(1)
+		}
+	case "get":
+		if len(os.Args) != 4 {
+			fmt.Fprintln(os.Stderr, "Usage: kelos-session-runtime attachment get <id>")
+			os.Exit(2)
+		}
+		attachment, data, err := store.Open(os.Args[3])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Opening Session attachment failed: %v\n", err)
+			os.Exit(1)
+		}
+		defer data.Close()
+		if err := json.NewEncoder(os.Stdout).Encode(attachment); err != nil {
+			fmt.Fprintf(os.Stderr, "Writing Session attachment metadata failed: %v\n", err)
+			os.Exit(1)
+		}
+		if _, err := io.Copy(os.Stdout, data); err != nil {
+			fmt.Fprintf(os.Stderr, "Writing Session attachment data failed: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown attachment command %q\n", os.Args[2])
 		os.Exit(2)
 	}
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -241,6 +241,17 @@ press Enter to send a message, Ctrl+J to insert a newline, and Ctrl+C or Esc to
 interrupt an active turn. Ctrl+C exits the terminal client when no turn is
 active. The terminal initially loads a bounded page of recent transcript items.
 Use `/history` or Page Up to load the previous page.
+Attach a local file with `/attach PATH`; the next message includes all staged
+files. In the interactive terminal UI, dragging a file into a terminal that
+supports bracketed paste stages the file directly. Use `/send` in the plain
+terminal to send staged files without message text. The web composer accepts
+files from its attachment button or by drag and drop. Each message supports up
+to eight files of 10 MiB each. A Session retains up to 128 attachments and 100
+MiB of attachment data. Attachments share the Session workspace lifecycle, so
+they survive Pod replacement only when `spec.volumeClaimTemplate` is configured
+and are removed by Session reset or deletion. Retained messages show attachment
+names, and the web client provides authenticated previews or downloads while
+the Session is ready.
 The terminal client shows live connecting, reconnecting, working,
 waiting-for-input, and interrupting progress with elapsed time. After a
 completed turn, both interactive and plain terminal output show a `Worked for

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/sessionattachment"
 	"github.com/kelos-dev/kelos/internal/sessionruntime"
 	"github.com/kelos-dev/kelos/internal/sessionsuspend"
 )
@@ -137,6 +138,7 @@ type sessionReconnectDependencies struct {
 	acknowledgeResume func(context.Context, string, string, string) error
 	openStream        func(context.Context, string, string, io.Writer) (*sessionPodStream, error)
 	runTerminal       func(context.Context, io.Reader, io.Writer, io.Reader, io.Writer, bool) error
+	uploadAttachment  func(context.Context, string, string, string) (sessionruntime.Attachment, error)
 }
 
 type sessionEventResult struct {
@@ -297,6 +299,10 @@ func connectSession(ctx context.Context, restConfig *rest.Config, namespace, nam
 	if err != nil {
 		return fmt.Errorf("creating Kubernetes client: %w", err)
 	}
+	attachmentClient, err := sessionattachment.New(restConfig)
+	if err != nil {
+		return err
+	}
 	dependencies := sessionReconnectDependencies{
 		getSession: func(ctx context.Context, namespace, name string) (*kelos.Session, error) {
 			session := &kelos.Session{}
@@ -326,6 +332,24 @@ func connectSession(ctx context.Context, restConfig *rest.Config, namespace, nam
 			return openSessionPodStream(ctx, restConfig, namespace, podName, diagnostics)
 		},
 		runTerminal: runSessionTerminal,
+		uploadAttachment: func(ctx context.Context, namespace, podName, path string) (sessionruntime.Attachment, error) {
+			file, err := os.Open(path)
+			if err != nil {
+				return sessionruntime.Attachment{}, fmt.Errorf("opening attachment %q: %w", path, err)
+			}
+			defer file.Close()
+			info, err := file.Stat()
+			if err != nil {
+				return sessionruntime.Attachment{}, fmt.Errorf("checking attachment %q: %w", path, err)
+			}
+			if !info.Mode().IsRegular() {
+				return sessionruntime.Attachment{}, fmt.Errorf("attachment %q is not a regular file", path)
+			}
+			if info.Size() > sessionruntime.MaxAttachmentBytes {
+				return sessionruntime.Attachment{}, fmt.Errorf("attachment %q exceeds the %d byte limit", path, sessionruntime.MaxAttachmentBytes)
+			}
+			return attachmentClient.Upload(ctx, namespace, podName, info.Name(), file)
+		},
 	}
 	return connectSessionWithDependencies(ctx, namespace, name, stdin, stdout, stderr, color, dependencies)
 }
@@ -538,6 +562,24 @@ func connectSessionWithDependencies(
 				return err
 			case request := <-requests:
 				if request.Type == "subscribe" {
+					continue
+				}
+				if request.Type == sessionTerminalRequestAttachment {
+					var event sessionruntime.Event
+					if dependencies.uploadAttachment == nil {
+						event = sessionruntime.Event{Type: sessionruntime.EventError, Text: "Session attachment upload is unavailable", Status: "rejected"}
+					} else {
+						attachment, err := dependencies.uploadAttachment(terminalCtx, namespace, session.Status.PodName, request.Text)
+						if err != nil {
+							event = sessionruntime.Event{Type: sessionruntime.EventError, Text: err.Error(), Status: "rejected"}
+						} else {
+							event = sessionruntime.Event{Type: sessionTerminalEventAttachmentAdded, Attachments: []sessionruntime.Attachment{attachment}}
+						}
+					}
+					if err := eventSink.send(event); err != nil {
+						stream.Close()
+						return err
+					}
 					continue
 				}
 				if request.RequestID == "" {

--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -18,7 +18,9 @@ import (
 )
 
 const (
-	sessionTerminalEventDiagnostic = "terminal.diagnostic"
+	sessionTerminalEventDiagnostic      = "terminal.diagnostic"
+	sessionTerminalEventAttachmentAdded = "terminal.attachment-added"
+	sessionTerminalRequestAttachment    = "terminal.attach"
 
 	sessionTerminalStatusConnected    = "connected"
 	sessionTerminalStatusConnecting   = "connecting"
@@ -188,6 +190,8 @@ func runSessionPlainTerminal(ctx context.Context, input io.Reader, output io.Wri
 func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, output io.Writer, decoder *json.Decoder, encoder *json.Encoder, color bool, terminalWidth func() int) error {
 	var writeMu sync.Mutex
 	var historyMu sync.Mutex
+	var attachmentMu sync.Mutex
+	pendingAttachments := make([]sessionruntime.Attachment, 0)
 	historyCursor := ""
 	pendingHistoryCursor := ""
 	historyLoading := false
@@ -297,7 +301,7 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				if event.HistoryState != nil && len(event.HistoryState.QueuedTurns) > 0 {
 					write("\n%s\n", formatter.muted("Queued messages:"))
 					for _, turn := range event.HistoryState.QueuedTurns {
-						write("%s\n", formatter.userMessage(turn.Text))
+						write("%s\n", formatter.userMessage(sessionTerminalMessageText(turn.Text, turn.Attachments)))
 					}
 				}
 				historyMu.Lock()
@@ -306,7 +310,7 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				if hasEarlierHistory {
 					write("\n%s\n", formatter.muted("Earlier Session history is available. Use /history to load the previous page."))
 				}
-				write("\n%s\n\n", formatter.muted("Connected. Type a message, /history, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
+				write("\n%s\n\n", formatter.muted("Connected. Type a message, /attach PATH, /history, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
 			case sessionruntime.EventRuntimeRecovered:
 				if !pageEvent {
 					recoveryActive = true
@@ -315,9 +319,16 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				write("%s\n", formatter.warning(event.Text))
 			case sessionruntime.EventUserMessage:
 				finishAssistant(assistant)
-				write("%s\n", formatter.userMessage(event.Text))
+				write("%s\n", formatter.userMessage(sessionTerminalMessageText(event.Text, event.Attachments)))
 				if color {
 					write("\n")
+				}
+			case sessionTerminalEventAttachmentAdded:
+				attachmentMu.Lock()
+				pendingAttachments = append(pendingAttachments, event.Attachments...)
+				attachmentMu.Unlock()
+				for _, attachment := range event.Attachments {
+					write("%s\n", formatter.muted(fmt.Sprintf("Attached %s (%d bytes). Send a message to include it.", attachment.Name, attachment.SizeBytes)))
 				}
 			case sessionruntime.EventTurnStarted:
 				if pageEvent {
@@ -448,6 +459,21 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 			if request.Type == "" {
 				continue
 			}
+			if request.Type == "message" {
+				attachmentMu.Lock()
+				if request.Text == "" && len(pendingAttachments) == 0 {
+					attachmentMu.Unlock()
+					continue
+				}
+				request.AttachmentIDs = sessionAttachmentIDs(pendingAttachments)
+				if err := encoder.Encode(request); err != nil {
+					attachmentMu.Unlock()
+					return err
+				}
+				pendingAttachments = nil
+				attachmentMu.Unlock()
+				continue
+			}
 			if err := encoder.Encode(request); err != nil {
 				return err
 			}
@@ -511,6 +537,16 @@ func formatSessionTurnSeparator(elapsed time.Duration, width int) string {
 
 func sessionTerminalRequest(line string) sessionruntime.ClientRequest {
 	line = strings.TrimSpace(line)
+	if line == "/send" {
+		return sessionruntime.ClientRequest{Type: "message"}
+	}
+	if strings.HasPrefix(line, "/attach ") {
+		path := strings.TrimSpace(strings.TrimPrefix(line, "/attach "))
+		if path != "" {
+			return sessionruntime.ClientRequest{Type: sessionTerminalRequestAttachment, Text: path}
+		}
+		return sessionruntime.ClientRequest{}
+	}
 	if line == "/interrupt" {
 		return sessionruntime.ClientRequest{Type: "interrupt"}
 	}
@@ -537,4 +573,27 @@ func sessionTerminalRequest(line string) sessionruntime.ClientRequest {
 		return sessionruntime.ClientRequest{}
 	}
 	return sessionruntime.ClientRequest{Type: "message", Text: line}
+}
+
+func sessionTerminalMessageText(text string, attachments []sessionruntime.Attachment) string {
+	if len(attachments) == 0 {
+		return text
+	}
+	names := make([]string, len(attachments))
+	for index := range attachments {
+		names[index] = attachments[index].Name
+	}
+	attachmentText := "Attachments: " + strings.Join(names, ", ")
+	if strings.TrimSpace(text) == "" {
+		return attachmentText
+	}
+	return text + "\n" + attachmentText
+}
+
+func sessionAttachmentIDs(attachments []sessionruntime.Attachment) []string {
+	ids := make([]string, len(attachments))
+	for index := range attachments {
+		ids[index] = attachments[index].ID
+	}
+	return ids
 }

--- a/internal/cli/session_terminal_test.go
+++ b/internal/cli/session_terminal_test.go
@@ -457,6 +457,8 @@ func TestSessionTerminalRequest(t *testing.T) {
 		want  sessionruntime.ClientRequest
 	}{
 		{input: "hello", want: sessionruntime.ClientRequest{Type: "message", Text: "hello"}},
+		{input: "/send", want: sessionruntime.ClientRequest{Type: "message"}},
+		{input: "/attach /tmp/screen shot.png", want: sessionruntime.ClientRequest{Type: sessionTerminalRequestAttachment, Text: "/tmp/screen shot.png"}},
 		{input: "/interrupt", want: sessionruntime.ClientRequest{Type: "interrupt"}},
 		{input: "/answer input-1 question-1 first, second", want: sessionruntime.ClientRequest{Type: "input", InputID: "input-1", Answers: map[string][]string{"question-1": {"first", "second"}}}},
 		{input: "/cancel-input input-2", want: sessionruntime.ClientRequest{Type: "input", InputID: "input-2", Cancel: true}},

--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -176,6 +177,7 @@ type sessionTUIModel struct {
 	quitRequested      bool
 	quitting           bool
 	runtimeStatus      sessionruntime.RuntimeStatus
+	pendingAttachments []sessionruntime.Attachment
 }
 
 func runSessionTUI(ctx context.Context, input io.Reader, output io.Writer, events *json.Decoder, requests *json.Encoder, color bool) error {
@@ -376,6 +378,11 @@ func (m *sessionTUIModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.quitRequested {
 			return m, nil
 		}
+		if message.Paste && m.ready {
+			if path, ok := sessionTerminalDroppedFile(string(message.Runes)); ok {
+				return m, m.attachFile(path)
+			}
+		}
 		switch message.Type {
 		case tea.KeyCtrlC:
 			if m.turnActive {
@@ -453,9 +460,20 @@ func (m *sessionTUIModel) submitInput() tea.Cmd {
 		return m.requestOlderHistory()
 	}
 	request := sessionTerminalRequest(line)
+	if request.Type == "" && len(m.pendingAttachments) > 0 && strings.TrimSpace(line) == "" {
+		request = sessionruntime.ClientRequest{Type: "message"}
+	}
 	if request.Type == "" {
 		m.input.Reset()
 		return nil
+	}
+	if request.Type == sessionTerminalRequestAttachment {
+		m.input.Reset()
+		m.resizeComposer()
+		return m.attachFile(request.Text)
+	}
+	if request.Type == "message" {
+		request.AttachmentIDs = sessionAttachmentIDs(m.pendingAttachments)
 	}
 	if err := m.requests.Encode(request); err != nil {
 		m.err = err
@@ -464,11 +482,50 @@ func (m *sessionTUIModel) submitInput() tea.Cmd {
 	if request.Type != "input" {
 		m.history = append(m.history, line)
 	}
+	if request.Type == "message" {
+		m.pendingAttachments = nil
+	}
 	m.historyAt = -1
 	m.draft = ""
 	m.input.Reset()
 	m.resizeComposer()
 	return nil
+}
+
+func (m *sessionTUIModel) attachFile(path string) tea.Cmd {
+	if len(m.pendingAttachments) >= sessionruntime.MaxAttachmentsPerMessage {
+		m.appendBlock(sessionTUIBlockError, fmt.Sprintf("error: a message supports at most %d attachments", sessionruntime.MaxAttachmentsPerMessage))
+		m.refreshActiveView()
+		return m.queueReadyBlocks()
+	}
+	if err := m.requests.Encode(sessionruntime.ClientRequest{Type: sessionTerminalRequestAttachment, Text: path}); err != nil {
+		m.err = err
+		return m.quit()
+	}
+	return nil
+}
+
+func sessionTerminalDroppedFile(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if strings.ContainsAny(value, "\r\n") {
+		return "", false
+	}
+	if strings.HasPrefix(value, "file://") {
+		parsed, err := url.Parse(value)
+		if err != nil || (parsed.Host != "" && parsed.Host != "localhost") {
+			return "", false
+		}
+		value = parsed.Path
+	}
+	if len(value) >= 2 && ((value[0] == '\'' && value[len(value)-1] == '\'') || (value[0] == '"' && value[len(value)-1] == '"')) {
+		value = value[1 : len(value)-1]
+	}
+	value = strings.ReplaceAll(value, `\ `, " ")
+	info, err := os.Stat(value)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > sessionruntime.MaxAttachmentBytes {
+		return "", false
+	}
+	return value, true
 }
 
 func (m *sessionTUIModel) previousInput() {
@@ -507,7 +564,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		if event.Type == sessionruntime.EventHistoryEnd && event.HistoryPage {
 			return m.finishOlderHistoryPage()
 		}
-		if event.Type == sessionTerminalEventDiagnostic || (event.Type == sessionruntime.EventHistoryStart && !event.HistoryPage) {
+		if event.Type == sessionTerminalEventDiagnostic || event.Type == sessionTerminalEventAttachmentAdded || (event.Type == sessionruntime.EventHistoryStart && !event.HistoryPage) {
 			m.cancelOlderHistoryPage()
 		} else {
 			m.historyPageEvents = append(m.historyPageEvents, event)
@@ -554,7 +611,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		// A terminal-height transcript in both the managed view and native scrollback
 		// makes Bubble Tea move the smaller footer to the top when the copy is removed.
 		m.hideNextHistory = !m.ready
-		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Ctrl+C quits when idle. Use /history or Page Up for earlier history, /answer INPUT QUESTION VALUE, or /quit.")
+		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Drag a file here or use /attach PATH. Use /history or Page Up for earlier history, /answer INPUT QUESTION VALUE, or /quit.")
 		m.ready = true
 		m.connectionStatus = ""
 		commands.ui = tea.Batch(m.input.Focus(), m.scheduleProgress())
@@ -579,9 +636,14 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 	case sessionruntime.EventUserMessage:
 		if event.TurnID == "" {
 			m.finishStreaming()
-			m.appendBlock(sessionTUIBlockUser, event.Text)
+			m.appendBlock(sessionTUIBlockUser, sessionTerminalMessageText(event.Text, event.Attachments))
 		} else {
-			m.appendQueuedUser(event.TurnID, event.Text)
+			m.appendQueuedUser(event.TurnID, sessionTerminalMessageText(event.Text, event.Attachments))
+		}
+	case sessionTerminalEventAttachmentAdded:
+		m.pendingAttachments = append(m.pendingAttachments, event.Attachments...)
+		for _, attachment := range event.Attachments {
+			m.appendBlock(sessionTUIBlockNotice, fmt.Sprintf("Attached %s (%d bytes). Send a message to include it.", attachment.Name, attachment.SizeBytes))
 		}
 	case sessionruntime.EventTurnStarted:
 		m.turnActive = true
@@ -676,7 +738,7 @@ func (m *sessionTUIModel) applyHistoryState(state *sessionruntime.HistoryState) 
 	m.queuedTurns = make(map[string]string, len(state.QueuedTurns))
 	m.queuedTurnOrder = make([]string, 0, len(state.QueuedTurns))
 	for _, turn := range state.QueuedTurns {
-		m.queuedTurns[turn.TurnID] = turn.Text
+		m.queuedTurns[turn.TurnID] = sessionTerminalMessageText(turn.Text, turn.Attachments)
 		m.queuedTurnOrder = append(m.queuedTurnOrder, turn.TurnID)
 	}
 	m.activeTurnID = state.ActiveTurnID
@@ -1321,6 +1383,14 @@ func (m *sessionTUIModel) composerView() string {
 		return blank + "\n" + loading + "\n" + blank
 	}
 	middle := strings.TrimSuffix(m.input.View(), "\n")
+	attachmentLine := ""
+	if len(m.pendingAttachments) > 0 {
+		names := make([]string, len(m.pendingAttachments))
+		for index := range m.pendingAttachments {
+			names[index] = m.pendingAttachments[index].Name
+		}
+		attachmentLine = m.renderUserRow("  " + m.styles.muted.Render("Attached: "+strings.Join(names, ", ")))
+	}
 	lines := strings.Split(middle, "\n")
 	continuation := strings.Repeat(" ", len(sessionTUIComposerPrompt))
 	for index := range lines {
@@ -1332,6 +1402,9 @@ func (m *sessionTUIModel) composerView() string {
 	}
 	middle = strings.Join(lines, "\n")
 	middle = m.renderUserRow(middle)
+	if attachmentLine != "" {
+		return attachmentLine + "\n" + middle + "\n" + blank
+	}
 	return blank + "\n" + middle + "\n" + blank
 }
 
@@ -1354,7 +1427,11 @@ func (m *sessionTUIModel) composerMaxHeight() int {
 }
 
 func (m *sessionTUIModel) composerHeight() int {
-	return m.input.Height() + sessionTUIComposerMinHeight - 1
+	height := m.input.Height() + sessionTUIComposerMinHeight - 1
+	if len(m.pendingAttachments) > 0 {
+		height++
+	}
+	return height
 }
 
 func (m *sessionTUIModel) footerHeight() int {

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -1196,6 +1197,44 @@ func TestSessionTUISubmittedTextRendersFromUserEventOnce(t *testing.T) {
 	}
 	if view := stripSessionTUIANSI(model.View()); strings.Contains(view, "hello") {
 		t.Fatalf("submitted text remains in inline view after commit: %q", view)
+	}
+}
+
+func TestSessionTUIDroppedFileIsAttachedToNextMessage(t *testing.T) {
+	path := t.TempDir() + "/screen shot.png"
+	if err := os.WriteFile(path, []byte("image"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	model, requests := newSessionTUITestModel()
+	model.ready = true
+	model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(path), Paste: true})
+	decoder := json.NewDecoder(requests)
+	var attachmentRequest sessionruntime.ClientRequest
+	if err := decoder.Decode(&attachmentRequest); err != nil {
+		t.Fatal(err)
+	}
+	if attachmentRequest.Type != sessionTerminalRequestAttachment || attachmentRequest.Text != path {
+		t.Fatalf("attachment request = %#v", attachmentRequest)
+	}
+
+	attachment := sessionruntime.Attachment{ID: "attachment-1", Name: "screen shot.png", MediaType: "image/png", SizeBytes: 5}
+	model.applyEvent(sessionruntime.Event{Type: sessionTerminalEventAttachmentAdded, Attachments: []sessionruntime.Attachment{attachment}})
+	if !strings.Contains(stripSessionTUIANSI(model.composerView()), "Attached: screen shot.png") {
+		t.Fatalf("composer = %q", stripSessionTUIANSI(model.composerView()))
+	}
+	model.input.SetValue("review this")
+	if cmd := model.submitInput(); cmd != nil {
+		t.Fatal("submitInput() returned a command")
+	}
+	var message sessionruntime.ClientRequest
+	if err := decoder.Decode(&message); err != nil {
+		t.Fatal(err)
+	}
+	if message.Type != "message" || message.Text != "review this" || !reflect.DeepEqual(message.AttachmentIDs, []string{"attachment-1"}) {
+		t.Fatalf("message request = %#v", message)
+	}
+	if len(model.pendingAttachments) != 0 {
+		t.Fatalf("pending attachments = %#v", model.pendingAttachments)
 	}
 }
 

--- a/internal/sessionattachment/client.go
+++ b/internal/sessionattachment/client.go
@@ -1,0 +1,115 @@
+package sessionattachment
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/sessionruntime"
+)
+
+const runtimeExecutable = "/kelos/bin/kelos-session-runtime"
+
+// Client transfers attachments through the Session Pod exec subresource.
+type Client struct {
+	clientset  kubernetes.Interface
+	restConfig *rest.Config
+}
+
+// New creates a Session attachment client.
+func New(restConfig *rest.Config) (*Client, error) {
+	if restConfig == nil {
+		return nil, errors.New("Kubernetes REST configuration must not be nil")
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+	return &Client{clientset: clientset, restConfig: restConfig}, nil
+}
+
+// Upload stores one attachment in a Session Pod.
+func (c *Client) Upload(ctx context.Context, namespace, podName, name string, source io.Reader) (sessionruntime.Attachment, error) {
+	var stdout bytes.Buffer
+	if err := c.stream(ctx, namespace, podName, []string{runtimeExecutable, "attachment", "put", "--name", name}, source, &stdout); err != nil {
+		return sessionruntime.Attachment{}, err
+	}
+	var attachment sessionruntime.Attachment
+	decoder := json.NewDecoder(&stdout)
+	if err := decoder.Decode(&attachment); err != nil {
+		return sessionruntime.Attachment{}, fmt.Errorf("decoding Session attachment metadata: %w", err)
+	}
+	if attachment.ID == "" || attachment.Name == "" || attachment.SizeBytes < 0 || attachment.SizeBytes > sessionruntime.MaxAttachmentBytes {
+		return sessionruntime.Attachment{}, errors.New("Session attachment metadata is invalid")
+	}
+	return attachment, nil
+}
+
+// Download loads one attachment and its metadata from a Session Pod.
+func (c *Client) Download(ctx context.Context, namespace, podName, id string) (sessionruntime.Attachment, []byte, error) {
+	var stdout bytes.Buffer
+	if err := c.stream(ctx, namespace, podName, []string{runtimeExecutable, "attachment", "get", id}, nil, &stdout); err != nil {
+		return sessionruntime.Attachment{}, nil, err
+	}
+	reader := bufio.NewReader(&stdout)
+	metadata, err := reader.ReadBytes('\n')
+	if err != nil {
+		return sessionruntime.Attachment{}, nil, fmt.Errorf("reading Session attachment metadata: %w", err)
+	}
+	var attachment sessionruntime.Attachment
+	if err := json.Unmarshal(metadata, &attachment); err != nil {
+		return sessionruntime.Attachment{}, nil, fmt.Errorf("decoding Session attachment metadata: %w", err)
+	}
+	data, err := io.ReadAll(io.LimitReader(reader, sessionruntime.MaxAttachmentBytes+1))
+	if err != nil {
+		return sessionruntime.Attachment{}, nil, fmt.Errorf("reading Session attachment data: %w", err)
+	}
+	if attachment.ID != id || int64(len(data)) != attachment.SizeBytes || int64(len(data)) > sessionruntime.MaxAttachmentBytes {
+		return sessionruntime.Attachment{}, nil, errors.New("Session attachment data is invalid")
+	}
+	return attachment, data, nil
+}
+
+func (c *Client) stream(ctx context.Context, namespace, podName string, command []string, stdin io.Reader, stdout io.Writer) error {
+	request := c.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("exec")
+	request.VersionedParams(&corev1.PodExecOptions{
+		Container: kelos.AgentContainerName,
+		Command:   command,
+		Stdin:     stdin != nil,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, clientgoscheme.ParameterCodec)
+	executor, err := remotecommand.NewSPDYExecutor(c.restConfig, "POST", request.URL())
+	if err != nil {
+		return fmt.Errorf("creating Session attachment exec connection: %w", err)
+	}
+	var stderr bytes.Buffer
+	if err := executor.StreamWithContext(ctx, remotecommand.StreamOptions{Stdin: stdin, Stdout: stdout, Stderr: &stderr}); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return fmt.Errorf("transferring Session attachment: %s: %w", message, err)
+		}
+		return fmt.Errorf("transferring Session attachment: %w", err)
+	}
+	if message := strings.TrimSpace(stderr.String()); message != "" {
+		return fmt.Errorf("transferring Session attachment: %s", message)
+	}
+	return nil
+}

--- a/internal/sessionruntime/attachment.go
+++ b/internal/sessionruntime/attachment.go
@@ -1,0 +1,315 @@
+package sessionruntime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	MaxAttachmentBytes         int64 = 10 * 1024 * 1024
+	MaxAttachmentsPerMessage         = 8
+	maxSessionAttachmentBytes  int64 = 100 * 1024 * 1024
+	maxSessionAttachmentCount        = 128
+	attachmentDirectoryName          = "attachments"
+	attachmentDataFileName           = "data"
+	attachmentMetadataFileName       = "metadata.json"
+)
+
+var (
+	ErrAttachmentNotFound      = errors.New("Session attachment not found")
+	ErrAttachmentTooLarge      = errors.New("Session attachment is too large")
+	ErrAttachmentQuotaExceeded = errors.New("Session attachment storage quota exceeded")
+)
+
+// Attachment describes one file supplied with a Session message.
+type Attachment struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	MediaType string `json:"mediaType"`
+	SizeBytes int64  `json:"sizeBytes"`
+}
+
+// ResolvedAttachment adds the runtime-local path used by provider adapters.
+type ResolvedAttachment struct {
+	Attachment
+	Path string `json:"-"`
+}
+
+// TurnInput is the provider-neutral input for one Session turn.
+type TurnInput struct {
+	Text        string
+	Attachments []ResolvedAttachment
+}
+
+// AttachmentStore persists Session attachments beneath the runtime state directory.
+type AttachmentStore struct {
+	directory string
+}
+
+// NewAttachmentStore constructs a store rooted in the Session state directory.
+func NewAttachmentStore(stateDir string) (*AttachmentStore, error) {
+	if strings.TrimSpace(stateDir) == "" {
+		return nil, errors.New("Session state directory must not be empty")
+	}
+	return &AttachmentStore{directory: filepath.Join(stateDir, attachmentDirectoryName)}, nil
+}
+
+// Put validates and atomically stores one attachment.
+func (s *AttachmentStore) Put(name string, source io.Reader) (Attachment, error) {
+	name, err := normalizeAttachmentName(name)
+	if err != nil {
+		return Attachment{}, err
+	}
+	if err := os.MkdirAll(s.directory, 0700); err != nil {
+		return Attachment{}, fmt.Errorf("creating Session attachment directory: %w", err)
+	}
+	lock, err := s.lock()
+	if err != nil {
+		return Attachment{}, err
+	}
+	defer func() {
+		_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+		_ = lock.Close()
+	}()
+	storedBytes, err := s.checkQuota()
+	if err != nil {
+		return Attachment{}, err
+	}
+
+	id := uuid.NewString()
+	temporary, err := os.MkdirTemp(s.directory, ".attachment-*")
+	if err != nil {
+		return Attachment{}, fmt.Errorf("creating temporary Session attachment: %w", err)
+	}
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.RemoveAll(temporary)
+		}
+	}()
+
+	dataPath := filepath.Join(temporary, attachmentDataFileName)
+	data, err := os.OpenFile(dataPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return Attachment{}, fmt.Errorf("creating Session attachment data: %w", err)
+	}
+	limited := io.LimitReader(source, MaxAttachmentBytes+1)
+	written, copyErr := io.Copy(data, limited)
+	closeErr := data.Close()
+	if copyErr != nil {
+		return Attachment{}, fmt.Errorf("writing Session attachment data: %w", copyErr)
+	}
+	if closeErr != nil {
+		return Attachment{}, fmt.Errorf("closing Session attachment data: %w", closeErr)
+	}
+	if written > MaxAttachmentBytes {
+		return Attachment{}, fmt.Errorf("%w: maximum size is %d bytes", ErrAttachmentTooLarge, MaxAttachmentBytes)
+	}
+	if storedBytes+written > maxSessionAttachmentBytes {
+		return Attachment{}, fmt.Errorf("%w: maximum is %d files or %d bytes", ErrAttachmentQuotaExceeded, maxSessionAttachmentCount, maxSessionAttachmentBytes)
+	}
+
+	mediaType, err := detectAttachmentMediaType(dataPath, name)
+	if err != nil {
+		return Attachment{}, err
+	}
+	attachment := Attachment{ID: id, Name: name, MediaType: mediaType, SizeBytes: written}
+	metadata, err := json.Marshal(attachment)
+	if err != nil {
+		return Attachment{}, fmt.Errorf("encoding Session attachment metadata: %w", err)
+	}
+	metadata = append(metadata, '\n')
+	if err := os.WriteFile(filepath.Join(temporary, attachmentMetadataFileName), metadata, 0600); err != nil {
+		return Attachment{}, fmt.Errorf("writing Session attachment metadata: %w", err)
+	}
+	if err := os.Rename(temporary, filepath.Join(s.directory, id)); err != nil {
+		return Attachment{}, fmt.Errorf("committing Session attachment: %w", err)
+	}
+	removeTemporary = false
+	return attachment, nil
+}
+
+func (s *AttachmentStore) lock() (*os.File, error) {
+	lock, err := os.OpenFile(filepath.Join(s.directory, ".lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("opening Session attachment lock: %w", err)
+	}
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX); err != nil {
+		_ = lock.Close()
+		return nil, fmt.Errorf("locking Session attachment store: %w", err)
+	}
+	return lock, nil
+}
+
+// Open validates metadata and opens an attachment for reading.
+func (s *AttachmentStore) Open(id string) (Attachment, *os.File, error) {
+	if _, err := uuid.Parse(id); err != nil {
+		return Attachment{}, nil, ErrAttachmentNotFound
+	}
+	directory := filepath.Join(s.directory, id)
+	metadata, err := os.ReadFile(filepath.Join(directory, attachmentMetadataFileName))
+	if errors.Is(err, os.ErrNotExist) {
+		return Attachment{}, nil, ErrAttachmentNotFound
+	}
+	if err != nil {
+		return Attachment{}, nil, fmt.Errorf("reading Session attachment metadata: %w", err)
+	}
+	var attachment Attachment
+	if err := json.Unmarshal(metadata, &attachment); err != nil {
+		return Attachment{}, nil, fmt.Errorf("decoding Session attachment metadata: %w", err)
+	}
+	if attachment.ID != id || attachment.Name == "" || attachment.MediaType == "" || attachment.SizeBytes < 0 || attachment.SizeBytes > MaxAttachmentBytes {
+		return Attachment{}, nil, errors.New("Session attachment metadata is invalid")
+	}
+	data, err := os.Open(filepath.Join(directory, attachmentDataFileName))
+	if errors.Is(err, os.ErrNotExist) {
+		return Attachment{}, nil, ErrAttachmentNotFound
+	}
+	if err != nil {
+		return Attachment{}, nil, fmt.Errorf("opening Session attachment data: %w", err)
+	}
+	info, err := data.Stat()
+	if err != nil {
+		_ = data.Close()
+		return Attachment{}, nil, fmt.Errorf("checking Session attachment data: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != attachment.SizeBytes {
+		_ = data.Close()
+		return Attachment{}, nil, errors.New("Session attachment data is invalid")
+	}
+	return attachment, data, nil
+}
+
+// Resolve loads attachment metadata and local paths for one provider turn.
+func (s *AttachmentStore) Resolve(ids []string) ([]ResolvedAttachment, error) {
+	if len(ids) > MaxAttachmentsPerMessage {
+		return nil, fmt.Errorf("a Session message supports at most %d attachments", MaxAttachmentsPerMessage)
+	}
+	resolved := make([]ResolvedAttachment, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, exists := seen[id]; exists {
+			return nil, fmt.Errorf("Session attachment %q is repeated", id)
+		}
+		seen[id] = struct{}{}
+		attachment, data, err := s.Open(id)
+		if err != nil {
+			return nil, fmt.Errorf("resolving Session attachment %q: %w", id, err)
+		}
+		_ = data.Close()
+		resolved = append(resolved, ResolvedAttachment{
+			Attachment: attachment,
+			Path:       filepath.Join(s.directory, id, attachmentDataFileName),
+		})
+	}
+	return resolved, nil
+}
+
+func (s *AttachmentStore) checkQuota() (int64, error) {
+	entries, err := os.ReadDir(s.directory)
+	if err != nil {
+		return 0, fmt.Errorf("listing Session attachments: %w", err)
+	}
+	count := 0
+	var size int64
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(s.directory, entry.Name(), attachmentDataFileName))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return 0, fmt.Errorf("checking Session attachment quota: %w", err)
+		}
+		count++
+		size += info.Size()
+	}
+	if count >= maxSessionAttachmentCount {
+		return 0, fmt.Errorf("%w: maximum is %d files or %d bytes", ErrAttachmentQuotaExceeded, maxSessionAttachmentCount, maxSessionAttachmentBytes)
+	}
+	return size, nil
+}
+
+func normalizeAttachmentName(name string) (string, error) {
+	name = strings.TrimSpace(strings.ReplaceAll(name, "\\", "/"))
+	name = filepath.Base(name)
+	if name == "" || name == "." || name == ".." || !utf8.ValidString(name) {
+		return "", errors.New("Session attachment name is invalid")
+	}
+	if len(name) > 255 {
+		return "", errors.New("Session attachment name must be at most 255 bytes")
+	}
+	for _, character := range name {
+		if unicode.IsControl(character) {
+			return "", errors.New("Session attachment name must not contain control characters")
+		}
+	}
+	return name, nil
+}
+
+func detectAttachmentMediaType(path, name string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening Session attachment for media detection: %w", err)
+	}
+	defer file.Close()
+	header := make([]byte, 512)
+	read, err := file.Read(header)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("reading Session attachment for media detection: %w", err)
+	}
+	mediaType := http.DetectContentType(header[:read])
+	if mediaType == "application/octet-stream" {
+		if extensionType := mime.TypeByExtension(strings.ToLower(filepath.Ext(name))); extensionType != "" {
+			if parsed, _, err := mime.ParseMediaType(extensionType); err == nil && !strings.HasPrefix(parsed, "image/") {
+				mediaType = parsed
+			}
+		}
+	}
+	if parsed, _, err := mime.ParseMediaType(mediaType); err == nil {
+		mediaType = parsed
+	}
+	return mediaType, nil
+}
+
+func attachmentPrompt(input TurnInput) string {
+	if len(input.Attachments) == 0 {
+		return input.Text
+	}
+	var builder strings.Builder
+	if strings.TrimSpace(input.Text) != "" {
+		builder.WriteString(input.Text)
+		builder.WriteString("\n\n")
+	}
+	builder.WriteString("The user attached these local files:\n")
+	for _, attachment := range input.Attachments {
+		fmt.Fprintf(&builder, "- %s (%s): %s\n", attachment.Name, attachment.MediaType, attachment.Path)
+	}
+	if strings.TrimSpace(input.Text) == "" {
+		builder.WriteString("Inspect the attached files and respond to the user.")
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func nativeImageAttachment(mediaType string) bool {
+	switch mediaType {
+	case "image/gif", "image/jpeg", "image/png", "image/webp":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sessionruntime/attachment_test.go
+++ b/internal/sessionruntime/attachment_test.go
@@ -1,0 +1,139 @@
+package sessionruntime
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAttachmentStorePutOpenAndResolve(t *testing.T) {
+	store, err := NewAttachmentStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := []byte("\x89PNG\r\n\x1a\n")
+	attachment, err := store.Put("../screen.png", bytes.NewReader(contents))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attachment.Name != "screen.png" || attachment.MediaType != "image/png" || attachment.SizeBytes != int64(len(contents)) {
+		t.Fatalf("attachment = %#v", attachment)
+	}
+
+	opened, data, err := store.Open(attachment.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer data.Close()
+	readContents, err := io.ReadAll(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opened != attachment || !bytes.Equal(readContents, contents) {
+		t.Fatalf("opened attachment = %#v data = %q", opened, readContents)
+	}
+
+	resolved, err := store.Resolve([]string{attachment.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolved) != 1 || resolved[0].Attachment != attachment || filepath.Base(resolved[0].Path) != attachmentDataFileName {
+		t.Fatalf("resolved attachments = %#v", resolved)
+	}
+}
+
+func TestAttachmentStoreRejectsOversizedInputAndCleansTemporaryData(t *testing.T) {
+	stateDir := t.TempDir()
+	store, err := NewAttachmentStore(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Put("large.bin", io.LimitReader(zeroReader{}, MaxAttachmentBytes+1))
+	if !errors.Is(err, ErrAttachmentTooLarge) {
+		t.Fatalf("Put() error = %v, want ErrAttachmentTooLarge", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(stateDir, attachmentDirectoryName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != ".lock" {
+			t.Fatalf("attachment directory contains %q after rejected upload", entry.Name())
+		}
+	}
+}
+
+func TestAttachmentStoreRejectsInvalidMetadataAndIdentifiers(t *testing.T) {
+	store, err := NewAttachmentStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Open("../../secret"); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("Open() error = %v, want ErrAttachmentNotFound", err)
+	}
+	if _, err := store.Put("bad\nname", strings.NewReader("data")); err == nil {
+		t.Fatal("Put() accepted a control character in the attachment name")
+	}
+}
+
+func TestAttachmentStoreEnforcesSessionFileQuota(t *testing.T) {
+	store, err := NewAttachmentStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < maxSessionAttachmentCount; index++ {
+		if _, err := store.Put(fmt.Sprintf("file-%03d.txt", index), strings.NewReader("data")); err != nil {
+			t.Fatalf("Put() attachment %d: %v", index, err)
+		}
+	}
+	if _, err := store.Put("over-quota.txt", strings.NewReader("data")); !errors.Is(err, ErrAttachmentQuotaExceeded) {
+		t.Fatalf("Put() error = %v, want ErrAttachmentQuotaExceeded", err)
+	}
+}
+
+func TestAttachmentPromptIncludesFilesAndSupportsFileOnlyInput(t *testing.T) {
+	input := TurnInput{Attachments: []ResolvedAttachment{{
+		Attachment: Attachment{Name: "screen.png", MediaType: "image/png"},
+		Path:       "/workspace/.kelos/session/attachments/id/data",
+	}}}
+	prompt := attachmentPrompt(input)
+	for _, expected := range []string{"screen.png", "image/png", input.Attachments[0].Path, "Inspect the attached files"} {
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("attachmentPrompt() = %q, want %q", prompt, expected)
+		}
+	}
+}
+
+func TestCodexTurnInputUsesNativeRasterImages(t *testing.T) {
+	input := TurnInput{
+		Text: "review these",
+		Attachments: []ResolvedAttachment{
+			{Attachment: Attachment{Name: "screen.png", MediaType: "image/png"}, Path: "/attachments/image/data"},
+			{Attachment: Attachment{Name: "notes.txt", MediaType: "text/plain"}, Path: "/attachments/text/data"},
+		},
+	}
+	items := codexTurnInputItems(input)
+	if len(items) != 2 {
+		t.Fatalf("Codex input items = %#v", items)
+	}
+	if items[1]["type"] != "localImage" || items[1]["path"] != input.Attachments[0].Path {
+		t.Fatalf("Codex image input = %#v", items[1])
+	}
+	if !strings.Contains(items[0]["text"].(string), input.Attachments[1].Path) {
+		t.Fatalf("Codex text input = %#v", items[0])
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(buffer []byte) (int, error) {
+	for index := range buffer {
+		buffer[index] = 0
+	}
+	return len(buffer), nil
+}

--- a/internal/sessionruntime/claude.go
+++ b/internal/sessionruntime/claude.go
@@ -151,7 +151,7 @@ func claudeCommandArgs(config ProviderConfig, sessionID string, resume bool) []s
 }
 
 // RunTurn sends one prompt while keeping the Claude Code process alive between turns.
-func (p *ClaudeProvider) RunTurn(ctx context.Context, prompt string, sink EventSink) error {
+func (p *ClaudeProvider) RunTurn(ctx context.Context, input TurnInput, sink EventSink) error {
 	p.turnMu.Lock()
 	defer p.turnMu.Unlock()
 
@@ -190,7 +190,7 @@ func (p *ClaudeProvider) RunTurn(ctx context.Context, prompt string, sink EventS
 			"role": "user",
 			"content": []map[string]string{{
 				"type": "text",
-				"text": prompt,
+				"text": attachmentPrompt(input),
 			}},
 		},
 		"parent_tool_use_id": nil,

--- a/internal/sessionruntime/codex.go
+++ b/internal/sessionruntime/codex.go
@@ -271,7 +271,7 @@ func codexTurnID(result json.RawMessage) string {
 }
 
 // RunTurn starts one Codex turn and waits for its completion notification.
-func (p *CodexProvider) RunTurn(ctx context.Context, prompt string, sink EventSink) error {
+func (p *CodexProvider) RunTurn(ctx context.Context, input TurnInput, sink EventSink) error {
 	p.turnMu.Lock()
 	defer p.turnMu.Unlock()
 
@@ -305,10 +305,7 @@ func (p *CodexProvider) RunTurn(ctx context.Context, prompt string, sink EventSi
 
 	params := map[string]any{
 		"threadId": p.threadID,
-		"input": []map[string]any{{
-			"type": "text",
-			"text": prompt,
-		}},
+		"input":    codexTurnInputItems(input),
 	}
 	if p.config.Model != "" {
 		params["model"] = p.config.Model
@@ -349,6 +346,19 @@ func (p *CodexProvider) RunTurn(ctx context.Context, prompt string, sink EventSi
 		}
 		return errors.New("Codex app-server stopped")
 	}
+}
+
+func codexTurnInputItems(input TurnInput) []map[string]any {
+	items := []map[string]any{{
+		"type": "text",
+		"text": attachmentPrompt(input),
+	}}
+	for _, attachment := range input.Attachments {
+		if nativeImageAttachment(attachment.MediaType) {
+			items = append(items, map[string]any{"type": "localImage", "path": attachment.Path})
+		}
+	}
+	return items
 }
 
 // Interrupt stops the active Codex turn without closing its thread.

--- a/internal/sessionruntime/history.go
+++ b/internal/sessionruntime/history.go
@@ -116,7 +116,11 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 			activeEventID = turn.activityEventID
 		}
 		if turn.user != nil && !turn.started && turn.activityEventID == 0 && !turn.completed {
-			queued = append(queued, HistoryQueuedTurn{TurnID: turnID, Text: boundedHistoryText(turn.user.Text, maxHistoryMessageBytes)})
+			queued = append(queued, HistoryQueuedTurn{
+				TurnID:      turnID,
+				Text:        boundedHistoryText(turn.user.Text, maxHistoryMessageBytes),
+				Attachments: turn.user.Attachments,
+			})
 			queuedEventIDs[turnID] = turn.userEventID
 		}
 	}

--- a/internal/sessionruntime/history_test.go
+++ b/internal/sessionruntime/history_test.go
@@ -25,7 +25,7 @@ func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
 		{ID: 13, Type: EventAssistantDelta, TurnID: "turn-2", Text: "Open"},
 		{ID: 14, Type: EventAssistantDelta, TurnID: "turn-2", Text: "Code answer"},
 		{ID: 15, Type: EventInputRequested, TurnID: "turn-2", InputID: "input-2", Questions: []InputQuestion{{ID: "confirm", Question: "Continue?"}}, Status: "pending"},
-		{ID: 16, Type: EventUserMessage, TurnID: "turn-3", Text: "queued first"},
+		{ID: 16, Type: EventUserMessage, TurnID: "turn-3", Text: "queued first", Attachments: []Attachment{{ID: "attachment-1", Name: "screen.png", MediaType: "image/png", SizeBytes: 7}}},
 		{ID: 17, Type: EventUserMessage, TurnID: "turn-4", Text: "queued second"},
 	}
 
@@ -38,6 +38,9 @@ func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
 	}
 	if len(state.QueuedTurns) != 2 || state.QueuedTurns[0].TurnID != "turn-3" || state.QueuedTurns[1].TurnID != "turn-4" {
 		t.Fatalf("queued turns = %#v", state.QueuedTurns)
+	}
+	if len(state.QueuedTurns[0].Attachments) != 1 || state.QueuedTurns[0].Attachments[0].Name != "screen.png" {
+		t.Fatalf("queued turn attachments = %#v", state.QueuedTurns[0].Attachments)
 	}
 	if len(essential) != 1 || essential[0].Type != EventInputRequested || essential[0].InputID != "input-2" || essential[0].TurnID != "" {
 		t.Fatalf("essential history events = %#v", essential)

--- a/internal/sessionruntime/opencode.go
+++ b/internal/sessionruntime/opencode.go
@@ -380,7 +380,7 @@ func openCodeVariant(provider, effort string) string {
 }
 
 // RunTurn submits one prompt to the persistent OpenCode session.
-func (p *OpenCodeProvider) RunTurn(ctx context.Context, prompt string, sink EventSink) error {
+func (p *OpenCodeProvider) RunTurn(ctx context.Context, input TurnInput, sink EventSink) error {
 	p.turnMu.Lock()
 	defer p.turnMu.Unlock()
 
@@ -427,8 +427,17 @@ func (p *OpenCodeProvider) RunTurn(ctx context.Context, prompt string, sink Even
 		p.activeMu.Unlock()
 	}()
 
+	parts := []map[string]string{{"type": "text", "text": attachmentPrompt(input)}}
+	for _, attachment := range input.Attachments {
+		parts = append(parts, map[string]string{
+			"type":     "file",
+			"mime":     attachment.MediaType,
+			"filename": attachment.Name,
+			"url":      (&url.URL{Scheme: "file", Path: attachment.Path}).String(),
+		})
+	}
 	request := map[string]any{
-		"parts": []map[string]string{{"type": "text", "text": prompt}},
+		"parts": parts,
 	}
 	if err := p.client.doJSON(ctx, http.MethodPost, "/session/"+url.PathEscape(p.currentSessionID())+"/prompt_async", true, request, nil); err != nil {
 		return fmt.Errorf("starting OpenCode turn: %w", err)

--- a/internal/sessionruntime/opencode_test.go
+++ b/internal/sessionruntime/opencode_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -41,11 +42,24 @@ func TestOpenCodeProviderStreamsOrderedEvents(t *testing.T) {
 
 	sink := newOpenCodeTestSink(nil)
 	turnDone := make(chan error, 1)
-	go func() { turnDone <- provider.RunTurn(t.Context(), "hello", sink) }()
+	attachmentPath := filepath.Join(t.TempDir(), "screen.png")
+	go func() {
+		turnDone <- provider.RunTurn(t.Context(), TurnInput{
+			Text: "hello",
+			Attachments: []ResolvedAttachment{{
+				Attachment: Attachment{Name: "screen.png", MediaType: "image/png"},
+				Path:       attachmentPath,
+			}},
+		}, sink)
+	}()
 	request := receiveOpenCodePrompt(t, fake.prompts)
 	parts, ok := request["parts"].([]any)
-	if !ok || len(parts) != 1 || parts[0].(map[string]any)["text"] != "hello" {
+	if !ok || len(parts) != 2 || !strings.Contains(parts[0].(map[string]any)["text"].(string), attachmentPath) {
 		t.Fatalf("OpenCode prompt request = %#v", request)
+	}
+	filePart := parts[1].(map[string]any)
+	if filePart["type"] != "file" || filePart["mime"] != "image/png" || filePart["filename"] != "screen.png" || filePart["url"] != (&url.URL{Scheme: "file", Path: attachmentPath}).String() {
+		t.Fatalf("OpenCode file part = %#v", filePart)
 	}
 
 	fake.emit("session.status", map[string]any{"sessionID": fake.sessionID, "status": map[string]string{"type": "busy"}})
@@ -89,7 +103,7 @@ func TestOpenCodeProviderAnswersQuestion(t *testing.T) {
 	provider := newTestOpenCodeProvider(t, fake, ProviderConfig{WorkingDir: t.TempDir(), StateDir: t.TempDir()})
 	sink := newOpenCodeTestSink(map[string][]string{"question-1": {"PostgreSQL"}})
 	turnDone := make(chan error, 1)
-	go func() { turnDone <- provider.RunTurn(t.Context(), "choose a database", sink) }()
+	go func() { turnDone <- provider.RunTurn(t.Context(), TurnInput{Text: "choose a database"}, sink) }()
 	receiveOpenCodePrompt(t, fake.prompts)
 
 	fake.emit("session.status", map[string]any{"sessionID": fake.sessionID, "status": map[string]string{"type": "busy"}})
@@ -139,7 +153,7 @@ func TestOpenCodeProviderRuntimeStatusMapping(t *testing.T) {
 	})
 	sink := newOpenCodeTestSink(nil)
 	turnDone := make(chan error, 1)
-	go func() { turnDone <- provider.RunTurn(t.Context(), "hello", sink) }()
+	go func() { turnDone <- provider.RunTurn(t.Context(), TurnInput{Text: "hello"}, sink) }()
 	receiveOpenCodePrompt(t, fake.prompts)
 
 	fake.emit("session.status", map[string]any{"sessionID": fake.sessionID, "status": map[string]string{"type": "busy"}})
@@ -192,7 +206,9 @@ func TestOpenCodeProviderInterruptsActiveTurn(t *testing.T) {
 	fake := newFakeOpenCodeServer(t)
 	provider := newTestOpenCodeProvider(t, fake, ProviderConfig{WorkingDir: t.TempDir(), StateDir: t.TempDir()})
 	turnDone := make(chan error, 1)
-	go func() { turnDone <- provider.RunTurn(t.Context(), "keep working", newOpenCodeTestSink(nil)) }()
+	go func() {
+		turnDone <- provider.RunTurn(t.Context(), TurnInput{Text: "keep working"}, newOpenCodeTestSink(nil))
+	}()
 	receiveOpenCodePrompt(t, fake.prompts)
 
 	if err := provider.Interrupt(t.Context()); err != nil {

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -53,6 +53,7 @@ type Event struct {
 	HistoryCursor  string          `json:"historyCursor,omitempty"`
 	HistoryState   *HistoryState   `json:"historyState,omitempty"`
 	Runtime        *RuntimeStatus  `json:"runtime,omitempty"`
+	Attachments    []Attachment    `json:"attachments,omitempty"`
 }
 
 // HistoryState describes conversation state that is independent of transcript paging.
@@ -67,8 +68,9 @@ type HistoryState struct {
 
 // HistoryQueuedTurn describes one user message waiting to run.
 type HistoryQueuedTurn struct {
-	TurnID string `json:"turnId"`
-	Text   string `json:"text"`
+	TurnID      string       `json:"turnId"`
+	Text        string       `json:"text"`
+	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
 // RuntimeStatus describes the current Session and workspace for connected clients.
@@ -110,6 +112,7 @@ type ClientRequest struct {
 	HistoryBytes  int                 `json:"historyBytes,omitempty"`
 	HistoryCursor string              `json:"historyCursor,omitempty"`
 	Text          string              `json:"text,omitempty"`
+	AttachmentIDs []string            `json:"attachmentIds,omitempty"`
 	InputID       string              `json:"inputId,omitempty"`
 	Answers       map[string][]string `json:"answers,omitempty"`
 	Cancel        bool                `json:"cancel,omitempty"`

--- a/internal/sessionruntime/provider.go
+++ b/internal/sessionruntime/provider.go
@@ -28,7 +28,7 @@ type ProviderConfig struct {
 
 // Provider runs turns against one provider-owned conversation.
 type Provider interface {
-	RunTurn(ctx context.Context, prompt string, sink EventSink) error
+	RunTurn(ctx context.Context, input TurnInput, sink EventSink) error
 	Interrupt(ctx context.Context) error
 	Done() <-chan struct{}
 	Close() error

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -55,9 +55,10 @@ type Config struct {
 }
 
 type turnRequest struct {
-	id       string
-	text     string
-	accepted chan struct{}
+	id          string
+	text        string
+	attachments []Attachment
+	accepted    chan struct{}
 }
 
 type sessionStatusPublishRequest struct {
@@ -88,6 +89,7 @@ type Server struct {
 	config            Config
 	journal           *Journal
 	provider          Provider
+	attachmentStore   *AttachmentStore
 	providerCloseOnce sync.Once
 	providerCloseErr  error
 
@@ -160,6 +162,7 @@ func NewServer(config Config, journal *Journal, provider Provider) *Server {
 	}
 	if config.StateDir != "" {
 		server.activityMarkerPath = filepath.Join(config.StateDir, activityPublishedFile)
+		server.attachmentStore, _ = NewAttachmentStore(config.StateDir)
 	}
 	if provider, ok := provider.(runtimeStatusProvider); ok {
 		server.updateProviderRuntimeStatus(provider.runtimeStatusSnapshot())
@@ -711,15 +714,21 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 		return
 	}
 	sink := &turnSink{server: s, turnID: turn.id}
+	resolvedAttachments, err := s.resolveAttachments(turn.attachments)
+	if err != nil {
+		_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: err.Error(), Status: "failed"})
+		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "failed"})
+		return
+	}
 	result := make(chan error, 1)
 	go func() {
-		result <- s.provider.RunTurn(turnCtx, turn.text, sink)
+		result <- s.provider.RunTurn(turnCtx, TurnInput{Text: turn.text, Attachments: resolvedAttachments}, sink)
 	}()
-	var err error
+	var runErr error
 	select {
-	case err = <-result:
+	case runErr = <-result:
 	case <-turnCtx.Done():
-		err = context.Cause(turnCtx)
+		runErr = context.Cause(turnCtx)
 	}
 	if s.config.AgentType == "claude-code" || s.config.AgentType == "opencode" {
 		if diff := workspaceDiff(turnCtx, s.config.WorkingDir); diff != "" {
@@ -727,15 +736,15 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 		}
 	}
 	sink.stop()
-	if errors.Is(err, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted) {
+	if errors.Is(runErr, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted) {
 		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "interrupted"})
 		return
 	}
-	if err != nil {
+	if runErr != nil {
 		if turnCtx.Err() != nil {
 			return
 		}
-		_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: err.Error(), Status: "failed"})
+		_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: runErr.Error(), Status: "failed"})
 		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "failed"})
 		return
 	}
@@ -756,9 +765,17 @@ func workspaceDiff(ctx context.Context, workingDir string) string {
 	return string(output)
 }
 
-func (s *Server) submitMessage(text, requestID string) error {
-	if strings.TrimSpace(text) == "" {
+func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) error {
+	if strings.TrimSpace(text) == "" && len(attachmentIDs) == 0 {
 		return errors.New("message must not be empty")
+	}
+	resolvedAttachments, err := s.resolveAttachmentIDs(attachmentIDs)
+	if err != nil {
+		return err
+	}
+	attachments := make([]Attachment, len(resolvedAttachments))
+	for index := range resolvedAttachments {
+		attachments[index] = resolvedAttachments[index].Attachment
 	}
 	s.submitMu.Lock()
 	defer s.submitMu.Unlock()
@@ -775,14 +792,15 @@ func (s *Server) submitMessage(text, requestID string) error {
 		return fmt.Errorf("recording Session message: %w", err)
 	}
 	turn := turnRequest{
-		id:       fmt.Sprintf("turn-%d", s.nextTurnID.Add(1)),
-		text:     text,
-		accepted: make(chan struct{}),
+		id:          fmt.Sprintf("turn-%d", s.nextTurnID.Add(1)),
+		text:        text,
+		attachments: attachments,
+		accepted:    make(chan struct{}),
 	}
 	select {
 	case s.turns <- turn:
 		s.outstanding++
-		if err := s.appendMessage(Event{Type: EventUserMessage, RequestID: requestID, TurnID: turn.id, Text: turn.text}); err != nil {
+		if err := s.appendMessage(Event{Type: EventUserMessage, RequestID: requestID, TurnID: turn.id, Text: turn.text, Attachments: turn.attachments}); err != nil {
 			s.outstanding--
 			return fmt.Errorf("recording Session message: %w", err)
 		}
@@ -793,6 +811,24 @@ func (s *Server) submitMessage(text, requestID string) error {
 	}
 }
 
+func (s *Server) resolveAttachmentIDs(ids []string) ([]ResolvedAttachment, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if s.attachmentStore == nil {
+		return nil, errors.New("Session attachment storage is unavailable")
+	}
+	return s.attachmentStore.Resolve(ids)
+}
+
+func (s *Server) resolveAttachments(attachments []Attachment) ([]ResolvedAttachment, error) {
+	ids := make([]string, len(attachments))
+	for index := range attachments {
+		ids[index] = attachments[index].ID
+	}
+	return s.resolveAttachmentIDs(ids)
+}
+
 type journalRecovery struct {
 	nextTurnID      int64
 	nextInputID     int64
@@ -801,10 +837,11 @@ type journalRecovery struct {
 }
 
 type journalTurnRecovery struct {
-	id        string
-	text      string
-	started   bool
-	completed bool
+	id          string
+	text        string
+	attachments []Attachment
+	started     bool
+	completed   bool
 }
 
 // hasUnsettledActivity reports whether the journal holds locally accepted turns
@@ -845,6 +882,7 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 		case EventUserMessage:
 			if turn != nil {
 				turn.text = event.Text
+				turn.attachments = event.Attachments
 			}
 		case EventTurnCompleted:
 			if turn != nil {
@@ -897,7 +935,7 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 		if !turn.started {
 			accepted := make(chan struct{})
 			close(accepted)
-			recovery.queuedTurns = append(recovery.queuedTurns, turnRequest{id: turn.id, text: turn.text, accepted: accepted})
+			recovery.queuedTurns = append(recovery.queuedTurns, turnRequest{id: turn.id, text: turn.text, attachments: turn.attachments, accepted: accepted})
 			continue
 		}
 		if err := journal.Append(Event{Type: EventTurnCompleted, TurnID: turnID, Status: "interrupted"}); err != nil {
@@ -1191,7 +1229,7 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			}
 		case "message":
 			subscribe(0, "", false, 0, 0)
-			if err := s.submitMessage(request.Text, request.RequestID); err != nil {
+			if err := s.submitMessage(request.Text, request.RequestID, request.AttachmentIDs...); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
 			}
 		case "input":

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -28,6 +28,7 @@ import (
 type fakeProvider struct {
 	mu        sync.Mutex
 	prompts   []string
+	inputs    []TurnInput
 	resume    chan struct{}
 	closed    bool
 	done      chan struct{}
@@ -41,7 +42,7 @@ type inputProvider struct {
 	closeOnce sync.Once
 }
 
-func (p *inputProvider) RunTurn(ctx context.Context, _ string, sink EventSink) error {
+func (p *inputProvider) RunTurn(ctx context.Context, _ TurnInput, sink EventSink) error {
 	answers, err := sink.RequestInput(ctx, InputRequest{
 		ID: "input-test",
 		Questions: []InputQuestion{
@@ -99,7 +100,7 @@ type turnCompletionRaceProvider struct {
 	closeOnce       sync.Once
 }
 
-func (p *turnCompletionRaceProvider) RunTurn(ctx context.Context, _ string, _ EventSink) error {
+func (p *turnCompletionRaceProvider) RunTurn(ctx context.Context, _ TurnInput, _ EventSink) error {
 	p.mu.Lock()
 	p.runCount++
 	runCount := p.runCount
@@ -138,7 +139,7 @@ func (p *turnCompletionRaceProvider) Close() error {
 	return nil
 }
 
-func (p *stuckInterruptProvider) RunTurn(ctx context.Context, _ string, _ EventSink) error {
+func (p *stuckInterruptProvider) RunTurn(ctx context.Context, _ TurnInput, _ EventSink) error {
 	p.startOnce.Do(func() { close(p.started) })
 	<-p.runStopped
 	return ctx.Err()
@@ -169,7 +170,7 @@ func (p *stuckInterruptProvider) Close() error {
 	return nil
 }
 
-func (p *interruptProvider) RunTurn(context.Context, string, EventSink) error {
+func (p *interruptProvider) RunTurn(context.Context, TurnInput, EventSink) error {
 	p.startOnce.Do(func() { close(p.started) })
 	<-p.interrupted
 	return ErrTurnInterrupted
@@ -186,9 +187,10 @@ func (p *interruptProvider) Close() error {
 	return nil
 }
 
-func (p *fakeProvider) RunTurn(ctx context.Context, prompt string, sink EventSink) error {
+func (p *fakeProvider) RunTurn(ctx context.Context, input TurnInput, sink EventSink) error {
 	p.mu.Lock()
-	p.prompts = append(p.prompts, prompt)
+	p.prompts = append(p.prompts, input.Text)
+	p.inputs = append(p.inputs, input)
 	p.mu.Unlock()
 	sink.Emit(Event{Type: EventAssistantDelta, Text: "working"})
 	if p.resume != nil {
@@ -220,6 +222,42 @@ func (p *fakeProvider) Close() error {
 		close(p.done)
 	})
 	return nil
+}
+
+func TestServerSubmitsAttachmentToProviderAndJournal(t *testing.T) {
+	stateDir := t.TempDir()
+	store, err := NewAttachmentStore(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attachment, err := store.Put("notes.txt", strings.NewReader("important context"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeProvider{}
+	server := NewServer(Config{StateDir: stateDir}, journal, provider)
+	if err := server.submitMessage("review this", "request-attachment", attachment.ID); err != nil {
+		t.Fatal(err)
+	}
+	turn := <-server.turns
+	<-turn.accepted
+	server.runTurn(t.Context(), turn)
+
+	provider.mu.Lock()
+	inputs := append([]TurnInput(nil), provider.inputs...)
+	provider.mu.Unlock()
+	if len(inputs) != 1 || inputs[0].Text != "review this" || len(inputs[0].Attachments) != 1 {
+		t.Fatalf("provider inputs = %#v", inputs)
+	}
+	if inputs[0].Attachments[0].ID != attachment.ID || !strings.HasSuffix(inputs[0].Attachments[0].Path, filepath.Join(attachment.ID, attachmentDataFileName)) {
+		t.Fatalf("resolved provider attachment = %#v", inputs[0].Attachments[0])
+	}
+	events := journal.Snapshot()
+	if len(events) == 0 || events[0].Type != EventUserMessage || !reflect.DeepEqual(events[0].Attachments, []Attachment{attachment}) {
+		t.Fatalf("journal events = %#v", events)
+	}
 }
 
 func TestSessionSetupEnvironmentKeepsWorkspaceSetupCommand(t *testing.T) {
@@ -2370,7 +2408,7 @@ done
 	if _, err := os.Stat(sessionPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Claude session ID exists before a completed turn: %v", err)
 	}
-	if err := provider.RunTurn(t.Context(), "hello", &collectingSink{}); err != nil {
+	if err := provider.RunTurn(t.Context(), TurnInput{Text: "hello"}, &collectingSink{}); err != nil {
 		t.Fatalf("RunTurn() error = %v", err)
 	}
 	data, err := os.ReadFile(sessionPath)

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"net/http"
 	"sort"
 	"strings"
@@ -39,6 +40,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/sessionattachment"
 	"github.com/kelos-dev/kelos/internal/sessionreset"
 	"github.com/kelos-dev/kelos/internal/sessionruntime"
 	"github.com/kelos-dev/kelos/internal/sessionsuspend"
@@ -51,6 +53,7 @@ const (
 	sessionSectionAnnotation = "kelos.dev/session-section"
 	maxSessionSectionLength  = 64
 	requestBodyLimit         = 1024 * 1024
+	attachmentRequestLimit   = sessionruntime.MaxAttachmentBytes + 1024*1024
 )
 
 //go:embed web/*
@@ -78,6 +81,12 @@ type Server struct {
 	handler          http.Handler
 	upgrader         websocket.Upgrader
 	bridge           func(context.Context, *sessionSocket, string, string, func() error) error
+	attachments      sessionAttachmentTransfer
+}
+
+type sessionAttachmentTransfer interface {
+	Upload(context.Context, string, string, string, io.Reader) (sessionruntime.Attachment, error)
+	Download(context.Context, string, string, string) (sessionruntime.Attachment, []byte, error)
 }
 
 type sessionSocket struct {
@@ -176,6 +185,10 @@ func New(config Config) (*Server, error) {
 	if config.Client == nil || config.Clientset == nil || config.RESTConfig == nil {
 		return nil, errors.New("Kubernetes clients and REST config are required")
 	}
+	attachmentClient, err := sessionattachment.New(config.RESTConfig)
+	if err != nil {
+		return nil, err
+	}
 	digest := hmac.New(sha256.New, []byte(config.Token))
 	_, _ = digest.Write([]byte("kelos-session-web-cookie-v1"))
 	server := &Server{
@@ -186,6 +199,7 @@ func New(config Config) (*Server, error) {
 		restConfig:       config.RESTConfig,
 		defaultNamespace: defaultNamespace,
 		secureCookie:     config.SecureCookie,
+		attachments:      attachmentClient,
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  16 * 1024,
 			WriteBufferSize: 16 * 1024,
@@ -323,6 +337,14 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 	namespace, name := parts[1], parts[2]
 	if len(parts) == 4 && parts[3] == "connect" && request.Method == http.MethodGet {
 		s.connectSession(writer, request, namespace, name)
+		return
+	}
+	if len(parts) == 4 && parts[3] == "attachments" && request.Method == http.MethodPost {
+		s.uploadSessionAttachment(writer, request, namespace, name)
+		return
+	}
+	if len(parts) == 5 && parts[3] == "attachments" && request.Method == http.MethodGet {
+		s.downloadSessionAttachment(writer, request, namespace, name, parts[4])
 		return
 	}
 	if len(parts) == 4 && parts[3] == "reset" && request.Method == http.MethodPost {
@@ -746,6 +768,95 @@ func sessionActivityTime(session *kelos.Session) time.Time {
 		activity = condition.LastTransitionTime.Time
 	}
 	return activity
+}
+
+func (s *Server) uploadSessionAttachment(writer http.ResponseWriter, request *http.Request, namespace, name string) {
+	session, ok := s.readySession(writer, request, namespace, name)
+	if !ok {
+		return
+	}
+	request.Body = http.MaxBytesReader(writer, request.Body, attachmentRequestLimit)
+	reader, err := request.MultipartReader()
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, "attachment upload must use multipart form data")
+		return
+	}
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			writeError(writer, http.StatusBadRequest, "attachment file is required")
+			return
+		}
+		if err != nil {
+			writeError(writer, http.StatusBadRequest, fmt.Sprintf("reading attachment upload: %v", err))
+			return
+		}
+		if part.FormName() != "file" || part.FileName() == "" {
+			_ = part.Close()
+			continue
+		}
+		attachment, err := s.attachments.Upload(request.Context(), namespace, session.Status.PodName, part.FileName(), part)
+		_ = part.Close()
+		if err != nil {
+			status := attachmentUploadStatus(err)
+			writeError(writer, status, fmt.Sprintf("uploading attachment to Session %q: %v", name, err))
+			return
+		}
+		writeJSON(writer, http.StatusCreated, attachment)
+		return
+	}
+}
+
+func (s *Server) downloadSessionAttachment(writer http.ResponseWriter, request *http.Request, namespace, name, id string) {
+	session, ok := s.readySession(writer, request, namespace, name)
+	if !ok {
+		return
+	}
+	attachment, data, err := s.attachments.Download(request.Context(), namespace, session.Status.PodName, id)
+	if err != nil {
+		status := http.StatusBadGateway
+		if strings.Contains(strings.ToLower(err.Error()), "attachment not found") {
+			status = http.StatusNotFound
+		}
+		writeError(writer, status, fmt.Sprintf("downloading attachment from Session %q: %v", name, err))
+		return
+	}
+	disposition := "attachment"
+	if strings.HasPrefix(attachment.MediaType, "image/") {
+		disposition = "inline"
+	}
+	writer.Header().Set("Cache-Control", "private, no-store")
+	writer.Header().Set("Content-Type", attachment.MediaType)
+	writer.Header().Set("Content-Disposition", mime.FormatMediaType(disposition, map[string]string{"filename": attachment.Name}))
+	writer.WriteHeader(http.StatusOK)
+	_, _ = writer.Write(data)
+}
+
+func attachmentUploadStatus(err error) int {
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "too large") || strings.Contains(message, "exceeds the"):
+		return http.StatusRequestEntityTooLarge
+	case strings.Contains(message, "storage quota exceeded"):
+		return http.StatusInsufficientStorage
+	case strings.Contains(message, "storing session attachment failed"):
+		return http.StatusBadRequest
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func (s *Server) readySession(writer http.ResponseWriter, request *http.Request, namespace, name string) (*kelos.Session, bool) {
+	var session kelos.Session
+	if err := s.client.Get(request.Context(), client.ObjectKey{Namespace: namespace, Name: name}, &session); err != nil {
+		writeKubernetesError(writer, fmt.Sprintf("getting Session %q", name), err)
+		return nil, false
+	}
+	if session.Status.Phase != kelos.SessionPhaseReady || session.Status.PodName == "" {
+		writeError(writer, http.StatusConflict, fmt.Sprintf("Session %q is not ready", name))
+		return nil, false
+	}
+	return &session, true
 }
 
 func (s *Server) connectSession(writer http.ResponseWriter, request *http.Request, namespace, name string) {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
@@ -27,8 +29,26 @@ import (
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/sessionreset"
+	"github.com/kelos-dev/kelos/internal/sessionruntime"
 	"github.com/kelos-dev/kelos/internal/sessionsuspend"
 )
+
+type fakeSessionAttachmentTransfer struct {
+	uploadedName string
+	uploadedData []byte
+	attachment   sessionruntime.Attachment
+	downloadData []byte
+}
+
+func (f *fakeSessionAttachmentTransfer) Upload(_ context.Context, _, _, name string, source io.Reader) (sessionruntime.Attachment, error) {
+	f.uploadedName = name
+	f.uploadedData, _ = io.ReadAll(source)
+	return f.attachment, nil
+}
+
+func (f *fakeSessionAttachmentTransfer) Download(_ context.Context, _, _, _ string) (sessionruntime.Attachment, []byte, error) {
+	return f.attachment, f.downloadData, nil
+}
 
 func TestAuthenticationProtectsApplicationAndAPI(t *testing.T) {
 	server := testServer(t)
@@ -559,6 +579,11 @@ func TestSessionComposerUsesOneSendAndInterruptAction(t *testing.T) {
 	if !strings.Contains(body, `id="session-progress"`) {
 		t.Error("Session composer does not contain the agent progress region")
 	}
+	for _, expected := range []string{`id="attachment-input" type="file" multiple`, `id="attach-files"`, `id="pending-attachments"`} {
+		if !strings.Contains(body, expected) {
+			t.Errorf("Session composer does not contain attachment control %s", expected)
+		}
+	}
 	if strings.Contains(body, `id="stop-session"`) {
 		t.Error("Session header contains a separate interrupt action")
 	}
@@ -600,9 +625,27 @@ func TestSessionComposerKeepsDraftsPerSession(t *testing.T) {
 		"draft clear key":         `state.promptDrafts.delete(sessionKey(session))`,
 		"Session selection save":  "function selectSession(session, resumeIdle = false) {\n  savePromptDraft(state.selected);",
 		"Session draft restore":   `state.promptDrafts.get(sessionKey(session))`,
-		"prompt submission clear": "state.socket.send(JSON.stringify({type: 'message', text}));\n    clearPromptDraft(state.selected);",
+		"prompt submission clear": "state.socket.send(JSON.stringify({type: 'message', text, attachmentIds: attachments.map(attachment => attachment.id)}));\n    clearPromptDraft(session);",
 		"Session deletion clear":  "selectSession(null);\n    clearPromptDraft(session);",
 		"composer input save":     "elements.input.addEventListener('input', () => {\n  savePromptDraft(state.selected);",
+	} {
+		if !strings.Contains(string(source), expected) {
+			t.Errorf("Session composer is missing %s: %s", description, expected)
+		}
+	}
+}
+
+func TestSessionComposerUploadsDroppedAttachments(t *testing.T) {
+	source, err := webFiles.ReadFile("web/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for description, expected := range map[string]string{
+		"drop handling":       "event.dataTransfer?.files?.length",
+		"multipart upload":    "const body = new FormData();",
+		"attachment endpoint": "/attachments`, {",
+		"message references":  "attachmentIds: attachments.map(attachment => attachment.id)",
+		"history rendering":   "appendMessageAttachments(bubble, event.attachments || [])",
 	} {
 		if !strings.Contains(string(source), expected) {
 			t.Errorf("Session composer is missing %s: %s", description, expected)
@@ -1522,6 +1565,55 @@ func TestConnectSessionBridgesAndAcknowledgesResumedSession(t *testing.T) {
 	}
 	if !sessionsuspend.ResumeAcknowledged(&updated) {
 		t.Fatalf("resume request was not acknowledged: %#v", updated.Annotations)
+	}
+}
+
+func TestSessionAttachmentUploadAndDownload(t *testing.T) {
+	server := testServer(t)
+	if err := server.client.Create(t.Context(), &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "team-a"},
+		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
+			Type:        "codex",
+			Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
+		}},
+		Status: kelos.SessionStatus{Phase: kelos.SessionPhaseReady, PodName: "chat-pod"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	transfer := &fakeSessionAttachmentTransfer{
+		attachment:   sessionruntime.Attachment{ID: "attachment-id", Name: "screen.png", MediaType: "image/png", SizeBytes: 7},
+		downloadData: []byte("content"),
+	}
+	server.attachments = transfer
+
+	var body bytes.Buffer
+	multipartWriter := multipart.NewWriter(&body)
+	part, err := multipartWriter.CreateFormFile("file", "screen.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = part.Write([]byte("content"))
+	if err := multipartWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/team-a/chat/attachments", &body)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	request.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated || transfer.uploadedName != "screen.png" || string(transfer.uploadedData) != "content" {
+		t.Fatalf("upload status = %d name = %q data = %q body = %s", response.Code, transfer.uploadedName, transfer.uploadedData, response.Body.String())
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/sessions/team-a/chat/attachments/attachment-id", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || response.Header().Get("Content-Type") != "image/png" || response.Body.String() != "content" {
+		t.Fatalf("download status = %d content-type = %q body = %q", response.Code, response.Header().Get("Content-Type"), response.Body.String())
+	}
+	if !strings.Contains(response.Header().Get("Content-Disposition"), "inline") || !strings.Contains(response.Header().Get("Content-Disposition"), "screen.png") {
+		t.Fatalf("download content disposition = %q", response.Header().Get("Content-Disposition"))
 	}
 }
 

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -163,6 +163,8 @@ function resetHarness() {
     changesSummary: new TestNode('span'),
     composerHint: new TestNode('span'),
     input: new TestNode('textarea'),
+    attachFiles: new TestNode('button'),
+    pendingAttachments: new TestNode('div'),
     send: new TestNode('button'),
     progress: new TestNode('div'),
     progressLabel: new TestNode('span'),
@@ -177,6 +179,8 @@ function resetHarness() {
     sessionViews: new Map(),
     socket: null,
     promptDrafts: new Map(),
+    attachmentDrafts: new Map(),
+    sendingMessage: false,
     lastEventID: 0,
     assistantSegmentByTurn: new Map(),
     assistantTextByTurn: new Map(),
@@ -257,7 +261,7 @@ vm.runInThisContext(applicationSlice('function renderUser', 'function renderTool
 vm.runInThisContext(applicationSlice('function renderTool', 'function renderInputRequest'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function renderDiff', 'function setActiveView'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function renderError', 'function scrollToBottom'), {filename: 'app.js'});
-vm.runInThisContext(applicationSlice('function submitComposer', "elements.composer.addEventListener('submit'"), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function currentAttachmentFiles', "elements.composer.addEventListener('submit'"), {filename: 'app.js'});
 
 function testSessionViewSaveAndRestore() {
   resetHarness();
@@ -373,6 +377,23 @@ function testComposerInterruptsWhileInputIsDisabled() {
   state.interrupting = true;
   updateComposerAction();
   assert.equal(elements.send.disabled, true);
+}
+
+async function testComposerIgnoresReentrantSubmission() {
+  resetHarness();
+  const sent = [];
+  state.selected = {namespace: 'default', name: 'one', uid: 'uid-one'};
+  state.socket = {
+    readyState: WebSocket.OPEN,
+    send: (message) => sent.push(message),
+  };
+  state.sendingMessage = true;
+  elements.input.value = 'duplicate';
+
+  await submitComposer();
+
+  assert.deepEqual(sent, []);
+  assert.equal(state.sendingMessage, true);
 }
 
 function testSessionProgressSurvivesCachedViewSwitch() {
@@ -752,6 +773,21 @@ function testHistoryToolCompletionRendersOutputWithoutStart() {
   assert.equal(card.querySelector('.tool-output-preview').textContent, 'result');
 }
 
+function testUserAttachmentRendering() {
+  resetHarness();
+  state.selected = {namespace: 'team-a', name: 'chat'};
+  renderAcceptedUser({
+    type: 'user.message',
+    text: 'review this',
+    attachments: [{id: 'attachment-1', name: 'screen.png', mediaType: 'image/png', sizeBytes: 7}],
+  });
+
+  const link = elements.messages.querySelector('.message-attachment');
+  assert.equal(link.href, '/api/sessions/team-a/chat/attachments/attachment-1');
+  assert.equal(link.querySelector('img').src, link.href);
+  assert.match(link.textContent, /screen\.png/);
+}
+
 testSessionViewSaveAndRestore();
 testSessionViewReset();
 testSessionProgressLifecycle();
@@ -774,5 +810,10 @@ testSessionTimestampElement();
 testToolOutputRendering();
 testToolOutputRenderingNormalizesCarriageReturns();
 testHistoryToolCompletionRendersOutputWithoutStart();
-
-process.stdout.write('Session history tests passed\n');
+testUserAttachmentRendering();
+testComposerIgnoresReentrantSubmission()
+  .then(() => process.stdout.write('Session history tests passed\n'))
+  .catch(error => {
+    process.stderr.write(`${error.stack}\n`);
+    process.exitCode = 1;
+  });

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -24,6 +24,9 @@ const elements = {
   composerWrap: document.querySelector('.composer-wrap'),
   composer: document.querySelector('#composer'),
   input: document.querySelector('#message-input'),
+  attachmentInput: document.querySelector('#attachment-input'),
+  attachFiles: document.querySelector('#attach-files'),
+  pendingAttachments: document.querySelector('#pending-attachments'),
   send: document.querySelector('#send-message'),
   composerHint: document.querySelector('#composer-hint'),
   runtimeStatus: document.querySelector('#session-runtime-status'),
@@ -86,6 +89,8 @@ const state = {
   fileChanges: new Map(),
   queuedMessages: new Map(),
   promptDrafts: new Map(),
+  attachmentDrafts: new Map(),
+  sendingMessage: false,
   activeTurn: false,
   activeTurnID: '',
   activeTurnStartedAt: 0,
@@ -474,6 +479,12 @@ function clearPromptDraft(session) {
     resizeComposer();
     updateComposerAction();
   }
+}
+
+function clearAttachmentDraft(session) {
+  if (!session) return;
+  state.attachmentDrafts.delete(sessionKey(session));
+  if (state.selected && sessionKey(state.selected) === sessionKey(session)) renderPendingAttachments();
 }
 
 function providerLabel(provider) {
@@ -1426,6 +1437,7 @@ function selectSession(session, resumeIdle = false) {
   state.currentView = null;
   setActiveView('conversation');
   restorePromptDraft(session);
+  renderPendingAttachments();
   elements.messages.replaceChildren();
   elements.queue.replaceChildren();
   elements.changesList.replaceChildren();
@@ -1547,6 +1559,7 @@ function setConnection(status, label) {
 
 function setComposer(enabled) {
   elements.input.disabled = !enabled;
+  elements.attachFiles.disabled = !enabled || state.sendingMessage;
   elements.input.placeholder = enabled ? 'Message the agent…' : 'Choose a ready session to start chatting';
   updateComposerAction();
 }
@@ -1556,7 +1569,7 @@ function usesTouchComposer() {
 }
 
 function composerInterruptAction() {
-  return state.activeTurn && (elements.input.disabled || !elements.input.value.trim());
+  return state.activeTurn && (elements.input.disabled || (!elements.input.value.trim() && currentAttachmentFiles().length === 0));
 }
 
 function updateComposerAction() {
@@ -1568,7 +1581,7 @@ function updateComposerAction() {
   elements.send.textContent = actionSymbol;
   elements.send.setAttribute('aria-label', interrupt ? 'Interrupt active work' : 'Send message');
   elements.send.title = interrupt ? 'Interrupt active work' : 'Send message';
-  elements.send.disabled = !connected || (interrupt ? state.interrupting : elements.input.disabled);
+  elements.send.disabled = !connected || state.sendingMessage || (interrupt ? state.interrupting : elements.input.disabled);
   elements.composerHint.textContent = usesTouchComposer()
     ? `Tap ${actionSymbol} to ${action} · Return for a new line`
     : (interrupt && elements.input.disabled
@@ -2597,6 +2610,7 @@ function renderAcceptedUser(event) {
   const bubble = document.createElement('div');
   bubble.className = 'message-bubble';
   renderMessageMarkdown(bubble, event.text);
+  appendMessageAttachments(bubble, event.attachments || []);
   message.append(bubble);
   row.append(message);
   elements.messages.append(row);
@@ -2609,7 +2623,8 @@ function renderQueuedUser(event) {
   item.className = 'queued-prompt';
   const text = document.createElement('div');
   text.className = 'queued-prompt-text';
-  text.textContent = event.text;
+  const names = (event.attachments || []).map(attachment => attachment.name);
+  text.textContent = [event.text, names.length ? `Attachments: ${names.join(', ')}` : ''].filter(Boolean).join(' · ');
   const status = document.createElement('span');
   status.className = 'queued-prompt-status';
   status.textContent = 'Queued';
@@ -2617,6 +2632,36 @@ function renderQueuedUser(event) {
   elements.queue.append(item);
   elements.queue.hidden = false;
   state.queuedMessages.set(event.turnId, {event, item});
+}
+
+function attachmentURL(attachment) {
+  if (!state.selected) return '#';
+  return `/api/sessions/${encodeURIComponent(state.selected.namespace)}/${encodeURIComponent(state.selected.name)}/attachments/${encodeURIComponent(attachment.id)}`;
+}
+
+function appendMessageAttachments(parent, attachments) {
+  if (!attachments.length) return;
+  const list = document.createElement('div');
+  list.className = 'message-attachments';
+  for (const attachment of attachments) {
+    const link = document.createElement('a');
+    link.className = 'message-attachment';
+    link.href = attachmentURL(attachment);
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    if ((attachment.mediaType || '').startsWith('image/')) {
+      const preview = document.createElement('img');
+      preview.src = link.href;
+      preview.alt = attachment.name;
+      preview.loading = 'lazy';
+      link.append(preview);
+    }
+    const label = document.createElement('span');
+    label.textContent = attachment.name;
+    link.append(label);
+    list.append(link);
+  }
+  parent.append(list);
 }
 
 function acceptQueuedMessage(turnID) {
@@ -3168,21 +3213,132 @@ function scheduleBottomAnchor() {
   });
 }
 
-function submitComposer() {
+function currentAttachmentFiles() {
+  if (!state.selected) return [];
+  return state.attachmentDrafts.get(sessionKey(state.selected)) || [];
+}
+
+function renderPendingAttachments() {
+  const files = currentAttachmentFiles();
+  elements.pendingAttachments.replaceChildren();
+  elements.pendingAttachments.hidden = files.length === 0;
+  files.forEach((file, index) => {
+    const item = document.createElement('span');
+    item.className = 'pending-attachment';
+    item.textContent = file.name;
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.setAttribute('aria-label', `Remove ${file.name}`);
+    remove.textContent = '×';
+    remove.addEventListener('click', () => {
+      const remaining = currentAttachmentFiles().filter((_, fileIndex) => fileIndex !== index);
+      state.attachmentDrafts.set(sessionKey(state.selected), remaining);
+      renderPendingAttachments();
+      updateComposerAction();
+    });
+    item.append(remove);
+    elements.pendingAttachments.append(item);
+  });
+}
+
+function stageAttachments(fileList) {
+  if (!state.selected || elements.input.disabled) return;
+  const incoming = Array.from(fileList || []);
+  const existing = currentAttachmentFiles();
+  const accepted = [];
+  for (const file of incoming) {
+    if (file.size > 10 * 1024 * 1024) {
+      showToast(`${file.name} exceeds the 10 MiB attachment limit`);
+      continue;
+    }
+    if (existing.length + accepted.length >= 8) {
+      showToast('A message supports at most 8 attachments');
+      break;
+    }
+    accepted.push(file);
+  }
+  if (accepted.length) state.attachmentDrafts.set(sessionKey(state.selected), [...existing, ...accepted]);
+  renderPendingAttachments();
+  updateComposerAction();
+}
+
+async function uploadAttachment(session, file) {
+  const body = new FormData();
+  body.append('file', file, file.name);
+  const response = await fetch(`/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/attachments`, {
+    method: 'POST',
+    body,
+  });
+  if (response.status === 401) {
+    window.location.replace('/login');
+    throw new Error('Authentication required');
+  }
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(payload.error || `${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function submitComposer() {
+  if (state.sendingMessage) return;
   const text = elements.input.value.trim();
   if (!state.socket || state.socket.readyState !== WebSocket.OPEN) return;
   if (composerInterruptAction()) {
     interruptActiveTurn();
-  } else if (text) {
-    state.socket.send(JSON.stringify({type: 'message', text}));
-    clearPromptDraft(state.selected);
+    return;
+  }
+  const session = state.selected;
+  const files = [...currentAttachmentFiles()];
+  if (!text && files.length === 0) return;
+  state.sendingMessage = true;
+  updateComposerAction();
+  elements.attachFiles.disabled = true;
+  try {
+    const attachments = await Promise.all(files.map(file => uploadAttachment(session, file)));
+    if (!state.selected || sessionViewKey(state.selected) !== sessionViewKey(session) || !state.socket || state.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('Session disconnected before the message could be sent');
+    }
+    state.socket.send(JSON.stringify({type: 'message', text, attachmentIds: attachments.map(attachment => attachment.id)}));
+    clearPromptDraft(session);
+    state.attachmentDrafts.delete(sessionKey(session));
+    renderPendingAttachments();
+  } catch (error) {
+    showToast(error.message);
+  } finally {
+    state.sendingMessage = false;
+    updateComposerAction();
+    elements.attachFiles.disabled = elements.input.disabled;
   }
 }
 
 elements.composer.addEventListener('submit', event => {
   event.preventDefault();
-  submitComposer();
+  void submitComposer();
 });
+
+elements.attachFiles.addEventListener('click', () => elements.attachmentInput.click());
+elements.attachmentInput.addEventListener('change', () => {
+  stageAttachments(elements.attachmentInput.files);
+  elements.attachmentInput.value = '';
+});
+for (const eventName of ['dragenter', 'dragover']) {
+  elements.composerWrap.addEventListener(eventName, event => {
+    if (!event.dataTransfer?.types?.includes('Files')) return;
+    event.preventDefault();
+    elements.composerWrap.classList.add('attachment-drop-target');
+    event.dataTransfer.dropEffect = 'copy';
+  });
+}
+for (const eventName of ['dragleave', 'drop']) {
+  elements.composerWrap.addEventListener(eventName, event => {
+    elements.composerWrap.classList.remove('attachment-drop-target');
+    if (eventName === 'drop' && event.dataTransfer?.files?.length) {
+      event.preventDefault();
+      stageAttachments(event.dataTransfer.files);
+    }
+  });
+}
 
 elements.input.addEventListener('keydown', event => {
   if (event.key === 'Enter' && !event.shiftKey && !event.isComposing && !usesTouchComposer()) {
@@ -3433,6 +3589,7 @@ elements.deleteButton.addEventListener('click', async () => {
     discardSessionView(session);
     selectSession(null);
     clearPromptDraft(session);
+    clearAttachmentDraft(session);
     await loadSessions();
     showToast('Session deleted');
   } catch (error) {
@@ -3449,6 +3606,7 @@ elements.resetButton.addEventListener('click', async () => {
     discardSessionView(session);
     state.currentView = null;
     clearPromptDraft(session);
+    clearAttachmentDraft(session);
     selectSession(resetting);
     await loadSessions();
     showToast('Session reset requested');

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -84,7 +84,10 @@
           <span id="session-progress-elapsed" aria-hidden="true"></span>
         </div>
         <div class="queued-prompts" id="queued-prompts" aria-label="Queued prompts" aria-live="polite" hidden></div>
+        <div class="pending-attachments" id="pending-attachments" aria-label="Files ready to attach" hidden></div>
         <form class="composer" id="composer">
+          <input id="attachment-input" type="file" multiple hidden>
+          <button class="attach-button" id="attach-files" type="button" aria-label="Attach files" title="Attach files" disabled>＋</button>
           <textarea id="message-input" rows="1" placeholder="Choose a ready session to start chatting" aria-label="Message" disabled></textarea>
           <button class="send-button" id="send-message" type="submit" aria-label="Send message" data-action="send" disabled>↑</button>
         </form>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -182,6 +182,9 @@ button { color: inherit; }
 .message-bubble pre { max-width: 100%; margin: 0; overflow-x: auto; border: 0; background: var(--code-bg); color: var(--code-ink); white-space: pre; overflow-wrap: normal; }
 .message-bubble pre code { display: block; min-width: max-content; padding: 12px 14px; font: 12px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; white-space: inherit; }
 .user .message-bubble { border-bottom-right-radius: 5px; background: #dfe9e2; }
+.message-attachments { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 9px; }
+.message-attachment { display: inline-flex; max-width: 260px; flex-direction: column; gap: 5px; padding: 6px 8px; border: 1px solid rgba(57,112,84,.2); border-radius: 9px; color: var(--accent-2); font-size: 11px; text-decoration: none !important; }
+.message-attachment img { display: block; max-width: 240px; max-height: 180px; border-radius: 6px; object-fit: contain; }
 .assistant { gap: 11px; align-items: flex-start; }
 .agent-avatar { flex: 0 0 auto; width: 29px; height: 29px; display: grid; place-items: center; margin-top: 2px; border-radius: 9px; background: var(--accent); color: white; font: 700 11px/1 ui-monospace, monospace; }
 .assistant .message-bubble { max-width: calc(100% - 45px); padding: 2px 2px 3px; border-radius: 0; background: transparent; }
@@ -251,6 +254,7 @@ button { color: inherit; }
 .turn-divider:not(:empty)::before { flex: 0 0 10px; }
 .turn-divider:not(:empty)::after { flex: 1; }
 .composer-wrap { min-width: 0; padding: 12px max(24px, calc((100% - 850px) / 2)) 19px; background: linear-gradient(transparent, var(--canvas) 20%); }
+.composer-wrap.attachment-drop-target .composer { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(57,112,84,.12); }
 .session-progress { display: flex; align-items: center; gap: 5px; min-height: 18px; margin: 0 4px 7px; color: var(--muted); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; }
 .session-progress[hidden] { display: none; }
 .session-progress-dot { color: var(--accent-2); animation: pulse 1.1s infinite; }
@@ -262,10 +266,16 @@ button { color: inherit; }
 .queued-prompt { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 9px 12px; border: 1px solid var(--line); border-radius: 11px; background: var(--accent-soft); }
 .queued-prompt-text { overflow: hidden; color: var(--ink); font-size: 11.5px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
 .queued-prompt-status { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.pending-attachments { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 4px 8px; }
+.pending-attachments[hidden] { display: none; }
+.pending-attachment { display: inline-flex; max-width: 220px; align-items: center; gap: 5px; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--accent-soft); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pending-attachment button { flex: none; padding: 0; border: 0; background: transparent; color: var(--muted); cursor: pointer; }
 .composer { display: flex; align-items: flex-end; gap: 10px; padding: 9px 9px 9px 16px; border: 1px solid #d1d8d2; border-radius: 17px; background: var(--card); box-shadow: 0 12px 38px rgba(28,45,36,.08); transition: border .15s, box-shadow .15s; }
 .composer:focus-within { border-color: #85a493; box-shadow: 0 12px 38px rgba(28,45,36,.1), 0 0 0 3px rgba(57,112,84,.08); }
 .composer textarea { flex: 1; max-height: 160px; resize: none; border: 0; outline: 0; padding: 8px 0 6px; background: transparent; color: var(--ink); font-size: 14px; line-height: 1.45; }
 .composer textarea::placeholder { color: #99a19c; }
+.attach-button { flex: none; width: 30px; height: 36px; padding: 0; border: 0; background: transparent; color: var(--accent-2); font-size: 22px; cursor: pointer; }
+.attach-button:disabled { color: var(--faint); cursor: default; }
 .send-button { flex: 0 0 auto; width: 36px; height: 36px; border: 0; border-radius: 11px; background: var(--accent); color: white; font-size: 20px; font-weight: 500; cursor: pointer; }
 .send-button[data-action="interrupt"] { background: var(--warning); font-size: 11px; }
 .send-button:disabled { background: #c8ceca; cursor: default; }

--- a/test/e2e/fixtures/fake-claude.js
+++ b/test/e2e/fixtures/fake-claude.js
@@ -48,11 +48,20 @@ function promptText(message) {
     .join('');
 }
 
+function readPromptAttachment(prompt) {
+  const match = prompt.match(/^- .+ \([^)]+\): (.+)$/m);
+  return match ? readFile(match[1], 'missing').trim() : 'missing';
+}
+
 function handleUser(message) {
   turn += 1;
   fs.mkdirSync(stateDirectory, {recursive: true});
   fs.writeFileSync(turnPath, String(turn));
   const prompt = promptText(message);
+  if (prompt.startsWith('attachment-check\n\n')) {
+    complete(`attachment: ${readPromptAttachment(prompt)}`);
+    return;
+  }
   if (prompt === 'question') {
     pending = {kind: 'question'};
     send({

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -214,6 +216,15 @@ var _ = Describe("Session remote control", func() {
 			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 7: state written"
 		})
 		waitForTurnCompletion(connection, "completed")
+
+		By("uploading an attachment before Session Pod recovery")
+		attachmentData := []byte("web attachment persisted across recovery\n")
+		attachment := uploadSessionAttachment(webClient, baseURL, f.Namespace, sessionName, "web-attachment.txt", attachmentData)
+		Expect(attachment.ID).NotTo(BeEmpty())
+		Expect(attachment.Name).To(Equal("web-attachment.txt"))
+		Expect(attachment.MediaType).To(Equal("text/plain"))
+		Expect(attachment.SizeBytes).To(Equal(int64(len(attachmentData))))
+
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "message", Text: "block"})
 		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
 			return event.Type == sessionruntime.EventTurnStarted && event.TurnID == "turn-8"
@@ -244,9 +255,30 @@ var _ = Describe("Session remote control", func() {
 		}
 		Expect(seenRecovery).To(BeTrue())
 		Expect(seenInterruptedTurn).To(BeTrue())
+
+		By("submitting the persisted attachment through web chat")
+		status, headers, downloaded := downloadSessionAttachment(webClient, baseURL, f.Namespace, sessionName, attachment.ID)
+		Expect(status).To(Equal(http.StatusOK), "Session attachment download response: %s", downloaded)
+		Expect(headers.Get("Content-Type")).To(Equal("text/plain"))
+		Expect(headers.Get("Content-Disposition")).To(ContainSubstring(`filename=web-attachment.txt`))
+		Expect(downloaded).To(Equal(attachmentData))
+		sendSessionRequest(connection, sessionruntime.ClientRequest{
+			Type:          "message",
+			Text:          "attachment-check",
+			AttachmentIDs: []string{attachment.ID},
+		})
+		message := waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
+			return event.Type == sessionruntime.EventUserMessage && event.Text == "attachment-check"
+		})
+		Expect(message.Attachments).To(Equal([]sessionruntime.Attachment{attachment}))
+		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
+			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "attachment: web attachment persisted across recovery"
+		})
+		waitForTurnCompletion(connection, "completed")
+
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "message", Text: "read-state"})
 		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
-			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 9: state preserved"
+			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 10: state preserved"
 		})
 		waitForTurnCompletion(connection, "completed")
 
@@ -274,12 +306,18 @@ var _ = Describe("Session remote control", func() {
 
 		connection = connectSessionWebSocket(webClient, baseURL, f.Namespace, sessionName)
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "subscribe"})
-		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
-			return event.Type == sessionruntime.EventHistoryEnd
-		})
+		seenAttachment := false
+		for {
+			event := readSessionEvent(connection)
+			seenAttachment = seenAttachment || (event.Type == sessionruntime.EventUserMessage && len(event.Attachments) == 1 && event.Attachments[0] == attachment)
+			if event.Type == sessionruntime.EventHistoryEnd {
+				break
+			}
+		}
+		Expect(seenAttachment).To(BeTrue())
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "message", Text: "read-state"})
 		waitForSessionEvent(connection, func(event sessionruntime.Event) bool {
-			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 10: state preserved"
+			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 11: state preserved"
 		})
 		waitForTurnCompletion(connection, "completed")
 
@@ -312,6 +350,13 @@ var _ = Describe("Session remote control", func() {
 			return event.Type == sessionruntime.EventAssistantDelta && event.Text == "turn 1: state missing"
 		})
 		waitForTurnCompletion(connection, "completed")
+		status, _, _ = downloadSessionAttachment(webClient, baseURL, f.Namespace, sessionName, attachment.ID)
+		Expect(status).To(Equal(http.StatusNotFound))
+
+		By("submitting an attachment through the terminal client")
+		terminalAttachmentPath := filepath.Join(GinkgoT().TempDir(), "terminal-attachment.txt")
+		Expect(os.WriteFile(terminalAttachmentPath, []byte("terminal attachment contents\n"), 0o600)).To(Succeed())
+		runTerminalAttachmentTurn(f.Namespace, sessionName, terminalAttachmentPath, "attachment-check", ContainSubstring("agent › attachment: terminal attachment contents"))
 
 		By("deleting the Session and its StatefulSet-backed Pod")
 		Expect(f.KelosClientset.ApiV1alpha2().Sessions(f.Namespace).Delete(context.TODO(), sessionName, metav1.DeleteOptions{})).To(Succeed())
@@ -1212,6 +1257,29 @@ func runTerminalTurn(namespace, name, prompt string, outputMatcher gomegatypes.G
 	Expect(command.Wait()).To(Succeed(), "terminal output:\n%s", output.String())
 }
 
+func runTerminalAttachmentTurn(namespace, name, path, prompt string, outputMatcher gomegatypes.GomegaMatcher) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, framework.KelosBin(), "session", "connect", name, "-n", namespace)
+	output := &lockedBuffer{}
+	command.Stdout = io.MultiWriter(GinkgoWriter, output)
+	command.Stderr = GinkgoWriter
+	stdin, err := command.StdinPipe()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(command.Start()).To(Succeed())
+	Eventually(output.String, 30*time.Second, 100*time.Millisecond).Should(ContainSubstring("Connected. Type a message"))
+	_, err = io.WriteString(stdin, "/attach "+path+"\n")
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(output.String, 3*time.Minute, 200*time.Millisecond).Should(ContainSubstring("Attached " + filepath.Base(path)))
+	_, err = io.WriteString(stdin, prompt+"\n")
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(output.String, 3*time.Minute, 200*time.Millisecond).Should(outputMatcher)
+	_, err = io.WriteString(stdin, "/quit\n")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(stdin.Close()).To(Succeed())
+	Expect(command.Wait()).To(Succeed(), "terminal output:\n%s", output.String())
+}
+
 func startSessionServerPortForward() string {
 	ctx, cancel := context.WithCancel(context.Background())
 	command := exec.CommandContext(ctx, "kubectl", "--namespace", "kelos-system", "port-forward", "--address", "127.0.0.1", "service/kelos-session-server", ":80")
@@ -1280,6 +1348,40 @@ func resetSessionThroughWeb(client *http.Client, baseURL, namespace, name string
 	}
 	Expect(json.Unmarshal(body, &summary)).To(Succeed())
 	Expect(summary.Resetting).To(BeTrue())
+}
+
+func uploadSessionAttachment(client *http.Client, baseURL, namespace, name, filename string, data []byte) sessionruntime.Attachment {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filename)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = part.Write(data)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(writer.Close()).To(Succeed())
+
+	endpoint := fmt.Sprintf("%s/api/sessions/%s/%s/attachments", baseURL, url.PathEscape(namespace), url.PathEscape(name))
+	request, err := http.NewRequest(http.MethodPost, endpoint, &body)
+	Expect(err).NotTo(HaveOccurred())
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	response, err := client.Do(request)
+	Expect(err).NotTo(HaveOccurred())
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(response.StatusCode).To(Equal(http.StatusCreated), "Session attachment upload response: %s", responseBody)
+	var attachment sessionruntime.Attachment
+	Expect(json.Unmarshal(responseBody, &attachment)).To(Succeed())
+	return attachment
+}
+
+func downloadSessionAttachment(client *http.Client, baseURL, namespace, name, id string) (int, http.Header, []byte) {
+	endpoint := fmt.Sprintf("%s/api/sessions/%s/%s/attachments/%s", baseURL, url.PathEscape(namespace), url.PathEscape(name), url.PathEscape(id))
+	response, err := client.Get(endpoint)
+	Expect(err).NotTo(HaveOccurred())
+	defer response.Body.Close()
+	data, err := io.ReadAll(response.Body)
+	Expect(err).NotTo(HaveOccurred())
+	return response.StatusCode, response.Header.Clone(), data
 }
 
 func listWebSessions(client *http.Client, baseURL, namespace string) []string {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds persisted input attachments to interactive Sessions so users can provide images and other local files from either client.

- stores validated attachments in the Session state directory with per-file, per-message, and per-Session limits
- journals attachment metadata and restores it with queued and retained messages
- maps raster images to native Codex image inputs, OpenCode attachments to file parts, and exposes local paths to every provider
- adds authenticated multipart upload and download endpoints to the Session web server
- adds file selection and drag-and-drop to the web composer
- adds `/attach PATH` to terminal chat and recognizes bracketed-paste file drops in the interactive terminal UI
- adds end-to-end coverage for web transfer, Pod recovery, history, reset cleanup, and terminal submission

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Attachments use the existing Session state volume. They survive Pod replacement only for Sessions configured with `spec.volumeClaimTemplate`; reset and deletion follow the existing workspace lifecycle. The current limits are 10 MiB per file, 8 files per message, and 100 MiB or 128 files per Session.

Verification completed with:

- `make verify`
- `make test`
- `make build`

#### Does this PR introduce a user-facing change?

```release-note
Sessions now support image and file attachments from the web composer and `kelos session connect`, including drag-and-drop in both interactive interfaces.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add file attachments to Sessions across web and terminal. Users can attach images and other files; attachments are stored in Session state, included in turns and history, and persist across Pod replacement when using `spec.volumeClaimTemplate`.

- **New Features**
  - Web composer: attach button and drag-and-drop, pending attachment chips, and inline image previews/downloads.
  - Terminal: `/attach PATH`, bracketed-paste drag-and-drop in the interactive UI, and `/send` to submit files without text.
  - Storage and limits: 10 MiB per file, up to 8 files per message, and up to 100 MiB or 128 files per Session. Attachments live in the Session state volume and follow the workspace lifecycle.
  - API and runtime: authenticated multipart upload `POST /api/sessions/{ns}/{name}/attachments` and download `GET /api/sessions/{ns}/{name}/attachments/{id}`; `kelos-session-runtime attachment put|get`; new `internal/sessionattachment` client using Pod exec.
  - Provider integration: raster images become native Codex local images; OpenCode receives file parts via `file://` URLs; all providers receive a prompt that includes an attachment summary.

- **Migration**
  - Providers: `Provider.RunTurn` now accepts `TurnInput` (text + attachments) instead of a string prompt. Update custom providers accordingly.
  - Socket clients: include `attachmentIds` on `message` requests if sending attachments.

<sup>Written for commit aec44d0c7a37b6a28ac321d2e0e4436efb89f2bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

