### PR TITLE
Fix custom session question answers

### DIFF
--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -391,6 +391,17 @@ func TestApplicationSectionChooserBehavior(t *testing.T) {
 	}
 }
 
+func TestApplicationInputRequestBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node.js is not installed")
+	}
+	command := exec.Command(node, "testdata/input_request_test.js")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("running input request tests: %v\n%s", err, output)
+	}
+}
+
 func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
 	server := testServer(t)
 	payload := `{

--- a/internal/sessionserver/testdata/input_request_test.js
+++ b/internal/sessionserver/testdata/input_request_test.js
@@ -1,0 +1,184 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+class TestNode {
+  constructor(tag) {
+    this.tag = tag;
+    this.children = [];
+    this.parent = null;
+    this.classes = new Set();
+    this.listeners = new Map();
+    this.checked = false;
+    this.disabled = false;
+    this.value = '';
+    this._text = '';
+  }
+
+  append(...nodes) {
+    for (const node of nodes) {
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type, event = {}) {
+    for (const listener of this.listeners.get(type) || []) listener(event);
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  set className(value) {
+    this.classes = new Set(String(value).split(/\s+/).filter(Boolean));
+  }
+
+  get className() {
+    return [...this.classes].join(' ');
+  }
+
+  set textContent(value) {
+    this._text = String(value);
+    this.children = [];
+  }
+
+  get textContent() {
+    return this.children.length
+      ? this.children.map(child => child.textContent).join('')
+      : this._text;
+  }
+}
+
+global.document = {
+  createElement: tag => new TestNode(tag),
+};
+global.WebSocket = {OPEN: 1};
+global.ensureConversation = () => {};
+global.scrollToBottom = () => {};
+
+const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
+const start = application.indexOf('function bindOtherAnswer');
+const end = application.indexOf('function resolveInputCard', start);
+assert.notEqual(start, -1, 'bindOtherAnswer not found');
+assert.notEqual(end, -1, 'resolveInputCard not found');
+vm.runInThisContext(application.slice(start, end), {filename: 'app.js'});
+
+let sentMessages;
+let toasts;
+
+function resetHarness() {
+  sentMessages = [];
+  toasts = [];
+  global.elements = {messages: new TestNode('div')};
+  global.state = {
+    inputs: new Map(),
+    socket: {
+      readyState: WebSocket.OPEN,
+      send: message => sentMessages.push(JSON.parse(message)),
+    },
+  };
+  global.showToast = message => toasts.push(message);
+}
+
+function findAll(node, predicate) {
+  const matches = predicate(node) ? [node] : [];
+  for (const child of node.children) matches.push(...findAll(child, predicate));
+  return matches;
+}
+
+function formControls(form) {
+  return {
+    options: findAll(form, node => node.tag === 'input' && !node.classes.has('input-other')),
+    other: findAll(form, node => node.classes.has('input-other'))[0],
+  };
+}
+
+function submit(form) {
+  form.dispatch('submit', {preventDefault: () => {}});
+}
+
+function testSingleChoiceFormKeepsAnswerExclusive() {
+  resetHarness();
+  renderInputRequest({
+    inputId: 'single-choice',
+    questions: [{
+      id: 'answer',
+      header: 'Answer',
+      question: 'Choose one',
+      options: [{label: 'First'}, {label: 'Second'}],
+    }],
+  });
+
+  const form = elements.messages.children[0];
+  const {options, other} = formControls(form);
+  options[0].checked = true;
+  other.value = '   ';
+  other.dispatch('input');
+  assert.equal(options[0].checked, true);
+  submit(form);
+  assert.deepEqual(sentMessages.pop(), {
+    type: 'input',
+    inputId: 'single-choice',
+    answers: {answer: ['First']},
+  });
+
+  other.value = 'Another answer';
+  other.dispatch('input');
+  assert.equal(options[0].checked, false);
+  submit(form);
+  assert.deepEqual(sentMessages.pop(), {
+    type: 'input',
+    inputId: 'single-choice',
+    answers: {answer: ['Another answer']},
+  });
+
+  options[1].checked = true;
+  options[1].dispatch('change');
+  assert.equal(other.value, '');
+  submit(form);
+  assert.deepEqual(sentMessages.pop(), {
+    type: 'input',
+    inputId: 'single-choice',
+    answers: {answer: ['Second']},
+  });
+  assert.deepEqual(toasts, []);
+}
+
+function testMultipleChoiceFormAllowsOptionsAndOtherText() {
+  resetHarness();
+  renderInputRequest({
+    inputId: 'multiple-choice',
+    questions: [{
+      id: 'answers',
+      header: 'Answers',
+      question: 'Choose several',
+      multiSelect: true,
+      options: [{label: 'First'}, {label: 'Second'}],
+    }],
+  });
+
+  const form = elements.messages.children[0];
+  const {options, other} = formControls(form);
+  options[0].checked = true;
+  other.value = 'Another answer';
+  other.dispatch('input');
+  assert.equal(options[0].checked, true);
+  submit(form);
+  assert.deepEqual(sentMessages, [{
+    type: 'input',
+    inputId: 'multiple-choice',
+    answers: {answers: ['First', 'Another answer']},
+  }]);
+  assert.deepEqual(toasts, []);
+}
+
+testSingleChoiceFormKeepsAnswerExclusive();
+testMultipleChoiceFormAllowsOptionsAndOtherText();

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -2805,6 +2805,19 @@ function completeTool(event) {
   renderToolOutput(card, event.output);
 }
 
+function bindOtherAnswer(controls, other, multiSelect) {
+  if (multiSelect) return;
+  for (const control of controls) {
+    control.addEventListener('change', () => {
+      if (control.checked) other.value = '';
+    });
+  }
+  other.addEventListener('input', () => {
+    if (!other.value.trim()) return;
+    controls.forEach(control => { control.checked = false; });
+  });
+}
+
 function renderInputRequest(event) {
   ensureConversation();
   if (!event.inputId || state.inputs.has(event.inputId)) return;
@@ -2848,6 +2861,7 @@ function renderInputRequest(event) {
     other.type = question.secret ? 'password' : 'text';
     other.placeholder = question.options?.length ? 'Or type another answer' : 'Type your answer';
     other.autocomplete = 'off';
+    bindOtherAnswer(controls, other, question.multiSelect);
     fieldset.append(legend, prompt, choices, other);
     card.append(fieldset);
     rows.push({question, controls, other});


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Keeps single-choice Session input requests visually consistent with the answer that will be submitted. Entering a custom answer now clears a previously selected option, and selecting an option clears existing custom text.

The custom answer already took precedence during submission, but the selected radio remained visible and made it appear that two answers were active. Multi-select questions remain additive and continue to allow options alongside custom text.

Validated with:

- `make test TEST_FLAGS='-run TestApplication'`
- `make verify`

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The browser behavior test covers both single-select exclusivity and unchanged multi-select behavior.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Session question prompts so entering a custom answer clears a previously selected single-choice option.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix single-choice Session questions so the UI matches the submitted answer. Typing a custom answer deselects any option, and selecting an option clears the custom text; multi-select questions remain additive.

- **Bug Fixes**
  - Added `bindOtherAnswer` to enforce single-choice exclusivity via change/input handlers.
  - Hooked into `renderInputRequest` when an "Other" input is rendered.
  - Added a Node-based behavior test (`internal/sessionserver/testdata/input_request_test.js`) and invoked it from `server_test.go` to verify single vs multi-select behavior.

<sup>Written for commit 774e692a97142ed6f480707c3cbf3d824c636a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

