### PR TITLE
Add Session Server display names

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -297,6 +297,14 @@ exact value is also available to assistive technology. A Session waiting for a
 user response is labeled **Waiting for input** in the sidebar and header, with a
 distinct red indicator in the sidebar.
 
+Use **Rename** beside the selected Session's title to set a display name for the
+web chat. The display name appears in the sidebar, conversation header, and web
+runtime status without changing the Session's Kubernetes resource name. An empty
+display name restores the resource name. Display names are stored in the
+`kelos.dev/session-display-name` annotation, so Session manifests can set the
+same annotation directly. Values are trimmed and limited to 64 characters when
+set through the web chat.
+
 Sessions can be categorized into sections from the creation form or from the
 section control beneath the selected Session's name. Both controls list the
 existing sections in the active namespace and include a **Create new section**

--- a/internal/manifests/charts/kelos/README.md
+++ b/internal/manifests/charts/kelos/README.md
@@ -247,7 +247,10 @@ the controls list existing section names in the active namespace or create a
 section once for later reuse. In the sidebar, Sessions can be dragged between
 sections, and section headings, including **Unsectioned**, can be dragged or
 moved with arrow controls. Each browser stores section order separately for each
-namespace. The creation dialog can generate a new Session from an existing
+namespace. The selected Session's **Rename** control sets a web-only display
+name without changing the Kubernetes resource name. Display names are stored in
+the `kelos.dev/session-display-name` annotation; clearing the value restores the
+resource name. The creation dialog can generate a new Session from an existing
 Session in that namespace,
 copying its complete `Session.spec` into the form and editable YAML manifest but
 not copying its metadata, conversation, or volume data. The creation form

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -47,13 +47,15 @@ import (
 )
 
 const (
-	authCookieName           = "kelos_session_auth"
-	sessionRuntimeClient     = "/kelos/bin/kelos-session-runtime"
-	sessionApplyManager      = "kelos-session-server"
-	sessionSectionAnnotation = "kelos.dev/session-section"
-	maxSessionSectionLength  = 64
-	requestBodyLimit         = 1024 * 1024
-	attachmentRequestLimit   = sessionruntime.MaxAttachmentBytes + 1024*1024
+	authCookieName               = "kelos_session_auth"
+	sessionRuntimeClient         = "/kelos/bin/kelos-session-runtime"
+	sessionApplyManager          = "kelos-session-server"
+	sessionDisplayNameAnnotation = "kelos.dev/session-display-name"
+	sessionSectionAnnotation     = "kelos.dev/session-section"
+	maxSessionDisplayNameLength  = 64
+	maxSessionSectionLength      = 64
+	requestBodyLimit             = 1024 * 1024
+	attachmentRequestLimit       = sessionruntime.MaxAttachmentBytes + 1024*1024
 )
 
 //go:embed web/*
@@ -108,6 +110,7 @@ func (c *sessionSocket) WriteMessage(messageType int, data []byte) error {
 
 type sessionSummary struct {
 	Name            string                    `json:"name"`
+	DisplayName     string                    `json:"displayName"`
 	Namespace       string                    `json:"namespace"`
 	UID             string                    `json:"uid,omitempty"`
 	Provider        string                    `json:"provider"`
@@ -150,6 +153,10 @@ type createSessionRequest struct {
 
 type updateSessionSectionRequest struct {
 	Section string `json:"section"`
+}
+
+type updateSessionDisplayNameRequest struct {
+	DisplayName string `json:"displayName"`
 }
 
 type sessionManifest struct {
@@ -357,6 +364,10 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 	}
 	if len(parts) == 4 && parts[3] == "section" && request.Method == http.MethodPatch {
 		s.updateSessionSection(writer, request, namespace, name)
+		return
+	}
+	if len(parts) == 4 && parts[3] == "display-name" && request.Method == http.MethodPatch {
+		s.updateSessionDisplayName(writer, request, namespace, name)
 		return
 	}
 	if len(parts) != 3 {
@@ -723,9 +734,71 @@ func normalizeSessionSection(value string) (string, error) {
 	return value, nil
 }
 
+func (s *Server) updateSessionDisplayName(writer http.ResponseWriter, request *http.Request, namespace, name string) {
+	var payload updateSessionDisplayNameRequest
+	if err := decodeJSON(request.Body, &payload); err != nil {
+		writeError(writer, http.StatusBadRequest, err.Error())
+		return
+	}
+	displayName, err := normalizeSessionDisplayName(payload.DisplayName)
+	if err != nil {
+		writeError(writer, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var session kelos.Session
+	if err := s.client.Get(request.Context(), client.ObjectKey{Namespace: namespace, Name: name}, &session); err != nil {
+		writeKubernetesError(writer, fmt.Sprintf("getting Session %q to update its display name", name), err)
+		return
+	}
+	original := session.DeepCopy()
+	if displayName == "" {
+		delete(session.Annotations, sessionDisplayNameAnnotation)
+	} else {
+		if session.Annotations == nil {
+			session.Annotations = map[string]string{}
+		}
+		session.Annotations[sessionDisplayNameAnnotation] = displayName
+	}
+	if err := s.client.Patch(
+		request.Context(),
+		&session,
+		client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}),
+	); err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case apierrors.IsNotFound(err):
+			status = http.StatusNotFound
+		case apierrors.IsInvalid(err):
+			status = http.StatusBadRequest
+		case apierrors.IsForbidden(err):
+			status = http.StatusForbidden
+		case apierrors.IsConflict(err):
+			status = http.StatusConflict
+		}
+		writeError(writer, status, fmt.Sprintf("updating display name for Session %q: %v", name, err))
+		return
+	}
+	writeJSON(writer, http.StatusOK, summarize(&session))
+}
+
+func normalizeSessionDisplayName(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if utf8.RuneCountInString(value) > maxSessionDisplayNameLength {
+		return "", fmt.Errorf("display name must be at most %d characters", maxSessionDisplayNameLength)
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return "", errors.New("display name must not contain control characters")
+		}
+	}
+	return value, nil
+}
+
 func summarize(session *kelos.Session) sessionSummary {
 	summary := sessionSummary{
 		Name:           session.Name,
+		DisplayName:    sessionDisplayName(session),
 		Namespace:      session.Namespace,
 		UID:            string(session.UID),
 		Provider:       session.Spec.Worker.Type,
@@ -749,6 +822,13 @@ func summarize(session *kelos.Session) sessionSummary {
 		summary.WaitingForInput = active && condition.Reason == "WaitingForInput"
 	}
 	return summary
+}
+
+func sessionDisplayName(session *kelos.Session) string {
+	if displayName := strings.TrimSpace(session.Annotations[sessionDisplayNameAnnotation]); displayName != "" {
+		return displayName
+	}
+	return session.Name
 }
 
 func sessionActiveCondition(session *kelos.Session) *metav1.Condition {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -391,6 +391,17 @@ func TestApplicationSectionChooserBehavior(t *testing.T) {
 	}
 }
 
+func TestApplicationDisplayNameBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node.js is not installed")
+	}
+	command := exec.Command(node, "testdata/display_name_test.js")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("running display name tests: %v\n%s", err, output)
+	}
+}
+
 func TestApplicationInputRequestBehavior(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
@@ -858,6 +869,64 @@ func TestSessionSectionAPI(t *testing.T) {
 	}
 }
 
+func TestSessionDisplayNameAPI(t *testing.T) {
+	server := testServer(t)
+	session := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "chat",
+			Namespace:   "team-a",
+			Annotations: map[string]string{"owner": "platform"},
+		},
+		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{Type: "codex"}},
+	}
+	if err := server.client.Create(t.Context(), session); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPatch, "/api/sessions/team-a/chat/display-name", strings.NewReader(`{"displayName":"  Investigate flaky CI  "}`))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("set display name status = %d body = %s", response.Code, response.Body.String())
+	}
+	var summary sessionSummary
+	if err := json.Unmarshal(response.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.Name != "chat" || summary.DisplayName != "Investigate flaky CI" {
+		t.Fatalf("set display name summary = %#v", summary)
+	}
+
+	var updated kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "team-a", Name: "chat"}, &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Annotations[sessionDisplayNameAnnotation] != "Investigate flaky CI" || updated.Annotations["owner"] != "platform" {
+		t.Fatalf("Session annotations after setting display name = %v", updated.Annotations)
+	}
+
+	request = httptest.NewRequest(http.MethodPatch, "/api/sessions/team-a/chat/display-name", strings.NewReader(`{"displayName":""}`))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("clear display name status = %d body = %s", response.Code, response.Body.String())
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.Name != "chat" || summary.DisplayName != "chat" {
+		t.Fatalf("cleared display name summary = %#v", summary)
+	}
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "team-a", Name: "chat"}, &updated); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := updated.Annotations[sessionDisplayNameAnnotation]; exists || updated.Annotations["owner"] != "platform" {
+		t.Fatalf("Session annotations after clearing display name = %v", updated.Annotations)
+	}
+}
+
 func TestSessionResumeAPIRequestsIdleResume(t *testing.T) {
 	server := testServer(t)
 	session := &kelos.Session{
@@ -920,6 +989,31 @@ func TestNormalizeSessionSection(t *testing.T) {
 	}
 }
 
+func TestNormalizeSessionDisplayName(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		value     string
+		want      string
+		wantError bool
+	}{
+		{name: "trimmed", value: "  Customer work  ", want: "Customer work"},
+		{name: "empty", value: "  ", want: ""},
+		{name: "unicode", value: strings.Repeat("界", maxSessionDisplayNameLength), want: strings.Repeat("界", maxSessionDisplayNameLength)},
+		{name: "too long", value: strings.Repeat("a", maxSessionDisplayNameLength+1), wantError: true},
+		{name: "control character", value: "one\ntwo", wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := normalizeSessionDisplayName(test.value)
+			if (err != nil) != test.wantError {
+				t.Fatalf("normalizeSessionDisplayName(%q) error = %v, wantError %t", test.value, err, test.wantError)
+			}
+			if got != test.want {
+				t.Fatalf("normalizeSessionDisplayName(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
 func TestSummarizeIncludesRuntimeStatus(t *testing.T) {
 	createdAt := metav1.NewTime(time.Now().Add(-time.Hour))
 	lastActivityAt := metav1.NewTime(time.Now().Add(-time.Minute))
@@ -949,7 +1043,7 @@ func TestSummarizeIncludesRuntimeStatus(t *testing.T) {
 	}
 
 	summary := summarize(session)
-	if summary.Active == nil || !*summary.Active || !summary.WaitingForInput || summary.Model != session.Status.Model || summary.Branch != session.Status.Branch || summary.PullRequest == nil || *summary.PullRequest != *session.Status.PullRequest || summary.Section != "Reviews" {
+	if summary.DisplayName != "chat" || summary.Active == nil || !*summary.Active || !summary.WaitingForInput || summary.Model != session.Status.Model || summary.Branch != session.Status.Branch || summary.PullRequest == nil || *summary.PullRequest != *session.Status.PullRequest || summary.Section != "Reviews" {
 		t.Fatalf("summarize() = %#v", summary)
 	}
 	if summary.CreatedAt == nil || !summary.CreatedAt.Equal(&createdAt) {
@@ -1149,6 +1243,51 @@ func TestSessionUISections(t *testing.T) {
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session styles are missing %s: %s", description, expected)
+		}
+	}
+}
+
+func TestSessionUIDisplayNames(t *testing.T) {
+	index, err := webFiles.ReadFile("web/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for description, expected := range map[string]string{
+		"rename control":      `id="session-display-name" type="button"`,
+		"display name dialog": `id="display-name-dialog"`,
+		"display name input":  `id="session-display-name-input" maxlength="64"`,
+	} {
+		if !strings.Contains(string(index), expected) {
+			t.Errorf("Session page is missing %s: %s", description, expected)
+		}
+	}
+
+	javascript, err := webFiles.ReadFile("web/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for description, expected := range map[string]string{
+		"display name fallback": `return session?.displayName || session?.name || '';`,
+		"sidebar display name":  `name.textContent = sessionDisplayName(session);`,
+		"header display name":   `elements.title.textContent = sessionDisplayName(session);`,
+		"runtime display name":  `sessionRuntimeStatusText(state.runtimeStatus, sessionDisplayName(state.selected))`,
+		"canonical API route":   `/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/display-name`,
+	} {
+		if !strings.Contains(string(javascript), expected) {
+			t.Errorf("Session display name behavior is missing %s: %s", description, expected)
+		}
+	}
+
+	styles, err := webFiles.ReadFile("web/styles.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for description, expected := range map[string]string{
+		"rename control": `.session-display-name-button {`,
+		"rename dialog":  `.display-name-dialog {`,
+	} {
+		if !strings.Contains(string(styles), expected) {
+			t.Errorf("Session display name styles are missing %s: %s", description, expected)
 		}
 	}
 }

--- a/internal/sessionserver/testdata/display_name_test.js
+++ b/internal/sessionserver/testdata/display_name_test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
+
+function applicationSlice(start, end) {
+  const startIndex = application.indexOf(start);
+  const endIndex = application.indexOf(end, startIndex);
+  assert.notEqual(startIndex, -1, `${start} not found`);
+  assert.notEqual(endIndex, -1, `${end} not found`);
+  return application.slice(startIndex, endIndex);
+}
+
+vm.runInThisContext(applicationSlice('function sessionKey', 'function sessionViewKey'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function sessionRuntimePath', 'function renderRuntimeStatus'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function saveSessionDisplayName', 'async function moveSessionToSection'), {filename: 'app.js'});
+
+async function testDisplayNameUpdatePreservesSessionIdentity() {
+  const session = {namespace: 'team-a', name: 'chat', displayName: 'chat'};
+  global.state = {
+    namespaceGeneration: 3,
+    sessions: [session],
+    selected: session,
+  };
+  let request;
+  let sessionsRendered = 0;
+  let headerRendered = 0;
+  let runtimeStatusRendered = 0;
+  global.api = async (requestPath, options) => {
+    request = {path: requestPath, options};
+    return {...session, displayName: 'Investigate flaky CI'};
+  };
+  global.renderSessions = () => { sessionsRendered++; };
+  global.renderHeader = () => {
+    headerRendered++;
+    renderRuntimeStatus();
+  };
+  global.renderRuntimeStatus = () => { runtimeStatusRendered++; };
+
+  await saveSessionDisplayName(session, 'Investigate flaky CI');
+
+  assert.equal(request.path, '/api/sessions/team-a/chat/display-name');
+  assert.deepEqual(JSON.parse(request.options.body), {displayName: 'Investigate flaky CI'});
+  assert.equal(state.sessions[0].name, 'chat');
+  assert.equal(state.sessions[0].displayName, 'Investigate flaky CI');
+  assert.equal(state.selected.displayName, 'Investigate flaky CI');
+  assert.equal(sessionsRendered, 1);
+  assert.equal(headerRendered, 1);
+  assert.equal(runtimeStatusRendered, 1);
+}
+
+function testDisplayNameRenderingFallsBackToResourceName() {
+  assert.equal(sessionDisplayName({name: 'chat', displayName: 'Investigate flaky CI'}), 'Investigate flaky CI');
+  assert.equal(sessionDisplayName({name: 'chat'}), 'chat');
+  assert.equal(
+    sessionRuntimeStatusText({sessionName: 'chat', agentType: 'codex'}, 'Investigate flaky CI'),
+    'Investigate flaky CI · codex',
+  );
+}
+
+testDisplayNameRenderingFallsBackToResourceName();
+testDisplayNameUpdatePreservesSessionIdentity().then(() => {
+  process.stdout.write('Display name tests passed\n');
+});

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -2,6 +2,13 @@ const elements = {
   list: document.querySelector('#session-list'),
   title: document.querySelector('#session-title'),
   meta: document.querySelector('#session-meta'),
+  displayNameButton: document.querySelector('#session-display-name'),
+  displayNameDialog: document.querySelector('#display-name-dialog'),
+  displayNameForm: document.querySelector('#display-name-form'),
+  displayNameDialogDescription: document.querySelector('#display-name-dialog-description'),
+  displayNameInput: document.querySelector('#session-display-name-input'),
+  displayNameDialogError: document.querySelector('#display-name-dialog-error'),
+  saveDisplayNameButton: document.querySelector('#save-session-display-name'),
   sectionButton: document.querySelector('#session-section'),
   sectionSelect: document.querySelector('#session-section-select'),
   sectionCustom: document.querySelector('#session-section-custom'),
@@ -120,6 +127,7 @@ const state = {
   creatingSession: false,
   sourceStorageClassNamePresent: false,
   loadedSource: null,
+  displayNameSaving: false,
   sectionSaving: false,
   sectionAssignments: new Set(),
   sectionOrders: new Map(),
@@ -158,6 +166,10 @@ function showToast(message) {
 
 function sessionKey(session) {
   return `${session.namespace}/${session.name}`;
+}
+
+function sessionDisplayName(session) {
+  return session?.displayName || session?.name || '';
 }
 
 function sessionViewKey(session) {
@@ -426,11 +438,11 @@ function formatSessionRuntimeTokens(value) {
   return `${Number(scaled.toFixed(decimals))}${suffix}`;
 }
 
-function sessionRuntimeStatusText(status) {
+function sessionRuntimeStatusText(status, displayName = '') {
   if (!status) return '';
   const parts = [];
   const add = value => { if (value) parts.push(value); };
-  add(status.sessionName);
+  add(displayName || status.sessionName);
   add(status.agentType);
   add(`${status.model || ''} ${status.effort || ''}`.trim());
   add(sessionRuntimePath(status.workingDir, status.homeDir));
@@ -451,7 +463,7 @@ function sessionRuntimeStatusText(status) {
 }
 
 function renderRuntimeStatus() {
-  const text = sessionRuntimeStatusText(state.runtimeStatus);
+  const text = sessionRuntimeStatusText(state.runtimeStatus, sessionDisplayName(state.selected));
   elements.runtimeStatus.textContent = text;
   elements.runtimeStatus.title = text;
   elements.runtimeStatus.hidden = !text;
@@ -682,7 +694,7 @@ function createSessionListItem(session, draggable = false) {
   titleRow.className = 'session-item-title-row';
   const name = document.createElement('div');
   name.className = 'session-item-name';
-  name.textContent = session.name;
+  name.textContent = sessionDisplayName(session);
   titleRow.append(name);
   const timestamp = createSessionTimestamp(session, true, 'session-item-time');
   if (timestamp) titleRow.append(timestamp);
@@ -692,7 +704,7 @@ function createSessionListItem(session, draggable = false) {
   provider.className = 'provider-badge';
   provider.textContent = providerLabel(session.provider);
   const namespace = document.createElement('span');
-  namespace.textContent = `· ${session.namespace}`;
+  namespace.textContent = sessionDisplayName(session) === session.name ? `· ${session.namespace}` : `· ${session.namespace}/${session.name}`;
   const activity = document.createElement('span');
   activity.textContent = `· ${displayStatus}`;
   meta.append(provider);
@@ -953,6 +965,20 @@ async function saveSessionSectionAssignment(session, section) {
   state.sessions = state.sessions.map(item => sessionKey(item) === sessionKey(updated) ? updated : item);
   if (state.selected && sessionKey(state.selected) === sessionKey(updated)) state.selected = updated;
   renderSectionOptions();
+  renderSessions();
+  renderHeader();
+  return updated;
+}
+
+async function saveSessionDisplayName(session, displayName) {
+  const generation = state.namespaceGeneration;
+  const updated = await api(
+    `/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/display-name`,
+    {method: 'PATCH', body: JSON.stringify({displayName})},
+  );
+  if (generation !== state.namespaceGeneration) return updated;
+  state.sessions = state.sessions.map(item => sessionKey(item) === sessionKey(updated) ? updated : item);
+  if (state.selected && sessionKey(state.selected) === sessionKey(updated)) state.selected = updated;
   renderSessions();
   renderHeader();
   return updated;
@@ -1504,6 +1530,8 @@ function createWelcome() {
 
 function renderHeader() {
   const session = state.selected;
+  elements.displayNameButton.hidden = !session;
+  elements.displayNameButton.disabled = !session;
   elements.sectionButton.hidden = !session;
   elements.sectionButton.disabled = !session;
   elements.resetButton.disabled = !session || session.resetting;
@@ -1516,12 +1544,14 @@ function renderHeader() {
     elements.meta.textContent = 'Select an existing conversation or create one.';
     setConnection('idle', 'Not connected');
     setComposer(false);
+    renderRuntimeStatus();
     return;
   }
-  elements.title.textContent = session.name;
+  elements.title.textContent = sessionDisplayName(session);
   elements.sectionButton.textContent = session.section ? `Section: ${session.section}` : '＋ Choose section';
   elements.sectionButton.title = session.section ? 'Move Session to another section' : 'Move Session to a section';
-  const details = [session.namespace, providerLabel(session.provider)];
+  const resourceName = sessionDisplayName(session) === session.name ? session.namespace : `${session.namespace}/${session.name}`;
+  const details = [resourceName, providerLabel(session.provider)];
   if (session.model) details.push(session.model);
   details.push(sessionDisplayStatus(session));
   if (session.branch) details.push(session.branch);
@@ -1550,6 +1580,7 @@ function renderHeader() {
     setConnection(session.phase === 'Failed' ? 'error' : 'connecting', session.phase || 'Pending');
     setComposer(false);
   }
+  renderRuntimeStatus();
 }
 
 function setConnection(status, label) {
@@ -3522,11 +3553,72 @@ elements.form.addEventListener('submit', async event => {
   }
 });
 
+function openDisplayNameDialog() {
+  const session = state.selected;
+  if (!session || state.displayNameSaving) return;
+  elements.displayNameDialogError.textContent = '';
+  elements.displayNameDialogDescription.textContent = `Set a display name for Session ${session.namespace}/${session.name} without changing its Kubernetes resource name.`;
+  elements.displayNameInput.value = sessionDisplayName(session) === session.name ? '' : sessionDisplayName(session);
+  elements.displayNameInput.placeholder = session.name;
+  elements.displayNameDialog.showModal();
+  window.setTimeout(() => elements.displayNameInput.focus(), 0);
+}
+
+function setDisplayNameSaving(saving) {
+  state.displayNameSaving = saving;
+  elements.displayNameInput.disabled = saving;
+  elements.saveDisplayNameButton.disabled = saving;
+  elements.displayNameDialog.setAttribute('aria-busy', String(saving));
+  document.querySelectorAll('.close-display-name-dialog').forEach(button => {
+    button.disabled = saving;
+  });
+}
+
+function closeDisplayNameDialog() {
+  if (!state.displayNameSaving) elements.displayNameDialog.close();
+}
+
+function handleDisplayNameDialogCancel(event) {
+  if (state.displayNameSaving) event.preventDefault();
+}
+
+elements.displayNameButton.addEventListener('click', openDisplayNameDialog);
+document.querySelectorAll('.close-display-name-dialog').forEach(button => {
+  button.addEventListener('click', closeDisplayNameDialog);
+});
+elements.displayNameDialog.addEventListener('cancel', handleDisplayNameDialogCancel);
+
+elements.displayNameForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  if (state.displayNameSaving) return;
+  const session = state.selected;
+  if (!session) {
+    elements.displayNameDialog.close();
+    return;
+  }
+  const displayName = elements.displayNameInput.value.trim();
+  if ((displayName || session.name) === sessionDisplayName(session)) {
+    elements.displayNameDialog.close();
+    return;
+  }
+  elements.displayNameDialogError.textContent = '';
+  setDisplayNameSaving(true);
+  try {
+    await saveSessionDisplayName(session, displayName);
+    elements.displayNameDialog.close();
+    showToast(displayName ? 'Session renamed' : 'Session name reset');
+  } catch (error) {
+    elements.displayNameDialogError.textContent = error.message;
+  } finally {
+    setDisplayNameSaving(false);
+  }
+});
+
 function openSectionDialog() {
   const session = state.selected;
   if (!session || state.sectionSaving) return;
   elements.sectionDialogError.textContent = '';
-  elements.sectionDialogDescription.textContent = `Choose where Session ${session.name} appears in the sidebar.`;
+  elements.sectionDialogDescription.textContent = `Choose where Session ${sessionDisplayName(session)} appears in the sidebar.`;
   elements.sectionChoiceCustom.value = '';
   populateSectionSelect(elements.sectionChoice, session.section || '', 'Unsectioned (remove assignment)');
   updateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -41,7 +41,10 @@
       <header class="conversation-header">
         <button class="icon-button mobile-only" id="open-sidebar" aria-label="Open sessions" aria-controls="sidebar" aria-expanded="false">☰</button>
         <div class="session-heading">
-          <div class="session-title" id="session-title">Choose a session</div>
+          <div class="session-title-row">
+            <div class="session-title" id="session-title">Choose a session</div>
+            <button class="session-display-name-button" id="session-display-name" type="button" disabled hidden>Rename</button>
+          </div>
           <div class="session-meta" id="session-meta">Select an existing conversation or create one.</div>
           <button class="session-section-button" id="session-section" type="button" disabled hidden>＋ Add section</button>
         </div>
@@ -264,6 +267,28 @@
       <div class="dialog-actions">
         <button class="secondary-button close-section-dialog" type="button">Cancel</button>
         <button class="primary-button" id="save-session-section">Save section</button>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog class="session-dialog display-name-dialog" id="display-name-dialog" aria-labelledby="display-name-dialog-title" aria-describedby="display-name-dialog-description">
+    <form id="display-name-form">
+      <div class="dialog-header">
+        <div>
+          <h2 id="display-name-dialog-title">Rename Session</h2>
+          <p id="display-name-dialog-description">Set a display name without changing the Kubernetes resource name.</p>
+        </div>
+        <button class="icon-button close-display-name-dialog" type="button" aria-label="Close">×</button>
+      </div>
+      <label class="section-field">
+        <span>Display name</span>
+        <input name="displayName" id="session-display-name-input" maxlength="64" autocomplete="off">
+        <small>Leave blank to display the Kubernetes resource name.</small>
+      </label>
+      <div class="dialog-error" id="display-name-dialog-error" role="alert"></div>
+      <div class="dialog-actions">
+        <button class="secondary-button close-display-name-dialog" type="button">Cancel</button>
+        <button class="primary-button" id="save-session-display-name">Save name</button>
       </div>
     </form>
   </dialog>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -102,7 +102,12 @@ button { color: inherit; }
 .conversation { min-width: 0; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; background: var(--canvas); }
 .conversation-header { min-height: 74px; display: flex; align-items: center; gap: 13px; padding: 13px 23px; border-bottom: 1px solid var(--line-soft); background: rgba(248,249,245,.88); backdrop-filter: blur(15px); }
 .session-heading { flex: 1; min-width: 0; }
-.session-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 17px/1.2 Georgia, "Times New Roman", serif; }
+.session-title-row { display: flex; align-items: center; gap: 7px; }
+.session-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 17px/1.2 Georgia, "Times New Roman", serif; }
+.session-display-name-button { flex: none; padding: 2px 6px; border: 0; border-radius: 6px; background: transparent; color: var(--faint); font-size: 9px; font-weight: 700; cursor: pointer; }
+.session-display-name-button:hover { background: var(--line-soft); color: var(--ink); }
+.session-display-name-button:disabled { opacity: .45; cursor: default; }
+.session-display-name-button[hidden] { display: none; }
 .session-meta { display: flex; align-items: center; gap: 5px; overflow: hidden; margin-top: 5px; color: var(--muted); font-size: 11px; white-space: nowrap; }
 .session-meta-details { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-meta-separator, .session-meta a, .session-meta-time { flex: none; }
@@ -290,6 +295,7 @@ button { color: inherit; }
 .session-dialog::backdrop { background: rgba(25,35,30,.38); backdrop-filter: blur(4px); }
 .session-dialog form { padding: 23px; }
 .section-dialog { width: min(94vw, 420px); }
+.display-name-dialog { width: min(94vw, 420px); }
 .dialog-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; }
 .dialog-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
 .dialog-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds mutable display names to the Session Server web application without changing a Session's Kubernetes resource name.

- stores the display name in the `kelos.dev/session-display-name` annotation
- adds a Rename dialog and an authenticated PATCH endpoint
- updates the sidebar, selected Session header, and web runtime status immediately
- keeps `metadata.name` as the identity for API routes, connections, and Kubernetes operations
- shows the canonical `namespace/name` alongside a custom display name for disambiguation
- falls back to the resource name when the annotation is absent or cleared
- documents the annotation and 64-character web validation

Validation:

- `make test` (with Session-injected Codex environment variables unset)
- `make verify` (with Session-injected Codex environment variables unset)

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is intentionally a Session Server-specific annotation rather than a new CRD field. The terminal client and Session runtime continue to use the canonical resource name.

#### Does this PR introduce a user-facing change?

```release-note
Session Server users can set a mutable display name for a Session without changing its Kubernetes resource name.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add mutable display names for Sessions in the Session Server without changing the Kubernetes resource name. Display names are stored in the `kelos.dev/session-display-name` annotation and appear in the sidebar, header, and runtime status.

- **New Features**
  - Added Rename dialog in the web app; shows display names in the sidebar and header, and uses them in runtime status; displays `namespace/name` alongside a custom name for clarity.
  - New authenticated PATCH endpoint: `/api/sessions/:namespace/:name/display-name`; trims input, rejects control chars, and enforces a 64‑character limit; empty values clear the annotation and fall back to the resource name.
  - Stores names in `kelos.dev/session-display-name`; keeps `metadata.name` as the identity for API routes, connections, and Kubernetes operations.
  - Updated docs to describe the annotation and web validation.

<sup>Written for commit 59abfdf16a8d1392563ec8c5a0c3fa2bbd6a9823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

