### PR TITLE
Align session composer placeholder

### DIFF
--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -702,6 +702,8 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"48-pixel touch targets":     `.icon-button { width: 48px; height: 48px; }`,
 		"phone safe-area padding":    `env(safe-area-inset-bottom)`,
 		"non-zooming form fields":    `.composer textarea, .yaml-panel textarea, .form-grid input`,
+		"desktop composer alignment": `.composer textarea { flex: 1; min-height: 36px;`,
+		"mobile composer alignment":  `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
 		"phone-sized dialog":         `max-height: calc(100dvh - 16px`,
 		"shrinking composer content": `.composer-wrap { min-width: 0;`,
 	} {

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -272,7 +272,7 @@ button { color: inherit; }
 .pending-attachment button { flex: none; padding: 0; border: 0; background: transparent; color: var(--muted); cursor: pointer; }
 .composer { display: flex; align-items: flex-end; gap: 10px; padding: 9px 9px 9px 16px; border: 1px solid #d1d8d2; border-radius: 17px; background: var(--card); box-shadow: 0 12px 38px rgba(28,45,36,.08); transition: border .15s, box-shadow .15s; }
 .composer:focus-within { border-color: #85a493; box-shadow: 0 12px 38px rgba(28,45,36,.1), 0 0 0 3px rgba(57,112,84,.08); }
-.composer textarea { flex: 1; max-height: 160px; resize: none; border: 0; outline: 0; padding: 7px 0; background: transparent; color: var(--ink); font-size: 14px; line-height: 1.45; }
+.composer textarea { flex: 1; min-height: 36px; max-height: 160px; resize: none; border: 0; outline: 0; padding: 8px 0; background: transparent; color: var(--ink); font-size: 14px; line-height: 20px; }
 .composer textarea::placeholder { color: #99a19c; }
 .attach-button { flex: none; width: 30px; height: 36px; padding: 0; border: 0; background: transparent; color: var(--accent-2); font-size: 22px; cursor: pointer; }
 .attach-button:disabled { color: var(--faint); cursor: default; }
@@ -371,6 +371,7 @@ button { color: inherit; }
   .composer-wrap { padding: 9px calc(10px + env(safe-area-inset-right)) calc(10px + env(safe-area-inset-bottom)) calc(10px + env(safe-area-inset-left)); }
   .composer { padding-left: 13px; }
   .composer textarea, .yaml-panel textarea, .form-grid input, .form-grid select, .source-picker select, .section-field input, .section-field select, .namespace-form input, .input-other { font-size: 16px; }
+  .composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }
   .send-button { width: 48px; height: 48px; }
   .message-bubble, .user-message { max-width: 90%; }
   .tool-card, .input-card, .diff-card, .error-card, .recovery-card { margin-left: 0; }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Matches the Session web composer's one-line textarea height to its adjacent controls: 36 pixels on desktop and 48 pixels on mobile. Explicit padding and line heights vertically center the placeholder, caret, and entered text at both responsive sizes.

The textarea previously remained shorter than the mobile control and was bottom-aligned within the composer, making the placeholder appear too low.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The textarea retains its existing 160-pixel maximum height and auto-growing multiline behavior. Responsive assertions cover both desktop and mobile sizing.

#### Does this PR introduce a user-facing change?

```release-note
Align the Session web composer placeholder and entered text on desktop and mobile.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the Session composer textarea with adjacent controls to center the placeholder and caret. Desktop min-height is 36px; mobile is 48px.

- **Bug Fixes**
  - Adjusted padding and line-height to vertically center text while keeping the 160px max height and auto-grow behavior.
  - Added a mobile-specific rule and updated tests to assert alignment on desktop and mobile.

<sup>Written for commit 503c7b5910b67c9d131885819fd34c103111e44e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

