### PR TITLE
Remove Session workload prefix

### DIFF
--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -1299,7 +1299,7 @@ func (r *SessionReconciler) ensureSessionWorkspaceClaimOwnership(ctx context.Con
 
 func (r *SessionReconciler) ensureSessionService(ctx context.Context, session *kelos.Session) error {
 	var existing corev1.Service
-	key := client.ObjectKey{Namespace: session.Namespace, Name: sessionWorkloadName(session)}
+	key := client.ObjectKey{Namespace: session.Namespace, Name: sessionServiceName(session)}
 	if err := r.Get(ctx, key, &existing); err == nil {
 		if !metav1.IsControlledBy(&existing, session) {
 			return fmt.Errorf("Service %q already exists and is not controlled by this Session", existing.Name)
@@ -1806,7 +1806,7 @@ func (r *SessionReconciler) buildSessionStatefulSet(session *kelos.Session, work
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:                             ptr.To(sessionRuntimeReplicas(session)),
-			ServiceName:                          sessionWorkloadName(session),
+			ServiceName:                          sessionServiceName(session),
 			PodManagementPolicy:                  appsv1.OrderedReadyPodManagement,
 			Selector:                             &metav1.LabelSelector{MatchLabels: selector},
 			UpdateStrategy:                       appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
@@ -1844,7 +1844,7 @@ func buildSessionService(session *kelos.Session) *corev1.Service {
 	labels := sessionSelectorLabels(session)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sessionWorkloadName(session),
+			Name:      sessionServiceName(session),
 			Namespace: session.Namespace,
 			Labels:    labels,
 		},
@@ -1856,7 +1856,11 @@ func buildSessionService(session *kelos.Session) *corev1.Service {
 }
 
 func sessionWorkloadName(session *kelos.Session) string {
-	return truncateResourceNameTo("session-"+session.Name, sessionWorkloadNameMaxLength)
+	return truncateResourceNameTo(session.Name, sessionWorkloadNameMaxLength)
+}
+
+func sessionServiceName(session *kelos.Session) string {
+	return truncateResourceName("s-" + session.Name)
 }
 
 func sessionSelectorLabels(session *kelos.Session) map[string]string {

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -160,7 +160,7 @@ func TestSessionReconcilerReconcilesSuspendedStatefulSetSpec(t *testing.T) {
 			session.Spec.Worker.Image = tt.imageOverride
 			statefulSet := testSessionStatefulSet(session)
 			statefulSet.Spec.Replicas = ptr.To(int32(0))
-			statefulSet.Spec.ServiceName = sessionWorkloadName(session)
+			statefulSet.Spec.ServiceName = sessionServiceName(session)
 			statefulSet.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 			statefulSet.Spec.Selector = &metav1.LabelSelector{MatchLabels: sessionSelectorLabels(session)}
 			statefulSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{{
@@ -328,7 +328,7 @@ func TestSessionGitHubTokenMinimumValidity(t *testing.T) {
 			currentStatefulSet: true,
 			replicas:           ptr.To(int32(0)),
 			phase:              kelos.SessionPhaseReady,
-			podName:            "session-token-policy-0",
+			podName:            "token-policy-0",
 			usesToken:          true,
 			want:               tokenRefreshMargin,
 		},
@@ -337,7 +337,7 @@ func TestSessionGitHubTokenMinimumValidity(t *testing.T) {
 			currentStatefulSet: true,
 			replicas:           ptr.To(int32(1)),
 			phase:              kelos.SessionPhasePending,
-			podName:            "session-token-policy-0",
+			podName:            "token-policy-0",
 			usesToken:          true,
 			want:               tokenRefreshMargin,
 		},
@@ -354,14 +354,14 @@ func TestSessionGitHubTokenMinimumValidity(t *testing.T) {
 			currentStatefulSet: true,
 			replicas:           ptr.To(int32(1)),
 			phase:              kelos.SessionPhaseReady,
-			podName:            "session-token-policy-0",
+			podName:            "token-policy-0",
 			want:               tokenRefreshMargin,
 		},
 		{
 			name:               "ready runtime using token",
 			currentStatefulSet: true,
 			phase:              kelos.SessionPhaseReady,
-			podName:            "session-token-policy-0",
+			podName:            "token-policy-0",
 			usesToken:          true,
 			want:               0,
 		},
@@ -403,7 +403,7 @@ func TestSessionReconcilerPreservesReadyStatusWhenInputReadFails(t *testing.T) {
 	session := testSession("ready-input-retry", "codex")
 	session.Spec.Worker.WorkspaceRef = &kelos.WorkspaceReference{Name: "workspace"}
 	session.Status.Phase = kelos.SessionPhaseReady
-	session.Status.PodName = "session-ready-input-retry-0"
+	session.Status.PodName = "ready-input-retry-0"
 	session.Status.PodUID = types.UID("ready-pod-uid")
 	session.Status.Conditions = []metav1.Condition{{
 		Type:               kelos.SessionConditionReady,
@@ -918,7 +918,7 @@ func TestSessionReconcilerDoesNotStealWorkspaceClaim(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(session, statefulSet, otherOwner, claim).Build()
 	reconciler := testSessionReconciler(cl, scheme)
 	err := reconciler.ensureSessionWorkspaceClaimOwnership(context.Background(), session, statefulSet)
-	if err == nil || !strings.Contains(err.Error(), `PersistentVolumeClaim "workspace-session-chat-0" is controlled by ConfigMap "other-owner"`) {
+	if err == nil || !strings.Contains(err.Error(), `PersistentVolumeClaim "workspace-chat-0" is controlled by ConfigMap "other-owner"`) {
 		t.Fatalf("ensureSessionWorkspaceClaimOwnership() error = %v", err)
 	}
 }
@@ -1282,8 +1282,9 @@ func TestSessionReconcilerCreatesStatefulSetAndObservesPod(t *testing.T) {
 	if statefulSet.Spec.Replicas == nil || *statefulSet.Spec.Replicas != 1 {
 		t.Fatalf("StatefulSet replicas = %v, want 1", statefulSet.Spec.Replicas)
 	}
-	if statefulSet.Spec.ServiceName != workloadKey.Name {
-		t.Fatalf("StatefulSet serviceName = %q, want %q", statefulSet.Spec.ServiceName, workloadKey.Name)
+	serviceKey := client.ObjectKey{Namespace: session.Namespace, Name: sessionServiceName(session)}
+	if statefulSet.Spec.ServiceName != serviceKey.Name {
+		t.Fatalf("StatefulSet serviceName = %q, want %q", statefulSet.Spec.ServiceName, serviceKey.Name)
 	}
 	if statefulSet.Spec.UpdateStrategy.Type != appsv1.OnDeleteStatefulSetStrategyType || statefulSet.Spec.UpdateStrategy.RollingUpdate != nil {
 		t.Fatalf("StatefulSet updateStrategy = %#v, want OnDelete", statefulSet.Spec.UpdateStrategy)
@@ -1293,7 +1294,7 @@ func TestSessionReconcilerCreatesStatefulSetAndObservesPod(t *testing.T) {
 		t.Fatalf("Session serviceAccountName = %q, want %q", statefulSet.Spec.Template.Spec.ServiceAccountName, accessName)
 	}
 	var service corev1.Service
-	if err := cl.Get(context.Background(), workloadKey, &service); err != nil {
+	if err := cl.Get(context.Background(), serviceKey, &service); err != nil {
 		t.Fatalf("getting Session Service: %v", err)
 	}
 	if !metav1.IsControlledBy(&service, session) || service.Spec.ClusterIP != corev1.ClusterIPNone {
@@ -1868,8 +1869,8 @@ func TestSessionGitHubTokenSecretNameBoundsLongNames(t *testing.T) {
 
 func TestSessionWorkloadNameBoundsStatefulSetRevisionLabel(t *testing.T) {
 	t.Parallel()
-	if got := sessionWorkloadName(testSession("chat", "codex")); got != "session-chat" {
-		t.Fatalf("Session workload name = %q, want %q", got, "session-chat")
+	if got := sessionWorkloadName(testSession("chat", "codex")); got != "chat" {
+		t.Fatalf("Session workload name = %q, want %q", got, "chat")
 	}
 
 	for _, sessionName := range []string{
@@ -1892,11 +1893,32 @@ func TestSessionWorkloadNameBoundsStatefulSetRevisionLabel(t *testing.T) {
 	}
 }
 
+func TestSessionServiceName(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		sessionName string
+		want        string
+	}{
+		{sessionName: "chat", want: "s-chat"},
+		{sessionName: "123-chat", want: "s-123-chat"},
+		{sessionName: "s-123-chat", want: "s-s-123-chat"},
+	} {
+		if got := sessionServiceName(testSession(tt.sessionName, "codex")); got != tt.want {
+			t.Errorf("Session Service name for %q = %q, want %q", tt.sessionName, got, tt.want)
+		}
+	}
+
+	longSession := testSession(strings.Repeat("a", 253), "codex")
+	if got := sessionServiceName(longSession); len(got) > 63 {
+		t.Fatalf("Session Service name length = %d, want at most 63", len(got))
+	}
+}
+
 func TestSessionReconcilerMapsStatefulSetPod(t *testing.T) {
 	t.Parallel()
 	reconciler := &SessionReconciler{}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-		Name:        "session-chat-0",
+		Name:        "chat-0",
 		Namespace:   "default",
 		Annotations: map[string]string{sessionNameAnnotation: "chat"},
 	}}
@@ -2361,7 +2383,7 @@ func TestSessionReconcilerSuspendsBeforeResolvingWorkspace(t *testing.T) {
 	session.Spec.Suspend = ptr.To(true)
 	session.Spec.Worker.WorkspaceRef = &kelos.WorkspaceReference{Name: "missing"}
 	session.Status.Phase = kelos.SessionPhaseReady
-	session.Status.PodName = "session-suspend-with-missing-workspace-0"
+	session.Status.PodName = "suspend-with-missing-workspace-0"
 	session.Status.PodUID = types.UID("stale-pod-uid")
 	statefulSet := testSessionStatefulSet(session)
 	statefulSet.Spec.Replicas = ptr.To(int32(1))

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -97,7 +97,7 @@ spec:
 
 		var statefulSet appsv1.StatefulSet
 		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}, &statefulSet)).To(Succeed())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: session.Name}, &statefulSet)).To(Succeed())
 			g.Expect(metav1.IsControlledBy(&statefulSet, session)).To(BeTrue())
 			g.Expect(statefulSet.Spec.Replicas).NotTo(BeNil())
 			g.Expect(*statefulSet.Spec.Replicas).To(Equal(int32(1)))
@@ -153,6 +153,23 @@ spec:
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 
+	It("creates a governing Service for a digit-leading Session name", func() {
+		session := validSession(namespace, "123-chat", "codex")
+		session.Spec.Suspend = ptr.To(true)
+		Expect(k8sClient.Create(ctx, session)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			var statefulSet appsv1.StatefulSet
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(session), &statefulSet)).To(Succeed())
+			g.Expect(statefulSet.Spec.ServiceName).To(Equal("s-" + session.Name))
+
+			var service corev1.Service
+			serviceKey := client.ObjectKey{Namespace: namespace, Name: statefulSet.Spec.ServiceName}
+			g.Expect(k8sClient.Get(ctx, serviceKey, &service)).To(Succeed())
+			g.Expect(metav1.IsControlledBy(&service, session)).To(BeTrue())
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
 	It("reconciles controller-managed fields on an existing persistent StatefulSet", func() {
 		session := validSession(namespace, "existing-statefulset", "codex")
 		session.Spec.Suspend = ptr.To(true)
@@ -165,7 +182,7 @@ spec:
 			g.Expect(current.Status.Message).To(Equal(`Waiting for AgentConfig "late-config"`))
 		}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 
-		workloadName := "session-" + session.Name
+		workloadName := session.Name
 		selector := map[string]string{
 			"kelos.dev/component": "session",
 			"kelos.dev/session":   session.Name,
@@ -178,7 +195,7 @@ spec:
 			},
 			Spec: appsv1.StatefulSetSpec{
 				Replicas:            ptr.To(int32(0)),
-				ServiceName:         workloadName,
+				ServiceName:         "s-" + workloadName,
 				PodManagementPolicy: appsv1.ParallelPodManagement,
 				Selector:            &metav1.LabelSelector{MatchLabels: selector},
 				UpdateStrategy:      appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
@@ -236,7 +253,7 @@ spec:
 		session := validSession(namespace, "suspend", "codex")
 		Expect(k8sClient.Create(ctx, session)).To(Succeed())
 
-		statefulSetKey := client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}
+		statefulSetKey := client.ObjectKey{Namespace: namespace, Name: session.Name}
 		Eventually(func(g Gomega) {
 			var statefulSet appsv1.StatefulSet
 			g.Expect(k8sClient.Get(ctx, statefulSetKey, &statefulSet)).To(Succeed())
@@ -246,7 +263,7 @@ spec:
 
 		claim := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "workspace-session-" + session.Name + "-0",
+				Name:            "workspace-" + session.Name + "-0",
 				Namespace:       namespace,
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(session, kelos.GroupVersion.WithKind("Session"))},
 			},
@@ -301,7 +318,7 @@ spec:
 		session := validSession(namespace, "runtime-update", "codex")
 		Expect(k8sClient.Create(ctx, session)).To(Succeed())
 
-		key := client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}
+		key := client.ObjectKey{Namespace: namespace, Name: session.Name}
 		var statefulSet appsv1.StatefulSet
 		Eventually(func(g Gomega) {
 			g.Expect(k8sClient.Get(ctx, key, &statefulSet)).To(Succeed())
@@ -349,7 +366,7 @@ spec:
 		Expect(k8sClient.Create(ctx, session)).To(Succeed())
 
 		Consistently(func() error {
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}, &appsv1.StatefulSet{})
+			return k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: session.Name}, &appsv1.StatefulSet{})
 		}, time.Second, 100*time.Millisecond).ShouldNot(Succeed())
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(session), session)).To(Succeed())
 
@@ -359,13 +376,13 @@ spec:
 		}
 		statefulSet := &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "session-" + session.Name,
+				Name:            session.Name,
 				Namespace:       namespace,
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(session, kelos.GroupVersion.WithKind("Session"))},
 			},
 			Spec: appsv1.StatefulSetSpec{
 				Replicas:             ptr.To(int32(0)),
-				ServiceName:          "session-" + session.Name,
+				ServiceName:          "s-" + session.Name,
 				RevisionHistoryLimit: ptr.To(int32(1)),
 				Selector:             &metav1.LabelSelector{MatchLabels: selector},
 				Template: corev1.PodTemplateSpec{
@@ -407,7 +424,7 @@ spec:
 		session.Spec.Worker.AgentConfigRefs = []kelos.AgentConfigReference{{Name: agentConfig.Name}}
 		Expect(k8sClient.Create(ctx, session)).To(Succeed())
 
-		key := client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}
+		key := client.ObjectKey{Namespace: namespace, Name: session.Name}
 		var originalChecksum string
 		var pluginConfigMapName string
 		Eventually(func(g Gomega) {
@@ -467,7 +484,7 @@ spec:
 
 		Eventually(func(g Gomega) {
 			var statefulSet appsv1.StatefulSet
-			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}, &statefulSet)).To(Succeed())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: session.Name}, &statefulSet)).To(Succeed())
 			g.Expect(statefulSet.Spec.VolumeClaimTemplates).To(BeEmpty())
 			var workspace *corev1.Volume
 			for i := range statefulSet.Spec.Template.Spec.Volumes {
@@ -519,7 +536,7 @@ spec:
 		session.Spec.Worker.Model = "initial-model"
 		Expect(k8sClient.Create(ctx, session)).To(Succeed())
 
-		statefulSetKey := client.ObjectKey{Namespace: namespace, Name: "session-" + session.Name}
+		statefulSetKey := client.ObjectKey{Namespace: namespace, Name: session.Name}
 		Eventually(func(g Gomega) {
 			var statefulSet appsv1.StatefulSet
 			g.Expect(k8sClient.Get(ctx, statefulSetKey, &statefulSet)).To(Succeed())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Uses the Session name directly for its StatefulSet instead of adding a `session-` prefix. The derived Pod and persistent workspace claim names follow the same convention, while long workload names remain bounded at 52 characters for StatefulSet revision label safety.

The governing Service uses `s-<session-name>` so its name always starts with a letter as required by Kubernetes Service validation, including when the Session name starts with a digit.

PR #1629 retained the workload prefix in its final implementation even though its description and release note said the prefix would be removed. This follow-up makes the implementation match that user-facing contract and aligns Session workload naming with Task workload naming.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Existing `session-`-prefixed StatefulSets, Services, and workspace PVCs are not migrated. After an upgrade, the controller uses the unprefixed workload identity and the `s-`-prefixed governing Service; operators must preserve required workspace data and recreate existing Sessions. Until old resources are cleaned up, a Session whose name matches another Session's prefixed workload name can encounter an ownership conflict.

Validation:

- `make test TEST_FLAGS='-run TestSession'`
- `make test-integration`
- `make verify`
- `make build`

#### Does this PR introduce a user-facing change?

```release-note
Session StatefulSets, Pods, and persistent workspace claims now derive their names directly from the Session name without a `session-` prefix. Governing Services use the shorter `s-` prefix required for valid Service names, including for digit-leading Session names.

[Action Required]
Existing Sessions must be recreated after upgrading because their `session-`-prefixed workloads, Services, and workspace PVCs are not migrated. Preserve any required workspace data before recreating those Sessions.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `session-` prefix from Session workload names. StatefulSets, Pods, and workspace PVCs now use the Session name directly, while the governing Service uses `s-<name>` for DNS-safe naming; workload names stay capped at 52 chars and Service names at 63.

- **Migration**
  - Existing `session-`-prefixed workloads, Services, and PVCs are not migrated.
  - Back up required workspace data and recreate Sessions after upgrading.
  - Clean up old prefixed resources to prevent ownership conflicts.

<sup>Written for commit 95c0b55cc5e49fbf6942baa69a4baab9202542a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
