### PR TITLE
Display and manage pending Session messages

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -281,7 +281,10 @@ provider conversation. Both clients can stream agent and tool activity, answer
 user-input requests, and interrupt active work without ending the provider
 conversation. While a turn is active, new submissions are combined into one
 pending message that runs next. In the web client, use **Edit** to revise its
-text before it starts; existing attachments remain on the message. Kelos first
+text before it starts or **Remove** to discard it; existing attachments remain
+on the message when it is edited. In the terminal UI, press **Up** on an empty
+composer to edit the pending message. Submitting the edit with no text removes
+the pending message. Kelos first
 asks the provider to interrupt gracefully, including
 while the runtime is draining. If the request fails or the turn does not finish
 within 10 seconds, Kelos marks the turn interrupted and restarts the provider.

--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -322,6 +322,8 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				if color {
 					write("\n")
 				}
+			case sessionruntime.EventUserMessageRemoved:
+				write("%s\n", formatter.muted("Pending message removed."))
 			case sessionTerminalEventAttachmentAdded:
 				attachmentMu.Lock()
 				pendingAttachments = append(pendingAttachments, event.Attachments...)

--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -132,6 +132,10 @@ type sessionTUIModel struct {
 	blocks             []sessionTUIBlock
 	pendingTurnID      string
 	pendingTurnText    string
+	pendingTurnInput   string
+	pendingRevision    int64
+	pendingEditTurnID  string
+	pendingEditRev     int64
 	toolNames          map[string]string
 	width              int
 	height             int
@@ -409,11 +413,16 @@ func (m *sessionTUIModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case tea.KeyUp:
 			if m.ready && !strings.Contains(m.input.Value(), "\n") {
-				m.previousInput()
-				return m, nil
+				if m.recallPendingTurn() {
+					return m, nil
+				}
+				if m.pendingEditTurnID == "" {
+					m.previousInput()
+					return m, nil
+				}
 			}
 		case tea.KeyDown:
-			if m.ready && !strings.Contains(m.input.Value(), "\n") {
+			if m.ready && m.pendingEditTurnID == "" && !strings.Contains(m.input.Value(), "\n") {
 				m.nextInput()
 				return m, nil
 			}
@@ -450,6 +459,29 @@ func (m *sessionTUIModel) readEvent() tea.Cmd {
 
 func (m *sessionTUIModel) submitInput() tea.Cmd {
 	line := m.input.Value()
+	if m.pendingEditTurnID != "" {
+		request := sessionruntime.ClientRequest{
+			Type:             "message.edit",
+			TurnID:           m.pendingEditTurnID,
+			Text:             line,
+			ExpectedRevision: m.pendingEditRev,
+		}
+		if strings.TrimSpace(line) == "" {
+			request.Type = "message.remove"
+			request.Text = ""
+		}
+		if err := m.requests.Encode(request); err != nil {
+			m.err = err
+			return m.quit()
+		}
+		m.pendingEditTurnID = ""
+		m.pendingEditRev = 0
+		m.historyAt = -1
+		m.draft = ""
+		m.input.Reset()
+		m.resizeComposer()
+		return nil
+	}
 	if line == "/quit" || line == "/exit" {
 		return m.quit()
 	}
@@ -542,6 +574,18 @@ func (m *sessionTUIModel) previousInput() {
 	m.resizeComposer()
 }
 
+func (m *sessionTUIModel) recallPendingTurn() bool {
+	if m.pendingTurnID == "" || m.input.Value() != "" || m.historyAt != -1 || len(m.pendingAttachments) > 0 {
+		return false
+	}
+	m.pendingEditTurnID = m.pendingTurnID
+	m.pendingEditRev = m.pendingRevision
+	m.input.SetValue(m.pendingTurnInput)
+	m.input.CursorEnd()
+	m.resizeComposer()
+	return true
+}
+
 func (m *sessionTUIModel) nextInput() {
 	if m.historyAt == -1 {
 		return
@@ -610,7 +654,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		// A terminal-height transcript in both the managed view and native scrollback
 		// makes Bubble Tea move the smaller footer to the top when the copy is removed.
 		m.hideNextHistory = !m.ready
-		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Drag a file here or use /attach PATH. Use /history or Page Up for earlier history, /answer INPUT QUESTION VALUE, or /quit.")
+		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Drag a file here or use /attach PATH. Press Up on an empty composer to edit pending work; submit an empty edit to remove it. Use /history or Page Up for earlier history, /answer INPUT QUESTION VALUE, or /quit.")
 		m.ready = true
 		m.connectionStatus = ""
 		commands.ui = tea.Batch(m.input.Focus(), m.scheduleProgress())
@@ -637,11 +681,17 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 			m.finishStreaming()
 			m.appendBlock(sessionTUIBlockUser, sessionTerminalMessageText(event.Text, event.Attachments))
 		} else {
-			m.setPendingUser(event.TurnID, sessionTerminalMessageText(event.Text, event.Attachments))
+			m.setPendingUser(event.TurnID, event.Text, event.Attachments, event.Revision)
 		}
 	case sessionruntime.EventUserMessageUpdated:
 		if m.pendingTurnID == event.TurnID {
 			m.pendingTurnText = sessionTerminalMessageText(event.Text, event.Attachments)
+			m.pendingTurnInput = event.Text
+			m.pendingRevision = max(1, event.Revision)
+		}
+	case sessionruntime.EventUserMessageRemoved:
+		if m.discardPendingTurn(event.TurnID) {
+			m.appendBlock(sessionTUIBlockNotice, "Pending message removed.")
 		}
 	case sessionTerminalEventAttachmentAdded:
 		m.pendingAttachments = append(m.pendingAttachments, event.Attachments...)
@@ -740,9 +790,16 @@ func (m *sessionTUIModel) applyHistoryState(state *sessionruntime.HistoryState) 
 	}
 	m.pendingTurnID = ""
 	m.pendingTurnText = ""
+	m.pendingTurnInput = ""
+	m.pendingRevision = 0
 	if state.PendingTurn != nil {
 		m.pendingTurnID = state.PendingTurn.TurnID
 		m.pendingTurnText = sessionTerminalMessageText(state.PendingTurn.Text, state.PendingTurn.Attachments)
+		m.pendingTurnInput = state.PendingTurn.Text
+		m.pendingRevision = max(1, state.PendingTurn.Revision)
+	}
+	if m.pendingEditTurnID != "" && m.pendingEditTurnID != m.pendingTurnID {
+		m.cancelPendingEdit(m.pendingEditTurnID)
 	}
 	m.activeTurnID = state.ActiveTurnID
 	m.turnActive = state.ActiveTurnID != ""
@@ -985,9 +1042,11 @@ func (m *sessionTUIModel) toolCompletionAttribution(event sessionruntime.Event) 
 	return name, true
 }
 
-func (m *sessionTUIModel) setPendingUser(turnID, text string) {
+func (m *sessionTUIModel) setPendingUser(turnID, text string, attachments []sessionruntime.Attachment, revision int64) {
 	m.pendingTurnID = turnID
-	m.pendingTurnText = text
+	m.pendingTurnText = sessionTerminalMessageText(text, attachments)
+	m.pendingTurnInput = text
+	m.pendingRevision = max(1, revision)
 }
 
 func (m *sessionTUIModel) acceptPendingTurn(turnID string) bool {
@@ -997,9 +1056,36 @@ func (m *sessionTUIModel) acceptPendingTurn(turnID string) bool {
 	text := m.pendingTurnText
 	m.pendingTurnID = ""
 	m.pendingTurnText = ""
+	m.pendingTurnInput = ""
+	m.pendingRevision = 0
+	m.cancelPendingEdit(turnID)
 	m.finishStreaming()
 	m.appendBlock(sessionTUIBlockUser, text)
 	return true
+}
+
+func (m *sessionTUIModel) discardPendingTurn(turnID string) bool {
+	if m.pendingTurnID != turnID {
+		return false
+	}
+	m.pendingTurnID = ""
+	m.pendingTurnText = ""
+	m.pendingTurnInput = ""
+	m.pendingRevision = 0
+	m.cancelPendingEdit(turnID)
+	return true
+}
+
+func (m *sessionTUIModel) cancelPendingEdit(turnID string) {
+	if m.pendingEditTurnID != turnID {
+		return
+	}
+	m.pendingEditTurnID = ""
+	m.pendingEditRev = 0
+	m.historyAt = -1
+	m.draft = ""
+	m.input.Reset()
+	m.resizeComposer()
 }
 
 func (m *sessionTUIModel) resize(width, height int) tea.Cmd {

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -1180,11 +1180,68 @@ func TestSessionTUISubmittedTextRendersFromUserEventOnce(t *testing.T) {
 
 func TestSessionTUIUpdatesPendingMessage(t *testing.T) {
 	model, _ := newSessionTUITestModel()
-	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "original"})
-	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessageUpdated, TurnID: "turn-2", Text: "revised"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "original", Revision: 1})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessageUpdated, TurnID: "turn-2", Text: "revised", Revision: 2})
 
-	if model.pendingTurnID != "turn-2" || model.pendingTurnText != "revised" {
-		t.Fatalf("pending message = ID %q text %q", model.pendingTurnID, model.pendingTurnText)
+	if model.pendingTurnID != "turn-2" || model.pendingTurnText != "revised" || model.pendingTurnInput != "revised" || model.pendingRevision != 2 {
+		t.Fatalf("pending message = ID %q text %q input %q revision %d", model.pendingTurnID, model.pendingTurnText, model.pendingTurnInput, model.pendingRevision)
+	}
+}
+
+func TestSessionTUIEditsPendingMessageWithUpArrow(t *testing.T) {
+	model, requests := newSessionTUITestModel()
+	model.ready = true
+	model.applyEvent(sessionruntime.Event{
+		Type:        sessionruntime.EventUserMessage,
+		TurnID:      "turn-2",
+		Text:        "original\nmessage",
+		Revision:    3,
+		Attachments: []sessionruntime.Attachment{{ID: "attachment-1", Name: "notes.txt"}},
+	})
+
+	model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if model.input.Value() != "original\nmessage" {
+		t.Fatalf("recalled input = %q", model.input.Value())
+	}
+	if model.pendingEditTurnID != "turn-2" || model.pendingEditRev != 3 {
+		t.Fatalf("pending edit = ID %q revision %d", model.pendingEditTurnID, model.pendingEditRev)
+	}
+	if !strings.Contains(model.pendingTurnText, "notes.txt") {
+		t.Fatalf("rendered pending message = %q", model.pendingTurnText)
+	}
+
+	model.input.SetValue("revised\nmessage")
+	if cmd := model.submitInput(); cmd != nil {
+		t.Fatal("submitInput() returned a command")
+	}
+	var request sessionruntime.ClientRequest
+	if err := json.NewDecoder(requests).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Type != "message.edit" || request.TurnID != "turn-2" || request.Text != "revised\nmessage" || request.ExpectedRevision != 3 {
+		t.Fatalf("edit request = %#v", request)
+	}
+}
+
+func TestSessionTUIRemovesPendingMessageWithEmptyEdit(t *testing.T) {
+	model, requests := newSessionTUITestModel()
+	model.ready = true
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessage, TurnID: "turn-2", Text: "remove this", Revision: 3})
+	model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model.input.Reset()
+	if cmd := model.submitInput(); cmd != nil {
+		t.Fatal("submitInput() returned a command")
+	}
+	var request sessionruntime.ClientRequest
+	if err := json.NewDecoder(requests).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Type != "message.remove" || request.TurnID != "turn-2" || request.ExpectedRevision != 3 {
+		t.Fatalf("remove request = %#v", request)
+	}
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventUserMessageRemoved, TurnID: "turn-2", Revision: 4})
+	if model.pendingTurnID != "" || model.pendingTurnText != "" || model.pendingTurnInput != "" || model.pendingRevision != 0 {
+		t.Fatalf("pending message remained after removal: ID %q text %q input %q revision %d", model.pendingTurnID, model.pendingTurnText, model.pendingTurnInput, model.pendingRevision)
 	}
 }
 

--- a/internal/sessionruntime/history.go
+++ b/internal/sessionruntime/history.go
@@ -33,7 +33,7 @@ type historyTurn struct {
 	activityEventID int64
 	startedAt       *time.Time
 	completed       bool
-	merged          bool
+	hidden          bool
 	interrupting    bool
 }
 
@@ -83,6 +83,9 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 				}
 				copy := event
 				turn.user = &copy
+			case EventUserMessageRemoved:
+				turn.completed = true
+				turn.hidden = true
 			case EventTurnStarted:
 				turn.started = true
 				turn.startedAt = event.Timestamp
@@ -90,10 +93,10 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 				turn.interrupting = true
 			case EventTurnCompleted:
 				turn.completed = true
-				turn.merged = event.Status == "merged"
+				turn.hidden = event.Status == "merged"
 				turn.interrupting = false
 			}
-			if event.Type != EventUserMessage && event.Type != EventUserMessageUpdated && event.Type != EventTurnCompleted {
+			if event.Type != EventUserMessage && event.Type != EventUserMessageUpdated && event.Type != EventUserMessageRemoved && event.Type != EventTurnCompleted {
 				turn.activityEventID = event.ID
 				if turn.startedAt == nil {
 					turn.startedAt = event.Timestamp
@@ -169,7 +172,7 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 
 	for _, event := range events {
 		turn := turns[event.TurnID]
-		if (pending != nil && event.TurnID == pending.TurnID) || (turn != nil && turn.merged) {
+		if (pending != nil && event.TurnID == pending.TurnID) || (turn != nil && turn.hidden) {
 			continue
 		}
 		if event.Type != EventAssistantDelta && event.Type != EventAssistantMessage {

--- a/internal/sessionruntime/history_test.go
+++ b/internal/sessionruntime/history_test.go
@@ -178,6 +178,17 @@ func TestProjectHistoryUsesLatestPendingMessageRevision(t *testing.T) {
 	}
 }
 
+func TestProjectHistoryHidesRemovedPendingMessage(t *testing.T) {
+	events := []Event{
+		{ID: 1, Type: EventUserMessage, TurnID: "turn-1", Text: "remove this", Revision: 1},
+		{ID: 2, Type: EventUserMessageRemoved, TurnID: "turn-1", Revision: 2, Status: "removed"},
+	}
+	items, state, _ := projectHistory(events)
+	if len(items) != 0 || state.PendingTurn != nil {
+		t.Fatalf("removed pending history = items %#v state %#v", items, state)
+	}
+}
+
 func assertHistoryEventIDs(t *testing.T, events []Event, want ...int64) {
 	t.Helper()
 	if len(events) != len(want) {

--- a/internal/sessionruntime/journal.go
+++ b/internal/sessionruntime/journal.go
@@ -290,7 +290,7 @@ func (j *Journal) updateUnstartedTurns(event Event) {
 	switch event.Type {
 	case EventUserMessage, EventUserMessageUpdated:
 		j.unstartedTurns[event.TurnID] = event
-	case EventTurnStarted, EventTurnCompleted:
+	case EventUserMessageRemoved, EventTurnStarted, EventTurnCompleted:
 		delete(j.unstartedTurns, event.TurnID)
 	}
 }

--- a/internal/sessionruntime/journal_test.go
+++ b/internal/sessionruntime/journal_test.go
@@ -420,3 +420,17 @@ func TestRecoverJournalKeepsCompletedTurnCompleted(t *testing.T) {
 		t.Fatalf("events = %#v", events)
 	}
 }
+
+func TestRecoverJournalDoesNotRestoreRemovedPendingTurn(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	journal.Append(Event{Type: EventUserMessage, TurnID: "turn-2", Text: "remove this", Revision: 1})
+	journal.Append(Event{Type: EventUserMessageRemoved, TurnID: "turn-2", Revision: 2, Status: "removed"})
+	recovery, err := recoverJournal(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovery.pendingTurn != nil || recovery.completedTurnID != 2 {
+		t.Fatalf("recovery = %#v, want removed turn completed", recovery)
+	}
+}

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -13,6 +13,7 @@ const (
 	EventRuntimeRecovered   = "runtime.recovered"
 	EventUserMessage        = "user.message"
 	EventUserMessageUpdated = "user.message.updated"
+	EventUserMessageRemoved = "user.message.removed"
 	EventTurnStarted        = "turn.started"
 	EventTurnInterrupting   = "turn.interrupting"
 	EventAssistantDelta     = "assistant.delta"

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -422,7 +422,11 @@ func (s *Server) runTurns(ctx context.Context) {
 				s.turns <- turn
 				return
 			}
-			s.runTurn(ctx, s.takePendingTurn(turn))
+			pending, exists := s.takePendingTurn(turn)
+			if !exists {
+				continue
+			}
+			s.runTurn(ctx, pending)
 			// Keep the pending turn out of reach of an interrupt call that is
 			// still settling after this turn returned.
 			s.interruptMu.Lock()
@@ -880,15 +884,65 @@ func (s *Server) editMessage(turnID, text string, expectedRevision int64, reques
 	return nil
 }
 
-func (s *Server) takePendingTurn(turn turnRequest) turnRequest {
+func (s *Server) removePendingMessage(turnID string, expectedRevision int64, requestID string) error {
+	s.submitMu.Lock()
+	if s.pendingTurn == nil || s.pendingTurn.id != turnID {
+		s.submitMu.Unlock()
+		return fmt.Errorf("Session turn %q is no longer pending", turnID)
+	}
+	turn := *s.pendingTurn
+	if expectedRevision <= 0 {
+		s.submitMu.Unlock()
+		return fmt.Errorf("removing Session turn %q: expectedRevision must be positive", turnID)
+	}
+	if turn.revision == 0 {
+		turn.revision = 1
+	}
+	if expectedRevision != turn.revision {
+		s.submitMu.Unlock()
+		return fmt.Errorf("removing Session turn %q: revision is %d, not %d", turnID, turn.revision, expectedRevision)
+	}
+	if err := s.appendMessage(Event{
+		Type:      EventUserMessageRemoved,
+		RequestID: requestID,
+		TurnID:    turn.id,
+		Revision:  turn.revision + 1,
+		Status:    "removed",
+	}); err != nil {
+		s.submitMu.Unlock()
+		return fmt.Errorf("recording removed Session turn %q: %w", turnID, err)
+	}
+	s.pendingTurn = nil
+	select {
+	case buffered := <-s.turns:
+		if buffered.id != turn.id {
+			s.turns <- buffered
+		}
+	default:
+	}
+	if s.outstanding > 0 {
+		s.outstanding--
+	}
+	shouldReport := (s.updateRequest != nil || s.idleDrainRequest != nil) && s.outstanding == 0
+	s.submitMu.Unlock()
+
+	s.markTurnCompleted(turn.id)
+	s.requestSessionStatusPublish()
+	if shouldReport {
+		s.signalSessionUpdateReport()
+	}
+	return nil
+}
+
+func (s *Server) takePendingTurn(turn turnRequest) (turnRequest, bool) {
 	s.submitMu.Lock()
 	defer s.submitMu.Unlock()
 	if s.pendingTurn == nil || s.pendingTurn.id != turn.id {
-		return turn
+		return turnRequest{}, false
 	}
 	pending := *s.pendingTurn
 	s.pendingTurn = nil
-	return pending
+	return pending, true
 }
 
 func (s *Server) resolveAttachmentIDs(ids []string) ([]ResolvedAttachment, error) {
@@ -969,7 +1023,7 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 					turn.revision = 1
 				}
 			}
-		case EventTurnCompleted:
+		case EventUserMessageRemoved, EventTurnCompleted:
 			if turn != nil {
 				turn.completed = true
 			}
@@ -1357,6 +1411,11 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 		case "message.edit":
 			subscribe(0, "", false, 0, 0)
 			if err := s.editMessage(request.TurnID, request.Text, request.ExpectedRevision, request.RequestID); err != nil {
+				out <- Event{Type: EventError, RequestID: request.RequestID, TurnID: request.TurnID, Text: err.Error(), Status: "rejected"}
+			}
+		case "message.remove":
+			subscribe(0, "", false, 0, 0)
+			if err := s.removePendingMessage(request.TurnID, request.ExpectedRevision, request.RequestID); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, TurnID: request.TurnID, Text: err.Error(), Status: "rejected"}
 			}
 		case "input":

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -281,7 +281,11 @@ func TestServerEditsPendingMessage(t *testing.T) {
 
 	turn := <-server.turns
 	<-turn.accepted
-	server.runTurn(t.Context(), server.takePendingTurn(turn))
+	pending, exists := server.takePendingTurn(turn)
+	if !exists {
+		t.Fatal("pending turn was not available")
+	}
+	server.runTurn(t.Context(), pending)
 
 	provider.mu.Lock()
 	prompts := append([]string(nil), provider.prompts...)
@@ -335,6 +339,59 @@ func TestServerCombinesSubmissionsIntoPendingMessage(t *testing.T) {
 	assertEventTypes(t, events, EventUserMessage, EventUserMessageUpdated)
 	if events[1].RequestID != "request-second" || events[1].TurnID != "turn-1" || events[1].Text != "first follow-up\n\nsecond follow-up" {
 		t.Fatalf("combined pending message = %#v", events[1])
+	}
+}
+
+func TestServerRemovesPendingMessage(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	server := NewServer(Config{}, journal, &fakeProvider{})
+	if err := server.submitMessage("pending work", "request-message"); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.removePendingMessage("turn-1", 2, "request-stale"); err == nil || !strings.Contains(err.Error(), "revision is 1, not 2") {
+		t.Fatalf("stale removal error = %v", err)
+	}
+	if err := server.removePendingMessage("turn-1", 1, "request-remove"); err != nil {
+		t.Fatal(err)
+	}
+	if server.pendingTurn != nil || server.outstanding != 0 || len(server.turns) != 0 {
+		t.Fatalf("pending runtime state = turn %#v outstanding %d buffered %d", server.pendingTurn, server.outstanding, len(server.turns))
+	}
+	if server.completedTurnID.Load() != 1 {
+		t.Fatalf("completed turn ID = %d, want 1", server.completedTurnID.Load())
+	}
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventUserMessage, EventUserMessageRemoved)
+	if events[1].RequestID != "request-remove" || events[1].TurnID != "turn-1" || events[1].Revision != 2 || events[1].Status != "removed" {
+		t.Fatalf("removed message event = %#v", events[1])
+	}
+	items, state, _ := projectHistory(events)
+	if len(items) != 0 || state.PendingTurn != nil {
+		t.Fatalf("removed pending history = items %#v state %#v", items, state)
+	}
+	if err := server.submitMessage("replacement", "request-replacement"); err != nil {
+		t.Fatalf("submitting replacement: %v", err)
+	}
+	if server.pendingTurn == nil || server.pendingTurn.id != "turn-2" || len(server.turns) != 1 {
+		t.Fatalf("replacement pending turn = %#v buffered %d", server.pendingTurn, len(server.turns))
+	}
+}
+
+func TestServerDoesNotRunPendingMessageRemovedAfterDispatch(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	server := NewServer(Config{}, journal, &fakeProvider{})
+	if err := server.submitMessage("pending work", "request-message"); err != nil {
+		t.Fatal(err)
+	}
+	turn := <-server.turns
+	<-turn.accepted
+	if err := server.removePendingMessage("turn-1", 1, "request-remove"); err != nil {
+		t.Fatal(err)
+	}
+	if pending, exists := server.takePendingTurn(turn); exists {
+		t.Fatalf("removed pending turn remained runnable: %#v", pending)
 	}
 }
 
@@ -1560,7 +1617,10 @@ func TestServerSerializesConcurrentPendingMessageUpdates(t *testing.T) {
 	if events[0].Text != "first" || events[1].Text != "first\n\nsecond" {
 		t.Fatalf("message order = %q, %q", events[0].Text, events[1].Text)
 	}
-	pending := server.takePendingTurn(<-server.turns)
+	pending, exists := server.takePendingTurn(<-server.turns)
+	if !exists {
+		t.Fatal("pending turn was not available")
+	}
 	if pending.text != "first\n\nsecond" || len(server.turns) != 0 {
 		t.Fatalf("pending turn = %#v, remaining turns %d", pending, len(server.turns))
 	}

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -608,6 +609,40 @@ func TestSessionComposerUsesOneSendAndInterruptAction(t *testing.T) {
 	}
 	if strings.Contains(body, `id="stop-session"`) {
 		t.Error("Session header contains a separate interrupt action")
+	}
+}
+
+func TestSessionPendingMessagePreservesLineBreaks(t *testing.T) {
+	styles, err := webFiles.ReadFile("web/styles.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules := regexp.MustCompile(`(?s)\.pending-message-text\s*\{([^}]*)\}`).FindAllStringSubmatch(string(styles), -1)
+	if len(rules) == 0 {
+		t.Fatal("Session pending message style is missing")
+	}
+	hasDeclaration := func(property, value string) bool {
+		pattern := regexp.MustCompile(`(?:^|;)\s*` + regexp.QuoteMeta(property) + `\s*:\s*` + regexp.QuoteMeta(value) + `\s*(?:;|$)`)
+		for _, rule := range rules {
+			if pattern.MatchString(rule[1]) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, declaration := range []struct {
+		property string
+		value    string
+		want     bool
+	}{
+		{property: "overflow-wrap", value: "anywhere", want: true},
+		{property: "white-space", value: "pre-wrap", want: true},
+		{property: "text-overflow", value: "ellipsis", want: false},
+		{property: "white-space", value: "nowrap", want: false},
+	} {
+		if got := hasDeclaration(declaration.property, declaration.value); got != declaration.want {
+			t.Errorf("Session pending message style contains %s: %s = %t, want %t", declaration.property, declaration.value, got, declaration.want)
+		}
 	}
 }
 

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -145,6 +145,7 @@ let toasts;
 
 global.window = {
   clearInterval: (timer) => progressTimers.delete(timer),
+  confirm: () => true,
   matchMedia: () => ({matches: false}),
   setInterval: (callback) => {
     const timer = progressTimers.size + 1;
@@ -834,6 +835,25 @@ function testPendingMessageEditing() {
   assert.doesNotMatch(pending.item.textContent, /original/);
 }
 
+function testPendingMessageRemoval() {
+  resetHarness();
+  const sent = [];
+  state.socket = {readyState: WebSocket.OPEN, send: (payload) => sent.push(JSON.parse(payload))};
+  renderPendingUser({type: 'user.message', turnId: 'turn-2', text: 'remove this', revision: 3});
+
+  state.pendingMessage.item.querySelector('.pending-message-remove').listeners.get('click')();
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].type, 'message.remove');
+  assert.equal(sent[0].turnId, 'turn-2');
+  assert.equal(sent[0].expectedRevision, 3);
+  handleEvent({type: 'user.message.removed', turnId: 'turn-2', revision: 4});
+  assert.equal(state.pendingMessage, null);
+  assert.equal(elements.pending.hidden, true);
+  assert.equal(elements.messages.hasChildNodes(), false);
+  assert.deepEqual(toasts, ['Pending message removed']);
+}
+
 function testPendingMessageSurvivesCompletedHistoryReplay() {
   resetHarness();
   renderPendingUser({type: 'user.message', turnId: 'turn-2', text: 'pending'});
@@ -871,6 +891,7 @@ testToolOutputRenderingNormalizesCarriageReturns();
 testHistoryToolCompletionRendersOutputWithoutStart();
 testUserAttachmentRendering();
 testPendingMessageEditing();
+testPendingMessageRemoval();
 testPendingMessageSurvivesCompletedHistoryReplay();
 testComposerIgnoresReentrantSubmission()
   .then(() => process.stdout.write('Session history tests passed\n'))

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -2599,6 +2599,10 @@ function handleEvent(event) {
     case 'user.message.updated':
       renderPendingUser(event);
       break;
+    case 'user.message.removed':
+      discardPendingMessage(event.turnId);
+      if (!state.replayingHistory) showToast('Pending message removed');
+      break;
     case 'turn.started':
       endAssistantSegment(event.turnId);
       if (!state.activeTurn || state.activeTurnID !== event.turnId) {
@@ -2726,7 +2730,29 @@ function renderPendingMessageContent(pending) {
   edit.textContent = 'Edit';
   edit.setAttribute('aria-label', 'Edit pending message');
   edit.addEventListener('click', () => editPendingUser(pending.event.turnId));
-  pending.actions.append(status, edit);
+  const remove = document.createElement('button');
+  remove.type = 'button';
+  remove.className = 'pending-message-remove';
+  remove.textContent = 'Remove';
+  remove.setAttribute('aria-label', 'Remove pending message');
+  remove.addEventListener('click', () => removePendingUser(pending.event.turnId));
+  pending.actions.append(status, edit, remove);
+}
+
+function removePendingUser(turnID) {
+  const pending = state.pendingMessage;
+  if (!pending || pending.event.turnId !== turnID) return;
+  if (!window.confirm('Remove this pending message?')) return;
+  if (!state.socket || state.socket.readyState !== WebSocket.OPEN) {
+    showToast('Session is disconnected');
+    return;
+  }
+  state.socket.send(JSON.stringify({
+    type: 'message.remove',
+    requestId: sessionRequestID('message-remove'),
+    turnId: pending.event.turnId,
+    expectedRevision: pending.event.revision,
+  }));
 }
 
 function editPendingUser(turnID) {
@@ -2804,6 +2830,15 @@ function acceptPendingMessage(turnID) {
   state.pendingMessage = null;
   elements.pending.hidden = true;
   renderAcceptedUser(pending.event);
+}
+
+function discardPendingMessage(turnID) {
+  const pending = state.pendingMessage;
+  if (!pending || pending.event.turnId !== turnID) return;
+  pending.item.remove();
+  state.pendingMessage = null;
+  elements.pending.hidden = true;
+  updateComposerAction();
 }
 
 function assistantBubble(turnID) {

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -274,15 +274,16 @@ button { color: inherit; }
 .pending-message[hidden] { display: none; }
 .pending-message-card { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 9px 12px; border: 1px solid var(--line); border-radius: 11px; background: var(--accent-soft); }
 .pending-message-card.editing { align-items: start; }
-.pending-message-text { overflow: hidden; color: var(--ink); font-size: 11.5px; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
+.pending-message-text { overflow: hidden; overflow-wrap: anywhere; color: var(--ink); font-size: 11.5px; line-height: 1.4; white-space: pre-wrap; }
 .pending-message-card.editing .pending-message-text { overflow: visible; white-space: normal; }
 .pending-message-input { width: 100%; min-height: 58px; resize: vertical; padding: 7px 8px; border: 1px solid var(--line); border-radius: 8px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; line-height: 1.4; }
 .pending-message-input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
 .pending-message-actions { display: flex; align-items: center; gap: 7px; }
 .pending-message-status { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
-.pending-message-edit, .pending-message-save { padding: 3px 6px; border: 0; border-radius: 6px; background: transparent; color: var(--muted); font-size: 9.5px; font-weight: 700; cursor: pointer; }
+.pending-message-edit, .pending-message-save, .pending-message-remove { padding: 3px 6px; border: 0; border-radius: 6px; background: transparent; color: var(--muted); font-size: 9.5px; font-weight: 700; cursor: pointer; }
 .pending-message-edit:hover { background: var(--line-soft); color: var(--ink); }
 .pending-message-save { background: var(--accent); color: white; }
+.pending-message-remove:hover { background: rgba(167,63,63,.08); color: var(--danger); }
 .pending-attachments { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 4px 8px; }
 .pending-attachments[hidden] { display: none; }
 .pending-attachment { display: inline-flex; max-width: 220px; align-items: center; gap: 5px; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--accent-soft); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Improves the single pending Session message in three ways:

- Preserves line breaks in the web pending-message card, so combined follow-up submissions remain readable.
- Adds **Remove** beside **Edit** in the web client.
- Lets terminal UI users press **Up** on an empty composer to recall and edit the pending message. Submitting the recalled message empty removes it, without adding a slash command.

Edits and removals use the pending message revision to reject stale requests. Removal is persisted as a dedicated event, frees the pending slot immediately, prevents the buffered turn from reaching the provider, and remains removed after runtime recovery.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The removal path covers both a turn still buffered in the runtime channel and the race where the dispatcher has received the turn but has not started it. Removed messages are omitted from conversation history.

Validated with `make test` and `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
Display combined pending Session messages on multiple lines and allow them to be edited or removed before they start.
```
