### PR TITLE
Use inline session section selector

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -320,17 +320,15 @@ same annotation directly. Values are trimmed and limited to 64 characters when
 set through the web chat.
 
 Sessions can be categorized into sections from the creation form or from the
-section control beneath the selected Session's name. Both controls list the
-existing sections in the active namespace and include a **Create new section**
-choice, so a section name is entered only when the section is first created.
-Choosing **Unsectioned (remove assignment)** from the selected Session's control
-removes its section assignment. Named sections are sorted alphabetically in the
-sidebar until they are reordered. Drag a Session onto a section heading to move
-it, or drag a heading to reorder sections. The arrow controls beside a heading
-provide the same ordering action without drag and drop. **Unsectioned** can be
-reordered like any named section and accepts dropped Sessions. Section order is
-stored in the browser separately for each namespace, while Sessions retain their
-activity order within a section. Assignments are stored in the
+selector beneath the selected Session's name. The selector applies an existing
+section or **Unsectioned** immediately. Choosing **Create new section** reveals
+an inline name field. Named sections are sorted alphabetically in the sidebar
+until they are reordered. Drag a Session onto a section heading to move it, or
+drag a heading to reorder sections. The arrow controls beside a heading provide
+the same ordering action without drag and drop. **Unsectioned** can be reordered
+like any named section and accepts dropped Sessions. Section order is stored in
+the browser separately for each namespace, while Sessions retain their activity
+order within a section. Assignments are stored in the
 `kelos.dev/session-section` annotation, so Session manifests can set the same
 annotation directly. New section names are trimmed and limited to 64 characters.
 

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -1252,11 +1252,11 @@ func TestSessionUISections(t *testing.T) {
 		t.Fatal(err)
 	}
 	for description, expected := range map[string]string{
-		"selected Session section control": `id="session-section" type="button"`,
-		"new Session section chooser":      `name="section" id="session-section-select"`,
-		"new section creation field":       `name="sectionCustom" id="session-section-custom" maxlength="64"`,
-		"section assignment dialog":        `id="section-dialog"`,
-		"assignment section chooser":       `name="sectionChoice" id="section-choice"`,
+		"selected Session section control":       `id="session-section-form"`,
+		"selected Session section chooser":       `id="session-section-choice" aria-label="Section"`,
+		"selected Session new section field":     `id="session-section-choice-custom" maxlength="64"`,
+		"new Session section chooser":            `name="section" id="session-section-select"`,
+		"new Session new section creation field": `name="sectionCustom" id="session-section-custom" maxlength="64"`,
 	} {
 		if !strings.Contains(string(index), expected) {
 			t.Errorf("Session page is missing %s: %s", description, expected)
@@ -1287,9 +1287,7 @@ func TestSessionUISections(t *testing.T) {
 	}
 	for description, expected := range map[string]string{
 		"section headings":       `.session-section-heading {`,
-		"section control":        `.session-section-button {`,
-		"section dialog":         `.section-dialog {`,
-		"section field":          `.section-field {`,
+		"inline section control": `.session-section-control {`,
 		"Session drop target":    `.session-section-group.session-drop-target {`,
 		"section order controls": `.session-section-order-button { width: 28px; height: 28px;`,
 	} {

--- a/internal/sessionserver/testdata/section_chooser_test.js
+++ b/internal/sessionserver/testdata/section_chooser_test.js
@@ -124,10 +124,8 @@ class TestNode {
   }
 }
 
-let closeButtons;
 global.document = {
   createElement: tag => new TestNode(tag),
-  querySelectorAll: selector => selector === '.close-section-dialog' ? closeButtons : [],
 };
 const storage = new Map();
 global.window = {
@@ -153,25 +151,15 @@ vm.runInThisContext(applicationSlice('function renderSessions', 'function sectio
 global.sectionOrderStoragePrefix = 'kelos-session-section-order:';
 vm.runInThisContext(applicationSlice('function sectionLabel', 'function sessionSectionNames'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function sessionSectionNames', 'async function loadSessions'), {filename: 'app.js'});
-vm.runInThisContext(applicationSlice('function openSectionDialog', 'function setSectionSaving'), {filename: 'app.js'});
-vm.runInThisContext(applicationSlice('function setSectionSaving', "elements.sectionButton.addEventListener"), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function updateSelectedSectionField', "elements.sectionChoice.addEventListener"), {filename: 'app.js'});
 
 function resetHarness() {
   focusedNode = null;
-  closeButtons = [new TestNode('button'), new TestNode('button')];
-  const sectionDialog = new TestNode('dialog');
-  sectionDialog.closeCount = 0;
-  sectionDialog.showModalCount = 0;
-  sectionDialog.close = () => { sectionDialog.closeCount++; };
-  sectionDialog.showModal = () => { sectionDialog.showModalCount++; };
   global.elements = {
     sectionSelect: new TestNode('select'),
     sectionCustom: new TestNode('input'),
     sectionChoice: new TestNode('select'),
     sectionChoiceCustom: new TestNode('input'),
-    sectionDialog,
-    sectionDialogDescription: new TestNode('p'),
-    sectionDialogError: new TestNode('div'),
     sectionForm: new TestNode('form'),
     saveSectionButton: new TestNode('button'),
   };
@@ -186,6 +174,7 @@ function resetHarness() {
     namespace: 'default',
     namespaceGeneration: 0,
   };
+  global.sessionKey = session => `${session.namespace}/${session.name}`;
   storage.clear();
 }
 
@@ -283,6 +272,42 @@ function testNamespaceResetClearsSectionInput() {
   assert.equal(elements.sectionCustom.value, '');
 }
 
+function testSelectedSessionUsesInlineChooser() {
+  resetHarness();
+  const planning = {namespace: 'default', name: 'demo', section: 'Planning'};
+  const reviews = {namespace: 'default', name: 'other', section: 'Reviews'};
+  state.sessions = [planning, reviews];
+  state.selected = planning;
+
+  renderSelectedSessionSection(planning);
+
+  assert.equal(elements.sectionForm.hidden, false);
+  assert.equal(elements.sectionChoice.value, 'Planning');
+  assert.equal(elements.sectionChoice.disabled, false);
+  assert.equal(elements.sectionChoiceCustom.hidden, true);
+  assert.equal(elements.saveSectionButton.hidden, true);
+
+  option(group(elements.sectionChoice, 'Actions'), '＋ Create new section…').selected = true;
+  updateSelectedSectionField();
+  elements.sectionChoiceCustom.value = 'Backlog';
+  renderSelectedSessionSection(planning);
+
+  assert.equal(elements.sectionChoiceCustom.hidden, false);
+  assert.equal(elements.sectionChoiceCustom.required, true);
+  assert.equal(elements.sectionChoiceCustom.value, 'Backlog');
+  assert.equal(elements.saveSectionButton.hidden, false);
+
+  state.selected = reviews;
+  renderSelectedSessionSection(reviews);
+  assert.equal(elements.sectionChoice.value, 'Reviews');
+  assert.equal(elements.sectionChoiceCustom.hidden, true);
+
+  state.selected = null;
+  renderSelectedSessionSection(null);
+  assert.equal(elements.sectionForm.hidden, true);
+  assert.equal(elements.sectionChoice.disabled, true);
+}
+
 function testSectionOrderingIncludesUnsectioned() {
   resetHarness();
   state.sessions = [
@@ -366,45 +391,37 @@ async function testDragAssignmentMovesSession() {
   assert.deepEqual(toasts, ['Moved Session to Reviews']);
 }
 
-async function testPendingSaveCannotDismissOrReopenChooser() {
+async function testPendingInlineSaveDisablesChooser() {
   resetHarness();
   state.sessions = [
     {namespace: 'default', name: 'demo', section: 'Planning'},
     {namespace: 'default', name: 'other', section: 'Reviews'},
   ];
   state.selected = state.sessions[0];
-  populateSectionSelect(elements.sectionChoice, 'Reviews', 'Unsectioned (remove assignment)');
+  renderSelectedSessionSection(state.selected);
+  elements.sectionChoice.value = 'Reviews';
 
   let resolveRequest;
   let request;
+  let requestCount = 0;
   global.api = (path, options) => {
+    requestCount++;
     request = {path, options};
     return new Promise(resolve => { resolveRequest = resolve; });
   };
-  global.sessionKey = session => `${session.namespace}/${session.name}`;
   global.renderSessions = () => {};
-  global.renderHeader = () => {};
+  global.renderHeader = () => renderSelectedSessionSection(state.selected);
   global.showToast = () => {};
 
-  vm.runInThisContext(
-    applicationSlice("elements.sectionForm.addEventListener('submit'", "elements.deleteButton.addEventListener"),
-    {filename: 'app.js'},
-  );
-
-  const submission = elements.sectionForm.dispatch('submit', {preventDefault() {}});
+  const submission = saveSelectedSessionSection('Reviews');
   assert.equal(state.sectionSaving, true);
   assert.equal(elements.sectionChoice.disabled, true);
+  assert.equal(elements.sectionChoiceCustom.disabled, true);
   assert.equal(elements.saveSectionButton.disabled, true);
-  assert.ok(closeButtons.every(button => button.disabled));
-  assert.equal(elements.sectionDialog.attributes.get('aria-busy'), 'true');
+  assert.equal(elements.sectionForm.attributes.get('aria-busy'), 'true');
 
-  closeSectionDialog();
-  assert.equal(elements.sectionDialog.closeCount, 0);
-  openSectionDialog();
-  assert.equal(elements.sectionDialog.showModalCount, 0);
-  let cancelPrevented = false;
-  handleSectionDialogCancel({preventDefault() { cancelPrevented = true; }});
-  assert.equal(cancelPrevented, true);
+  await saveSelectedSessionSection('Reviews');
+  assert.equal(requestCount, 1);
 
   assert.equal(request.path, '/api/sessions/default/demo/section');
   assert.deepEqual(JSON.parse(request.options.body), {section: 'Reviews'});
@@ -412,18 +429,59 @@ async function testPendingSaveCannotDismissOrReopenChooser() {
   await submission;
 
   assert.equal(state.sectionSaving, false);
-  assert.equal(elements.sectionDialog.closeCount, 1);
-  assert.ok(closeButtons.every(button => !button.disabled));
-  assert.equal(elements.sectionDialog.attributes.get('aria-busy'), 'false');
+  assert.equal(elements.sectionChoice.disabled, false);
+  assert.equal(elements.sectionChoice.value, 'Reviews');
+  assert.equal(elements.sectionForm.attributes.get('aria-busy'), 'false');
+}
+
+async function testInlineNewSectionSubmission() {
+  resetHarness();
+  const session = {namespace: 'default', name: 'demo', section: 'Planning'};
+  state.sessions = [session];
+  state.selected = session;
+  let request;
+  global.api = async (path, options) => {
+    request = {path, options};
+    return {...session, section: JSON.parse(options.body).section};
+  };
+  global.renderSessions = () => {};
+  global.renderHeader = () => renderSelectedSessionSection(state.selected);
+  global.showToast = () => {};
+
+  vm.runInThisContext(
+    applicationSlice("elements.sectionChoice.addEventListener", "elements.deleteButton.addEventListener"),
+    {filename: 'app.js'},
+  );
+  renderSelectedSessionSection(session);
+  option(group(elements.sectionChoice, 'Actions'), '＋ Create new section…').selected = true;
+  await elements.sectionChoice.dispatch('change');
+
+  assert.equal(elements.sectionChoiceCustom.hidden, false);
+  assert.equal(elements.saveSectionButton.hidden, false);
+  assert.equal(focusedNode, elements.sectionChoiceCustom);
+
+  elements.sectionChoiceCustom.value = '  Backlog  ';
+  await elements.sectionChoiceCustom.dispatch('input');
+  await elements.sectionForm.dispatch('submit', {preventDefault() {}});
+
+  assert.equal(request.path, '/api/sessions/default/demo/section');
+  assert.deepEqual(JSON.parse(request.options.body), {section: 'Backlog'});
+  assert.equal(state.selected.section, 'Backlog');
+  assert.equal(elements.sectionChoice.value, 'Backlog');
+  assert.equal(elements.sectionChoiceCustom.hidden, true);
 }
 
 testSectionOptionsDistinguishActionsFromValidNames();
 testSectionPayloadsAndValidation();
 testRefreshPreservesCustomInput();
 testNamespaceResetClearsSectionInput();
+testSelectedSessionUsesInlineChooser();
 testSectionOrderingIncludesUnsectioned();
 testUnsectionedCanMoveLikeNamedSections();
 testSectionOrderFocusFollowsMovedSection();
-testDragAssignmentMovesSession().then(testPendingSaveCannotDismissOrReopenChooser).then(() => {
-  process.stdout.write('Section chooser tests passed\n');
-});
+testDragAssignmentMovesSession()
+  .then(testPendingInlineSaveDisablesChooser)
+  .then(testInlineNewSectionSubmission)
+  .then(() => {
+    process.stdout.write('Section chooser tests passed\n');
+  });

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -9,15 +9,11 @@ const elements = {
   displayNameInput: document.querySelector('#session-display-name-input'),
   displayNameDialogError: document.querySelector('#display-name-dialog-error'),
   saveDisplayNameButton: document.querySelector('#save-session-display-name'),
-  sectionButton: document.querySelector('#session-section'),
   sectionSelect: document.querySelector('#session-section-select'),
   sectionCustom: document.querySelector('#session-section-custom'),
-  sectionDialog: document.querySelector('#section-dialog'),
-  sectionForm: document.querySelector('#section-form'),
-  sectionDialogDescription: document.querySelector('#section-dialog-description'),
-  sectionChoice: document.querySelector('#section-choice'),
-  sectionChoiceCustom: document.querySelector('#section-choice-custom'),
-  sectionDialogError: document.querySelector('#section-dialog-error'),
+  sectionForm: document.querySelector('#session-section-form'),
+  sectionChoice: document.querySelector('#session-section-choice'),
+  sectionChoiceCustom: document.querySelector('#session-section-choice-custom'),
   saveSectionButton: document.querySelector('#save-session-section'),
   messages: document.querySelector('#messages'),
   changes: document.querySelector('#changes-view'),
@@ -1552,8 +1548,7 @@ function renderHeader() {
   const session = state.selected;
   elements.displayNameButton.hidden = !session;
   elements.displayNameButton.disabled = !session;
-  elements.sectionButton.hidden = !session;
-  elements.sectionButton.disabled = !session;
+  renderSelectedSessionSection(session);
   elements.resetButton.disabled = !session || session.resetting;
   elements.deleteButton.disabled = !session;
   elements.conversationTab.disabled = !session;
@@ -1568,8 +1563,6 @@ function renderHeader() {
     return;
   }
   elements.title.textContent = sessionDisplayName(session);
-  elements.sectionButton.textContent = session.section ? `Section: ${session.section}` : '＋ Choose section';
-  elements.sectionButton.title = session.section ? 'Move Session to another section' : 'Move Session to a section';
   const resourceName = sessionDisplayName(session) === session.name ? session.namespace : `${session.namespace}/${session.name}`;
   const details = [resourceName, providerLabel(session.provider)];
   if (session.model) details.push(session.model);
@@ -3751,77 +3744,89 @@ elements.displayNameForm.addEventListener('submit', async event => {
   }
 });
 
-function openSectionDialog() {
-  const session = state.selected;
-  if (!session || state.sectionSaving) return;
-  elements.sectionDialogError.textContent = '';
-  elements.sectionDialogDescription.textContent = `Choose where Session ${sessionDisplayName(session)} appears in the sidebar.`;
-  elements.sectionChoiceCustom.value = '';
-  populateSectionSelect(elements.sectionChoice, session.section || '', 'Unsectioned (remove assignment)');
+function updateSelectedSectionField() {
   updateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
-  elements.sectionDialog.showModal();
-  window.setTimeout(() => elements.sectionChoice.focus(), 0);
+  elements.saveSectionButton.hidden = elements.sectionChoiceCustom.hidden;
+}
+
+function renderSelectedSessionSection(session, preserveEditing = true) {
+  elements.sectionForm.hidden = !session;
+  if (!session) {
+    elements.sectionForm.dataset.session = '';
+    elements.sectionChoiceCustom.value = '';
+    populateSectionSelect(elements.sectionChoice, '', 'Choose section');
+    updateSelectedSectionField();
+    elements.sectionChoice.disabled = true;
+    return;
+  }
+
+  const sessionID = sessionKey(session);
+  const editing = preserveEditing
+    && elements.sectionForm.dataset.session === sessionID
+    && createsNewSection(elements.sectionChoice);
+  elements.sectionForm.dataset.session = sessionID;
+  if (!editing) {
+    elements.sectionChoiceCustom.value = '';
+    const emptyLabel = session.section ? 'Unsectioned (remove assignment)' : 'Choose section';
+    populateSectionSelect(elements.sectionChoice, session.section || '', emptyLabel);
+  }
+  updateSelectedSectionField();
+  elements.sectionChoice.disabled = state.sectionSaving;
 }
 
 function setSectionSaving(saving) {
   state.sectionSaving = saving;
-  elements.sectionChoice.disabled = saving;
-  elements.sectionChoiceCustom.disabled = saving;
-  elements.saveSectionButton.disabled = saving;
-  elements.sectionDialog.setAttribute('aria-busy', String(saving));
-  document.querySelectorAll('.close-section-dialog').forEach(button => {
-    button.disabled = saving;
-  });
+  const disabled = saving || !state.selected;
+  elements.sectionChoice.disabled = disabled;
+  elements.sectionChoiceCustom.disabled = disabled;
+  elements.saveSectionButton.disabled = disabled;
+  elements.sectionForm.setAttribute('aria-busy', String(saving));
 }
 
-function closeSectionDialog() {
-  if (!state.sectionSaving) elements.sectionDialog.close();
+async function saveSelectedSessionSection(section) {
+  const session = state.selected;
+  if (!session || state.sectionSaving) return;
+  if (section === (session.section || '')) {
+    renderSelectedSessionSection(session, false);
+    return;
+  }
+
+  const creating = createsNewSection(elements.sectionChoice);
+  setSectionSaving(true);
+  try {
+    await saveSessionSectionAssignment(session, section);
+    if (state.selected && sessionKey(state.selected) === sessionKey(session)) {
+      renderSelectedSessionSection(state.selected, false);
+    }
+    showToast(section ? `Moved Session to ${section}` : 'Moved Session to Unsectioned');
+  } catch (error) {
+    if (!creating && state.selected && sessionKey(state.selected) === sessionKey(session)) {
+      renderSelectedSessionSection(session, false);
+    }
+    showToast(error.message);
+  } finally {
+    setSectionSaving(false);
+  }
 }
 
-function handleSectionDialogCancel(event) {
-  if (state.sectionSaving) event.preventDefault();
-}
-
-elements.sectionButton.addEventListener('click', openSectionDialog);
 elements.sectionChoice.addEventListener('change', () => {
-  updateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
-  if (!elements.sectionChoiceCustom.hidden) elements.sectionChoiceCustom.focus();
+  updateSelectedSectionField();
+  if (!elements.sectionChoiceCustom.hidden) {
+    elements.sectionChoiceCustom.focus();
+    return;
+  }
+  void saveSelectedSessionSection(elements.sectionChoice.value);
 });
 elements.sectionChoiceCustom.addEventListener('input', () => {
   validateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
 });
-document.querySelectorAll('.close-section-dialog').forEach(button => {
-  button.addEventListener('click', closeSectionDialog);
-});
-elements.sectionDialog.addEventListener('cancel', handleSectionDialogCancel);
 
 elements.sectionForm.addEventListener('submit', async event => {
   event.preventDefault();
-  if (state.sectionSaving) return;
+  if (state.sectionSaving || !createsNewSection(elements.sectionChoice)) return;
   validateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
   if (!elements.sectionForm.reportValidity()) return;
-  const session = state.selected;
-  if (!session) {
-    elements.sectionDialog.close();
-    return;
-  }
-  const sectionPayload = selectedSectionPayload(elements.sectionChoice, elements.sectionChoiceCustom, true);
-  const section = sectionPayload.section;
-  if (section === (session.section || '')) {
-    elements.sectionDialog.close();
-    return;
-  }
-  elements.sectionDialogError.textContent = '';
-  setSectionSaving(true);
-  try {
-    await saveSessionSectionAssignment(session, section);
-    elements.sectionDialog.close();
-    showToast(section ? `Moved Session to ${section}` : 'Moved Session to Unsectioned');
-  } catch (error) {
-    elements.sectionDialogError.textContent = error.message;
-  } finally {
-    setSectionSaving(false);
-  }
+  await saveSelectedSessionSection(elements.sectionChoiceCustom.value.trim());
 });
 
 elements.deleteButton.addEventListener('click', async () => {

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -46,7 +46,17 @@
             <button class="session-display-name-button" id="session-display-name" type="button" disabled hidden>Rename</button>
           </div>
           <div class="session-meta" id="session-meta">Select an existing conversation or create one.</div>
-          <button class="session-section-button" id="session-section" type="button" disabled hidden>＋ Add section</button>
+          <form class="session-section-control" id="session-section-form" hidden>
+            <label for="session-section-choice">Section</label>
+            <select id="session-section-choice" aria-label="Section" disabled>
+              <optgroup label="Actions">
+                <option value="">Choose section</option>
+                <option value="" data-create-section="true">＋ Create new section…</option>
+              </optgroup>
+            </select>
+            <input id="session-section-choice-custom" maxlength="64" placeholder="New section name" aria-label="New section name" autocomplete="off" hidden>
+            <button id="save-session-section" type="submit" hidden>Add</button>
+          </form>
         </div>
         <div class="header-actions">
           <div class="view-tabs" role="tablist" aria-label="Session view">
@@ -239,34 +249,6 @@
       <div class="dialog-actions">
         <button class="secondary-button close-dialog" type="button">Cancel</button>
         <button class="primary-button" id="create-session" value="default">Create session</button>
-      </div>
-    </form>
-  </dialog>
-
-  <dialog class="session-dialog section-dialog" id="section-dialog" aria-labelledby="section-dialog-title" aria-describedby="section-dialog-description">
-    <form id="section-form">
-      <div class="dialog-header">
-        <div>
-          <h2 id="section-dialog-title">Move to section</h2>
-          <p id="section-dialog-description">Choose where this Session appears in the sidebar.</p>
-        </div>
-        <button class="icon-button close-section-dialog" type="button" aria-label="Close">×</button>
-      </div>
-      <label class="section-field">
-        <span>Section</span>
-        <select name="sectionChoice" id="section-choice">
-          <optgroup label="Actions">
-            <option value="">Unsectioned (remove assignment)</option>
-            <option value="" data-create-section="true">＋ Create new section…</option>
-          </optgroup>
-        </select>
-        <input name="sectionChoiceCustom" id="section-choice-custom" maxlength="64" placeholder="New section name" autocomplete="off" hidden>
-        <small>New section names become available to other Sessions in this namespace.</small>
-      </label>
-      <div class="dialog-error" id="section-dialog-error" role="alert"></div>
-      <div class="dialog-actions">
-        <button class="secondary-button close-section-dialog" type="button">Cancel</button>
-        <button class="primary-button" id="save-session-section">Save section</button>
       </div>
     </form>
   </dialog>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -118,10 +118,13 @@ button { color: inherit; }
 .session-meta-time { font-variant-numeric: tabular-nums; }
 .session-meta a { color: var(--accent-2); font-weight: 700; text-decoration: none; }
 .session-meta a:hover { text-decoration: underline; }
-.session-section-button { max-width: 100%; display: inline-flex; margin-top: 6px; padding: 3px 7px; overflow: hidden; border: 1px solid var(--line); border-radius: 999px; background: var(--card); color: var(--muted); font-size: 9.5px; font-weight: 700; line-height: 1.2; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
-.session-section-button:hover { border-color: #c5ccc6; color: var(--ink); }
-.session-section-button:disabled { opacity: .45; cursor: default; }
-.session-section-button[hidden] { display: none; }
+.session-section-control { max-width: 100%; display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin-top: 6px; color: var(--faint); font-size: 9.5px; font-weight: 700; }
+.session-section-control[hidden] { display: none; }
+.session-section-control select, .session-section-control input { min-width: 0; max-width: 190px; padding: 3px 7px; border: 1px solid var(--line); border-radius: 999px; outline: none; background: var(--card); color: var(--muted); font: inherit; }
+.session-section-control input { width: 150px; }
+.session-section-control select:focus, .session-section-control input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); color: var(--ink); }
+.session-section-control button { padding: 3px 8px; border: 1px solid var(--accent); border-radius: 999px; background: var(--accent); color: white; font: inherit; cursor: pointer; }
+.session-section-control :disabled { opacity: .55; cursor: wait; }
 .header-actions { display: flex; align-items: center; gap: 8px; }
 .view-tabs { display: flex; padding: 3px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
 .view-tabs button { padding: 6px 9px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 10.5px; font-weight: 700; cursor: pointer; }
@@ -307,7 +310,6 @@ button { color: inherit; }
 .session-dialog { width: min(94vw, 610px); max-height: calc(100dvh - 32px); overflow-y: auto; padding: 0; border: 1px solid var(--line); border-radius: 20px; background: var(--card); color: var(--ink); box-shadow: 0 35px 110px rgba(18,31,24,.24); }
 .session-dialog::backdrop { background: rgba(25,35,30,.38); backdrop-filter: blur(4px); }
 .session-dialog form { padding: 23px; }
-.section-dialog { width: min(94vw, 420px); }
 .display-name-dialog { width: min(94vw, 420px); }
 .dialog-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; }
 .dialog-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
@@ -336,9 +338,8 @@ button { color: inherit; }
 .form-grid select + input { margin-top: 8px; }
 .section-field { display: block; margin-top: 20px; }
 .section-field > span { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 700; }
-.section-field select, .section-field input { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
-.section-field select:focus, .section-field input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
-.section-field select + input { margin-top: 8px; }
+.section-field input { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
+.section-field input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
 .section-field small { display: block; margin-top: 5px; color: var(--faint); font-size: 9.5px; line-height: 1.4; }
 .option-picker { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
 .secondary-button.compact { padding: 9px 13px; }
@@ -389,7 +390,7 @@ button { color: inherit; }
   .changes-view { padding: 22px calc(14px + env(safe-area-inset-right)) 32px calc(14px + env(safe-area-inset-left)); overscroll-behavior: contain; }
   .composer-wrap { padding: 9px calc(10px + env(safe-area-inset-right)) calc(10px + env(safe-area-inset-bottom)) calc(10px + env(safe-area-inset-left)); }
   .composer { padding-left: 13px; }
-  .composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input, .form-grid select, .source-picker select, .section-field input, .section-field select, .namespace-form input, .input-other { font-size: 16px; }
+  .composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input, .form-grid select, .source-picker select, .section-field input, .session-section-control input, .session-section-control select, .namespace-form input, .input-other { font-size: 16px; }
   .composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }
   .send-button { width: 48px; height: 48px; }
   .message-bubble, .user-message { max-width: 90%; }
@@ -414,5 +415,5 @@ button { color: inherit; }
   .diff-lines { background: #121915; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
-  .form-grid input, .form-grid select, .form-grid textarea, .source-picker select, .section-field input, .section-field select { border-color: #3a4740; }
+  .form-grid input, .form-grid select, .form-grid textarea, .source-picker select, .section-field input, .session-section-control input, .session-section-control select { border-color: #3a4740; }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces the selected Session's section assignment dialog with an inline selector in the conversation header. Existing sections and Unsectioned apply immediately, while Create new section reveals an inline name field and Add action.

This keeps the section workflow in context and avoids opening a separate panel for a compact selection task. The removed dialog behavior, styles, tests, and documentation are rewritten around the inline interaction.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with:

- `make test TEST_FLAGS='-run TestApplicationSectionChooserBehavior\|TestSessionUISections -count=1'`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
The web chat now assigns sections from an inline selector beneath the selected Session's name instead of opening a separate dialog.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assigns a Session’s section from an inline selector in the header instead of a modal dialog. Previously a button opened a dialog; now changing the “Section” select applies immediately, and “Create new section…” reveals an inline name field and Add action. While saving, the form sets aria-busy and disables inputs; when no Session is selected, the control hides.

- Review notes:
  - Selectors updated:
    - Removed: `#session-section`, `#section-dialog`, `.close-section-dialog`, `.section-dialog`, `.session-section-button`.
    - Added: `#session-section-form`, `#session-section-choice` (aria-label "Section"), `#session-section-choice-custom`, `#save-session-section`, `.session-section-control`.
  - Implementation:
    - Added `renderSelectedSessionSection`, `saveSelectedSessionSection`, `updateSelectedSectionField`; integrated into `renderHeader`.
    - Removed dialog flow: `openSectionDialog`, `closeSectionDialog`, `handleSectionDialogCancel`.
    - Inline select change saves immediately; creating a new section validates, trims to 64 chars, and submits via the inline form.
  - Docs updated to describe the inline selector and existing limits on new section names.

<sup>Written for commit 6273ab651252808e78010fada2f68aa2566e8f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

