### PR TITLE
Align session composer text

### DIFF
--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -272,7 +272,7 @@ button { color: inherit; }
 .pending-attachment button { flex: none; padding: 0; border: 0; background: transparent; color: var(--muted); cursor: pointer; }
 .composer { display: flex; align-items: flex-end; gap: 10px; padding: 9px 9px 9px 16px; border: 1px solid #d1d8d2; border-radius: 17px; background: var(--card); box-shadow: 0 12px 38px rgba(28,45,36,.08); transition: border .15s, box-shadow .15s; }
 .composer:focus-within { border-color: #85a493; box-shadow: 0 12px 38px rgba(28,45,36,.1), 0 0 0 3px rgba(57,112,84,.08); }
-.composer textarea { flex: 1; max-height: 160px; resize: none; border: 0; outline: 0; padding: 8px 0 6px; background: transparent; color: var(--ink); font-size: 14px; line-height: 1.45; }
+.composer textarea { flex: 1; max-height: 160px; resize: none; border: 0; outline: 0; padding: 7px 0; background: transparent; color: var(--ink); font-size: 14px; line-height: 1.45; }
 .composer textarea::placeholder { color: #99a19c; }
 .attach-button { flex: none; width: 30px; height: 36px; padding: 0; border: 0; background: transparent; color: var(--accent-2); font-size: 22px; cursor: pointer; }
 .attach-button:disabled { color: var(--faint); cursor: default; }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Balances the Session web composer's textarea padding so its text and caret are vertically centered. The previous asymmetric padding shifted the content slightly within the control.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The total vertical padding remains unchanged, so the composer retains its existing height.

#### Does this PR introduce a user-facing change?

```release-note
Align the Session web composer text and caret vertically within the input.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Session web composer’s textarea by balancing vertical padding so the text and caret are centered. Keeps total padding the same, so the composer height is unchanged.

<sup>Written for commit 10a067c24e67f32e9aa9b5f23e58e6fe40b6e3af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

