### PR TITLE
Show merge queue status for Sessions

### DIFF
--- a/api/v1alpha2/session_types.go
+++ b/api/v1alpha2/session_types.go
@@ -29,7 +29,7 @@ const (
 	SessionReasonIdlePolicyTriggered = "IdlePolicyTriggered"
 )
 
-// SessionPullRequestState represents the lifecycle state of a Session pull request.
+// SessionPullRequestState represents the observed state of a Session pull request.
 type SessionPullRequestState string
 
 const (
@@ -37,6 +37,8 @@ const (
 	SessionPullRequestStateDraft SessionPullRequestState = "Draft"
 	// SessionPullRequestStateOpen means the pull request is open for review.
 	SessionPullRequestStateOpen SessionPullRequestState = "Open"
+	// SessionPullRequestStateQueued means the pull request is in a merge queue.
+	SessionPullRequestStateQueued SessionPullRequestState = "Queued"
 	// SessionPullRequestStateMerged means the pull request has been merged.
 	SessionPullRequestStateMerged SessionPullRequestState = "Merged"
 	// SessionPullRequestStateClosed means the pull request was closed without merging.
@@ -75,11 +77,11 @@ type SessionPullRequest struct {
 	// URL is the pull request web URL.
 	URL string `json:"url"`
 
-	// State is the pull request lifecycle state.
-	// +kubebuilder:validation:Enum=Draft;Open;Merged;Closed
+	// State is the observed pull request state.
+	// +kubebuilder:validation:Enum=Draft;Open;Queued;Merged;Closed
 	State SessionPullRequestState `json:"state"`
 
-	// Checks summarizes the GitHub checks reported for the pull request.
+	// Checks summarizes the GitHub checks for the pull request or its merge queue entry.
 	// +optional
 	Checks *SessionPullRequestChecks `json:"checks,omitempty"`
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -229,8 +229,8 @@ the Session resource and is visible through the Kubernetes API.
 | `status.conditions[type=Active]` | Whether the runtime has an unfinished turn; `reason: WaitingForInput` means the turn is waiting for a user response, and `Unknown` means activity has not been reported | Output |
 | `status.branch` | Currently checked-out git branch in the Session workspace | Output |
 | `status.pullRequest.url` | Web URL of the pull request associated with the current branch | Output |
-| `status.pullRequest.state` | Pull request lifecycle state: `Draft`, `Open`, `Merged`, or `Closed` | Output |
-| `status.pullRequest.checks.state` | Aggregate GitHub check state: `Pending`, `Success`, or `Failure`. Cancelled checks are failures | Output |
+| `status.pullRequest.state` | Pull request state: `Draft`, `Open`, `Queued`, `Merged`, or `Closed`. `Queued` means the pull request is in a merge queue | Output |
+| `status.pullRequest.checks.state` | Aggregate GitHub check state: `Pending`, `Success`, or `Failure`. Queued pull requests use the merge queue commit's checks. Cancelled checks are failures | Output |
 | `status.pullRequest.checks.completed` | Number of GitHub checks that have completed | Output |
 | `status.pullRequest.checks.total` | Total number of GitHub checks reported for the pull request | Output |
 

--- a/internal/manifests/charts/kelos/charts/kelos-crds/templates/session-crd.yaml
+++ b/internal/manifests/charts/kelos/charts/kelos-crds/templates/session-crd.yaml
@@ -7343,8 +7343,8 @@ spec:
                   Branch, when one exists.
                 properties:
                   checks:
-                    description: Checks summarizes the GitHub checks reported for
-                      the pull request.
+                    description: Checks summarizes the GitHub checks for the pull
+                      request or its merge queue entry.
                     properties:
                       completed:
                         description: Completed is the number of checks that have completed.
@@ -7369,10 +7369,11 @@ spec:
                     - total
                     type: object
                   state:
-                    description: State is the pull request lifecycle state.
+                    description: State is the observed pull request state.
                     enum:
                     - Draft
                     - Open
+                    - Queued
                     - Merged
                     - Closed
                     type: string

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -7984,8 +7984,8 @@ spec:
                   Branch, when one exists.
                 properties:
                   checks:
-                    description: Checks summarizes the GitHub checks reported for
-                      the pull request.
+                    description: Checks summarizes the GitHub checks for the pull
+                      request or its merge queue entry.
                     properties:
                       completed:
                         description: Completed is the number of checks that have completed.
@@ -8010,10 +8010,11 @@ spec:
                     - total
                     type: object
                   state:
-                    description: State is the pull request lifecycle state.
+                    description: State is the observed pull request state.
                     enum:
                     - Draft
                     - Open
+                    - Queued
                     - Merged
                     - Closed
                     type: string

--- a/internal/sessionruntime/workspace_status.go
+++ b/internal/sessionruntime/workspace_status.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -19,6 +20,7 @@ import (
 const (
 	workspaceStatusFileName       = "workspace-status.json"
 	workspaceStatusCommandTimeout = 5 * time.Second
+	pullRequestMergeQueueQuery    = `query($id:ID!){node(id:$id){... on PullRequest{mergeQueueEntry{headCommit{statusCheckRollup{contexts(first:100){nodes{__typename ... on CheckRun{status conclusion} ... on StatusContext{state}}}}}}}}}`
 )
 
 // WorkspaceStatus describes the git work currently visible in a Session.
@@ -36,6 +38,16 @@ type githubStatusCheck struct {
 	Status     string `json:"status"`
 	Conclusion string `json:"conclusion"`
 	State      string `json:"state"`
+}
+
+type githubMergeQueueEntry struct {
+	HeadCommit *struct {
+		StatusCheckRollup *struct {
+			Contexts struct {
+				Nodes []githubStatusCheck `json:"nodes"`
+			} `json:"contexts"`
+		} `json:"statusCheckRollup"`
+	} `json:"headCommit"`
 }
 
 type realWorkspaceStatusRunner struct{}
@@ -120,7 +132,7 @@ func repositoryOwnerFromRemoteURL(remoteURL string) (string, error) {
 }
 
 func findPullRequest(ctx context.Context, runner workspaceStatusRunner, workingDir, branch, repo, headOwner string) (*kelos.SessionPullRequest, error) {
-	args := []string{"pr", "list", "--head", branch, "--state", "all", "--json", "url,headRepositoryOwner,state,isDraft,statusCheckRollup", "--limit", "100"}
+	args := []string{"pr", "list", "--head", branch, "--state", "all", "--json", "id,url,headRepositoryOwner,state,isDraft,statusCheckRollup", "--limit", "100"}
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}
@@ -132,6 +144,7 @@ func findPullRequest(ctx context.Context, runner workspaceStatusRunner, workingD
 		return nil, nil
 	}
 	var pullRequests []struct {
+		ID                  string `json:"id"`
 		URL                 string `json:"url"`
 		State               string `json:"state"`
 		IsDraft             bool   `json:"isDraft"`
@@ -149,14 +162,43 @@ func findPullRequest(ctx context.Context, runner workspaceStatusRunner, workingD
 			if err != nil {
 				return nil, err
 			}
+			checks := pullRequest.StatusCheckRollup
+			mergeQueueEntry, err := findPullRequestMergeQueueEntry(ctx, runner, workingDir, pullRequest.ID)
+			if err != nil {
+				log.Printf("Unable to read pull request merge queue, using pull request checks error=%v", err)
+			} else if mergeQueueEntry != nil {
+				state = kelos.SessionPullRequestStateQueued
+				checks = nil
+				if mergeQueueEntry.HeadCommit != nil && mergeQueueEntry.HeadCommit.StatusCheckRollup != nil {
+					checks = mergeQueueEntry.HeadCommit.StatusCheckRollup.Contexts.Nodes
+				}
+			}
 			return &kelos.SessionPullRequest{
 				URL:    pullRequest.URL,
 				State:  state,
-				Checks: sessionPullRequestChecks(pullRequest.StatusCheckRollup),
+				Checks: sessionPullRequestChecks(checks),
 			}, nil
 		}
 	}
 	return nil, nil
+}
+
+func findPullRequestMergeQueueEntry(ctx context.Context, runner workspaceStatusRunner, workingDir, pullRequestID string) (*githubMergeQueueEntry, error) {
+	output, err := runner.run(ctx, workingDir, "gh", "api", "graphql", "-F", "id="+pullRequestID, "-f", "query="+pullRequestMergeQueueQuery)
+	if err != nil {
+		return nil, fmt.Errorf("reading pull request merge queue: %w", err)
+	}
+	var response struct {
+		Data struct {
+			Node struct {
+				MergeQueueEntry *githubMergeQueueEntry `json:"mergeQueueEntry"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		return nil, fmt.Errorf("decoding pull request merge queue: %w", err)
+	}
+	return response.Data.Node.MergeQueueEntry, nil
 }
 
 func sessionPullRequestChecks(checks []githubStatusCheck) *kelos.SessionPullRequestChecks {

--- a/internal/sessionruntime/workspace_status_test.go
+++ b/internal/sessionruntime/workspace_status_test.go
@@ -36,9 +36,10 @@ func TestCaptureWorkspaceStatus(t *testing.T) {
 		"/repo: git branch --show-current":                                              {output: "feature/status"},
 		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: ""},
 		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: `[{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""},{"__typename":"StatusContext","state":"SUCCESS"}]}]`,
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
+			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""},{"__typename":"StatusContext","state":"SUCCESS"}]}]`,
 		},
+		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {output: `{"data":{"node":{"mergeQueueEntry":null}}}`},
 	}}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
@@ -62,15 +63,84 @@ func TestCaptureWorkspaceStatus(t *testing.T) {
 	}
 }
 
+func TestCaptureWorkspaceStatusUsesMergeQueueChecks(t *testing.T) {
+	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
+		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
+		"/repo: git branch --show-current":                                              {output: "feature/status"},
+		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: ""},
+		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
+			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}]`,
+		},
+		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {
+			output: `{"data":{"node":{"mergeQueueEntry":{"headCommit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""}]}}}}}}}`,
+		},
+	}}
+
+	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := WorkspaceStatus{
+		Branch: "feature/status",
+		PullRequest: &kelos.SessionPullRequest{
+			URL:   "https://github.com/kelos-dev/kelos/pull/42",
+			State: kelos.SessionPullRequestStateQueued,
+			Checks: &kelos.SessionPullRequestChecks{
+				State:     kelos.SessionPullRequestChecksStatePending,
+				Completed: 1,
+				Total:     2,
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("captureWorkspaceStatus() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCaptureWorkspaceStatusUsesPullRequestChecksOnMergeQueueLookupError(t *testing.T) {
+	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
+		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
+		"/repo: git branch --show-current":                                              {output: "feature/status"},
+		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: ""},
+		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
+			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}]`,
+		},
+		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {err: errors.New("merge queue unavailable")},
+	}}
+
+	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := WorkspaceStatus{
+		Branch: "feature/status",
+		PullRequest: &kelos.SessionPullRequest{
+			URL:   "https://github.com/kelos-dev/kelos/pull/42",
+			State: kelos.SessionPullRequestStateOpen,
+			Checks: &kelos.SessionPullRequestChecks{
+				State:     kelos.SessionPullRequestChecksStateSuccess,
+				Completed: 1,
+				Total:     1,
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("captureWorkspaceStatus() = %#v, want %#v", got, want)
+	}
+}
+
 func TestCaptureWorkspaceStatusUsesBranchPushRemote(t *testing.T) {
 	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
 		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
 		"/repo: git branch --show-current":                                              {output: "feature/status"},
 		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "fork"},
 		"/repo: git remote get-url --push fork":                                         {output: "git@github.com:gjkim/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: `[{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"gjkim"}}]`,
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
+			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"gjkim"}}]`,
 		},
+		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {output: `{"data":{"node":{"mergeQueueEntry":null}}}`},
 	}}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
@@ -111,12 +181,13 @@ func TestCaptureWorkspaceStatusUsesUpstreamRepository(t *testing.T) {
 		"/repo: git branch --show-current":                                              {output: "feature/status"},
 		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "origin"},
 		"/repo: git remote get-url --push origin":                                       {output: "git@github.com:gjkim/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
 			output: "[]",
 		},
-		"/repo: gh pr list --head feature/status --state all --json url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100 --repo kelos-dev/kelos": {
-			output: `[{"url":"https://github.com/kelos-dev/kelos/pull/41","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"another-fork"}},{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":true,"headRepositoryOwner":{"login":"gjkim"}}]`,
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100 --repo kelos-dev/kelos": {
+			output: `[{"id":"PR_41","url":"https://github.com/kelos-dev/kelos/pull/41","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"another-fork"}},{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":true,"headRepositoryOwner":{"login":"gjkim"}}]`,
 		},
+		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {output: `{"data":{"node":{"mergeQueueEntry":null}}}`},
 	}}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", []string{"KELOS_UPSTREAM_REPO=kelos-dev/kelos"})
@@ -215,7 +286,7 @@ func TestRefreshWorkspaceStatusClearsPullRequestAfterSuccessfulLookup(t *testing
 		"/repo: git branch --show-current":                                              {output: "feature/status"},
 		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "origin"},
 		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
+		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
 			output: "[]",
 		},
 	}}

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -1192,6 +1192,7 @@ func TestSessionViewsIncludeRuntimeStatus(t *testing.T) {
 	for state, expected := range map[string]string{
 		"draft":  `.pull-request-link[data-state="draft"] { color: var(--faint); }`,
 		"open":   `.pull-request-link[data-state="open"] { color: var(--pr-open); }`,
+		"queued": `.pull-request-link[data-state="queued"] { color: var(--warning); }`,
 		"merged": `.pull-request-link[data-state="merged"] { color: var(--pr-merged); }`,
 		"closed": `.pull-request-link[data-state="closed"] { color: var(--pr-closed); }`,
 	} {

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -591,7 +591,7 @@ function pullRequestLabel(url) {
 }
 
 function sessionPRState(value) {
-  return ['Draft', 'Open', 'Merged', 'Closed'].includes(value) ? value : '';
+  return ['Draft', 'Open', 'Queued', 'Merged', 'Closed'].includes(value) ? value : '';
 }
 
 function sessionPRChecks(checks) {

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -88,6 +88,7 @@ button { color: inherit; }
 .pull-request-link::before { flex: none; width: 6px; height: 6px; border-radius: 50%; background: currentColor; content: ''; }
 .pull-request-link[data-state="draft"] { color: var(--faint); }
 .pull-request-link[data-state="open"] { color: var(--pr-open); }
+.pull-request-link[data-state="queued"] { color: var(--warning); }
 .pull-request-link[data-state="merged"] { color: var(--pr-merged); }
 .pull-request-link[data-state="closed"] { color: var(--pr-closed); }
 .pull-request-checks[data-state="pending"] { color: var(--warning); }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Sessions now report `status.pullRequest.state` as `Queued` while their pull request has a GitHub merge queue entry. While queued, the Session runtime aggregates checks from the merge queue commit instead of retaining the pull request head checks.

The Session web interface recognizes and styles the queued state, and the generated CRDs and reference documentation include the new API value.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make update`
- `env -u CODEX_AUTH_JSON -u CODEX_HOME make test`
- `make verify`
- Live read-only validation of the merge queue GraphQL query with `gh api graphql`

#### Does this PR introduce a user-facing change?

```release-note
Sessions now show when their pull request is in the GitHub merge queue and report checks from the merge queue commit.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sessions now show a `Queued` pull request state when the PR is in GitHub’s merge queue. While queued, checks come from the merge queue head commit instead of the PR head.

- **New Features**
  - Added `Queued` to `status.pullRequest.state` in the API and CRDs; docs updated.
  - Detect merge queue via `gh api graphql` and set state to `Queued` when an entry exists.
  - Web UI recognizes and styles `Queued`; checks summarize the merge queue commit’s status.

<sup>Written for commit 245606d48c4a7da829132e93825365315d28a81a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

