### PR TITLE
Maintain one editable pending Session message

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -279,11 +279,14 @@ from retained history that does not contain event timestamps and from turns
 interrupted by runtime recovery. Both clients use the same event stream and
 provider conversation. Both clients can stream agent and tool activity, answer
 user-input requests, and interrupt active work without ending the provider
-conversation. Kelos first asks the provider to interrupt gracefully, including
+conversation. While a turn is active, new submissions are combined into one
+pending message that runs next. In the web client, use **Edit** to revise its
+text before it starts; existing attachments remain on the message. Kelos first
+asks the provider to interrupt gracefully, including
 while the runtime is draining. If the request fails or the turn does not finish
 within 10 seconds, Kelos marks the turn interrupted and restarts the provider.
-Clients reconnect to the retained conversation after a provider restart, and
-queued prompts accepted before the restart resume in their original order.
+Clients reconnect to the retained conversation after a provider restart, and a
+pending message accepted before the restart resumes automatically.
 
 Completed tool output is retained with Session history up to 512 KiB per tool
 result. Larger results keep their beginning and end around an

--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -298,11 +298,10 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				}
 				closeAssistantLine(&liveAssistant)
 				liveAssistant.streaming = liveAssistant.streaming && activeTurnID != ""
-				if event.HistoryState != nil && len(event.HistoryState.QueuedTurns) > 0 {
-					write("\n%s\n", formatter.muted("Queued messages:"))
-					for _, turn := range event.HistoryState.QueuedTurns {
-						write("%s\n", formatter.userMessage(sessionTerminalMessageText(turn.Text, turn.Attachments)))
-					}
+				if event.HistoryState != nil && event.HistoryState.PendingTurn != nil {
+					write("\n%s\n", formatter.muted("Pending message:"))
+					turn := event.HistoryState.PendingTurn
+					write("%s\n", formatter.userMessage(sessionTerminalMessageText(turn.Text, turn.Attachments)))
 				}
 				historyMu.Lock()
 				hasEarlierHistory := historyCursor != ""
@@ -317,7 +316,7 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				}
 				finishAssistant(assistant)
 				write("%s\n", formatter.warning(event.Text))
-			case sessionruntime.EventUserMessage:
+			case sessionruntime.EventUserMessage, sessionruntime.EventUserMessageUpdated:
 				finishAssistant(assistant)
 				write("%s\n", formatter.userMessage(sessionTerminalMessageText(event.Text, event.Attachments)))
 				if color {

--- a/internal/cli/session_terminal_test.go
+++ b/internal/cli/session_terminal_test.go
@@ -19,9 +19,10 @@ func TestSessionTerminalRendersANSIEvents(t *testing.T) {
 	var events bytes.Buffer
 	encoder := json.NewEncoder(&events)
 	for _, event := range []sessionruntime.Event{
-		{Type: sessionruntime.EventHistoryEnd, HistoryState: &sessionruntime.HistoryState{QueuedTurns: []sessionruntime.HistoryQueuedTurn{{TurnID: "turn-2", Text: "queued"}}}},
+		{Type: sessionruntime.EventHistoryEnd, HistoryState: &sessionruntime.HistoryState{PendingTurn: &sessionruntime.HistoryPendingTurn{TurnID: "turn-2", Text: "pending"}}},
 		{Type: sessionruntime.EventRuntimeRecovered, Text: "Session runtime restarted"},
 		{Type: sessionruntime.EventUserMessage, Text: "hello"},
+		{Type: sessionruntime.EventUserMessageUpdated, TurnID: "turn-2", Text: "pending\n\nwith more context"},
 		{Type: sessionruntime.EventAssistantDelta, Text: "working"},
 		{Type: sessionruntime.EventToolStarted, ToolName: "shell"},
 		{Type: sessionruntime.EventToolCompleted, Status: "completed"},
@@ -55,7 +56,8 @@ func TestSessionTerminalRendersANSIEvents(t *testing.T) {
 	got := output.String()
 	for _, want := range []string{
 		"\x1b[7m  hello  \x1b[0m",
-		"\x1b[7m  queued  \x1b[0m",
+		"\x1b[7m  pending  \x1b[0m",
+		"\x1b[7m  with more context  \x1b[0m",
 		"\x1b[1m\x1b[33mSession runtime restarted\x1b[0m",
 		"\x1b[1m\x1b[36m↳ shell\x1b[0m",
 		"\x1b[32mcompleted\x1b[0m",

--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -33,7 +33,7 @@ const (
 	sessionTUIComposerGap            = 1
 	sessionTUIComposerPrompt         = "> "
 	sessionTUIStatusBarHeight        = 1
-	sessionTUIQueueMaxHeight         = 8
+	sessionTUIPendingMaxHeight       = 8
 	sessionTUIIndent                 = 2
 	sessionTUIToolOutputMaxLines     = 5
 	sessionTUIFrameInterval          = time.Second / 30
@@ -130,8 +130,8 @@ type sessionTUIModel struct {
 	input              textarea.Model
 	styles             sessionTUIStyles
 	blocks             []sessionTUIBlock
-	queuedTurns        map[string]string
-	queuedTurnOrder    []string
+	pendingTurnID      string
+	pendingTurnText    string
 	toolNames          map[string]string
 	width              int
 	height             int
@@ -241,7 +241,6 @@ func newSessionTUIModel(events *json.Decoder, requests *json.Encoder, output io.
 		requests:           requests,
 		input:              input,
 		styles:             styles,
-		queuedTurns:        make(map[string]string),
 		toolNames:          make(map[string]string),
 		width:              sessionTUIDefaultWidth,
 		height:             sessionTUIDefaultHeight,
@@ -638,7 +637,11 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 			m.finishStreaming()
 			m.appendBlock(sessionTUIBlockUser, sessionTerminalMessageText(event.Text, event.Attachments))
 		} else {
-			m.appendQueuedUser(event.TurnID, sessionTerminalMessageText(event.Text, event.Attachments))
+			m.setPendingUser(event.TurnID, sessionTerminalMessageText(event.Text, event.Attachments))
+		}
+	case sessionruntime.EventUserMessageUpdated:
+		if m.pendingTurnID == event.TurnID {
+			m.pendingTurnText = sessionTerminalMessageText(event.Text, event.Attachments)
 		}
 	case sessionTerminalEventAttachmentAdded:
 		m.pendingAttachments = append(m.pendingAttachments, event.Attachments...)
@@ -647,7 +650,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		}
 	case sessionruntime.EventTurnStarted:
 		m.turnActive = true
-		m.acceptQueuedTurn(event.TurnID)
+		m.acceptPendingTurn(event.TurnID)
 		if m.activeTurnID != event.TurnID {
 			m.activeTurnStarted = sessionTerminalTurnStartedAt(event, m.now(), m.replayingHistory)
 		}
@@ -695,7 +698,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		m.appendBlock(sessionTUIBlockDiff, event.Diff)
 	case sessionruntime.EventTurnCompleted:
 		m.turnActive = false
-		m.acceptQueuedTurn(event.TurnID)
+		m.acceptPendingTurn(event.TurnID)
 		m.finishStreaming()
 		elapsed, hasElapsed := sessionTerminalTurnElapsed(m.activeTurnID, m.activeTurnStarted, event, m.now(), m.replayingHistory, recoveredCompletion)
 		if event.TurnID == "" || event.TurnID == m.activeTurnID {
@@ -735,11 +738,11 @@ func (m *sessionTUIModel) applyHistoryState(state *sessionruntime.HistoryState) 
 	if state == nil {
 		return
 	}
-	m.queuedTurns = make(map[string]string, len(state.QueuedTurns))
-	m.queuedTurnOrder = make([]string, 0, len(state.QueuedTurns))
-	for _, turn := range state.QueuedTurns {
-		m.queuedTurns[turn.TurnID] = sessionTerminalMessageText(turn.Text, turn.Attachments)
-		m.queuedTurnOrder = append(m.queuedTurnOrder, turn.TurnID)
+	m.pendingTurnID = ""
+	m.pendingTurnText = ""
+	if state.PendingTurn != nil {
+		m.pendingTurnID = state.PendingTurn.TurnID
+		m.pendingTurnText = sessionTerminalMessageText(state.PendingTurn.Text, state.PendingTurn.Attachments)
 	}
 	m.activeTurnID = state.ActiveTurnID
 	m.turnActive = state.ActiveTurnID != ""
@@ -817,7 +820,6 @@ func (m *sessionTUIModel) cancelOlderHistoryPage() {
 func (m *sessionTUIModel) replayHistoryPage(events []sessionruntime.Event) []sessionTUIBlock {
 	replay := &sessionTUIModel{
 		styles:          m.styles,
-		queuedTurns:     make(map[string]string),
 		toolNames:       make(map[string]string),
 		width:           m.width,
 		height:          m.height,
@@ -983,27 +985,18 @@ func (m *sessionTUIModel) toolCompletionAttribution(event sessionruntime.Event) 
 	return name, true
 }
 
-func (m *sessionTUIModel) appendQueuedUser(turnID, text string) bool {
-	if _, exists := m.queuedTurns[turnID]; exists {
-		return false
-	}
-	m.queuedTurns[turnID] = text
-	m.queuedTurnOrder = append(m.queuedTurnOrder, turnID)
-	return true
+func (m *sessionTUIModel) setPendingUser(turnID, text string) {
+	m.pendingTurnID = turnID
+	m.pendingTurnText = text
 }
 
-func (m *sessionTUIModel) acceptQueuedTurn(turnID string) bool {
-	text, exists := m.queuedTurns[turnID]
-	if !exists {
+func (m *sessionTUIModel) acceptPendingTurn(turnID string) bool {
+	if m.pendingTurnID != turnID {
 		return false
 	}
-	delete(m.queuedTurns, turnID)
-	for index, queuedTurnID := range m.queuedTurnOrder {
-		if queuedTurnID == turnID {
-			m.queuedTurnOrder = append(m.queuedTurnOrder[:index], m.queuedTurnOrder[index+1:]...)
-			break
-		}
-	}
+	text := m.pendingTurnText
+	m.pendingTurnID = ""
+	m.pendingTurnText = ""
 	m.finishStreaming()
 	m.appendBlock(sessionTUIBlockUser, text)
 	return true
@@ -1292,8 +1285,8 @@ func (m *sessionTUIModel) renderUserBlock(text string) string {
 	return m.renderUserBlockWithStatus(text, "")
 }
 
-func (m *sessionTUIModel) renderQueuedUserBlock(text string) string {
-	return m.renderUserBlockWithStatus(text, "Queued")
+func (m *sessionTUIModel) renderPendingUserBlock(text string) string {
+	return m.renderUserBlockWithStatus(text, "Pending")
 }
 
 func (m *sessionTUIModel) renderUserBlockWithStatus(text, status string) string {
@@ -1443,9 +1436,9 @@ func (m *sessionTUIModel) footerView() string {
 	if progress := m.progressView(); progress != "" {
 		parts = append(parts, progress)
 	}
-	queue := m.queueView()
-	if queue != "" {
-		parts = append(parts, queue)
+	pending := m.pendingView()
+	if pending != "" {
+		parts = append(parts, pending)
 	}
 	parts = append(parts, "", m.composerView(), m.statusBarView())
 	return strings.Join(parts, "\n")
@@ -1503,8 +1496,8 @@ func (m *sessionTUIModel) statusBarFallback() string {
 		return "Connecting"
 	case m.turnActive:
 		return "Working"
-	case len(m.queuedTurnOrder) > 0:
-		return "Queued"
+	case m.pendingTurnID != "":
+		return "Pending"
 	default:
 		return "Ready"
 	}
@@ -1609,17 +1602,16 @@ func formatSessionTUITokens(value int64) string {
 	return formatted + suffix
 }
 
-func (m *sessionTUIModel) queueView() string {
-	blocks := make([]string, 0, len(m.queuedTurnOrder))
-	for _, turnID := range m.queuedTurnOrder {
-		blocks = append(blocks, m.renderQueuedUserBlock(m.queuedTurns[turnID]))
+func (m *sessionTUIModel) pendingView() string {
+	if m.pendingTurnID == "" {
+		return ""
 	}
-	lines := strings.Split(strings.Join(blocks, "\n"), "\n")
+	lines := strings.Split(m.renderPendingUserBlock(m.pendingTurnText), "\n")
 	progressHeight := 0
 	if m.progressVisible() {
 		progressHeight = 1
 	}
-	maxHeight := min(sessionTUIQueueMaxHeight, max(0, m.height-m.footerHeight()-progressHeight))
+	maxHeight := min(sessionTUIPendingMaxHeight, max(0, m.height-m.footerHeight()-progressHeight))
 	if len(lines) > maxHeight {
 		lines = lines[:maxHeight]
 	}

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -211,7 +211,7 @@ func TestSessionTUIContextUsedPercent(t *testing.T) {
 	}
 }
 
-func TestSessionTUIQueueStaysAboveComposerUntilAccepted(t *testing.T) {
+func TestSessionTUIPendingMessageStaysAboveComposerUntilAccepted(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	history := captureSessionTUIHistory(model)
 	model.ready = true
@@ -219,8 +219,8 @@ func TestSessionTUIQueueStaysAboveComposerUntilAccepted(t *testing.T) {
 
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-1", Text: "waiting"})
 	view := stripSessionTUIANSI(model.View())
-	if !strings.Contains(view, "Queued") || !strings.Contains(view, "> waiting") {
-		t.Fatalf("terminal view = %q, want queued user block", view)
+	if !strings.Contains(view, "Pending") || !strings.Contains(view, "> waiting") {
+		t.Fatalf("terminal view = %q, want pending user block", view)
 	}
 
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-1"})
@@ -717,17 +717,15 @@ func TestSessionTUIAppliesStateFromProjectedHistory(t *testing.T) {
 			ActiveTurnID:      "turn-2",
 			ActiveTurnStarted: &startedAt,
 			WaitingForInput:   true,
-			QueuedTurns: []sessionruntime.HistoryQueuedTurn{
-				{TurnID: "turn-3", Text: "queued request"},
-			},
+			PendingTurn:       &sessionruntime.HistoryPendingTurn{TurnID: "turn-3", Text: "pending request"},
 		},
 	})
 
 	if !model.turnActive || model.activeTurnID != "turn-2" || !model.activeTurnStarted.Equal(startedAt) || !model.waitingForInput {
 		t.Fatalf("active state = active %t ID %q started %v waiting %t", model.turnActive, model.activeTurnID, model.activeTurnStarted, model.waitingForInput)
 	}
-	if len(model.queuedTurnOrder) != 1 || model.queuedTurns["turn-3"] != "queued request" {
-		t.Fatalf("queued state = order %#v turns %#v", model.queuedTurnOrder, model.queuedTurns)
+	if model.pendingTurnID != "turn-3" || model.pendingTurnText != "pending request" {
+		t.Fatalf("pending state = ID %q text %q", model.pendingTurnID, model.pendingTurnText)
 	}
 	if transcript := stripSessionTUIANSI(model.renderTranscript()); !strings.Contains(transcript, "active request") || !strings.Contains(transcript, "Continue?") {
 		t.Fatalf("projected transcript = %q", transcript)
@@ -920,7 +918,7 @@ func TestSessionTUIReconnectNoticesKeepStreamingResponseTogether(t *testing.T) {
 	}
 }
 
-func TestSessionTUIQueuedUserMessagePreservesActiveResponse(t *testing.T) {
+func TestSessionTUIPendingUserMessagePreservesActiveResponse(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	model.ready = true
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventAssistantDelta, Text: "active"})
@@ -931,13 +929,13 @@ func TestSessionTUIQueuedUserMessagePreservesActiveResponse(t *testing.T) {
 		t.Fatalf("active assistant block = %q, want active response", got)
 	}
 	transcript := stripSessionTUIANSI(model.renderTranscript())
-	if strings.Contains(transcript, "follow up") || strings.Contains(transcript, "Queued") {
-		t.Fatalf("queued message rendered in transcript: %q", transcript)
+	if strings.Contains(transcript, "follow up") || strings.Contains(transcript, "Pending") {
+		t.Fatalf("pending message rendered in transcript: %q", transcript)
 	}
-	queue := stripSessionTUIANSI(model.queueView())
-	for _, want := range []string{"> follow up", "Queued"} {
-		if !strings.Contains(queue, want) {
-			t.Fatalf("queue = %q, want %q", queue, want)
+	pending := stripSessionTUIANSI(model.pendingView())
+	for _, want := range []string{"> follow up", "Pending"} {
+		if !strings.Contains(pending, want) {
+			t.Fatalf("pending = %q, want %q", pending, want)
 		}
 	}
 
@@ -945,8 +943,8 @@ func TestSessionTUIQueuedUserMessagePreservesActiveResponse(t *testing.T) {
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Status: "completed"})
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-2"})
 	accepted := stripSessionTUIANSI(model.renderTranscript())
-	if strings.Contains(accepted, "Queued") {
-		t.Fatalf("accepted transcript still marks message queued: %q", accepted)
+	if strings.Contains(accepted, "Pending") {
+		t.Fatalf("accepted transcript still marks message pending: %q", accepted)
 	}
 	if got := strings.Count(accepted, "follow up"); got != 1 {
 		t.Fatalf("accepted message rendered %d times, want once: %q", got, accepted)
@@ -954,27 +952,27 @@ func TestSessionTUIQueuedUserMessagePreservesActiveResponse(t *testing.T) {
 	if strings.Index(accepted, "search") > strings.Index(accepted, "follow up") {
 		t.Fatalf("accepted message appears before prior turn output: %q", accepted)
 	}
-	if queue := stripSessionTUIANSI(model.queueView()); queue != "" {
-		t.Fatalf("accepted message remains queued: %q", queue)
+	if pending := stripSessionTUIANSI(model.pendingView()); pending != "" {
+		t.Fatalf("accepted message remains pending: %q", pending)
 	}
 }
 
-func TestSessionTUICompletedQueuedTurnLoadsAsAccepted(t *testing.T) {
+func TestSessionTUICompletedPendingTurnLoadsAsAccepted(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-1", Text: "loaded message"})
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnCompleted, TurnID: "turn-1", Status: "completed"})
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
 
 	rendered := stripSessionTUIANSI(model.renderTranscript())
-	if strings.Contains(rendered, "Queued") {
-		t.Fatalf("completed history still marks message queued: %q", rendered)
+	if strings.Contains(rendered, "Pending") {
+		t.Fatalf("completed history still marks message pending: %q", rendered)
 	}
 	if !strings.Contains(rendered, "> loaded message") {
 		t.Fatalf("completed history = %q, want accepted user message", rendered)
 	}
 }
 
-func TestSessionTUIUnstartedTurnRemainsQueuedAfterHistory(t *testing.T) {
+func TestSessionTUIUnstartedTurnRemainsPendingAfterHistory(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "still waiting"})
 	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventHistoryEnd})
@@ -982,31 +980,11 @@ func TestSessionTUIUnstartedTurnRemainsQueuedAfterHistory(t *testing.T) {
 	if transcript := stripSessionTUIANSI(model.renderTranscript()); strings.Contains(transcript, "still waiting") {
 		t.Fatalf("unstarted message rendered in transcript: %q", transcript)
 	}
-	queue := stripSessionTUIANSI(model.queueView())
-	for _, want := range []string{"> still waiting", "Queued"} {
-		if !strings.Contains(queue, want) {
-			t.Fatalf("queue = %q, want %q", queue, want)
+	pending := stripSessionTUIANSI(model.pendingView())
+	for _, want := range []string{"> still waiting", "Pending"} {
+		if !strings.Contains(pending, want) {
+			t.Fatalf("pending = %q, want %q", pending, want)
 		}
-	}
-}
-
-func TestSessionTUIQueuedMessagesKeepSubmissionOrder(t *testing.T) {
-	model, _ := newSessionTUITestModel()
-	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "first queued"})
-	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-3", Text: "second queued"})
-
-	queue := stripSessionTUIANSI(model.queueView())
-	if strings.Index(queue, "first queued") > strings.Index(queue, "second queued") {
-		t.Fatalf("queued messages are out of order: %q", queue)
-	}
-
-	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventTurnStarted, TurnID: "turn-2"})
-	if transcript := stripSessionTUIANSI(model.renderTranscript()); !strings.Contains(transcript, "> first queued") {
-		t.Fatalf("accepted message missing from transcript: %q", transcript)
-	}
-	queue = stripSessionTUIANSI(model.queueView())
-	if strings.Contains(queue, "first queued") || !strings.Contains(queue, "second queued") {
-		t.Fatalf("remaining queue = %q, want only second message", queue)
 	}
 }
 
@@ -1197,6 +1175,16 @@ func TestSessionTUISubmittedTextRendersFromUserEventOnce(t *testing.T) {
 	}
 	if view := stripSessionTUIANSI(model.View()); strings.Contains(view, "hello") {
 		t.Fatalf("submitted text remains in inline view after commit: %q", view)
+	}
+}
+
+func TestSessionTUIUpdatesPendingMessage(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "original"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessageUpdated, TurnID: "turn-2", Text: "revised"})
+
+	if model.pendingTurnID != "turn-2" || model.pendingTurnText != "revised" {
+		t.Fatalf("pending message = ID %q text %q", model.pendingTurnID, model.pendingTurnText)
 	}
 }
 

--- a/internal/sessionruntime/history.go
+++ b/internal/sessionruntime/history.go
@@ -33,6 +33,7 @@ type historyTurn struct {
 	activityEventID int64
 	startedAt       *time.Time
 	completed       bool
+	merged          bool
 	interrupting    bool
 }
 
@@ -76,6 +77,12 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 				copy := event
 				turn.user = &copy
 				turn.userEventID = event.ID
+			case EventUserMessageUpdated:
+				if turn.userEventID == 0 {
+					turn.userEventID = event.ID
+				}
+				copy := event
+				turn.user = &copy
 			case EventTurnStarted:
 				turn.started = true
 				turn.startedAt = event.Timestamp
@@ -83,9 +90,10 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 				turn.interrupting = true
 			case EventTurnCompleted:
 				turn.completed = true
+				turn.merged = event.Status == "merged"
 				turn.interrupting = false
 			}
-			if event.Type != EventUserMessage && event.Type != EventTurnCompleted {
+			if event.Type != EventUserMessage && event.Type != EventUserMessageUpdated && event.Type != EventTurnCompleted {
 				turn.activityEventID = event.ID
 				if turn.startedAt == nil {
 					turn.startedAt = event.Timestamp
@@ -105,8 +113,8 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 	}
 
 	state := HistoryState{FileDiff: fileDiff}
-	queued := make([]HistoryQueuedTurn, 0)
-	queuedEventIDs := make(map[string]int64)
+	var pending *HistoryPendingTurn
+	var pendingEventID int64
 	var activeEventID int64
 	for turnID, turn := range turns {
 		if turn.activityEventID > 0 && !turn.completed && turn.activityEventID >= activeEventID {
@@ -115,25 +123,18 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 			state.TurnInterrupting = turn.interrupting
 			activeEventID = turn.activityEventID
 		}
-		if turn.user != nil && !turn.started && turn.activityEventID == 0 && !turn.completed {
-			queued = append(queued, HistoryQueuedTurn{
+		if turn.user != nil && !turn.started && turn.activityEventID == 0 && !turn.completed && turn.userEventID >= pendingEventID {
+			pending = &HistoryPendingTurn{
 				TurnID:      turnID,
 				Text:        boundedHistoryText(turn.user.Text, maxHistoryMessageBytes),
+				Revision:    max(1, turn.user.Revision),
 				Attachments: turn.user.Attachments,
-			})
-			queuedEventIDs[turnID] = turn.userEventID
+			}
+			pendingEventID = turn.userEventID
 		}
 	}
-	sort.Slice(queued, func(i, j int) bool {
-		return queuedEventIDs[queued[i].TurnID] < queuedEventIDs[queued[j].TurnID]
-	})
-	state.QueuedTurns = queued
+	state.PendingTurn = pending
 	state.WaitingForInput = len(pendingInputs) > 0
-
-	queuedTurnIDs := make(map[string]struct{}, len(queued))
-	for _, turn := range queued {
-		queuedTurnIDs[turn.TurnID] = struct{}{}
-	}
 
 	items := make([]historyItem, 0)
 	assistants := make(map[string]historyAssistant)
@@ -167,7 +168,8 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 	}
 
 	for _, event := range events {
-		if _, queued := queuedTurnIDs[event.TurnID]; queued {
+		turn := turns[event.TurnID]
+		if (pending != nil && event.TurnID == pending.TurnID) || (turn != nil && turn.merged) {
 			continue
 		}
 		if event.Type != EventAssistantDelta && event.Type != EventAssistantMessage {
@@ -175,9 +177,24 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 		}
 
 		switch event.Type {
-		case EventUserMessage:
-			event.Text = boundedHistoryText(event.Text, maxHistoryMessageBytes)
-			addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+		case EventUserMessage, EventUserMessageUpdated:
+			if event.TurnID == "" {
+				if event.Type == EventUserMessageUpdated {
+					continue
+				}
+				event.Text = boundedHistoryText(event.Text, maxHistoryMessageBytes)
+				addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+				continue
+			}
+			turn := turns[event.TurnID]
+			if turn == nil || turn.userEventID != event.ID || turn.user == nil {
+				continue
+			}
+			latest := *turn.user
+			latest.ID = event.ID
+			latest.Type = EventUserMessage
+			latest.Text = boundedHistoryText(latest.Text, maxHistoryMessageBytes)
+			addItem(event.ID, event.ID, normalizedHistoryEvent(latest))
 		case EventAssistantDelta:
 			assistant := assistants[event.TurnID]
 			if assistant.firstEventID == 0 {

--- a/internal/sessionruntime/history_test.go
+++ b/internal/sessionruntime/history_test.go
@@ -25,8 +25,8 @@ func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
 		{ID: 13, Type: EventAssistantDelta, TurnID: "turn-2", Text: "Open"},
 		{ID: 14, Type: EventAssistantDelta, TurnID: "turn-2", Text: "Code answer"},
 		{ID: 15, Type: EventInputRequested, TurnID: "turn-2", InputID: "input-2", Questions: []InputQuestion{{ID: "confirm", Question: "Continue?"}}, Status: "pending"},
-		{ID: 16, Type: EventUserMessage, TurnID: "turn-3", Text: "queued first", Attachments: []Attachment{{ID: "attachment-1", Name: "screen.png", MediaType: "image/png", SizeBytes: 7}}},
-		{ID: 17, Type: EventUserMessage, TurnID: "turn-4", Text: "queued second"},
+		{ID: 16, Type: EventUserMessage, TurnID: "turn-3", Text: "pending first", Revision: 1, Attachments: []Attachment{{ID: "attachment-1", Name: "screen.png", MediaType: "image/png", SizeBytes: 7}}},
+		{ID: 17, Type: EventUserMessageUpdated, TurnID: "turn-3", Text: "pending first\n\npending second", Revision: 2, Attachments: []Attachment{{ID: "attachment-1", Name: "screen.png", MediaType: "image/png", SizeBytes: 7}}},
 	}
 
 	items, state, essential := projectHistory(events)
@@ -36,11 +36,11 @@ func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
 	if !state.WaitingForInput || state.TurnInterrupting {
 		t.Fatalf("history state = %#v, want waiting active turn", state)
 	}
-	if len(state.QueuedTurns) != 2 || state.QueuedTurns[0].TurnID != "turn-3" || state.QueuedTurns[1].TurnID != "turn-4" {
-		t.Fatalf("queued turns = %#v", state.QueuedTurns)
+	if state.PendingTurn == nil || state.PendingTurn.TurnID != "turn-3" || state.PendingTurn.Text != "pending first\n\npending second" || state.PendingTurn.Revision != 2 {
+		t.Fatalf("pending turn = %#v", state.PendingTurn)
 	}
-	if len(state.QueuedTurns[0].Attachments) != 1 || state.QueuedTurns[0].Attachments[0].Name != "screen.png" {
-		t.Fatalf("queued turn attachments = %#v", state.QueuedTurns[0].Attachments)
+	if len(state.PendingTurn.Attachments) != 1 || state.PendingTurn.Attachments[0].Name != "screen.png" {
+		t.Fatalf("pending turn attachments = %#v", state.PendingTurn.Attachments)
 	}
 	if len(essential) != 1 || essential[0].Type != EventInputRequested || essential[0].InputID != "input-2" || essential[0].TurnID != "" {
 		t.Fatalf("essential history events = %#v", essential)
@@ -138,19 +138,43 @@ func TestProjectHistoryBoundsLargeMessages(t *testing.T) {
 	}
 }
 
-func TestProjectHistoryBoundsQueuedMessages(t *testing.T) {
+func TestProjectHistoryBoundsPendingMessage(t *testing.T) {
 	_, state, _ := projectHistory([]Event{{
 		ID:     1,
 		Type:   EventUserMessage,
 		TurnID: "turn-1",
 		Text:   strings.Repeat("界", maxHistoryMessageBytes),
 	}})
-	if len(state.QueuedTurns) != 1 {
-		t.Fatalf("queued turns = %#v, want one turn", state.QueuedTurns)
+	if state.PendingTurn == nil {
+		t.Fatal("pending turn is nil")
 	}
-	text := state.QueuedTurns[0].Text
+	text := state.PendingTurn.Text
 	if len(text) > maxHistoryMessageBytes || !strings.Contains(text, historyTruncationMarker) || !utf8.ValidString(text) {
-		t.Fatalf("queued message preview is not a bounded UTF-8 string")
+		t.Fatalf("pending message preview is not a bounded UTF-8 string")
+	}
+}
+
+func TestProjectHistoryUsesLatestPendingMessageRevision(t *testing.T) {
+	events := []Event{
+		{ID: 1, Type: EventUserMessage, TurnID: "turn-1", Text: "original", Revision: 1},
+		{ID: 2, Type: EventUserMessageUpdated, TurnID: "turn-1", Text: "revised", Revision: 2},
+	}
+	items, state, _ := projectHistory(events)
+	if len(items) != 0 {
+		t.Fatalf("pending history items = %#v, want none", items)
+	}
+	if state.PendingTurn == nil || state.PendingTurn.Text != "revised" || state.PendingTurn.Revision != 2 {
+		t.Fatalf("pending turn = %#v, want revised turn", state.PendingTurn)
+	}
+
+	events = append(events,
+		Event{ID: 3, Type: EventTurnStarted, TurnID: "turn-1", Status: "running"},
+		Event{ID: 4, Type: EventTurnCompleted, TurnID: "turn-1", Status: "completed"},
+	)
+	items, _, _ = projectHistory(events)
+	page, cursor := historyItemsPage(items, 0, DefaultHistoryItemLimit, DefaultHistoryByteLimit)
+	if cursor != 0 || len(page) != 1 || page[0].Type != EventUserMessage || page[0].Text != "revised" || page[0].ID != 1 {
+		t.Fatalf("projected history = %#v cursor=%d", page, cursor)
 	}
 }
 

--- a/internal/sessionruntime/journal.go
+++ b/internal/sessionruntime/journal.go
@@ -35,12 +35,12 @@ type Journal struct {
 	path        string
 	file        *os.File
 	journalID   string
-	// pendingTurns keeps accepted prompts durable after they leave replay history.
-	pendingTurns map[string]Event
-	failure      chan struct{}
-	failureErr   error
-	failureOnce  sync.Once
-	closed       bool
+	// unstartedTurns keeps accepted prompts durable after they leave replay history.
+	unstartedTurns map[string]Event
+	failure        chan struct{}
+	failureErr     error
+	failureOnce    sync.Once
+	closed         bool
 }
 
 type journalSubscriber struct {
@@ -63,12 +63,12 @@ func NewJournal() *Journal {
 
 func newJournal(maxEvents int) *Journal {
 	return &Journal{
-		maxEvents:    maxEvents,
-		nextID:       1,
-		journalID:    uuid.New().String(),
-		pendingTurns: map[string]Event{},
-		subscribers:  map[int]*journalSubscriber{},
-		failure:      make(chan struct{}),
+		maxEvents:      maxEvents,
+		nextID:         1,
+		journalID:      uuid.New().String(),
+		unstartedTurns: map[string]Event{},
+		subscribers:    map[int]*journalSubscriber{},
+		failure:        make(chan struct{}),
 	}
 }
 
@@ -217,7 +217,7 @@ func (j *Journal) load() (string, bool, error) {
 			event.JournalID = ""
 		}
 		j.nextID = event.ID + 1
-		j.updatePendingTurns(event)
+		j.updateUnstartedTurns(event)
 		j.appendRetained(event)
 		offset += int64(len(line))
 		total++
@@ -263,7 +263,7 @@ func (j *Journal) Append(event Event) error {
 		}
 	}
 	j.nextID++
-	j.updatePendingTurns(event)
+	j.updateUnstartedTurns(event)
 	compacted := j.appendRetained(event)
 	if compacted && j.file != nil {
 		if err := j.rewrite(); err != nil {
@@ -283,15 +283,15 @@ func (j *Journal) Append(event Event) error {
 	return nil
 }
 
-func (j *Journal) updatePendingTurns(event Event) {
+func (j *Journal) updateUnstartedTurns(event Event) {
 	if event.TurnID == "" {
 		return
 	}
 	switch event.Type {
-	case EventUserMessage:
-		j.pendingTurns[event.TurnID] = event
+	case EventUserMessage, EventUserMessageUpdated:
+		j.unstartedTurns[event.TurnID] = event
 	case EventTurnStarted, EventTurnCompleted:
-		delete(j.pendingTurns, event.TurnID)
+		delete(j.unstartedTurns, event.TurnID)
 	}
 }
 
@@ -301,7 +301,7 @@ func (j *Journal) recoveryEvents() []Event {
 	for _, event := range events {
 		retained[event.ID] = struct{}{}
 	}
-	for _, event := range j.pendingTurns {
+	for _, event := range j.unstartedTurns {
 		if _, exists := retained[event.ID]; !exists {
 			events = append(events, event)
 		}

--- a/internal/sessionruntime/journal_test.go
+++ b/internal/sessionruntime/journal_test.go
@@ -101,8 +101,8 @@ func TestJournalRecoveryHandlesEventsWithoutTurnIDs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(recovery.queuedTurns) != 0 {
-		t.Fatalf("recovered queued turns = %#v", recovery.queuedTurns)
+	if recovery.pendingTurn != nil {
+		t.Fatalf("recovered pending turn = %#v", recovery.pendingTurn)
 	}
 	events := journal.Snapshot()
 	assertEventTypes(t, events,
@@ -117,7 +117,7 @@ func TestJournalRecoveryHandlesEventsWithoutTurnIDs(t *testing.T) {
 	}
 }
 
-func TestJournalCompactionPreservesQueuedTurnForRecovery(t *testing.T) {
+func TestJournalCompactionPreservesPendingTurnForRecovery(t *testing.T) {
 	path := filepath.Join(t.TempDir(), journalFileName)
 	journal, err := openJournal(path, 3)
 	if err != nil {
@@ -131,13 +131,13 @@ func TestJournalCompactionPreservesQueuedTurnForRecovery(t *testing.T) {
 	}
 	appendEvent(Event{Type: EventUserMessage, TurnID: "turn-1", Text: "active work"})
 	appendEvent(Event{Type: EventTurnStarted, TurnID: "turn-1", Status: "running"})
-	appendEvent(Event{Type: EventUserMessage, TurnID: "turn-2", Text: "queued work"})
+	appendEvent(Event{Type: EventUserMessage, TurnID: "turn-2", Text: "pending work"})
 	for i := 0; i < 3; i++ {
 		appendEvent(Event{Type: EventAssistantDelta, TurnID: "turn-1", Text: fmt.Sprintf("event-%d", i+1)})
 	}
 	for _, event := range journal.Snapshot() {
 		if event.TurnID == "turn-2" {
-			t.Fatalf("queued turn remained in replay history after compaction: %#v", event)
+			t.Fatalf("pending turn remained in replay history after compaction: %#v", event)
 		}
 	}
 	journal.Close()
@@ -151,8 +151,46 @@ func TestJournalCompactionPreservesQueuedTurnForRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(recovery.queuedTurns) != 1 || recovery.queuedTurns[0].id != "turn-2" || recovery.queuedTurns[0].text != "queued work" {
-		t.Fatalf("recovered queued turns = %#v", recovery.queuedTurns)
+	if recovery.pendingTurn == nil || recovery.pendingTurn.id != "turn-2" || recovery.pendingTurn.text != "pending work" {
+		t.Fatalf("recovered pending turn = %#v", recovery.pendingTurn)
+	}
+}
+
+func TestJournalRecoveryCombinesPendingTurns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), journalFileName)
+	journal, err := openJournal(path, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range []Event{
+		{Type: EventUserMessage, TurnID: "turn-1", Text: "active work", Revision: 1},
+		{Type: EventTurnStarted, TurnID: "turn-1", Status: "running"},
+		{Type: EventUserMessage, TurnID: "turn-2", Text: "original", Revision: 1},
+		{Type: EventUserMessage, TurnID: "turn-3", Text: "later", Revision: 1},
+		{Type: EventUserMessageUpdated, TurnID: "turn-2", Text: "revised", Revision: 2},
+		{Type: EventAssistantDelta, TurnID: "turn-1", Text: "working"},
+	} {
+		if err := journal.Append(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	journal.Close()
+
+	reopened, err := openJournal(path, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	recovery, err := recoverJournal(reopened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovery.pendingTurn == nil || recovery.pendingTurn.id != "turn-2" || recovery.pendingTurn.text != "revised\n\nlater" || recovery.pendingTurn.revision != 3 {
+		t.Fatalf("recovered pending turn = %#v", recovery.pendingTurn)
+	}
+	items, state, _ := projectHistory(reopened.Snapshot())
+	if len(items) != 0 || state.PendingTurn == nil || state.PendingTurn.TurnID != "turn-2" || state.PendingTurn.Text != "revised\n\nlater" {
+		t.Fatalf("projected pending state = items %#v state %#v", items, state)
 	}
 }
 

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -6,23 +6,24 @@ import (
 )
 
 const (
-	EventHistoryStart     = "history.start"
-	EventHistoryEnd       = "history.end"
-	EventRuntimeStatus    = "runtime.status"
-	EventRequestAccepted  = "request.accepted"
-	EventRuntimeRecovered = "runtime.recovered"
-	EventUserMessage      = "user.message"
-	EventTurnStarted      = "turn.started"
-	EventTurnInterrupting = "turn.interrupting"
-	EventAssistantDelta   = "assistant.delta"
-	EventAssistantMessage = "assistant.message"
-	EventToolStarted      = "tool.started"
-	EventToolCompleted    = "tool.completed"
-	EventInputRequested   = "input.requested"
-	EventInputResolved    = "input.resolved"
-	EventFileDiff         = "file.diff"
-	EventTurnCompleted    = "turn.completed"
-	EventError            = "error"
+	EventHistoryStart       = "history.start"
+	EventHistoryEnd         = "history.end"
+	EventRuntimeStatus      = "runtime.status"
+	EventRequestAccepted    = "request.accepted"
+	EventRuntimeRecovered   = "runtime.recovered"
+	EventUserMessage        = "user.message"
+	EventUserMessageUpdated = "user.message.updated"
+	EventTurnStarted        = "turn.started"
+	EventTurnInterrupting   = "turn.interrupting"
+	EventAssistantDelta     = "assistant.delta"
+	EventAssistantMessage   = "assistant.message"
+	EventToolStarted        = "tool.started"
+	EventToolCompleted      = "tool.completed"
+	EventInputRequested     = "input.requested"
+	EventInputResolved      = "input.resolved"
+	EventFileDiff           = "file.diff"
+	EventTurnCompleted      = "turn.completed"
+	EventError              = "error"
 
 	DefaultHistoryItemLimit = 20
 	DefaultHistoryByteLimit = 128 * 1024
@@ -37,6 +38,7 @@ type Event struct {
 	RequestID      string          `json:"requestId,omitempty"`
 	TurnID         string          `json:"turnId,omitempty"`
 	Text           string          `json:"text,omitempty"`
+	Revision       int64           `json:"revision,omitempty"`
 	ToolID         string          `json:"toolId,omitempty"`
 	ToolName       string          `json:"toolName,omitempty"`
 	Output         string          `json:"output,omitempty"`
@@ -62,14 +64,15 @@ type HistoryState struct {
 	ActiveTurnStarted *time.Time          `json:"activeTurnStarted,omitempty"`
 	TurnInterrupting  bool                `json:"turnInterrupting,omitempty"`
 	WaitingForInput   bool                `json:"waitingForInput,omitempty"`
-	QueuedTurns       []HistoryQueuedTurn `json:"queuedTurns,omitempty"`
+	PendingTurn       *HistoryPendingTurn `json:"pendingTurn,omitempty"`
 	FileDiff          string              `json:"fileDiff,omitempty"`
 }
 
-// HistoryQueuedTurn describes one user message waiting to run.
-type HistoryQueuedTurn struct {
+// HistoryPendingTurn describes the user message waiting to run.
+type HistoryPendingTurn struct {
 	TurnID      string       `json:"turnId"`
 	Text        string       `json:"text"`
+	Revision    int64        `json:"revision"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
@@ -103,19 +106,21 @@ type RuntimeRateLimit struct {
 
 // ClientRequest is a command sent by a web or terminal client.
 type ClientRequest struct {
-	Type          string              `json:"type"`
-	RequestID     string              `json:"requestId,omitempty"`
-	Since         int64               `json:"since,omitempty"`
-	JournalID     string              `json:"journalId,omitempty"`
-	HistoryBounds bool                `json:"historyBounds,omitempty"`
-	HistoryItems  int                 `json:"historyItems,omitempty"`
-	HistoryBytes  int                 `json:"historyBytes,omitempty"`
-	HistoryCursor string              `json:"historyCursor,omitempty"`
-	Text          string              `json:"text,omitempty"`
-	AttachmentIDs []string            `json:"attachmentIds,omitempty"`
-	InputID       string              `json:"inputId,omitempty"`
-	Answers       map[string][]string `json:"answers,omitempty"`
-	Cancel        bool                `json:"cancel,omitempty"`
+	Type             string              `json:"type"`
+	RequestID        string              `json:"requestId,omitempty"`
+	Since            int64               `json:"since,omitempty"`
+	JournalID        string              `json:"journalId,omitempty"`
+	HistoryBounds    bool                `json:"historyBounds,omitempty"`
+	HistoryItems     int                 `json:"historyItems,omitempty"`
+	HistoryBytes     int                 `json:"historyBytes,omitempty"`
+	HistoryCursor    string              `json:"historyCursor,omitempty"`
+	TurnID           string              `json:"turnId,omitempty"`
+	Text             string              `json:"text,omitempty"`
+	ExpectedRevision int64               `json:"expectedRevision,omitempty"`
+	AttachmentIDs    []string            `json:"attachmentIds,omitempty"`
+	InputID          string              `json:"inputId,omitempty"`
+	Answers          map[string][]string `json:"answers,omitempty"`
+	Cancel           bool                `json:"cancel,omitempty"`
 }
 
 // InputOption describes one structured answer offered by a provider.

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -57,6 +58,7 @@ type Config struct {
 type turnRequest struct {
 	id          string
 	text        string
+	revision    int64
 	attachments []Attachment
 	accepted    chan struct{}
 }
@@ -96,6 +98,7 @@ type Server struct {
 	submitMu      sync.Mutex
 	appendMessage func(Event) error
 	turns         chan turnRequest
+	pendingTurn   *turnRequest
 	nextTurnID    atomic.Int64
 	outstanding   int
 	// completedTurnID is the highest turn ID that has finished running (completed,
@@ -148,7 +151,7 @@ func NewServer(config Config, journal *Journal, provider Provider) *Server {
 		journal:                      journal,
 		provider:                     provider,
 		appendMessage:                journal.Append,
-		turns:                        make(chan turnRequest, 32),
+		turns:                        make(chan turnRequest, 1),
 		updateReport:                 make(chan struct{}, 1),
 		runtimeStatus:                newRuntimeStatus(config),
 		runtimeStatusSubscribers:     map[int]chan RuntimeStatus{},
@@ -233,7 +236,7 @@ func Run(ctx context.Context, config Config) error {
 	server.nextTurnID.Store(recovery.nextTurnID)
 	server.nextInputID.Store(recovery.nextInputID)
 	server.completedTurnID.Store(recovery.completedTurnID)
-	if err := server.restoreTurns(recovery.queuedTurns); err != nil {
+	if err := server.restoreTurn(recovery.pendingTurn); err != nil {
 		_ = provider.Close()
 		journal.Close()
 		return err
@@ -248,7 +251,7 @@ func Run(ctx context.Context, config Config) error {
 		server.settledTurnID.Store(settledTurnID)
 	}
 	// Republish activity when the journal holds locally accepted turns that were
-	// never durably settled to a published idle status. This covers queued or
+	// never durably settled to a published idle status. This covers pending or
 	// interrupted turns and turns that completed while their ordered Active status
 	// publications were still retrying: a container restart drops the in-memory
 	// publish queue, so without this a surviving idle-drain request could be
@@ -410,17 +413,17 @@ func (s *Server) runTurns(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-s.providerStop:
-				// Leave accepted but unstarted work queued for journal recovery.
+				// Leave accepted but unstarted work pending for journal recovery.
 				s.turns <- turn
 				return
 			}
 			if s.providerStopping.Load() {
-				// Leave accepted but unstarted work queued for journal recovery.
+				// Leave accepted but unstarted work pending for journal recovery.
 				s.turns <- turn
 				return
 			}
-			s.runTurn(ctx, turn)
-			// Keep the next queued turn out of reach of an interrupt call that is
+			s.runTurn(ctx, s.takePendingTurn(turn))
+			// Keep the pending turn out of reach of an interrupt call that is
 			// still settling after this turn returned.
 			s.interruptMu.Lock()
 			s.interruptMu.Unlock()
@@ -791,24 +794,101 @@ func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) 
 	if err := s.journal.Err(); err != nil {
 		return fmt.Errorf("recording Session message: %w", err)
 	}
+	if s.pendingTurn != nil {
+		turn := *s.pendingTurn
+		turn.text = mergePendingMessageText(turn.text, text)
+		turn.attachments = append(turn.attachments, attachments...)
+		turn.revision = max(1, turn.revision) + 1
+		if err := s.appendMessage(Event{
+			Type:        EventUserMessageUpdated,
+			RequestID:   requestID,
+			TurnID:      turn.id,
+			Text:        turn.text,
+			Revision:    turn.revision,
+			Attachments: turn.attachments,
+		}); err != nil {
+			return fmt.Errorf("recording pending Session message: %w", err)
+		}
+		s.pendingTurn = &turn
+		return nil
+	}
 	turn := turnRequest{
 		id:          fmt.Sprintf("turn-%d", s.nextTurnID.Add(1)),
 		text:        text,
+		revision:    1,
 		attachments: attachments,
 		accepted:    make(chan struct{}),
 	}
 	select {
 	case s.turns <- turn:
+		s.pendingTurn = &turn
 		s.outstanding++
-		if err := s.appendMessage(Event{Type: EventUserMessage, RequestID: requestID, TurnID: turn.id, Text: turn.text, Attachments: turn.attachments}); err != nil {
+		if err := s.appendMessage(Event{Type: EventUserMessage, RequestID: requestID, TurnID: turn.id, Text: turn.text, Revision: turn.revision, Attachments: turn.attachments}); err != nil {
+			s.pendingTurn = nil
 			s.outstanding--
 			return fmt.Errorf("recording Session message: %w", err)
 		}
 		close(turn.accepted)
 		return nil
 	default:
-		return errors.New("Session message queue is full")
+		return errors.New("Session already has a pending message")
 	}
+}
+
+func mergePendingMessageText(current, addition string) string {
+	if strings.TrimSpace(current) == "" {
+		return addition
+	}
+	if strings.TrimSpace(addition) == "" {
+		return current
+	}
+	return current + "\n\n" + addition
+}
+
+func (s *Server) editMessage(turnID, text string, expectedRevision int64, requestID string) error {
+	s.submitMu.Lock()
+	defer s.submitMu.Unlock()
+	if s.pendingTurn == nil || s.pendingTurn.id != turnID {
+		return fmt.Errorf("Session turn %q is no longer pending", turnID)
+	}
+	turn := *s.pendingTurn
+	if expectedRevision <= 0 {
+		return fmt.Errorf("editing Session turn %q: expectedRevision must be positive", turnID)
+	}
+	if turn.revision == 0 {
+		turn.revision = 1
+	}
+	if expectedRevision != turn.revision {
+		return fmt.Errorf("editing Session turn %q: revision is %d, not %d", turnID, turn.revision, expectedRevision)
+	}
+	if strings.TrimSpace(text) == "" && len(turn.attachments) == 0 {
+		return fmt.Errorf("editing Session turn %q: message must not be empty", turnID)
+	}
+	turn.text = text
+	turn.revision++
+	if err := s.appendMessage(Event{
+		Type:        EventUserMessageUpdated,
+		RequestID:   requestID,
+		TurnID:      turn.id,
+		Text:        turn.text,
+		Revision:    turn.revision,
+		Attachments: turn.attachments,
+	}); err != nil {
+		return fmt.Errorf("recording edited Session turn %q: %w", turnID, err)
+	}
+	s.pendingTurn = &turn
+	return nil
+}
+
+func (s *Server) takePendingTurn(turn turnRequest) turnRequest {
+	s.submitMu.Lock()
+	defer s.submitMu.Unlock()
+	if s.pendingTurn == nil || s.pendingTurn.id != turn.id {
+		return turn
+	}
+	pending := *s.pendingTurn
+	s.pendingTurn = nil
+	return pending
 }
 
 func (s *Server) resolveAttachmentIDs(ids []string) ([]ResolvedAttachment, error) {
@@ -833,12 +913,13 @@ type journalRecovery struct {
 	nextTurnID      int64
 	nextInputID     int64
 	completedTurnID int64
-	queuedTurns     []turnRequest
+	pendingTurn     *turnRequest
 }
 
 type journalTurnRecovery struct {
 	id          string
 	text        string
+	revision    int64
 	attachments []Attachment
 	started     bool
 	completed   bool
@@ -846,7 +927,7 @@ type journalTurnRecovery struct {
 
 // hasUnsettledActivity reports whether the journal holds locally accepted turns
 // beyond the given durably-settled high-water mark. nextTurnID is the highest
-// turn ID observed in the journal, so any queued, interrupted, or completed turn
+// turn ID observed in the journal, so any pending, interrupted, or completed turn
 // whose idle status was never durably published leaves nextTurnID above
 // settledTurnID.
 func (r journalRecovery) hasUnsettledActivity(settledTurnID int64) bool {
@@ -879,10 +960,14 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 			turn = turns[event.TurnID]
 		}
 		switch event.Type {
-		case EventUserMessage:
+		case EventUserMessage, EventUserMessageUpdated:
 			if turn != nil {
 				turn.text = event.Text
 				turn.attachments = event.Attachments
+				turn.revision = event.Revision
+				if turn.revision == 0 {
+					turn.revision = 1
+				}
 			}
 		case EventTurnCompleted:
 			if turn != nil {
@@ -927,6 +1012,7 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 			}
 		}
 	}
+	unstartedTurns := make([]turnRequest, 0, 1)
 	for _, turnID := range turnOrder {
 		turn := turns[turnID]
 		if turn.completed {
@@ -935,7 +1021,7 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 		if !turn.started {
 			accepted := make(chan struct{})
 			close(accepted)
-			recovery.queuedTurns = append(recovery.queuedTurns, turnRequest{id: turn.id, text: turn.text, attachments: turn.attachments, accepted: accepted})
+			unstartedTurns = append(unstartedTurns, turnRequest{id: turn.id, text: turn.text, revision: turn.revision, attachments: turn.attachments, accepted: accepted})
 			continue
 		}
 		if err := journal.Append(Event{Type: EventTurnCompleted, TurnID: turnID, Status: "interrupted"}); err != nil {
@@ -945,19 +1031,55 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 			recovery.completedTurnID = value
 		}
 	}
+	if len(unstartedTurns) > 0 {
+		sort.SliceStable(unstartedTurns, func(i, j int) bool {
+			left := numericEventID(unstartedTurns[i].id, "turn-")
+			right := numericEventID(unstartedTurns[j].id, "turn-")
+			if left > 0 && right > 0 {
+				return left < right
+			}
+			if (left > 0) != (right > 0) {
+				return left > 0
+			}
+			return unstartedTurns[i].id < unstartedTurns[j].id
+		})
+		pending := unstartedTurns[0]
+		if len(unstartedTurns) > 1 {
+			for _, turn := range unstartedTurns[1:] {
+				pending.text = mergePendingMessageText(pending.text, turn.text)
+				pending.attachments = append(pending.attachments, turn.attachments...)
+				if err := journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "merged"}); err != nil {
+					return recovery, fmt.Errorf("recording merged Session turn: %w", err)
+				}
+				if value := numericEventID(turn.id, "turn-"); value > recovery.completedTurnID {
+					recovery.completedTurnID = value
+				}
+			}
+			pending.revision = max(1, pending.revision) + 1
+			if err := journal.Append(Event{
+				Type:        EventUserMessageUpdated,
+				TurnID:      pending.id,
+				Text:        pending.text,
+				Revision:    pending.revision,
+				Attachments: pending.attachments,
+			}); err != nil {
+				return recovery, fmt.Errorf("recording pending Session message: %w", err)
+			}
+		}
+		recovery.pendingTurn = &pending
+	}
 	return recovery, nil
 }
 
-func (s *Server) restoreTurns(turns []turnRequest) error {
-	if len(turns) > cap(s.turns) {
-		return fmt.Errorf("restoring %d queued Session turns: queue capacity is %d", len(turns), cap(s.turns))
+func (s *Server) restoreTurn(turn *turnRequest) error {
+	if turn == nil {
+		return nil
 	}
 	s.submitMu.Lock()
 	defer s.submitMu.Unlock()
-	for _, turn := range turns {
-		s.turns <- turn
-		s.outstanding++
-	}
+	s.turns <- *turn
+	s.pendingTurn = turn
+	s.outstanding++
 	return nil
 }
 
@@ -1231,6 +1353,11 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			subscribe(0, "", false, 0, 0)
 			if err := s.submitMessage(request.Text, request.RequestID, request.AttachmentIDs...); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
+			}
+		case "message.edit":
+			subscribe(0, "", false, 0, 0)
+			if err := s.editMessage(request.TurnID, request.Text, request.ExpectedRevision, request.RequestID); err != nil {
+				out <- Event{Type: EventError, RequestID: request.RequestID, TurnID: request.TurnID, Text: err.Error(), Status: "rejected"}
 			}
 		case "input":
 			subscribe(0, "", false, 0, 0)

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -260,6 +260,84 @@ func TestServerSubmitsAttachmentToProviderAndJournal(t *testing.T) {
 	}
 }
 
+func TestServerEditsPendingMessage(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeProvider{}
+	server := NewServer(Config{StateDir: t.TempDir()}, journal, provider)
+	attachment, err := server.attachmentStore.Put("notes.txt", strings.NewReader("context"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.submitMessage("original", "request-message", attachment.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.editMessage("turn-1", "revised", 1, "request-edit"); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.editMessage("turn-1", "stale", 1, "request-stale"); err == nil || !strings.Contains(err.Error(), "revision is 2, not 1") {
+		t.Fatalf("stale edit error = %v", err)
+	}
+
+	turn := <-server.turns
+	<-turn.accepted
+	server.runTurn(t.Context(), server.takePendingTurn(turn))
+
+	provider.mu.Lock()
+	prompts := append([]string(nil), provider.prompts...)
+	inputs := append([]TurnInput(nil), provider.inputs...)
+	provider.mu.Unlock()
+	if !reflect.DeepEqual(prompts, []string{"revised"}) {
+		t.Fatalf("provider prompts = %v, want revised message", prompts)
+	}
+	if len(inputs) != 1 || len(inputs[0].Attachments) != 1 || inputs[0].Attachments[0].ID != attachment.ID {
+		t.Fatalf("provider inputs = %#v, want retained attachment", inputs)
+	}
+	if err := server.editMessage("turn-1", "too late", 2, "request-late"); err == nil || !strings.Contains(err.Error(), `turn "turn-1" is no longer pending`) {
+		t.Fatalf("late edit error = %v", err)
+	}
+
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventUserMessage, EventUserMessageUpdated, EventTurnStarted, EventAssistantDelta, EventAssistantDelta, EventTurnCompleted)
+	if events[1].Text != "revised" || events[1].Revision != 2 || events[1].RequestID != "request-edit" || !reflect.DeepEqual(events[1].Attachments, []Attachment{attachment}) {
+		t.Fatalf("message update = %#v", events[1])
+	}
+}
+
+func TestServerCombinesSubmissionsIntoPendingMessage(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	server := NewServer(Config{StateDir: t.TempDir()}, journal, &fakeProvider{})
+	firstAttachment, err := server.attachmentStore.Put("first.txt", strings.NewReader("first"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondAttachment, err := server.attachmentStore.Put("second.txt", strings.NewReader("second"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.submitMessage("first follow-up", "request-first", firstAttachment.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.submitMessage("second follow-up", "request-second", secondAttachment.ID); err != nil {
+		t.Fatal(err)
+	}
+	if len(server.turns) != 1 || server.outstanding != 1 {
+		t.Fatalf("pending runtime state = turns %d outstanding %d", len(server.turns), server.outstanding)
+	}
+	if server.pendingTurn == nil || server.pendingTurn.id != "turn-1" || server.pendingTurn.text != "first follow-up\n\nsecond follow-up" || server.pendingTurn.revision != 2 {
+		t.Fatalf("pending turn = %#v", server.pendingTurn)
+	}
+	if !reflect.DeepEqual(server.pendingTurn.attachments, []Attachment{firstAttachment, secondAttachment}) {
+		t.Fatalf("pending attachments = %#v", server.pendingTurn.attachments)
+	}
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventUserMessage, EventUserMessageUpdated)
+	if events[1].RequestID != "request-second" || events[1].TurnID != "turn-1" || events[1].Text != "first follow-up\n\nsecond follow-up" {
+		t.Fatalf("combined pending message = %#v", events[1])
+	}
+}
+
 func TestSessionSetupEnvironmentKeepsWorkspaceSetupCommand(t *testing.T) {
 	setupCommand := `KELOS_SETUP_COMMAND=["sh","-c","pip install --user some-tool"]`
 	environment := sessionSetupEnvironment([]string{setupCommand, "KELOS_SESSION_SETUP_ONLY=0"})
@@ -1152,9 +1230,6 @@ func TestServerDoesNotInterruptNextTurnWhenCompletionRacesWithInterrupt(t *testi
 	if err := server.submitMessage("first", "request-first"); err != nil {
 		t.Fatal(err)
 	}
-	if err := server.submitMessage("second", "request-second"); err != nil {
-		t.Fatal(err)
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
 	go func() {
@@ -1165,6 +1240,9 @@ func TestServerDoesNotInterruptNextTurnWhenCompletionRacesWithInterrupt(t *testi
 	case <-provider.firstStarted:
 	case <-time.After(time.Second):
 		t.Fatal("first provider turn did not start")
+	}
+	if err := server.submitMessage("second", "request-second"); err != nil {
+		t.Fatal(err)
 	}
 	interruptDone := make(chan error, 1)
 	go func() {
@@ -1194,10 +1272,10 @@ func TestServerDoesNotInterruptNextTurnWhenCompletionRacesWithInterrupt(t *testi
 	<-runDone
 }
 
-func TestServerPreservesQueuedTurnAcrossForcedProviderRestart(t *testing.T) {
+func TestServerPreservesPendingTurnAcrossForcedProviderRestart(t *testing.T) {
 	server, provider, turnDone := startStuckInterruptServer(t, false)
 	server.interruptTimeout = 20 * time.Millisecond
-	if err := server.submitMessage("queued work", "request-queued"); err != nil {
+	if err := server.submitMessage("pending work", "request-pending"); err != nil {
 		t.Fatal(err)
 	}
 	podUID := server.config.PodUID
@@ -1216,19 +1294,19 @@ func TestServerPreservesQueuedTurnAcrossForcedProviderRestart(t *testing.T) {
 	}
 	assertStuckTurnInterrupted(t, server, provider, turnDone)
 	if report, _ := server.sessionDrainReports(); report == nil || report.Phase != sessionupdate.PhaseDraining {
-		t.Fatalf("runtime update report = %#v, want Draining while queued work remains", report)
+		t.Fatalf("runtime update report = %#v, want Draining while pending work remains", report)
 	}
 
 	recovery, err := recoverJournal(server.journal)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(recovery.queuedTurns) != 1 || recovery.queuedTurns[0].id != "turn-2" || recovery.queuedTurns[0].text != "queued work" {
-		t.Fatalf("recovered queued turns = %#v", recovery.queuedTurns)
+	if recovery.pendingTurn == nil || recovery.pendingTurn.id != "turn-2" || recovery.pendingTurn.text != "pending work" {
+		t.Fatalf("recovered pending turn = %#v", recovery.pendingTurn)
 	}
 	restartedProvider := &fakeProvider{}
 	restarted := NewServer(Config{}, server.journal, restartedProvider)
-	if err := restarted.restoreTurns(recovery.queuedTurns); err != nil {
+	if err := restarted.restoreTurn(recovery.pendingTurn); err != nil {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1242,11 +1320,11 @@ func TestServerPreservesQueuedTurnAcrossForcedProviderRestart(t *testing.T) {
 		restartedProvider.mu.Lock()
 		prompts := append([]string(nil), restartedProvider.prompts...)
 		restartedProvider.mu.Unlock()
-		if reflect.DeepEqual(prompts, []string{"queued work"}) {
+		if reflect.DeepEqual(prompts, []string{"pending work"}) {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("provider prompts = %v, want queued work", prompts)
+			t.Fatalf("provider prompts = %v, want pending work", prompts)
 		}
 		time.Sleep(time.Millisecond)
 	}
@@ -1261,7 +1339,7 @@ func TestServerStopsAcceptingAndDispatchingTurnsWhileProviderRestarts(t *testing
 	server := NewServer(Config{}, journal, provider)
 	accepted := make(chan struct{})
 	close(accepted)
-	server.turns <- turnRequest{id: "turn-1", text: "queued work", accepted: accepted}
+	server.turns <- turnRequest{id: "turn-1", text: "pending work", accepted: accepted}
 	server.providerStopping.Store(true)
 
 	runDone := make(chan struct{})
@@ -1275,7 +1353,7 @@ func TestServerStopsAcceptingAndDispatchingTurnsWhileProviderRestarts(t *testing
 		t.Fatal("turn dispatcher did not stop")
 	}
 	if len(server.turns) != 1 {
-		t.Fatalf("queued turns = %d, want 1", len(server.turns))
+		t.Fatalf("pending turns = %d, want 1", len(server.turns))
 	}
 	if err := server.submitMessage("late work", "request-late"); err == nil || !strings.Contains(err.Error(), "restarting") {
 		t.Fatalf("submitMessage() error = %v, want provider restart rejection", err)
@@ -1427,7 +1505,7 @@ func TestSubmitMessageDoesNotStartProviderWhenJournalWriteFails(t *testing.T) {
 	}
 }
 
-func TestServerSerializesConcurrentMessageAcceptance(t *testing.T) {
+func TestServerSerializesConcurrentPendingMessageUpdates(t *testing.T) {
 	journal := NewJournal()
 	defer journal.Close()
 	server := NewServer(Config{}, journal, &fakeProvider{})
@@ -1436,11 +1514,11 @@ func TestServerSerializesConcurrentMessageAcceptance(t *testing.T) {
 	secondAppending := make(chan struct{})
 	appendMessage := server.appendMessage
 	server.appendMessage = func(event Event) error {
-		switch event.Text {
-		case "first":
+		switch event.RequestID {
+		case "request-first":
 			close(firstAppending)
 			<-releaseFirst
-		case "second":
+		case "request-second":
 			close(secondAppending)
 		}
 		return appendMessage(event)
@@ -1478,14 +1556,13 @@ func TestServerSerializesConcurrentMessageAcceptance(t *testing.T) {
 	}
 
 	events := journal.Snapshot()
-	assertEventTypes(t, events, EventUserMessage, EventUserMessage)
-	if events[0].Text != "first" || events[1].Text != "second" {
+	assertEventTypes(t, events, EventUserMessage, EventUserMessageUpdated)
+	if events[0].Text != "first" || events[1].Text != "first\n\nsecond" {
 		t.Fatalf("message order = %q, %q", events[0].Text, events[1].Text)
 	}
-	firstTurn := <-server.turns
-	secondTurn := <-server.turns
-	if firstTurn.text != "first" || secondTurn.text != "second" {
-		t.Fatalf("turn order = %q, %q", firstTurn.text, secondTurn.text)
+	pending := server.takePendingTurn(<-server.turns)
+	if pending.text != "first\n\nsecond" || len(server.turns) != 0 {
+		t.Fatalf("pending turn = %#v, remaining turns %d", pending, len(server.turns))
 	}
 }
 
@@ -2071,14 +2148,14 @@ func TestServerPreservesStateOutsideProjectedHistoryPage(t *testing.T) {
 	journal := NewJournal()
 	defer journal.Close()
 	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
-	queuedText := strings.Repeat("queued ", maxHistoryMessageBytes)
+	pendingText := strings.Repeat("pending ", maxHistoryMessageBytes)
 	for _, event := range []Event{
 		{Type: EventFileDiff, Diff: "diff --git a/old.txt b/old.txt\n-old\n+new"},
 		{Type: EventUserMessage, TurnID: "turn-1", Text: "active request"},
 		{Type: EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt, Status: "running"},
 		{Type: EventAssistantDelta, TurnID: "turn-1", Text: "partial answer"},
 		{Type: EventInputRequested, TurnID: "turn-1", InputID: "input-1", Questions: []InputQuestion{{ID: "confirm", Question: "Continue?"}}, Status: "pending"},
-		{Type: EventUserMessage, TurnID: "turn-2", Text: queuedText},
+		{Type: EventUserMessage, TurnID: "turn-2", Text: pendingText},
 	} {
 		if err := journal.Append(event); err != nil {
 			t.Fatal(err)
@@ -2133,14 +2210,14 @@ func TestServerPreservesStateOutsideProjectedHistoryPage(t *testing.T) {
 	if state.ActiveTurnID != "turn-1" || state.ActiveTurnStarted == nil || !state.ActiveTurnStarted.Equal(startedAt) || !state.WaitingForInput {
 		t.Fatalf("history state = %#v, want active turn waiting for input", state)
 	}
-	if len(state.QueuedTurns) != 1 || state.QueuedTurns[0].TurnID != "turn-2" {
-		t.Fatalf("queued turns = %#v, want turn-2", state.QueuedTurns)
+	if state.PendingTurn == nil || state.PendingTurn.TurnID != "turn-2" {
+		t.Fatalf("pending turn = %#v, want turn-2", state.PendingTurn)
 	}
 	if state.FileDiff != "diff --git a/old.txt b/old.txt\n-old\n+new" {
 		t.Fatalf("file diff = %q, want state outside projected history page", state.FileDiff)
 	}
-	if text := state.QueuedTurns[0].Text; len(text) > maxHistoryMessageBytes || !strings.Contains(text, historyTruncationMarker) {
-		t.Fatalf("queued message preview has %d bytes", len(text))
+	if text := state.PendingTurn.Text; len(text) > maxHistoryMessageBytes || !strings.Contains(text, historyTruncationMarker) {
+		t.Fatalf("pending message preview has %d bytes", len(text))
 	}
 }
 

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -595,8 +595,8 @@ func TestSessionComposerUsesOneSendAndInterruptAction(t *testing.T) {
 	if !strings.Contains(body, `id="send-message" type="submit" aria-label="Send message" data-action="send"`) {
 		t.Error("Session composer does not contain the send action")
 	}
-	if !strings.Contains(body, `id="queued-prompts"`) {
-		t.Error("Session composer does not contain the queued prompts region")
+	if !strings.Contains(body, `id="pending-message"`) {
+		t.Error("Session composer does not contain the pending message region")
 	}
 	if !strings.Contains(body, `id="session-progress"`) {
 		t.Error("Session composer does not contain the agent progress region")
@@ -723,7 +723,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"two-row phone header":       `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
 		"48-pixel touch targets":     `.icon-button { width: 48px; height: 48px; }`,
 		"phone safe-area padding":    `env(safe-area-inset-bottom)`,
-		"non-zooming form fields":    `.composer textarea, .yaml-panel textarea, .form-grid input`,
+		"non-zooming form fields":    `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
 		"desktop composer alignment": `.composer textarea { flex: 1; min-height: 36px;`,
 		"mobile composer alignment":  `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
 		"phone-sized dialog":         `max-height: calc(100dvh - 16px`,

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -157,7 +157,7 @@ global.WebSocket = {OPEN: 1};
 function resetHarness() {
   global.elements = {
     messages: new TestNode('div'),
-    queue: new TestNode('div'),
+    pending: new TestNode('div'),
     changesList: new TestNode('div'),
     changesCount: new TestNode('span'),
     changesSummary: new TestNode('span'),
@@ -188,7 +188,7 @@ function resetHarness() {
     inputs: new Map(),
     diffs: new Map(),
     fileChanges: new Map(),
-    queuedMessages: new Map(),
+    pendingMessage: null,
     activeTurn: false,
     activeTurnID: '',
     activeTurnStartedAt: 0,
@@ -232,7 +232,7 @@ global.connectSocket = () => { socketConnections++; };
 global.updateComposerAction = () => {};
 global.updateFileChangesHeader = () => {};
 global.endAssistantSegment = () => {};
-global.acceptQueuedMessage = () => {};
+global.acceptPendingMessage = () => {};
 global.renderInputRequest = () => {};
 global.resolveInputCard = () => {};
 global.scrollToBottom = () => {};
@@ -377,6 +377,17 @@ function testComposerInterruptsWhileInputIsDisabled() {
   state.interrupting = true;
   updateComposerAction();
   assert.equal(elements.send.disabled, true);
+}
+
+function testComposerLabelsPendingSubmission() {
+  resetHarness();
+  state.socket = {readyState: WebSocket.OPEN};
+  state.pendingMessage = {event: {turnId: 'turn-2'}};
+  elements.input.value = 'another detail';
+
+  updateComposerAction();
+
+  assert.equal(elements.composerHint.textContent, 'Enter to add to pending · Shift+Enter for a new line');
 }
 
 async function testComposerIgnoresReentrantSubmission() {
@@ -575,7 +586,7 @@ function testProjectedHistoryRestoresStateAndReconnectHighWater() {
       activeTurnStarted: '2026-08-08T12:00:00Z',
       waitingForInput: true,
       turnInterrupting: true,
-      queuedTurns: [{turnId: 'turn-2', text: 'queued request'}],
+      pendingTurn: {turnId: 'turn-2', text: 'pending request'},
       fileDiff,
     },
   });
@@ -591,12 +602,24 @@ function testProjectedHistoryRestoresStateAndReconnectHighWater() {
   assert.equal(state.interrupting, true);
   assert.equal(state.assistantTextByTurn.get('turn-1'), 'working');
   assert.equal(state.assistantTextByTurn.has('current'), false);
-  assert.equal(state.queuedMessages.get('turn-2').event.text, 'queued request');
+  assert.equal(state.pendingMessage.event.text, 'pending request');
   assert.equal(state.fileChanges.get('old.txt'), fileDiff);
   assert.equal(elements.messages.querySelector('.history-page-control').textContent, 'Load earlier messages');
 
   handleEvent({type: 'assistant.message', id: 13, turnId: 'turn-1', text: 'working done'});
   assert.equal(elements.messages.textContent.match(/working done/g).length, 1);
+}
+
+function testProjectedHistoryHidesEmptyPendingRegion() {
+  resetHarness();
+  renderPendingUser({type: 'user.message', turnId: 'turn-2', text: 'pending request'});
+  assert.equal(elements.pending.hidden, false);
+
+  applyHistoryState({});
+
+  assert.equal(state.pendingMessage, null);
+  assert.equal(elements.pending.hidden, true);
+  assert.equal(elements.pending.hasChildNodes(), false);
 }
 
 function testOlderHistoryPageIsPrependedWithoutChangingLiveState() {
@@ -788,10 +811,45 @@ function testUserAttachmentRendering() {
   assert.match(link.textContent, /screen\.png/);
 }
 
+function testPendingMessageEditing() {
+  resetHarness();
+  const sent = [];
+  state.socket = {readyState: WebSocket.OPEN, send: (payload) => sent.push(JSON.parse(payload))};
+  renderPendingUser({type: 'user.message', turnId: 'turn-2', text: 'original', revision: 1});
+
+  editPendingUser('turn-2');
+  const pending = state.pendingMessage;
+  const input = pending.item.querySelector('.pending-message-input');
+  input.value = 'revised';
+  pending.item.querySelector('.pending-message-save').listeners.get('click')();
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].type, 'message.edit');
+  assert.equal(sent[0].turnId, 'turn-2');
+  assert.equal(sent[0].text, 'revised');
+  assert.equal(sent[0].expectedRevision, 1);
+  handleEvent({type: 'user.message.updated', turnId: 'turn-2', text: 'revised', revision: 2});
+  assert.equal(state.pendingMessage.event.revision, 2);
+  assert.match(pending.item.textContent, /revised/);
+  assert.doesNotMatch(pending.item.textContent, /original/);
+}
+
+function testPendingMessageSurvivesCompletedHistoryReplay() {
+  resetHarness();
+  renderPendingUser({type: 'user.message', turnId: 'turn-2', text: 'pending'});
+
+  renderPendingUser({type: 'user.message', turnId: 'turn-1', text: 'completed'});
+
+  assert.equal(state.pendingMessage.event.turnId, 'turn-2');
+  assert.equal(state.pendingMessage.event.text, 'pending');
+  assert.match(elements.messages.textContent, /completed/);
+}
+
 testSessionViewSaveAndRestore();
 testSessionViewReset();
 testSessionProgressLifecycle();
 testComposerInterruptsWhileInputIsDisabled();
+testComposerLabelsPendingSubmission();
 testSessionProgressSurvivesCachedViewSwitch();
 testSessionProgressElapsedFormatting();
 testRuntimeStatusLifecycle();
@@ -803,6 +861,7 @@ testRuntimeRecoveryDividerOmitsDuration();
 testSessionResetClearsPromptDraft();
 testHistoryReplayCompletion();
 testProjectedHistoryRestoresStateAndReconnectHighWater();
+testProjectedHistoryHidesEmptyPendingRegion();
 testOlderHistoryPageIsPrependedWithoutChangingLiveState();
 testReselectRefreshesStatusPlaceholder();
 testSessionTimestampFormatting();
@@ -811,6 +870,8 @@ testToolOutputRendering();
 testToolOutputRenderingNormalizesCarriageReturns();
 testHistoryToolCompletionRendersOutputWithoutStart();
 testUserAttachmentRendering();
+testPendingMessageEditing();
+testPendingMessageSurvivesCompletedHistoryReplay();
 testComposerIgnoresReentrantSubmission()
   .then(() => process.stdout.write('Session history tests passed\n'))
   .catch(error => {

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -40,7 +40,7 @@ const elements = {
   progress: document.querySelector('#session-progress'),
   progressLabel: document.querySelector('#session-progress-label'),
   progressElapsed: document.querySelector('#session-progress-elapsed'),
-  queue: document.querySelector('#queued-prompts'),
+  pending: document.querySelector('#pending-message'),
   connection: document.querySelector('#connection-pill'),
   dialog: document.querySelector('#session-dialog'),
   form: document.querySelector('#session-form'),
@@ -94,7 +94,7 @@ const state = {
   inputs: new Map(),
   diffs: new Map(),
   fileChanges: new Map(),
-  queuedMessages: new Map(),
+  pendingMessage: null,
   promptDrafts: new Map(),
   attachmentDrafts: new Map(),
   sendingMessage: false,
@@ -185,7 +185,7 @@ function moveChildren(element) {
 function createSessionView() {
   return {
     messages: document.createDocumentFragment(),
-    queue: document.createDocumentFragment(),
+    pending: document.createDocumentFragment(),
     changes: document.createDocumentFragment(),
     lastEventID: 0,
     journalID: '',
@@ -195,7 +195,7 @@ function createSessionView() {
     inputs: new Map(),
     diffs: new Map(),
     fileChanges: new Map(),
-    queuedMessages: new Map(),
+    pendingMessage: null,
     activeTurn: false,
     activeTurnID: '',
     activeTurnStartedAt: 0,
@@ -216,7 +216,7 @@ function saveCurrentSessionView() {
   const view = state.currentView;
   if (!view) return;
   view.messages = moveChildren(elements.messages);
-  view.queue = moveChildren(elements.queue);
+  view.pending = moveChildren(elements.pending);
   view.changes = moveChildren(elements.changesList);
   view.lastEventID = state.lastEventID;
   view.assistantSegmentByTurn = state.assistantSegmentByTurn;
@@ -225,7 +225,7 @@ function saveCurrentSessionView() {
   view.inputs = state.inputs;
   view.diffs = state.diffs;
   view.fileChanges = state.fileChanges;
-  view.queuedMessages = state.queuedMessages;
+  view.pendingMessage = state.pendingMessage;
   view.activeTurn = state.activeTurn;
   view.activeTurnID = state.activeTurnID;
   view.activeTurnStartedAt = state.activeTurnStartedAt;
@@ -254,7 +254,7 @@ function activateSessionView(view) {
   state.inputs = view.inputs;
   state.diffs = view.diffs;
   state.fileChanges = view.fileChanges;
-  state.queuedMessages = view.queuedMessages;
+  state.pendingMessage = view.pendingMessage;
   state.activeTurn = view.activeTurn;
   state.activeTurnID = view.activeTurnID;
   state.activeTurnStartedAt = view.activeTurnStartedAt;
@@ -274,9 +274,9 @@ function activateSessionView(view) {
   state.fileChangesDirty = view.fileChangesDirty;
   const hasChanges = view.changes.hasChildNodes();
   elements.messages.replaceChildren(view.messages);
-  elements.queue.replaceChildren(view.queue);
+  elements.pending.replaceChildren(view.pending);
   elements.changesList.replaceChildren(view.changes);
-  elements.queue.hidden = state.queuedMessages.size === 0;
+  elements.pending.hidden = !state.pendingMessage;
   updateFileChangesHeader();
   if (!hasChanges) renderFileChanges();
   refreshSessionProgress();
@@ -309,7 +309,7 @@ function resetCurrentSessionView() {
   state.inputs = new Map();
   state.diffs = new Map();
   state.fileChanges = new Map();
-  state.queuedMessages = new Map();
+  state.pendingMessage = null;
   state.activeTurn = false;
   state.activeTurnID = '';
   state.activeTurnStartedAt = 0;
@@ -328,8 +328,8 @@ function resetCurrentSessionView() {
   state.pinHistoryToBottom = true;
   state.fileChangesDirty = false;
   elements.messages.replaceChildren();
-  elements.queue.replaceChildren();
-  elements.queue.hidden = true;
+  elements.pending.replaceChildren();
+  elements.pending.hidden = true;
   renderFileChanges();
   if (view) {
     view.historyLoaded = false;
@@ -343,7 +343,7 @@ function resetCurrentSessionView() {
     view.inputs = state.inputs;
     view.diffs = state.diffs;
     view.fileChanges = state.fileChanges;
-    view.queuedMessages = state.queuedMessages;
+    view.pendingMessage = state.pendingMessage;
     view.activeTurn = false;
     view.activeTurnID = '';
     view.activeTurnStartedAt = 0;
@@ -1485,7 +1485,7 @@ function selectSession(session, resumeIdle = false) {
   restorePromptDraft(session);
   renderPendingAttachments();
   elements.messages.replaceChildren();
-  elements.queue.replaceChildren();
+  elements.pending.replaceChildren();
   elements.changesList.replaceChildren();
   renderSessions();
   renderHeader();
@@ -1626,7 +1626,7 @@ function composerInterruptAction() {
 function updateComposerAction() {
   const connected = state.socket && state.socket.readyState === WebSocket.OPEN;
   const interrupt = composerInterruptAction();
-  const action = interrupt ? 'interrupt' : (state.activeTurn ? 'queue' : 'send');
+  const action = interrupt ? 'interrupt' : ((state.activeTurn || state.pendingMessage) ? 'add to pending' : 'send');
   const actionSymbol = interrupt ? '■' : '↑';
   elements.send.dataset.action = interrupt ? 'interrupt' : 'send';
   elements.send.textContent = actionSymbol;
@@ -2359,9 +2359,13 @@ function completedAssistantText(eventText, streamedText) {
   return eventText || streamedText || '';
 }
 
-function sessionHistoryRequestID() {
+function sessionRequestID(prefix) {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
-  return `history-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function sessionHistoryRequestID() {
+  return sessionRequestID('history');
 }
 
 function renderHistoryControl() {
@@ -2425,10 +2429,18 @@ function applyHistoryState(historyState) {
   state.waitingForInput = Boolean(historyState.waitingForInput);
   state.interrupting = Boolean(historyState.turnInterrupting);
   if (historyState.fileDiff) updateFileChanges(parseFileDiffs(historyState.fileDiff));
-  elements.queue.replaceChildren();
-  state.queuedMessages = new Map();
-  for (const turn of historyState.queuedTurns || []) {
-    renderQueuedUser({type: 'user.message', turnId: turn.turnId, text: turn.text});
+  elements.pending.replaceChildren();
+  elements.pending.hidden = true;
+  state.pendingMessage = null;
+  if (historyState.pendingTurn) {
+    const turn = historyState.pendingTurn;
+    renderPendingUser({
+      type: 'user.message',
+      turnId: turn.turnId,
+      text: turn.text,
+      revision: turn.revision,
+      attachments: turn.attachments || [],
+    });
   }
   refreshSessionProgress();
   updateComposerAction();
@@ -2584,6 +2596,9 @@ function handleEvent(event) {
     case 'user.message':
       renderUser(event);
       break;
+    case 'user.message.updated':
+      renderPendingUser(event);
+      break;
     case 'turn.started':
       endAssistantSegment(event.turnId);
       if (!state.activeTurn || state.activeTurnID !== event.turnId) {
@@ -2594,7 +2609,7 @@ function handleEvent(event) {
       state.activeTurnID = event.turnId || '';
       state.waitingForInput = false;
       state.interrupting = false;
-      acceptQueuedMessage(event.turnId);
+      acceptPendingMessage(event.turnId);
       updateComposerAction();
       refreshSessionProgress();
       break;
@@ -2646,7 +2661,7 @@ function handleEvent(event) {
 
 function renderUser(event) {
   if (event.turnId) {
-    renderQueuedUser(event);
+    renderPendingUser(event);
     return;
   }
   renderAcceptedUser(event);
@@ -2668,21 +2683,88 @@ function renderAcceptedUser(event) {
   scrollToBottom();
 }
 
-function renderQueuedUser(event) {
-  if (state.queuedMessages.has(event.turnId)) return;
+function renderPendingUser(event) {
+  const existing = state.pendingMessage;
+  if (existing) {
+    if (existing.event.turnId !== event.turnId) {
+      renderAcceptedUser(event);
+      return;
+    }
+    existing.event = {...event, revision: event.revision || 1};
+    renderPendingMessageContent(existing);
+    return;
+  }
   const item = document.createElement('div');
-  item.className = 'queued-prompt';
+  item.className = 'pending-message-card';
   const text = document.createElement('div');
-  text.className = 'queued-prompt-text';
+  text.className = 'pending-message-text';
+  const actions = document.createElement('div');
+  actions.className = 'pending-message-actions';
+  item.append(text, actions);
+  elements.pending.append(item);
+  elements.pending.hidden = false;
+  const pending = {event: {...event, revision: event.revision || 1}, item, text, actions};
+  state.pendingMessage = pending;
+  renderPendingMessageContent(pending);
+}
+
+function pendingMessageText(event) {
   const names = (event.attachments || []).map(attachment => attachment.name);
-  text.textContent = [event.text, names.length ? `Attachments: ${names.join(', ')}` : ''].filter(Boolean).join(' · ');
+  return [event.text, names.length ? `Attachments: ${names.join(', ')}` : ''].filter(Boolean).join(' · ');
+}
+
+function renderPendingMessageContent(pending) {
+  pending.item.classList.remove('editing');
+  pending.text.textContent = pendingMessageText(pending.event);
+  pending.actions.replaceChildren();
   const status = document.createElement('span');
-  status.className = 'queued-prompt-status';
-  status.textContent = 'Queued';
-  item.append(text, status);
-  elements.queue.append(item);
-  elements.queue.hidden = false;
-  state.queuedMessages.set(event.turnId, {event, item});
+  status.className = 'pending-message-status';
+  status.textContent = 'Pending';
+  const edit = document.createElement('button');
+  edit.type = 'button';
+  edit.className = 'pending-message-edit';
+  edit.textContent = 'Edit';
+  edit.setAttribute('aria-label', 'Edit pending message');
+  edit.addEventListener('click', () => editPendingUser(pending.event.turnId));
+  pending.actions.append(status, edit);
+}
+
+function editPendingUser(turnID) {
+  const pending = state.pendingMessage;
+  if (!pending || pending.event.turnId !== turnID) return;
+  pending.item.classList.add('editing');
+  const input = document.createElement('textarea');
+  input.className = 'pending-message-input';
+  input.value = pending.event.text || '';
+  input.setAttribute('aria-label', 'Pending message');
+  pending.text.replaceChildren(input);
+  const cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.className = 'pending-message-edit';
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => renderPendingMessageContent(pending));
+  const save = document.createElement('button');
+  save.type = 'button';
+  save.className = 'pending-message-save';
+  save.textContent = 'Save';
+  save.addEventListener('click', () => {
+    const text = input.value.trim();
+    if (!text && !(pending.event.attachments || []).length) return;
+    if (!state.socket || state.socket.readyState !== WebSocket.OPEN) {
+      showToast('Session is disconnected');
+      return;
+    }
+    state.socket.send(JSON.stringify({
+      type: 'message.edit',
+      requestId: sessionRequestID('message-edit'),
+      turnId: pending.event.turnId,
+      text,
+      expectedRevision: pending.event.revision,
+    }));
+    renderPendingMessageContent(pending);
+  });
+  pending.actions.replaceChildren(cancel, save);
+  if (typeof input.focus === 'function') input.focus();
 }
 
 function attachmentURL(attachment) {
@@ -2715,13 +2797,13 @@ function appendMessageAttachments(parent, attachments) {
   parent.append(list);
 }
 
-function acceptQueuedMessage(turnID) {
-  const queued = state.queuedMessages.get(turnID);
-  if (!queued) return;
-  queued.item.remove();
-  state.queuedMessages.delete(turnID);
-  elements.queue.hidden = state.queuedMessages.size === 0;
-  renderAcceptedUser(queued.event);
+function acceptPendingMessage(turnID) {
+  const pending = state.pendingMessage;
+  if (!pending || pending.event.turnId !== turnID) return;
+  pending.item.remove();
+  state.pendingMessage = null;
+  elements.pending.hidden = true;
+  renderAcceptedUser(pending.event);
 }
 
 function assistantBubble(turnID) {
@@ -3231,7 +3313,7 @@ function renderTurnEnd(event, recoveredCompletion = false) {
   state.activeTurnStartedAt = 0;
   state.waitingForInput = false;
   state.interrupting = false;
-  acceptQueuedMessage(event.turnId);
+  acceptPendingMessage(event.turnId);
   updateComposerAction();
   refreshSessionProgress();
   if (event.status === 'interrupted' && !state.replayingHistory) showToast('Active work interrupted');

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -86,7 +86,7 @@
           <span id="session-progress-label"></span>
           <span id="session-progress-elapsed" aria-hidden="true"></span>
         </div>
-        <div class="queued-prompts" id="queued-prompts" aria-label="Queued prompts" aria-live="polite" hidden></div>
+        <div class="pending-message" id="pending-message" aria-label="Pending message" aria-live="polite" hidden></div>
         <div class="pending-attachments" id="pending-attachments" aria-label="Files ready to attach" hidden></div>
         <form class="composer" id="composer">
           <input id="attachment-input" type="file" multiple hidden>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -270,11 +270,19 @@ button { color: inherit; }
 .session-progress[data-state="waiting"] .session-progress-dot { color: var(--warning); animation: none; }
 .session-progress[data-state="interrupting"] { color: var(--warning); }
 .session-progress[data-state="interrupting"] .session-progress-dot { color: var(--warning); }
-.queued-prompts { max-height: 150px; display: grid; gap: 6px; margin-bottom: 8px; overflow-y: auto; }
-.queued-prompts[hidden] { display: none; }
-.queued-prompt { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 9px 12px; border: 1px solid var(--line); border-radius: 11px; background: var(--accent-soft); }
-.queued-prompt-text { overflow: hidden; color: var(--ink); font-size: 11.5px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
-.queued-prompt-status { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.pending-message { max-height: 150px; display: grid; margin-bottom: 8px; overflow-y: auto; }
+.pending-message[hidden] { display: none; }
+.pending-message-card { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 9px 12px; border: 1px solid var(--line); border-radius: 11px; background: var(--accent-soft); }
+.pending-message-card.editing { align-items: start; }
+.pending-message-text { overflow: hidden; color: var(--ink); font-size: 11.5px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
+.pending-message-card.editing .pending-message-text { overflow: visible; white-space: normal; }
+.pending-message-input { width: 100%; min-height: 58px; resize: vertical; padding: 7px 8px; border: 1px solid var(--line); border-radius: 8px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; line-height: 1.4; }
+.pending-message-input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.pending-message-actions { display: flex; align-items: center; gap: 7px; }
+.pending-message-status { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+.pending-message-edit, .pending-message-save { padding: 3px 6px; border: 0; border-radius: 6px; background: transparent; color: var(--muted); font-size: 9.5px; font-weight: 700; cursor: pointer; }
+.pending-message-edit:hover { background: var(--line-soft); color: var(--ink); }
+.pending-message-save { background: var(--accent); color: white; }
 .pending-attachments { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 4px 8px; }
 .pending-attachments[hidden] { display: none; }
 .pending-attachment { display: inline-flex; max-width: 220px; align-items: center; gap: 5px; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--accent-soft); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -380,7 +388,7 @@ button { color: inherit; }
   .changes-view { padding: 22px calc(14px + env(safe-area-inset-right)) 32px calc(14px + env(safe-area-inset-left)); overscroll-behavior: contain; }
   .composer-wrap { padding: 9px calc(10px + env(safe-area-inset-right)) calc(10px + env(safe-area-inset-bottom)) calc(10px + env(safe-area-inset-left)); }
   .composer { padding-left: 13px; }
-  .composer textarea, .yaml-panel textarea, .form-grid input, .form-grid select, .source-picker select, .section-field input, .section-field select, .namespace-form input, .input-other { font-size: 16px; }
+  .composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input, .form-grid select, .source-picker select, .section-field input, .section-field select, .namespace-form input, .input-other { font-size: 16px; }
   .composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }
   .send-button { width: 48px; height: 48px; }
   .message-bubble, .user-message { max-width: 90%; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Maintains at most one pending Session message while a turn is active. Additional submissions append their text and attachments to that message, and the combined message runs as the next turn after active work completes.

The web client provides inline Edit, Save, and Cancel controls for the pending message. Edits are revision-checked, persisted in the Session journal, reflected in connected terminal clients, and recovered after a runtime restart. Journals containing multiple accepted but unstarted turns are consolidated into one pending message during recovery.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Edit replaces the pending text while a normal submission appends to it. Existing attachments remain attached, and optimistic revisions prevent a stale client from overwriting a newer update.

#### Does this PR introduce a user-facing change?

```release-note
Combine follow-up Session submissions into one editable pending message that runs after active work completes.
```