### PR TITLE
Add Session goal and shell commands

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -247,8 +247,9 @@ metadata, conversation, or persistent-volume data.
 Use `kelos session connect NAME` for terminal chat. In an interactive terminal,
 press Enter to send a message, Ctrl+J to insert a newline, and Ctrl+C or Esc to
 interrupt an active turn. Ctrl+C exits the terminal client when no turn is
-active. The terminal initially loads a bounded page of recent transcript items.
-Use `/history` or Page Up to load the previous page.
+active. `/quit` and `/exit` detach the terminal client without interrupting work
+that is still running. The terminal initially loads a bounded page of recent
+transcript items. Use `/history` or Page Up to load the previous page.
 Attach a local file with `/attach PATH`; the next message includes all staged
 files. In the interactive terminal UI, dragging a file into a terminal that
 supports bracketed paste stages the file directly. Use `/send` in the plain
@@ -260,6 +261,33 @@ they survive Pod replacement only when `spec.volumeClaimTemplate` is configured
 and are removed by Session reset or deletion. Retained messages show attachment
 names, and the web client provides authenticated previews or downloads while
 the Session is ready.
+
+Both terminal and web chat recognize `!COMMAND` and `/goal` before ordinary
+messages are submitted. `!COMMAND` runs `/bin/sh -lc COMMAND` directly in the
+Session working directory with the Session environment. It does not ask the
+agent for approval or send the command to the model. Its live and retained
+output appears as tool activity, and interrupting the Session turn stops the
+command.
+
+`/goal` is available only in Codex Sessions and uses the persisted goal owned by
+the Codex conversation:
+
+| Command | Behavior |
+|---------|----------|
+| `/goal` | Show the current goal |
+| `/goal OBJECTIVE` | Start an objective when no unfinished goal exists |
+| `/goal edit OBJECTIVE` | Replace the current objective while preserving its status |
+| `/goal pause` | Finish the current Codex turn, then stop automatic continuation |
+| `/goal resume` | Resume automatic continuation |
+| `/goal clear` | Remove the current goal |
+
+An active goal keeps starting Codex turns until Codex marks it complete,
+blocked, usage-limited, or budget-limited, or until it is paused or cleared.
+Interrupting active goal work pauses the goal before interrupting its current
+turn; detaching with `/quit` or `/exit` leaves it running. The goal and its
+accounting survive client reconnection and runtime container restart. They
+survive Pod replacement only when the Session workspace is persistent.
+
 The terminal client shows live connecting, reconnecting, working,
 waiting-for-input, and interrupting progress with elapsed time. After a
 completed turn, both interactive and plain terminal output show a `Worked for

--- a/examples/16-session/README.md
+++ b/examples/16-session/README.md
@@ -18,7 +18,10 @@ kelos session connect interactive-review
 
 The terminal client prints commands when interaction is required. Use
 `/interrupt` to stop active work and `/answer INPUT_ID QUESTION_ID VALUE` for a
-provider question.
+provider question. Both terminal and web chat accept `!COMMAND` to run a shell
+command in the Session workspace. Codex Sessions also accept `/goal OBJECTIVE`;
+use `/goal` to inspect it and `/goal pause`, `/goal resume`, or `/goal clear` to
+control it.
 
 The same conversation is available in the Session web application when the
 shared Session server is enabled. Disconnecting either client does not stop the

--- a/internal/cli/session_terminal.go
+++ b/internal/cli/session_terminal.go
@@ -46,6 +46,11 @@ type sessionPlainAssistantState struct {
 	lineOpen  bool
 }
 
+type sessionPlainToolState struct {
+	streamed bool
+	lineOpen bool
+}
+
 func (f sessionTerminalFormatter) style(style, text string) string {
 	if !f.color || style == "" || text == "" {
 		return text
@@ -221,6 +226,7 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 		historyPageReading := false
 		recoveryActive := false
 		activeTurnID := ""
+		streamedTools := make(map[string]sessionPlainToolState)
 		var activeTurnStarted time.Time
 		for {
 			var event sessionruntime.Event
@@ -309,7 +315,7 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				if hasEarlierHistory {
 					write("\n%s\n", formatter.muted("Earlier Session history is available. Use /history to load the previous page."))
 				}
-				write("\n%s\n\n", formatter.muted("Connected. Type a message, /attach PATH, /history, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
+				write("\n%s\n\n", formatter.muted("Connected. Type a message, !COMMAND, /goal, /attach PATH, /history, /interrupt, /answer INPUT QUESTION VALUE, or /quit."))
 			case sessionruntime.EventRuntimeRecovered:
 				if !pageEvent {
 					recoveryActive = true
@@ -354,9 +360,26 @@ func runSessionPlainTerminalWithWidth(ctx context.Context, input io.Reader, outp
 				}
 			case sessionruntime.EventToolStarted:
 				finishAssistant(assistant)
-				write("%s\n", formatter.tool(event.ToolName))
+				write("%s\n", formatter.tool(sanitizeSessionTUIToolOutput(event.ToolName)))
+			case sessionruntime.EventToolDelta:
+				output := sanitizeSessionTUIToolOutput(event.Output)
+				if output != "" {
+					streamedTools[event.ToolID] = sessionPlainToolState{streamed: true, lineOpen: !strings.HasSuffix(output, "\n")}
+				}
+				write("%s", output)
 			case sessionruntime.EventToolCompleted:
+				if state := streamedTools[event.ToolID]; state.streamed {
+					if state.lineOpen {
+						write("\n")
+					}
+					delete(streamedTools, event.ToolID)
+				} else if event.Output != "" {
+					write("%s\n", sanitizeSessionTUIToolOutput(event.Output))
+				}
 				write("%s\n", formatter.toolStatus(event.Status))
+			case sessionruntime.EventGoalUpdated:
+				finishAssistant(assistant)
+				write("%s\n", formatter.muted(sessionGoalText(event.Goal, event.Status)))
 			case sessionruntime.EventInputRequested:
 				finishAssistant(assistant)
 				write("\n%s\n", formatter.inputHeading(fmt.Sprintf("Input %s requested:", event.InputID)))
@@ -574,6 +597,22 @@ func sessionTerminalRequest(line string) sessionruntime.ClientRequest {
 		return sessionruntime.ClientRequest{}
 	}
 	return sessionruntime.ClientRequest{Type: "message", Text: line}
+}
+
+func sessionGoalText(goal *sessionruntime.Goal, status string) string {
+	if goal == nil {
+		if status == "cleared" {
+			return "Goal cleared."
+		}
+		return "No goal is currently set."
+	}
+	usage := ""
+	if goal.TokenBudget != nil {
+		usage = fmt.Sprintf(" (%d/%d tokens)", goal.TokensUsed, *goal.TokenBudget)
+	} else if goal.TokensUsed > 0 {
+		usage = fmt.Sprintf(" (%d tokens)", goal.TokensUsed)
+	}
+	return fmt.Sprintf("Goal %s%s: %s", goal.Status, usage, goal.Objective)
 }
 
 func sessionTerminalMessageText(text string, attachments []sessionruntime.Attachment) string {

--- a/internal/cli/session_terminal_test.go
+++ b/internal/cli/session_terminal_test.go
@@ -116,6 +116,38 @@ func TestSessionTerminalSeparatesStreamedTextBlocks(t *testing.T) {
 	}
 }
 
+func TestSessionPlainTerminalDoesNotRepeatStreamedToolOutput(t *testing.T) {
+	var events bytes.Buffer
+	encoder := json.NewEncoder(&events)
+	for _, event := range []sessionruntime.Event{
+		{Type: sessionruntime.EventHistoryEnd},
+		{Type: sessionruntime.EventToolStarted, ToolID: "tool-1", ToolName: "make test"},
+		{Type: sessionruntime.EventToolDelta, ToolID: "tool-1", Output: "first\n"},
+		{Type: sessionruntime.EventToolDelta, ToolID: "tool-1", Output: "second\n"},
+		{Type: sessionruntime.EventToolCompleted, ToolID: "tool-1", Output: "first\nsecond\n", Status: "completed"},
+	} {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	input, inputWriter := io.Pipe()
+	defer input.Close()
+	defer inputWriter.Close()
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := runSessionTerminal(ctx, input, &output, &events, io.Discard, false); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, line := range []string{"first", "second"} {
+		if count := strings.Count(output.String(), line); count != 1 {
+			t.Fatalf("terminal output contains %q %d times, want 1: %q", line, count, output.String())
+		}
+	}
+}
+
 func TestSessionPlainTerminalIsolatesHistoryPagesFromLiveStream(t *testing.T) {
 	var events bytes.Buffer
 	encoder := json.NewEncoder(&events)

--- a/internal/cli/session_terminal_tui.go
+++ b/internal/cli/session_terminal_tui.go
@@ -137,6 +137,7 @@ type sessionTUIModel struct {
 	pendingEditTurnID  string
 	pendingEditRev     int64
 	toolNames          map[string]string
+	toolOutputAt       map[string]int
 	width              int
 	height             int
 	ready              bool
@@ -246,6 +247,7 @@ func newSessionTUIModel(events *json.Decoder, requests *json.Encoder, output io.
 		input:              input,
 		styles:             styles,
 		toolNames:          make(map[string]string),
+		toolOutputAt:       make(map[string]int),
 		width:              sessionTUIDefaultWidth,
 		height:             sessionTUIDefaultHeight,
 		connectionStatus:   sessionTerminalStatusConnecting,
@@ -654,7 +656,7 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 		// A terminal-height transcript in both the managed view and native scrollback
 		// makes Bubble Tea move the smaller footer to the top when the copy is removed.
 		m.hideNextHistory = !m.ready
-		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, and Ctrl+C or Esc interrupts active work. Drag a file here or use /attach PATH. Press Up on an empty composer to edit pending work; submit an empty edit to remove it. Use /history or Page Up for earlier history, /answer INPUT QUESTION VALUE, or /quit.")
+		m.appendBlock(sessionTUIBlockNotice, "Connected. Enter sends, Ctrl+J inserts a newline, Ctrl+C or Esc interrupts active work, Page Up loads earlier history, and dragging a file attaches it (or use /attach PATH). Press Up on an empty composer to edit pending work. Use !COMMAND, /goal, /answer INPUT QUESTION VALUE, or /quit.")
 		m.ready = true
 		m.connectionStatus = ""
 		commands.ui = tea.Batch(m.input.Focus(), m.scheduleProgress())
@@ -719,10 +721,13 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 	case sessionruntime.EventToolStarted:
 		m.finishStreaming()
 		m.appendToolStart(event)
+	case sessionruntime.EventToolDelta:
+		m.appendToolDelta(event)
 	case sessionruntime.EventToolCompleted:
+		streamed := m.completeToolOutput(event)
 		toolName, needsAttribution := m.toolCompletionAttribution(event)
 		output := strings.TrimRight(sanitizeSessionTUIToolOutput(event.Output), "\n")
-		if output != "" {
+		if output != "" && !streamed {
 			m.appendToolOutput(event.ToolID, toolName, output)
 		}
 		if output == "" || !sessionTUIToolSucceeded(event.Status) {
@@ -732,6 +737,9 @@ func (m *sessionTUIModel) applyEvent(event sessionruntime.Event) sessionTUIComma
 			}
 			m.appendBlock(sessionTUIBlockToolStatus, status)
 		}
+	case sessionruntime.EventGoalUpdated:
+		m.finishStreaming()
+		m.appendBlock(sessionTUIBlockNotice, sessionGoalText(event.Goal, event.Status))
 	case sessionruntime.EventInputRequested:
 		m.finishStreaming()
 		m.waitingForInput = true
@@ -878,6 +886,7 @@ func (m *sessionTUIModel) replayHistoryPage(events []sessionruntime.Event) []ses
 	replay := &sessionTUIModel{
 		styles:          m.styles,
 		toolNames:       make(map[string]string),
+		toolOutputAt:    make(map[string]int),
 		width:           m.width,
 		height:          m.height,
 		streamingAt:     -1,
@@ -902,6 +911,9 @@ func (m *sessionTUIModel) prependHistoryBlocks(blocks []sessionTUIBlock) tea.Cmd
 	}
 	if m.historyNoticeAt >= 0 {
 		m.historyNoticeAt += count
+	}
+	for toolID, index := range m.toolOutputAt {
+		m.toolOutputAt[toolID] = index + count
 	}
 	m.committed += count
 	m.historyQueued += count
@@ -1018,6 +1030,51 @@ func (m *sessionTUIModel) appendToolOutput(toolID, toolName, output string) {
 		toolID:   toolID,
 		toolName: toolName,
 	})
+}
+
+func (m *sessionTUIModel) appendToolDelta(event sessionruntime.Event) {
+	if event.Output == "" {
+		return
+	}
+	index, exists := m.toolOutputAt[event.ToolID]
+	if !exists {
+		m.blocks = append(m.blocks, sessionTUIBlock{
+			kind:     sessionTUIBlockToolOutput,
+			stream:   &strings.Builder{},
+			dirty:    true,
+			toolID:   event.ToolID,
+			toolName: "",
+		})
+		index = len(m.blocks) - 1
+		m.toolOutputAt[event.ToolID] = index
+		m.streamingAt = index
+	}
+	block := &m.blocks[index]
+	if block.stream == nil {
+		block.stream = &strings.Builder{}
+		block.stream.WriteString(block.text)
+		block.text = ""
+	}
+	block.stream.WriteString(sanitizeSessionTUIToolOutput(event.Output))
+	block.dirty = true
+}
+
+func (m *sessionTUIModel) completeToolOutput(event sessionruntime.Event) bool {
+	index, exists := m.toolOutputAt[event.ToolID]
+	if !exists {
+		return false
+	}
+	if m.streamingAt == index {
+		m.finishStreaming()
+	}
+	block := &m.blocks[index]
+	if event.Output != "" {
+		block.text = strings.TrimRight(sanitizeSessionTUIToolOutput(event.Output), "\n")
+	}
+	block.stream = nil
+	block.dirty = true
+	delete(m.toolOutputAt, event.ToolID)
+	return true
 }
 
 func (m *sessionTUIModel) toolCompletionAttribution(event sessionruntime.Event) (string, bool) {

--- a/internal/cli/session_terminal_tui_test.go
+++ b/internal/cli/session_terminal_tui_test.go
@@ -334,6 +334,42 @@ func TestSessionTUIToolOutputStripsTerminalControlSequences(t *testing.T) {
 	}
 }
 
+func TestSessionTUIStreamsToolOutputIntoCompletion(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventToolStarted, ToolID: "tool-1", ToolName: "make test"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventToolDelta, ToolID: "tool-1", Output: "first\n"})
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventToolDelta, ToolID: "tool-1", Output: "second\n"})
+
+	if rendered := stripSessionTUIANSI(model.renderTranscript()); !strings.Contains(rendered, "first") || !strings.Contains(rendered, "second") {
+		t.Fatalf("streamed tool output = %q", rendered)
+	}
+	model.applyEvent(sessionruntime.Event{Type: sessionruntime.EventToolCompleted, ToolID: "tool-1", Output: "first\nsecond\n", Status: "completed"})
+	rendered := stripSessionTUIANSI(model.renderTranscript())
+	if strings.Count(rendered, "first") != 1 || strings.Count(rendered, "second") != 1 {
+		t.Fatalf("completed streamed tool output = %q", rendered)
+	}
+}
+
+func TestSessionTUIRendersGoalStatus(t *testing.T) {
+	model, _ := newSessionTUITestModel()
+	budget := int64(1000)
+	model.applyEvent(sessionruntime.Event{
+		Type:   sessionruntime.EventGoalUpdated,
+		Status: "active",
+		Goal: &sessionruntime.Goal{
+			Objective:   "Improve coverage",
+			Status:      "active",
+			TokenBudget: &budget,
+			TokensUsed:  125,
+		},
+	})
+
+	rendered := stripSessionTUIANSI(model.renderTranscript())
+	if !strings.Contains(rendered, "Goal active (125/1000 tokens): Improve coverage") {
+		t.Fatalf("goal status = %q", rendered)
+	}
+}
+
 func TestSessionTUIAttributesParallelToolCompletion(t *testing.T) {
 	model, _ := newSessionTUITestModel()
 	model.Update(tea.WindowSizeMsg{Width: 40, Height: 12})

--- a/internal/sessionruntime/codex.go
+++ b/internal/sessionruntime/codex.go
@@ -30,6 +30,21 @@ type codexTurnResult struct {
 	error  string
 }
 
+type codexInteractionKind string
+
+const (
+	codexInteractionMessage codexInteractionKind = "message"
+	codexInteractionGoal    codexInteractionKind = "goal"
+)
+
+type codexGoalResponse struct {
+	Goal *Goal `json:"goal"`
+}
+
+type codexGoalClearResponse struct {
+	Cleared bool `json:"cleared"`
+}
+
 type codexToolResult struct {
 	Content []json.RawMessage `json:"content"`
 }
@@ -74,9 +89,13 @@ type CodexProvider struct {
 	turnDone          chan codexTurnResult
 	activeTurn        string
 	activeReady       chan struct{}
+	interactionKind   codexInteractionKind
 	interactionCtx    context.Context
 	interactionCancel context.CancelFunc
 	turnMu            sync.Mutex
+	goalCommandMu     sync.Mutex
+	goalMu            sync.Mutex
+	goal              *Goal
 
 	statusMu    sync.Mutex
 	model       string
@@ -142,6 +161,10 @@ func NewCodexProvider(ctx context.Context, config ProviderConfig) (*CodexProvide
 		provider.Close()
 		return nil, err
 	}
+	if err := provider.loadGoal(initCtx); err != nil {
+		provider.Close()
+		return nil, err
+	}
 	rateLimitCtx, rateLimitCancel := context.WithTimeout(ctx, 5*time.Second)
 	if result, err := provider.request(rateLimitCtx, "account/rateLimits/read", nil); err == nil {
 		if limit := codexWeeklyRateLimit(result); limit != nil {
@@ -152,6 +175,19 @@ func NewCodexProvider(ctx context.Context, config ProviderConfig) (*CodexProvide
 	}
 	rateLimitCancel()
 	return provider, nil
+}
+
+func (p *CodexProvider) loadGoal(ctx context.Context) error {
+	result, err := p.request(ctx, "thread/goal/get", map[string]string{"threadId": p.threadID})
+	if err != nil {
+		return fmt.Errorf("reading Codex goal: %w", err)
+	}
+	goal, err := decodeCodexGoal(result)
+	if err != nil {
+		return fmt.Errorf("reading Codex goal: %w", err)
+	}
+	p.setGoal(goal)
+	return nil
 }
 
 func (p *CodexProvider) openThread(ctx context.Context) error {
@@ -272,6 +308,53 @@ func codexTurnID(result json.RawMessage) string {
 
 // RunTurn starts one Codex turn and waits for its completion notification.
 func (p *CodexProvider) RunTurn(ctx context.Context, input TurnInput, sink EventSink) error {
+	return p.runInteraction(ctx, sink, codexInteractionMessage, func() (bool, error) {
+		params := map[string]any{
+			"threadId": p.threadID,
+			"input":    codexTurnInputItems(input),
+		}
+		if p.config.Model != "" {
+			params["model"] = p.config.Model
+		}
+		if p.config.Effort != "" {
+			params["effort"] = p.config.Effort
+		}
+		result, err := p.request(ctx, "turn/start", params)
+		if err != nil {
+			return false, fmt.Errorf("starting Codex turn: %w", err)
+		}
+		turnID := codexTurnID(result)
+		if turnID == "" {
+			return false, errors.New("starting Codex turn: response did not include a turn ID")
+		}
+		p.setActiveTurn(turnID)
+		return true, nil
+	})
+}
+
+func (p *CodexProvider) RunGoal(ctx context.Context, command goalCommand, sink EventSink) error {
+	return p.runInteraction(ctx, sink, codexInteractionGoal, func() (bool, error) {
+		if err := p.applyGoalCommand(ctx, command, sink); err != nil {
+			return false, err
+		}
+		return command.action != goalCommandShow && p.goalIsActive(), nil
+	})
+}
+
+func (p *CodexProvider) ControlGoal(ctx context.Context, command goalCommand, sink EventSink) error {
+	return p.applyGoalCommand(ctx, command, sink)
+}
+
+func (p *CodexProvider) ActiveGoal() *Goal {
+	p.goalMu.Lock()
+	defer p.goalMu.Unlock()
+	if p.goal == nil || p.goal.Status != "active" {
+		return nil
+	}
+	return cloneGoal(p.goal)
+}
+
+func (p *CodexProvider) runInteraction(ctx context.Context, sink EventSink, kind codexInteractionKind, start func() (bool, error)) error {
 	p.turnMu.Lock()
 	defer p.turnMu.Unlock()
 
@@ -282,8 +365,12 @@ func (p *CodexProvider) RunTurn(ctx context.Context, input TurnInput, sink Event
 	p.activeSink = sink
 	p.turnDone = done
 	p.activeReady = ready
+	p.interactionKind = kind
 	p.interactionCtx = interactionCtx
 	p.interactionCancel = interactionCancel
+	if p.activeTurn != "" {
+		close(ready)
+	}
 	p.activeMu.Unlock()
 	p.emitRuntimeStatus(sink)
 	defer func() {
@@ -298,34 +385,16 @@ func (p *CodexProvider) RunTurn(ctx context.Context, input TurnInput, sink Event
 		p.turnDone = nil
 		p.activeTurn = ""
 		p.activeReady = nil
+		p.interactionKind = ""
 		p.interactionCtx = nil
 		p.interactionCancel = nil
 		p.activeMu.Unlock()
 	}()
 
-	params := map[string]any{
-		"threadId": p.threadID,
-		"input":    codexTurnInputItems(input),
+	wait, err := start()
+	if err != nil || !wait {
+		return err
 	}
-	if p.config.Model != "" {
-		params["model"] = p.config.Model
-	}
-	if p.config.Effort != "" {
-		params["effort"] = p.config.Effort
-	}
-	result, err := p.request(ctx, "turn/start", params)
-	if err != nil {
-		return fmt.Errorf("starting Codex turn: %w", err)
-	}
-	turnID := codexTurnID(result)
-	if turnID == "" {
-		return errors.New("starting Codex turn: response did not include a turn ID")
-	}
-	p.activeMu.Lock()
-	p.activeTurn = turnID
-	close(ready)
-	p.activeMu.Unlock()
-
 	select {
 	case result := <-done:
 		if result.status == "interrupted" {
@@ -348,6 +417,19 @@ func (p *CodexProvider) RunTurn(ctx context.Context, input TurnInput, sink Event
 	}
 }
 
+func (p *CodexProvider) setActiveTurn(turnID string) {
+	p.activeMu.Lock()
+	p.activeTurn = turnID
+	if p.activeReady != nil {
+		select {
+		case <-p.activeReady:
+		default:
+			close(p.activeReady)
+		}
+	}
+	p.activeMu.Unlock()
+}
+
 func codexTurnInputItems(input TurnInput) []map[string]any {
 	items := []map[string]any{{
 		"type": "text",
@@ -361,14 +443,189 @@ func codexTurnInputItems(input TurnInput) []map[string]any {
 	return items
 }
 
+func (p *CodexProvider) applyGoalCommand(ctx context.Context, command goalCommand, sink EventSink) error {
+	p.goalCommandMu.Lock()
+	defer p.goalCommandMu.Unlock()
+
+	existing, err := p.readGoal(ctx)
+	if err != nil {
+		return err
+	}
+	switch command.action {
+	case goalCommandShow:
+		p.emitGoal(sink, existing, goalEventStatus(existing, "empty"))
+		return nil
+	case goalCommandCreate:
+		if existing != nil && existing.Status != "complete" {
+			return errors.New("a goal is already set; use /goal edit <objective> or /goal clear")
+		}
+		return p.setCodexGoal(ctx, sink, map[string]any{
+			"threadId":  p.threadID,
+			"objective": command.objective,
+			"status":    "active",
+		})
+	case goalCommandEdit:
+		if existing == nil {
+			return errors.New("no goal is currently set")
+		}
+		return p.setCodexGoal(ctx, sink, map[string]any{
+			"threadId":  p.threadID,
+			"objective": command.objective,
+		})
+	case goalCommandPause:
+		if existing == nil {
+			return errors.New("no goal is currently set")
+		}
+		return p.setCodexGoal(ctx, sink, map[string]any{
+			"threadId": p.threadID,
+			"status":   "paused",
+		})
+	case goalCommandResume:
+		if existing == nil {
+			return errors.New("no goal is currently set")
+		}
+		return p.setCodexGoal(ctx, sink, map[string]any{
+			"threadId": p.threadID,
+			"status":   "active",
+		})
+	case goalCommandClear:
+		result, err := p.request(ctx, "thread/goal/clear", map[string]string{"threadId": p.threadID})
+		if err != nil {
+			return fmt.Errorf("clearing Codex goal: %w", err)
+		}
+		var response codexGoalClearResponse
+		if err := json.Unmarshal(result, &response); err != nil {
+			return fmt.Errorf("decoding cleared Codex goal: %w", err)
+		}
+		p.setGoal(nil)
+		if response.Cleared {
+			p.emitGoal(sink, nil, "cleared")
+		} else {
+			p.emitGoal(sink, nil, "empty")
+		}
+		p.finishInteractionIfGoalStopped()
+		return nil
+	default:
+		return errors.New(goalUsage)
+	}
+}
+
+func (p *CodexProvider) readGoal(ctx context.Context) (*Goal, error) {
+	result, err := p.request(ctx, "thread/goal/get", map[string]string{"threadId": p.threadID})
+	if err != nil {
+		return nil, fmt.Errorf("reading Codex goal: %w", err)
+	}
+	goal, err := decodeCodexGoal(result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding Codex goal: %w", err)
+	}
+	p.setGoal(goal)
+	return goal, nil
+}
+
+func (p *CodexProvider) setCodexGoal(ctx context.Context, sink EventSink, params map[string]any) error {
+	result, err := p.request(ctx, "thread/goal/set", params)
+	if err != nil {
+		return fmt.Errorf("updating Codex goal: %w", err)
+	}
+	goal, err := decodeCodexGoal(result)
+	if err != nil {
+		return fmt.Errorf("decoding updated Codex goal: %w", err)
+	}
+	if goal == nil {
+		return errors.New("updating Codex goal: response did not include a goal")
+	}
+	p.setGoal(goal)
+	p.emitGoal(sink, goal, goal.Status)
+	p.finishInteractionIfGoalStopped()
+	return nil
+}
+
+func decodeCodexGoal(data json.RawMessage) (*Goal, error) {
+	var response codexGoalResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, err
+	}
+	return cloneGoal(response.Goal), nil
+}
+
+func cloneGoal(goal *Goal) *Goal {
+	if goal == nil {
+		return nil
+	}
+	cloned := *goal
+	if goal.TokenBudget != nil {
+		budget := *goal.TokenBudget
+		cloned.TokenBudget = &budget
+	}
+	return &cloned
+}
+
+func (p *CodexProvider) setGoal(goal *Goal) bool {
+	p.goalMu.Lock()
+	changed := !goalsEqual(p.goal, goal)
+	p.goal = cloneGoal(goal)
+	p.goalMu.Unlock()
+	return changed
+}
+
+func goalsEqual(left, right *Goal) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	if left.Objective != right.Objective || left.Status != right.Status || left.TokensUsed != right.TokensUsed || left.TimeUsedSeconds != right.TimeUsedSeconds {
+		return false
+	}
+	if left.TokenBudget == nil || right.TokenBudget == nil {
+		return left.TokenBudget == nil && right.TokenBudget == nil
+	}
+	return *left.TokenBudget == *right.TokenBudget
+}
+
+func (p *CodexProvider) goalIsActive() bool {
+	p.goalMu.Lock()
+	defer p.goalMu.Unlock()
+	return p.goal != nil && p.goal.Status == "active"
+}
+
+func (p *CodexProvider) emitGoal(sink EventSink, goal *Goal, status string) {
+	if sink == nil {
+		return
+	}
+	sink.Emit(Event{Type: EventGoalUpdated, Goal: cloneGoal(goal), Status: status})
+}
+
+func goalEventStatus(goal *Goal, empty string) string {
+	if goal == nil {
+		return empty
+	}
+	return goal.Status
+}
+
 // Interrupt stops the active Codex turn without closing its thread.
 func (p *CodexProvider) Interrupt(ctx context.Context) error {
 	p.activeMu.Lock()
 	turnID := p.activeTurn
 	ready := p.activeReady
+	kind := p.interactionKind
+	sink := p.activeSink
 	p.activeMu.Unlock()
-	if turnID == "" && ready == nil {
+	if kind == "" || ready == nil {
 		return ErrNoActiveTurn
+	}
+	goalPaused := false
+	pauseGoal := func() error {
+		if kind != codexInteractionGoal || !p.goalIsActive() {
+			return nil
+		}
+		if err := p.applyGoalCommand(ctx, goalCommand{action: goalCommandPause}, sink); err != nil {
+			return fmt.Errorf("pausing Codex goal: %w", err)
+		}
+		goalPaused = true
+		return nil
+	}
+	if err := pauseGoal(); err != nil {
+		return err
 	}
 	if turnID == "" {
 		select {
@@ -381,7 +638,15 @@ func (p *CodexProvider) Interrupt(ctx context.Context) error {
 		p.activeMu.Lock()
 		turnID = p.activeTurn
 		p.activeMu.Unlock()
+		if !goalPaused {
+			if err := pauseGoal(); err != nil {
+				return err
+			}
+		}
 		if turnID == "" {
+			if goalPaused {
+				return nil
+			}
 			return ErrNoActiveTurn
 		}
 	}
@@ -496,9 +761,27 @@ func (p *CodexProvider) handleNotification(method string, params json.RawMessage
 	p.activeMu.Lock()
 	sink := p.activeSink
 	done := p.turnDone
+	kind := p.interactionKind
 	p.activeMu.Unlock()
 
 	switch method {
+	case "thread/goal/updated":
+		goal, err := decodeCodexGoal(params)
+		if err == nil && goal != nil {
+			changed := p.setGoal(goal)
+			if changed && sink != nil {
+				p.emitGoal(sink, goal, goal.Status)
+			}
+			p.finishInteractionIfGoalStopped()
+		}
+		return
+	case "thread/goal/cleared":
+		changed := p.setGoal(nil)
+		if changed && sink != nil {
+			p.emitGoal(sink, nil, "cleared")
+		}
+		p.finishInteractionIfGoalStopped()
+		return
 	case "thread/tokenUsage/updated":
 		if usage := codexRuntimeUsage(params); usage != nil {
 			p.statusMu.Lock()
@@ -518,6 +801,37 @@ func (p *CodexProvider) handleNotification(method string, params json.RawMessage
 				sink.Emit(Event{Type: EventRuntimeStatus, Runtime: &RuntimeStatus{WeeklyLimit: limit}})
 			}
 		}
+		return
+	}
+	if method == "turn/started" {
+		if turnID := codexNotificationTurnID(params); turnID != "" {
+			p.setActiveTurn(turnID)
+		}
+		return
+	}
+	if method == "turn/completed" {
+		var value struct {
+			Turn struct {
+				Status string          `json:"status"`
+				Error  json.RawMessage `json:"error"`
+			} `json:"turn"`
+		}
+		if json.Unmarshal(params, &value) == nil {
+			result := codexTurnResult{status: value.Turn.Status}
+			if len(value.Turn.Error) > 0 && string(value.Turn.Error) != "null" {
+				result.error = string(value.Turn.Error)
+			}
+			p.activeMu.Lock()
+			p.activeTurn = ""
+			p.activeMu.Unlock()
+			if done != nil && (result.status == "failed" || result.status == "interrupted" || kind != codexInteractionGoal || !p.goalIsActive()) {
+				select {
+				case done <- result:
+				default:
+				}
+			}
+		}
+		p.clearCodexCommandOutputs()
 		return
 	}
 	if sink == nil {
@@ -549,26 +863,38 @@ func (p *CodexProvider) handleNotification(method string, params json.RawMessage
 		if json.Unmarshal(params, &value) == nil && value.Diff != "" {
 			sink.Emit(Event{Type: EventFileDiff, Diff: value.Diff})
 		}
-	case "turn/completed":
-		var value struct {
-			Turn struct {
-				Status string          `json:"status"`
-				Error  json.RawMessage `json:"error"`
-			} `json:"turn"`
-		}
-		if json.Unmarshal(params, &value) == nil && done != nil {
-			result := codexTurnResult{status: value.Turn.Status}
-			if len(value.Turn.Error) > 0 && string(value.Turn.Error) != "null" {
-				result.error = string(value.Turn.Error)
-			}
-			select {
-			case done <- result:
-			default:
-			}
-		}
-		p.clearCodexCommandOutputs()
 	case "error":
 		sink.Emit(Event{Type: EventError, Text: string(params)})
+	}
+}
+
+func codexNotificationTurnID(params json.RawMessage) string {
+	var value struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	if json.Unmarshal(params, &value) != nil {
+		return ""
+	}
+	return value.Turn.ID
+}
+
+func (p *CodexProvider) finishInteractionIfGoalStopped() {
+	if p.goalIsActive() {
+		return
+	}
+	p.activeMu.Lock()
+	done := p.turnDone
+	turnID := p.activeTurn
+	kind := p.interactionKind
+	p.activeMu.Unlock()
+	if done == nil || turnID != "" || kind != codexInteractionGoal {
+		return
+	}
+	select {
+	case done <- codexTurnResult{status: "completed"}:
+	default:
 	}
 }
 

--- a/internal/sessionruntime/command.go
+++ b/internal/sessionruntime/command.go
@@ -1,0 +1,92 @@
+package sessionruntime
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const goalUsage = "usage: /goal [<objective>|clear|edit <objective>|pause|resume]"
+
+type sessionCommandKind string
+
+const (
+	sessionCommandMessage sessionCommandKind = "message"
+	sessionCommandShell   sessionCommandKind = "shell"
+	sessionCommandGoal    sessionCommandKind = "goal"
+)
+
+type sessionCommand struct {
+	kind sessionCommandKind
+	text string
+	goal goalCommand
+}
+
+type goalCommandAction string
+
+const (
+	goalCommandShow   goalCommandAction = "show"
+	goalCommandCreate goalCommandAction = "create"
+	goalCommandEdit   goalCommandAction = "edit"
+	goalCommandClear  goalCommandAction = "clear"
+	goalCommandPause  goalCommandAction = "pause"
+	goalCommandResume goalCommandAction = "resume"
+)
+
+type goalCommand struct {
+	action    goalCommandAction
+	objective string
+}
+
+func parseSessionCommand(text string) (sessionCommand, error) {
+	trimmed := strings.TrimSpace(text)
+	if strings.HasPrefix(trimmed, "!") {
+		command := strings.TrimSpace(strings.TrimPrefix(trimmed, "!"))
+		if command == "" {
+			return sessionCommand{}, errors.New("shell command must not be empty")
+		}
+		return sessionCommand{kind: sessionCommandShell, text: command}, nil
+	}
+	if !hasCommandPrefix(trimmed, "/goal") {
+		return sessionCommand{kind: sessionCommandMessage, text: text}, nil
+	}
+
+	arguments := strings.TrimSpace(strings.TrimPrefix(trimmed, "/goal"))
+	if arguments == "" {
+		return sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandShow}}, nil
+	}
+	fields := strings.Fields(arguments)
+	switch fields[0] {
+	case "clear":
+		if len(fields) == 1 {
+			return sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandClear}}, nil
+		}
+	case "pause":
+		if len(fields) == 1 {
+			return sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandPause}}, nil
+		}
+	case "resume":
+		if len(fields) == 1 {
+			return sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandResume}}, nil
+		}
+	case "edit":
+		objective := strings.TrimSpace(strings.TrimPrefix(arguments, fields[0]))
+		if objective == "" {
+			return sessionCommand{}, errors.New(goalUsage)
+		}
+		return sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandEdit, objective: objective}}, nil
+	}
+	return sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandCreate, objective: arguments}}, nil
+}
+
+func hasCommandPrefix(text, command string) bool {
+	if text == command {
+		return true
+	}
+	if !strings.HasPrefix(text, command) || len(text) == len(command) {
+		return false
+	}
+	value, _ := utf8.DecodeRuneInString(text[len(command):])
+	return unicode.IsSpace(value)
+}

--- a/internal/sessionruntime/command_test.go
+++ b/internal/sessionruntime/command_test.go
@@ -1,0 +1,50 @@
+package sessionruntime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSessionCommand(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		kind          sessionCommandKind
+		text          string
+		goalAction    goalCommandAction
+		goalObjective string
+	}{
+		{name: "message", input: "review this", kind: sessionCommandMessage, text: "review this"},
+		{name: "unrecognized slash command", input: "/review", kind: sessionCommandMessage, text: "/review"},
+		{name: "shell", input: "! make test", kind: sessionCommandShell, text: "make test"},
+		{name: "show goal", input: "/goal", kind: sessionCommandGoal, goalAction: goalCommandShow},
+		{name: "create goal", input: "/goal improve coverage", kind: sessionCommandGoal, goalAction: goalCommandCreate, goalObjective: "improve coverage"},
+		{name: "multiline goal", input: "/goal\nimprove coverage", kind: sessionCommandGoal, goalAction: goalCommandCreate, goalObjective: "improve coverage"},
+		{name: "edit goal", input: "/goal edit improve tests", kind: sessionCommandGoal, goalAction: goalCommandEdit, goalObjective: "improve tests"},
+		{name: "clear goal", input: "/goal clear", kind: sessionCommandGoal, goalAction: goalCommandClear},
+		{name: "pause goal", input: "/goal pause", kind: sessionCommandGoal, goalAction: goalCommandPause},
+		{name: "resume goal", input: "/goal resume", kind: sessionCommandGoal, goalAction: goalCommandResume},
+		{name: "objective starts with command", input: "/goal clear tech debt", kind: sessionCommandGoal, goalAction: goalCommandCreate, goalObjective: "clear tech debt"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command, err := parseSessionCommand(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if command.kind != test.kind || command.text != test.text || command.goal.action != test.goalAction || command.goal.objective != test.goalObjective {
+				t.Fatalf("parseSessionCommand(%q) = %#v", test.input, command)
+			}
+		})
+	}
+}
+
+func TestParseSessionCommandRejectsInvalidCommands(t *testing.T) {
+	for _, input := range []string{"!", "/goal edit"} {
+		t.Run(strings.ReplaceAll(input, " ", "_"), func(t *testing.T) {
+			if _, err := parseSessionCommand(input); err == nil {
+				t.Fatalf("parseSessionCommand(%q) returned no error", input)
+			}
+		})
+	}
+}

--- a/internal/sessionruntime/history.go
+++ b/internal/sessionruntime/history.go
@@ -231,6 +231,8 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 				continue
 			}
 			tools[historyToolKey(event)] = historyPendingEvent{event: event, firstEventID: event.ID}
+		case EventToolDelta:
+			// The completed tool event carries the bounded retained output.
 		case EventToolCompleted:
 			completion := normalizedHistoryEvent(event)
 			completion.Output = boundedHistoryText(completion.Output, maxHistoryToolOutputBytes)
@@ -264,6 +266,12 @@ func projectHistory(source []Event) ([]historyItem, HistoryState, []Event) {
 			delete(inputs, event.InputID)
 		case EventFileDiff:
 			event.Diff = boundedHistoryText(event.Diff, maxHistoryDiffBytes)
+			addItem(event.ID, event.ID, normalizedHistoryEvent(event))
+		case EventGoalUpdated:
+			if event.Goal != nil {
+				event.Goal = cloneGoal(event.Goal)
+				event.Goal.Objective = boundedHistoryText(event.Goal.Objective, maxHistoryMessageBytes)
+			}
 			addItem(event.ID, event.ID, normalizedHistoryEvent(event))
 		case EventRuntimeRecovered, EventError, EventTurnInterrupting:
 			event.Text = boundedHistoryText(event.Text, maxHistoryNoticeBytes)
@@ -424,6 +432,10 @@ func normalizedHistoryEvent(event Event) Event {
 	event.HistoryCursor = ""
 	event.HistoryState = nil
 	event.Runtime = nil
+	event.SessionCommand = false
+	if event.Goal != nil {
+		event.Goal = cloneGoal(event.Goal)
+	}
 	event.ToolID = boundedHistoryText(event.ToolID, maxHistoryIdentifierBytes)
 	event.ToolName = boundedHistoryText(event.ToolName, maxHistoryIdentifierBytes)
 	event.InputID = boundedHistoryText(event.InputID, maxHistoryIdentifierBytes)

--- a/internal/sessionruntime/history_test.go
+++ b/internal/sessionruntime/history_test.go
@@ -10,7 +10,7 @@ import (
 func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
 	startedAt := time.Date(2026, time.August, 8, 12, 0, 0, 0, time.UTC)
 	events := []Event{
-		{ID: 1, Type: EventUserMessage, TurnID: "turn-1", Text: "first request"},
+		{ID: 1, Type: EventUserMessage, TurnID: "turn-1", Text: "first request", SessionCommand: true},
 		{ID: 2, Type: EventTurnStarted, TurnID: "turn-1", Timestamp: &startedAt, Status: "running"},
 		{ID: 3, Type: EventAssistantDelta, TurnID: "turn-1", Text: "Claude "},
 		{ID: 4, Type: EventAssistantDelta, TurnID: "turn-1", Text: "answer"},
@@ -61,7 +61,7 @@ func TestProjectHistoryNormalizesProviderEventsAndPreservesState(t *testing.T) {
 		EventAssistantMessage,
 	)
 	for _, event := range projected {
-		if event.TurnID != "" || event.RequestID != "" {
+		if event.TurnID != "" || event.RequestID != "" || event.SessionCommand {
 			t.Fatalf("projected event retains transient state: %#v", event)
 		}
 	}
@@ -120,6 +120,28 @@ func TestProjectHistoryKeepsActiveAssistantStreaming(t *testing.T) {
 	assertEventTypes(t, page, EventUserMessage, EventAssistantDelta)
 	if page[1].Text != "partial answer" {
 		t.Fatalf("active assistant text = %q", page[1].Text)
+	}
+}
+
+func TestProjectHistoryRetainsShellCompletionAndGoal(t *testing.T) {
+	budget := int64(1000)
+	items, _, _ := projectHistory([]Event{
+		{ID: 1, Type: EventToolStarted, TurnID: "turn-1", ToolID: "turn-1-shell", ToolName: "make test", Status: "running"},
+		{ID: 2, Type: EventToolDelta, TurnID: "turn-1", ToolID: "turn-1-shell", Output: "partial"},
+		{ID: 3, Type: EventToolCompleted, TurnID: "turn-1", ToolID: "turn-1-shell", ToolName: "make test", Output: "final", Status: "completed"},
+		{ID: 4, Type: EventGoalUpdated, Goal: &Goal{Objective: "Improve coverage", Status: "active", TokenBudget: &budget, TokensUsed: 125}, Status: "active"},
+	})
+
+	page, cursor := historyItemsPage(items, 0, DefaultHistoryItemLimit, DefaultHistoryByteLimit)
+	if cursor != 0 {
+		t.Fatalf("history cursor = %d, want all items", cursor)
+	}
+	assertEventTypes(t, page, EventToolStarted, EventToolCompleted, EventGoalUpdated)
+	if page[1].Output != "final" {
+		t.Fatalf("retained shell output = %q, want final", page[1].Output)
+	}
+	if page[2].Goal == nil || page[2].Goal.Objective != "Improve coverage" || page[2].Goal.TokenBudget == nil || *page[2].Goal.TokenBudget != budget {
+		t.Fatalf("retained goal = %#v", page[2].Goal)
 	}
 }
 

--- a/internal/sessionruntime/journal_test.go
+++ b/internal/sessionruntime/journal_test.go
@@ -194,6 +194,38 @@ func TestJournalRecoveryCombinesPendingTurns(t *testing.T) {
 	}
 }
 
+func TestJournalRecoveryPreservesSessionCommandIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		text        string
+		command     bool
+		wantKind    sessionCommandKind
+		wantCommand string
+	}{
+		{name: "shell command", text: "!pwd", command: true, wantKind: sessionCommandShell, wantCommand: "pwd"},
+		{name: "ordinary command-like prompt", text: "!", wantKind: sessionCommandMessage, wantCommand: "!"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			journal := NewJournal()
+			t.Cleanup(journal.Close)
+			if err := journal.Append(Event{Type: EventUserMessage, TurnID: "turn-1", Text: test.text, Revision: 1, SessionCommand: test.command}); err != nil {
+				t.Fatal(err)
+			}
+
+			recovery, err := recoverJournal(journal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if recovery.pendingTurn == nil {
+				t.Fatal("pending turn was not recovered")
+			}
+			if recovery.pendingTurn.command.kind != test.wantKind || recovery.pendingTurn.command.text != test.wantCommand {
+				t.Fatalf("recovered command = %#v", recovery.pendingTurn.command)
+			}
+		})
+	}
+}
+
 func TestJournalIdentityPersistsUntilJournalIsReplaced(t *testing.T) {
 	path := filepath.Join(t.TempDir(), journalFileName)
 	journal, err := OpenJournal(path)

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -19,7 +19,9 @@ const (
 	EventAssistantDelta     = "assistant.delta"
 	EventAssistantMessage   = "assistant.message"
 	EventToolStarted        = "tool.started"
+	EventToolDelta          = "tool.delta"
 	EventToolCompleted      = "tool.completed"
+	EventGoalUpdated        = "goal.updated"
 	EventInputRequested     = "input.requested"
 	EventInputResolved      = "input.resolved"
 	EventFileDiff           = "file.diff"
@@ -40,6 +42,7 @@ type Event struct {
 	TurnID         string          `json:"turnId,omitempty"`
 	Text           string          `json:"text,omitempty"`
 	Revision       int64           `json:"revision,omitempty"`
+	SessionCommand bool            `json:"sessionCommand,omitempty"`
 	ToolID         string          `json:"toolId,omitempty"`
 	ToolName       string          `json:"toolName,omitempty"`
 	Output         string          `json:"output,omitempty"`
@@ -56,7 +59,17 @@ type Event struct {
 	HistoryCursor  string          `json:"historyCursor,omitempty"`
 	HistoryState   *HistoryState   `json:"historyState,omitempty"`
 	Runtime        *RuntimeStatus  `json:"runtime,omitempty"`
+	Goal           *Goal           `json:"goal,omitempty"`
 	Attachments    []Attachment    `json:"attachments,omitempty"`
+}
+
+// Goal describes the persisted objective owned by a Codex Session.
+type Goal struct {
+	Objective       string `json:"objective"`
+	Status          string `json:"status"`
+	TokenBudget     *int64 `json:"tokenBudget,omitempty"`
+	TokensUsed      int64  `json:"tokensUsed,omitempty"`
+	TimeUsedSeconds int64  `json:"timeUsedSeconds,omitempty"`
 }
 
 // HistoryState describes conversation state that is independent of transcript paging.

--- a/internal/sessionruntime/provider.go
+++ b/internal/sessionruntime/provider.go
@@ -34,6 +34,12 @@ type Provider interface {
 	Close() error
 }
 
+type goalProvider interface {
+	RunGoal(context.Context, goalCommand, EventSink) error
+	ControlGoal(context.Context, goalCommand, EventSink) error
+	ActiveGoal() *Goal
+}
+
 // NewProvider creates the configured conversation adapter.
 func NewProvider(ctx context.Context, config ProviderConfig) (Provider, error) {
 	switch config.AgentType {

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -34,6 +35,7 @@ const (
 	activityPublishedFile               = "activity-published"
 	initializedFile                     = "initialized"
 	defaultInterruptTimeout             = 10 * time.Second
+	shellCommandWaitDelay               = 250 * time.Millisecond
 	defaultSessionStatusPublishInterval = 30 * time.Second
 	defaultSessionStatusRetryInterval   = 2 * time.Second
 )
@@ -60,6 +62,7 @@ type turnRequest struct {
 	text        string
 	revision    int64
 	attachments []Attachment
+	command     sessionCommand
 	accepted    chan struct{}
 }
 
@@ -118,11 +121,13 @@ type Server struct {
 	interruptMu        sync.Mutex
 	activeMu           sync.Mutex
 	activeTurn         string
+	activeKind         sessionCommandKind
 	activeTurnCancel   context.CancelCauseFunc
 	activeTurnDone     chan struct{}
 	providerStopping   atomic.Bool
 	providerStopOnce   sync.Once
 	providerStop       chan struct{}
+	recoveredGoalTurn  *turnRequest
 	interruptTimeout   time.Duration
 	pendingInputCount  atomic.Int64
 
@@ -240,6 +245,16 @@ func Run(ctx context.Context, config Config) error {
 		_ = provider.Close()
 		journal.Close()
 		return err
+	}
+	if goalManager, ok := provider.(goalProvider); ok && goalManager.ActiveGoal() != nil {
+		turn := turnRequest{
+			id:       fmt.Sprintf("turn-%d", server.nextTurnID.Add(1)),
+			text:     "/goal resume",
+			revision: 1,
+			command:  sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandResume}},
+		}
+		server.recoveredGoalTurn = &turn
+		server.outstanding++
 	}
 	if server.activityMarkerPath != "" {
 		settledTurnID, err := loadSettledTurnID(server.activityMarkerPath)
@@ -401,6 +416,20 @@ func (s *Server) deliverInitialPrompt() error {
 }
 
 func (s *Server) runTurns(ctx context.Context) {
+	if s.recoveredGoalTurn != nil {
+		turn := s.recoveredGoalTurn
+		s.recoveredGoalTurn = nil
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.providerStop:
+			return
+		default:
+			s.runTurn(ctx, *turn)
+			s.interruptMu.Lock()
+			s.interruptMu.Unlock()
+		}
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -694,8 +723,13 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 	defer s.requestWorkspaceStatusRefresh()
 	turnCtx, cancelTurn := context.WithCancelCause(ctx)
 	turnDone := make(chan struct{})
+	command := turn.command
+	if command.kind == "" {
+		command = sessionCommand{kind: sessionCommandMessage, text: turn.text}
+	}
 	s.activeMu.Lock()
 	s.activeTurn = turn.id
+	s.activeKind = command.kind
 	s.activeTurnCancel = cancelTurn
 	s.activeTurnDone = turnDone
 	s.activeMu.Unlock()
@@ -705,6 +739,7 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 		s.activeMu.Lock()
 		if s.activeTurn == turn.id {
 			s.activeTurn = ""
+			s.activeKind = ""
 			s.activeTurnCancel = nil
 			s.activeTurnDone = nil
 		}
@@ -721,6 +756,43 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 		return
 	}
 	sink := &turnSink{server: s, turnID: turn.id}
+	if command.kind == sessionCommandShell {
+		runErr := s.runShellCommand(turnCtx, turn.id, command.text, sink)
+		sink.stop()
+		if errors.Is(runErr, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted) {
+			_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "interrupted"})
+			return
+		}
+		if runErr != nil && turnCtx.Err() != nil {
+			return
+		}
+		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "completed"})
+		return
+	}
+	if command.kind == sessionCommandGoal {
+		provider, ok := s.provider.(goalProvider)
+		if !ok {
+			_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: "/goal is available only in Codex Sessions", Status: "failed"})
+			_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "failed"})
+			return
+		}
+		runErr := provider.RunGoal(turnCtx, command.goal, sink)
+		sink.stop()
+		if errors.Is(runErr, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted) {
+			_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "interrupted"})
+			return
+		}
+		if runErr != nil {
+			if turnCtx.Err() != nil {
+				return
+			}
+			_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: runErr.Error(), Status: "failed"})
+			_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "failed"})
+			return
+		}
+		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "completed"})
+		return
+	}
 	resolvedAttachments, err := s.resolveAttachments(turn.attachments)
 	if err != nil {
 		_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: err.Error(), Status: "failed"})
@@ -758,6 +830,86 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 	_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "completed"})
 }
 
+func (s *Server) runShellCommand(ctx context.Context, turnID, script string, sink EventSink) error {
+	toolID := turnID + "-shell"
+	sink.Emit(Event{Type: EventToolStarted, ToolID: toolID, ToolName: script, Status: "running"})
+	command := exec.CommandContext(ctx, "/bin/sh", "-lc", script)
+	command.Dir = s.config.WorkingDir
+	command.Env = s.config.Environment
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.WaitDelay = shellCommandWaitDelay
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	outputReader, outputWriter := io.Pipe()
+	command.Stdout = outputWriter
+	command.Stderr = outputWriter
+	if err := command.Start(); err != nil {
+		_ = outputReader.Close()
+		_ = outputWriter.Close()
+		sink.Emit(Event{Type: EventToolCompleted, ToolID: toolID, ToolName: script, Output: err.Error(), Status: "failed"})
+		return nil
+	}
+
+	output := newBoundedToolOutput(maxToolOutputBytes)
+	readDone := make(chan error, 1)
+	go func() {
+		defer outputReader.Close()
+		buffer := make([]byte, 32*1024)
+		streamed := 0
+		for {
+			count, err := outputReader.Read(buffer)
+			if count > 0 {
+				chunk := string(buffer[:count])
+				output.WriteString(chunk)
+				if streamed < maxToolOutputBytes {
+					remaining := maxToolOutputBytes - streamed
+					if len(chunk) > remaining {
+						chunk = chunk[:remaining]
+					}
+					streamed += len(chunk)
+					sink.Emit(Event{Type: EventToolDelta, ToolID: toolID, ToolName: script, Output: chunk, Status: "running"})
+				}
+			}
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					readDone <- nil
+				} else {
+					readDone <- err
+				}
+				return
+			}
+		}
+	}()
+	waitErr := command.Wait()
+	_ = outputWriter.Close()
+	readErr := <-readDone
+	if readErr != nil && waitErr == nil {
+		waitErr = readErr
+	}
+	status := "completed"
+	if ctx.Err() != nil {
+		status = "interrupted"
+	} else if waitErr != nil && !errors.Is(waitErr, exec.ErrWaitDelay) {
+		status = "failed"
+		if output.String() == "" {
+			output.WriteString(waitErr.Error())
+		}
+	}
+	sink.Emit(Event{Type: EventToolCompleted, ToolID: toolID, ToolName: script, Output: output.String(), Status: status})
+	if ctx.Err() != nil {
+		return context.Cause(ctx)
+	}
+	return nil
+}
+
 func workspaceDiff(ctx context.Context, workingDir string) string {
 	command := exec.CommandContext(ctx, "git", "diff", "--no-ext-diff", "--no-color")
 	command.Dir = workingDir
@@ -773,6 +925,10 @@ func workspaceDiff(ctx context.Context, workingDir string) string {
 }
 
 func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) error {
+	return s.submitParsedMessage(text, requestID, sessionCommand{kind: sessionCommandMessage, text: text}, attachmentIDs...)
+}
+
+func (s *Server) submitParsedMessage(text, requestID string, command sessionCommand, attachmentIDs ...string) error {
 	if strings.TrimSpace(text) == "" && len(attachmentIDs) == 0 {
 		return errors.New("message must not be empty")
 	}
@@ -783,6 +939,14 @@ func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) 
 	attachments := make([]Attachment, len(resolvedAttachments))
 	for index := range resolvedAttachments {
 		attachments[index] = resolvedAttachments[index].Attachment
+	}
+	if command.kind != sessionCommandMessage && len(attachments) > 0 {
+		return errors.New("Session commands do not accept attachments")
+	}
+	if command.kind == sessionCommandGoal {
+		if _, ok := s.provider.(goalProvider); !ok {
+			return errors.New("/goal is available only in Codex Sessions")
+		}
 	}
 	s.submitMu.Lock()
 	defer s.submitMu.Unlock()
@@ -800,16 +964,24 @@ func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) 
 	}
 	if s.pendingTurn != nil {
 		turn := *s.pendingTurn
+		pendingKind := turn.command.kind
+		if pendingKind == "" {
+			pendingKind = sessionCommandMessage
+		}
+		if command.kind != sessionCommandMessage || pendingKind != sessionCommandMessage {
+			return errors.New("Session already has a pending command or message")
+		}
 		turn.text = mergePendingMessageText(turn.text, text)
 		turn.attachments = append(turn.attachments, attachments...)
 		turn.revision = max(1, turn.revision) + 1
 		if err := s.appendMessage(Event{
-			Type:        EventUserMessageUpdated,
-			RequestID:   requestID,
-			TurnID:      turn.id,
-			Text:        turn.text,
-			Revision:    turn.revision,
-			Attachments: turn.attachments,
+			Type:           EventUserMessageUpdated,
+			RequestID:      requestID,
+			TurnID:         turn.id,
+			Text:           turn.text,
+			Revision:       turn.revision,
+			SessionCommand: false,
+			Attachments:    turn.attachments,
 		}); err != nil {
 			return fmt.Errorf("recording pending Session message: %w", err)
 		}
@@ -821,13 +993,14 @@ func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) 
 		text:        text,
 		revision:    1,
 		attachments: attachments,
+		command:     command,
 		accepted:    make(chan struct{}),
 	}
 	select {
 	case s.turns <- turn:
 		s.pendingTurn = &turn
 		s.outstanding++
-		if err := s.appendMessage(Event{Type: EventUserMessage, RequestID: requestID, TurnID: turn.id, Text: turn.text, Revision: turn.revision, Attachments: turn.attachments}); err != nil {
+		if err := s.appendMessage(Event{Type: EventUserMessage, RequestID: requestID, TurnID: turn.id, Text: turn.text, Revision: turn.revision, SessionCommand: command.kind != sessionCommandMessage, Attachments: turn.attachments}); err != nil {
 			s.pendingTurn = nil
 			s.outstanding--
 			return fmt.Errorf("recording Session message: %w", err)
@@ -837,6 +1010,38 @@ func (s *Server) submitMessage(text, requestID string, attachmentIDs ...string) 
 	default:
 		return errors.New("Session already has a pending message")
 	}
+}
+
+func (s *Server) submitClientMessage(ctx context.Context, text, requestID string, attachmentIDs ...string) error {
+	command, err := parseSessionCommand(text)
+	if err != nil {
+		return err
+	}
+	if command.kind != sessionCommandMessage && len(attachmentIDs) > 0 {
+		return errors.New("Session commands do not accept attachments")
+	}
+	if command.kind == sessionCommandGoal {
+		if _, ok := s.provider.(goalProvider); !ok {
+			return errors.New("/goal is available only in Codex Sessions")
+		}
+	}
+	if command.kind == sessionCommandGoal {
+		s.activeMu.Lock()
+		turnID := s.activeTurn
+		activeKind := s.activeKind
+		s.activeMu.Unlock()
+		if turnID != "" && activeKind == sessionCommandGoal {
+			provider, ok := s.provider.(goalProvider)
+			if !ok {
+				return errors.New("/goal is available only in Codex Sessions")
+			}
+			if err := s.journal.Append(Event{Type: EventUserMessage, RequestID: requestID, Text: text, SessionCommand: true}); err != nil {
+				return fmt.Errorf("recording Session goal command: %w", err)
+			}
+			return provider.ControlGoal(ctx, command.goal, &turnSink{server: s})
+		}
+	}
+	return s.submitParsedMessage(text, requestID, command, attachmentIDs...)
 }
 
 func mergePendingMessageText(current, addition string) string {
@@ -868,15 +1073,29 @@ func (s *Server) editMessage(turnID, text string, expectedRevision int64, reques
 	if strings.TrimSpace(text) == "" && len(turn.attachments) == 0 {
 		return fmt.Errorf("editing Session turn %q: message must not be empty", turnID)
 	}
+	command, err := parseSessionCommand(text)
+	if err != nil {
+		return err
+	}
+	if command.kind != sessionCommandMessage && len(turn.attachments) > 0 {
+		return errors.New("Session commands do not accept attachments")
+	}
+	if command.kind == sessionCommandGoal {
+		if _, ok := s.provider.(goalProvider); !ok {
+			return errors.New("/goal is available only in Codex Sessions")
+		}
+	}
 	turn.text = text
+	turn.command = command
 	turn.revision++
 	if err := s.appendMessage(Event{
-		Type:        EventUserMessageUpdated,
-		RequestID:   requestID,
-		TurnID:      turn.id,
-		Text:        turn.text,
-		Revision:    turn.revision,
-		Attachments: turn.attachments,
+		Type:           EventUserMessageUpdated,
+		RequestID:      requestID,
+		TurnID:         turn.id,
+		Text:           turn.text,
+		Revision:       turn.revision,
+		SessionCommand: command.kind != sessionCommandMessage,
+		Attachments:    turn.attachments,
 	}); err != nil {
 		return fmt.Errorf("recording edited Session turn %q: %w", turnID, err)
 	}
@@ -975,6 +1194,7 @@ type journalTurnRecovery struct {
 	text        string
 	revision    int64
 	attachments []Attachment
+	command     bool
 	started     bool
 	completed   bool
 }
@@ -1018,6 +1238,7 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 			if turn != nil {
 				turn.text = event.Text
 				turn.attachments = event.Attachments
+				turn.command = event.SessionCommand
 				turn.revision = event.Revision
 				if turn.revision == 0 {
 					turn.revision = 1
@@ -1075,7 +1296,15 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 		if !turn.started {
 			accepted := make(chan struct{})
 			close(accepted)
-			unstartedTurns = append(unstartedTurns, turnRequest{id: turn.id, text: turn.text, revision: turn.revision, attachments: turn.attachments, accepted: accepted})
+			command := sessionCommand{kind: sessionCommandMessage, text: turn.text}
+			if turn.command {
+				var err error
+				command, err = parseSessionCommand(turn.text)
+				if err != nil {
+					return recovery, fmt.Errorf("recovering Session command %q: %w", turn.id, err)
+				}
+			}
+			unstartedTurns = append(unstartedTurns, turnRequest{id: turn.id, text: turn.text, revision: turn.revision, attachments: turn.attachments, command: command, accepted: accepted})
 			continue
 		}
 		if err := journal.Append(Event{Type: EventTurnCompleted, TurnID: turnID, Status: "interrupted"}); err != nil {
@@ -1111,11 +1340,12 @@ func recoverJournal(journal *Journal) (journalRecovery, error) {
 			}
 			pending.revision = max(1, pending.revision) + 1
 			if err := journal.Append(Event{
-				Type:        EventUserMessageUpdated,
-				TurnID:      pending.id,
-				Text:        pending.text,
-				Revision:    pending.revision,
-				Attachments: pending.attachments,
+				Type:           EventUserMessageUpdated,
+				TurnID:         pending.id,
+				Text:           pending.text,
+				Revision:       pending.revision,
+				SessionCommand: pending.command.kind != sessionCommandMessage,
+				Attachments:    pending.attachments,
 			}); err != nil {
 				return recovery, fmt.Errorf("recording pending Session message: %w", err)
 			}
@@ -1161,6 +1391,7 @@ func (s *Server) interruptTurn(runtimeCtx context.Context, requestID string) err
 	defer s.interruptMu.Unlock()
 	s.activeMu.Lock()
 	activeTurn := s.activeTurn
+	activeKind := s.activeKind
 	s.activeMu.Unlock()
 	if activeTurn != turnID {
 		return nil
@@ -1170,6 +1401,18 @@ func (s *Server) interruptTurn(runtimeCtx context.Context, requestID string) err
 	}
 	interruptCtx, cancel := context.WithTimeout(runtimeCtx, s.interruptTimeout)
 	defer cancel()
+	if activeKind == sessionCommandShell {
+		if turnCancel == nil || turnDone == nil {
+			return errors.New("Session active shell command cannot be stopped")
+		}
+		turnCancel(ErrTurnInterrupted)
+		select {
+		case <-turnDone:
+			return nil
+		case <-interruptCtx.Done():
+			return interruptCtx.Err()
+		}
+	}
 	interruptResult := make(chan error, 1)
 	go func() {
 		interruptResult <- s.provider.Interrupt(interruptCtx)
@@ -1405,7 +1648,7 @@ func (s *Server) handleConnection(ctx context.Context, connection net.Conn) {
 			}
 		case "message":
 			subscribe(0, "", false, 0, 0)
-			if err := s.submitMessage(request.Text, request.RequestID, request.AttachmentIDs...); err != nil {
+			if err := s.submitClientMessage(ctx, request.Text, request.RequestID, request.AttachmentIDs...); err != nil {
 				out <- Event{Type: EventError, RequestID: request.RequestID, Text: err.Error(), Status: "rejected"}
 			}
 		case "message.edit":

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -34,6 +35,62 @@ type fakeProvider struct {
 	done      chan struct{}
 	doneOnce  sync.Once
 	closeOnce sync.Once
+}
+
+type fakeGoalProvider struct {
+	fakeProvider
+	goalCommands chan goalCommand
+	goal         *Goal
+	goalStarted  chan struct{}
+	goalStopped  chan struct{}
+	startOnce    sync.Once
+	stopOnce     sync.Once
+}
+
+func (p *fakeGoalProvider) RunGoal(ctx context.Context, command goalCommand, sink EventSink) error {
+	p.goalCommands <- command
+	p.mu.Lock()
+	p.goal = &Goal{Objective: command.objective, Status: "active"}
+	p.mu.Unlock()
+	if p.goalStarted != nil {
+		p.startOnce.Do(func() { close(p.goalStarted) })
+	}
+	if p.goalStopped != nil {
+		select {
+		case <-p.goalStopped:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	p.mu.Lock()
+	p.goal.Status = "complete"
+	goal := cloneGoal(p.goal)
+	p.mu.Unlock()
+	sink.Emit(Event{Type: EventGoalUpdated, Goal: goal, Status: goal.Status})
+	return nil
+}
+
+func (p *fakeGoalProvider) ControlGoal(_ context.Context, command goalCommand, sink EventSink) error {
+	p.goalCommands <- command
+	p.mu.Lock()
+	goal := cloneGoal(p.goal)
+	p.mu.Unlock()
+	if sink != nil {
+		sink.Emit(Event{Type: EventGoalUpdated, Goal: goal, Status: goalEventStatus(goal, "empty")})
+	}
+	if p.goalStopped != nil && (command.action == goalCommandPause || command.action == goalCommandClear) {
+		p.stopOnce.Do(func() { close(p.goalStopped) })
+	}
+	return nil
+}
+
+func (p *fakeGoalProvider) ActiveGoal() *Goal {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.goal == nil || p.goal.Status != "active" {
+		return nil
+	}
+	return cloneGoal(p.goal)
 }
 
 type inputProvider struct {
@@ -449,6 +506,363 @@ func TestRunTurnQueuesWorkspaceStatusRefresh(t *testing.T) {
 	close(releaseRefresh)
 }
 
+func TestRunTurnExecutesShellCommandInWorkspace(t *testing.T) {
+	workingDir := t.TempDir()
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeProvider{}
+	server := NewServer(Config{WorkingDir: workingDir, Environment: os.Environ()}, journal, provider)
+
+	server.runTurn(t.Context(), turnRequest{id: "turn-1", text: "!printf 'shell output'", command: sessionCommand{kind: sessionCommandShell, text: "printf 'shell output'"}})
+
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventTurnStarted, EventToolStarted, EventToolDelta, EventToolCompleted, EventTurnCompleted)
+	if events[1].ToolName != "printf 'shell output'" || events[2].Output != "shell output" {
+		t.Fatalf("shell command events = %#v", events)
+	}
+	if events[3].Status != "completed" || events[3].Output != "shell output" {
+		t.Fatalf("shell command completion = %#v", events[3])
+	}
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.prompts) != 0 {
+		t.Fatalf("shell command was sent to provider: %#v", provider.prompts)
+	}
+}
+
+func TestServerInterruptsShellCommandWithoutStoppingProvider(t *testing.T) {
+	workingDir := t.TempDir()
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeProvider{}
+	server := NewServer(Config{WorkingDir: workingDir, Environment: os.Environ()}, journal, provider)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(ctx)
+		close(runDone)
+	}()
+
+	pidPath := filepath.Join(workingDir, "shell-pid")
+	if err := server.submitClientMessage(t.Context(), "!printf '%d\\n' $$ > shell-pid; while :; do sleep 60; done", "request-shell"); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	var shellPID int
+	for {
+		data, err := os.ReadFile(pidPath)
+		if err == nil {
+			shellPID, err = strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				t.Fatalf("shell PID = %q: %v", data, err)
+			}
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("shell command did not start")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if err := server.interruptTurn(t.Context(), "request-interrupt"); err != nil {
+		t.Fatalf("interruptTurn() error = %v", err)
+	}
+	provider.mu.Lock()
+	providerClosed := provider.closed
+	provider.mu.Unlock()
+	if providerClosed {
+		t.Fatal("interrupting shell command stopped the provider")
+	}
+	events := journal.Snapshot()
+	var toolInterrupted bool
+	for _, event := range events {
+		if event.Type == EventToolCompleted && event.Status == "interrupted" {
+			toolInterrupted = true
+		}
+	}
+	if !toolInterrupted {
+		t.Fatalf("shell tool was not interrupted: %#v", events)
+	}
+	if completion := events[len(events)-1]; completion.Type != EventTurnCompleted || completion.Status != "interrupted" {
+		t.Fatalf("shell command completion = %#v", completion)
+	}
+	if err := syscall.Kill(shellPID, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("shell process %d remains after interrupt: %v", shellPID, err)
+	}
+
+	cancel()
+	<-runDone
+}
+
+func TestRunTurnCompletesWhenBackgroundProcessKeepsOutputOpen(t *testing.T) {
+	workingDir := t.TempDir()
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	server := NewServer(Config{WorkingDir: workingDir, Environment: os.Environ()}, journal, &fakeProvider{})
+
+	started := time.Now()
+	server.runTurn(t.Context(), turnRequest{
+		id:      "turn-1",
+		text:    "!sleep 30 & printf '%d\\n' $! > background-pid",
+		command: sessionCommand{kind: sessionCommandShell, text: "sleep 30 & printf '%d\\n' $! > background-pid"},
+	})
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("shell command took %s after its shell exited", elapsed)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workingDir, "background-pid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	backgroundPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("background PID = %q: %v", data, err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(backgroundPID, syscall.SIGKILL) })
+
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventTurnStarted, EventToolStarted, EventToolCompleted, EventTurnCompleted)
+	if events[2].Status != "completed" || events[3].Status != "completed" {
+		t.Fatalf("shell command completion = %#v", events)
+	}
+}
+
+func TestRunTurnDispatchesGoalToCodexProvider(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeGoalProvider{goalCommands: make(chan goalCommand, 1)}
+	server := NewServer(Config{}, journal, provider)
+
+	server.runTurn(t.Context(), turnRequest{id: "turn-1", text: "/goal improve coverage", command: sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandCreate, objective: "improve coverage"}}})
+
+	command := <-provider.goalCommands
+	if command.action != goalCommandCreate || command.objective != "improve coverage" {
+		t.Fatalf("goal command = %#v", command)
+	}
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventTurnStarted, EventGoalUpdated, EventTurnCompleted)
+	if events[1].Goal == nil || events[1].Goal.Objective != "improve coverage" {
+		t.Fatalf("goal event = %#v", events[1])
+	}
+}
+
+func TestRunTurnsResumesRecoveredGoalBeforePendingMessage(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeGoalProvider{goalCommands: make(chan goalCommand)}
+	server := NewServer(Config{}, journal, provider)
+	accepted := make(chan struct{})
+	close(accepted)
+	if err := server.restoreTurn(&turnRequest{id: "turn-1", text: "pending work", revision: 1, accepted: accepted}); err != nil {
+		t.Fatal(err)
+	}
+	server.recoveredGoalTurn = &turnRequest{id: "turn-2", text: "/goal resume", revision: 1, command: sessionCommand{kind: sessionCommandGoal, goal: goalCommand{action: goalCommandResume}}}
+	server.outstanding++
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(ctx)
+		close(runDone)
+	}()
+
+	select {
+	case command := <-provider.goalCommands:
+		if command.action != goalCommandResume {
+			t.Fatalf("recovered goal command = %#v", command)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("recovered goal did not resume")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		provider.mu.Lock()
+		prompts := append([]string(nil), provider.prompts...)
+		provider.mu.Unlock()
+		if reflect.DeepEqual(prompts, []string{"pending work"}) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("provider prompts = %#v, want pending work", prompts)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	cancel()
+	<-runDone
+}
+
+func TestSubmitClientMessageControlsActiveGoal(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeGoalProvider{
+		goalCommands: make(chan goalCommand, 2),
+		goalStarted:  make(chan struct{}),
+		goalStopped:  make(chan struct{}),
+	}
+	server := NewServer(Config{}, journal, provider)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(ctx)
+		close(runDone)
+	}()
+
+	if err := server.submitClientMessage(t.Context(), "/goal improve coverage", "request-goal"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-provider.goalStarted:
+	case <-time.After(time.Second):
+		t.Fatal("goal did not start")
+	}
+	if err := server.submitClientMessage(t.Context(), "/goal pause", "request-pause"); err != nil {
+		t.Fatalf("submitClientMessage() error = %v", err)
+	}
+	started := <-provider.goalCommands
+	paused := <-provider.goalCommands
+	if started.action != goalCommandCreate || paused.action != goalCommandPause {
+		t.Fatalf("goal commands = %#v, %#v", started, paused)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		events := journal.Snapshot()
+		if len(events) > 0 && events[len(events)-1].Type == EventTurnCompleted {
+			var recordedControl bool
+			var recordedFeedback bool
+			for _, event := range events {
+				if event.Type == EventUserMessage && event.RequestID == "request-pause" && event.TurnID == "" {
+					recordedControl = true
+				}
+				if event.Type == EventGoalUpdated && event.TurnID == "" {
+					recordedFeedback = true
+				}
+			}
+			if !recordedControl {
+				t.Fatalf("active goal control was not recorded: %#v", events)
+			}
+			if !recordedFeedback {
+				t.Fatalf("active goal control feedback was not recorded: %#v", events)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("goal turn did not stop after pause")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	cancel()
+	<-runDone
+}
+
+func TestSubmitClientMessageQueuesGoalCommandDuringOrdinaryTurn(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	resume := make(chan struct{})
+	provider := &fakeGoalProvider{
+		fakeProvider: fakeProvider{resume: resume},
+		goalCommands: make(chan goalCommand, 1),
+	}
+	server := NewServer(Config{}, journal, provider)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	runDone := make(chan struct{})
+	go func() {
+		server.runTurns(ctx)
+		close(runDone)
+	}()
+
+	if err := server.submitMessage("review this", "request-message"); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		provider.mu.Lock()
+		started := len(provider.prompts) == 1
+		provider.mu.Unlock()
+		if started {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("ordinary turn did not start")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := server.submitClientMessage(t.Context(), "/goal improve coverage", "request-goal"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case command := <-provider.goalCommands:
+		t.Fatalf("goal command ran during ordinary turn: %#v", command)
+	default:
+	}
+	server.submitMu.Lock()
+	pending := server.pendingTurn
+	server.submitMu.Unlock()
+	if pending == nil || pending.command.kind != sessionCommandGoal {
+		t.Fatalf("pending turn = %#v, want goal command", pending)
+	}
+
+	close(resume)
+	select {
+	case command := <-provider.goalCommands:
+		if command.action != goalCommandCreate || command.objective != "improve coverage" {
+			t.Fatalf("goal command = %#v", command)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued goal command did not run")
+	}
+	cancel()
+	<-runDone
+}
+
+func TestSubmitMessageRejectsGoalForOtherProviders(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	server := NewServer(Config{}, journal, &fakeProvider{})
+
+	err := server.submitClientMessage(t.Context(), "/goal improve coverage", "request-goal")
+	if err == nil || !strings.Contains(err.Error(), "only in Codex Sessions") {
+		t.Fatalf("submitMessage() error = %v", err)
+	}
+	if len(journal.Snapshot()) != 0 {
+		t.Fatalf("rejected goal was recorded: %#v", journal.Snapshot())
+	}
+}
+
+func TestSubmitMessageDoesNotMergeCommandsWithPendingMessages(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{name: "command after message", first: "review this", second: "!pwd"},
+		{name: "message after command", first: "!pwd", second: "review this"},
+		{name: "command after command", first: "!pwd", second: "!git status"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			journal := NewJournal()
+			t.Cleanup(journal.Close)
+			server := NewServer(Config{}, journal, &fakeProvider{})
+			if err := server.submitClientMessage(t.Context(), test.first, "request-first"); err != nil {
+				t.Fatal(err)
+			}
+			if err := server.submitClientMessage(t.Context(), test.second, "request-second"); err == nil || !strings.Contains(err.Error(), "pending") {
+				t.Fatalf("second submit error = %v", err)
+			}
+			if events := journal.Snapshot(); len(events) != 1 || events[0].Text != test.first {
+				t.Fatalf("journal events = %#v", events)
+			}
+		})
+	}
+}
+
 func TestServerQueuesStatusPublicationAfterWorkspaceRefresh(t *testing.T) {
 	journal := NewJournal()
 	defer journal.Close()
@@ -790,6 +1204,39 @@ func TestServerSubmitsInitialPromptOnlyWithoutHistory(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestServerTreatsCommandLikeInitialPromptsAsMessages(t *testing.T) {
+	for _, prompt := range []string{"![diagram](image.png)", "!", "/goal edit"} {
+		t.Run(prompt, func(t *testing.T) {
+			journal := NewJournal()
+			t.Cleanup(journal.Close)
+			provider := &fakeProvider{}
+			server := NewServer(Config{InitialPrompt: prompt}, journal, provider)
+
+			if err := server.deliverInitialPrompt(); err != nil {
+				t.Fatalf("deliverInitialPrompt() error = %v", err)
+			}
+			turn := <-server.turns
+			<-turn.accepted
+			turn, ok := server.takePendingTurn(turn)
+			if !ok {
+				t.Fatal("initial prompt was not pending")
+			}
+			server.runTurn(t.Context(), turn)
+
+			provider.mu.Lock()
+			prompts := append([]string(nil), provider.prompts...)
+			provider.mu.Unlock()
+			if !reflect.DeepEqual(prompts, []string{prompt}) {
+				t.Fatalf("provider prompts = %#v, want %#v", prompts, []string{prompt})
+			}
+			events := journal.Snapshot()
+			if len(events) == 0 || events[0].Type != EventUserMessage || events[0].SessionCommand {
+				t.Fatalf("initial prompt event = %#v", events)
+			}
+		})
+	}
 }
 
 func TestServerHealthWaitsForInitialPromptSubmission(t *testing.T) {
@@ -2617,6 +3064,136 @@ func TestCodexEventMapping(t *testing.T) {
 	}
 }
 
+func TestCodexOrdinaryInteractionCompletesWhileGoalIsActive(t *testing.T) {
+	done := make(chan codexTurnResult, 1)
+	provider := &CodexProvider{
+		turnDone:        done,
+		activeTurn:      "codex-turn-1",
+		interactionKind: codexInteractionMessage,
+	}
+	provider.setGoal(&Goal{Objective: "improve coverage", Status: "active"})
+
+	provider.handleNotification("turn/completed", json.RawMessage(`{"turn":{"status":"completed"}}`))
+	select {
+	case result := <-done:
+		if result.status != "completed" {
+			t.Fatalf("Codex turn result = %#v", result)
+		}
+	default:
+		t.Fatal("ordinary Codex turn did not complete while a goal was active")
+	}
+}
+
+func TestCodexGoalNotificationDoesNotCompleteOrdinaryInteraction(t *testing.T) {
+	done := make(chan codexTurnResult, 1)
+	provider := &CodexProvider{
+		turnDone:        done,
+		interactionKind: codexInteractionMessage,
+	}
+	provider.setGoal(&Goal{Objective: "improve coverage", Status: "active"})
+
+	provider.handleNotification("thread/goal/updated", json.RawMessage(`{
+		"goal":{"objective":"improve coverage","status":"paused"}
+	}`))
+	select {
+	case result := <-done:
+		t.Fatalf("goal notification completed ordinary interaction: %#v", result)
+	default:
+	}
+}
+
+func TestCodexGoalKeepsInteractionOpenUntilTerminalTurnCompletes(t *testing.T) {
+	sink := &collectingSink{}
+	done := make(chan codexTurnResult, 1)
+	provider := &CodexProvider{activeSink: sink, turnDone: done, activeTurn: "codex-turn-1", interactionKind: codexInteractionGoal}
+
+	provider.handleNotification("thread/goal/updated", json.RawMessage(`{
+		"goal":{"objective":"improve coverage","status":"active","tokensUsed":100}
+	}`))
+	provider.handleNotification("turn/completed", json.RawMessage(`{"turn":{"status":"completed"}}`))
+	select {
+	case result := <-done:
+		t.Fatalf("active goal completed interaction early: %#v", result)
+	default:
+	}
+
+	provider.handleNotification("turn/started", json.RawMessage(`{"turn":{"id":"codex-turn-2"}}`))
+	provider.handleNotification("thread/goal/updated", json.RawMessage(`{
+		"goal":{"objective":"improve coverage","status":"complete","tokensUsed":200}
+	}`))
+	select {
+	case result := <-done:
+		t.Fatalf("goal completed before its terminal turn: %#v", result)
+	default:
+	}
+	provider.handleNotification("turn/completed", json.RawMessage(`{"turn":{"status":"completed"}}`))
+
+	select {
+	case result := <-done:
+		if result.status != "completed" {
+			t.Fatalf("Codex goal result = %#v", result)
+		}
+	default:
+		t.Fatal("completed Codex goal did not finish the interaction")
+	}
+	assertEventTypes(t, sink.events, EventGoalUpdated, EventGoalUpdated)
+	if sink.events[1].Goal == nil || sink.events[1].Goal.Status != "complete" {
+		t.Fatalf("completed goal event = %#v", sink.events[1])
+	}
+}
+
+func TestCodexGoalCommandUsesAppServerProtocol(t *testing.T) {
+	reader, writer := io.Pipe()
+	sink := &collectingSink{}
+	provider := &CodexProvider{
+		stdin:    writer,
+		pending:  map[string]chan codexResponse{},
+		threadID: "thread-1",
+		done:     make(chan struct{}),
+	}
+	commandDone := make(chan error, 1)
+	go func() {
+		commandDone <- provider.applyGoalCommand(t.Context(), goalCommand{action: goalCommandCreate, objective: "improve coverage"}, sink)
+	}()
+
+	decoder := json.NewDecoder(reader)
+	for index, wantMethod := range []string{"thread/goal/get", "thread/goal/set"} {
+		var request struct {
+			ID     int64  `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				ThreadID  string `json:"threadId"`
+				Objective string `json:"objective"`
+				Status    string `json:"status"`
+			} `json:"params"`
+		}
+		if err := decoder.Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Method != wantMethod || request.Params.ThreadID != "thread-1" {
+			t.Fatalf("goal request %d = %#v", index, request)
+		}
+		if wantMethod == "thread/goal/set" && (request.Params.Objective != "improve coverage" || request.Params.Status != "active") {
+			t.Fatalf("goal set params = %#v", request.Params)
+		}
+		provider.pendingMu.Lock()
+		pending := provider.pending[strconv.FormatInt(request.ID, 10)]
+		provider.pendingMu.Unlock()
+		if wantMethod == "thread/goal/get" {
+			pending <- codexResponse{Result: json.RawMessage(`{"goal":null}`)}
+		} else {
+			pending <- codexResponse{Result: json.RawMessage(`{"goal":{"objective":"improve coverage","status":"active","tokensUsed":125,"timeUsedSeconds":10}}`)}
+		}
+	}
+	if err := <-commandDone; err != nil {
+		t.Fatalf("applyGoalCommand() error = %v", err)
+	}
+	assertEventTypes(t, sink.events, EventGoalUpdated)
+	if sink.events[0].Goal == nil || sink.events[0].Goal.Status != "active" || sink.events[0].Goal.TokensUsed != 125 {
+		t.Fatalf("goal event = %#v", sink.events[0])
+	}
+}
+
 func TestCodexRuntimeStatusMapping(t *testing.T) {
 	sink := &collectingSink{}
 	provider := &CodexProvider{activeSink: sink}
@@ -2811,12 +3388,16 @@ func TestCodexInputResponse(t *testing.T) {
 func TestCodexInterruptUsesActiveTurn(t *testing.T) {
 	reader, writer := io.Pipe()
 	interactionCtx, interactionCancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	close(ready)
 	provider := &CodexProvider{
 		ctx:               context.Background(),
 		stdin:             writer,
 		pending:           map[string]chan codexResponse{},
 		threadID:          "thread-1",
 		activeTurn:        "turn-1",
+		activeReady:       ready,
+		interactionKind:   codexInteractionMessage,
 		interactionCtx:    interactionCtx,
 		interactionCancel: interactionCancel,
 		done:              make(chan struct{}),
@@ -2849,6 +3430,153 @@ func TestCodexInterruptUsesActiveTurn(t *testing.T) {
 	default:
 		t.Fatal("Codex interaction context was not cancelled")
 	}
+}
+
+func TestCodexInterruptPausesActiveGoalBeforeInterruptingTurn(t *testing.T) {
+	reader, writer := io.Pipe()
+	interactionCtx, interactionCancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	close(ready)
+	sink := &collectingSink{}
+	provider := &CodexProvider{
+		ctx:               context.Background(),
+		stdin:             writer,
+		pending:           map[string]chan codexResponse{},
+		threadID:          "thread-1",
+		activeSink:        sink,
+		activeTurn:        "turn-1",
+		activeReady:       ready,
+		interactionKind:   codexInteractionGoal,
+		interactionCtx:    interactionCtx,
+		interactionCancel: interactionCancel,
+		done:              make(chan struct{}),
+	}
+	provider.setGoal(&Goal{Objective: "improve coverage", Status: "active"})
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- provider.Interrupt(t.Context()) }()
+	decoder := json.NewDecoder(reader)
+	for index, wantMethod := range []string{"thread/goal/get", "thread/goal/set", "turn/interrupt"} {
+		var request struct {
+			ID     int64  `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				Status string `json:"status"`
+				TurnID string `json:"turnId"`
+			} `json:"params"`
+		}
+		if err := decoder.Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Method != wantMethod {
+			t.Fatalf("request %d method = %q, want %q", index, request.Method, wantMethod)
+		}
+		switch wantMethod {
+		case "thread/goal/get":
+			respondCodexRequest(t, provider, request.ID, `{"goal":{"objective":"improve coverage","status":"active"}}`)
+		case "thread/goal/set":
+			if request.Params.Status != "paused" {
+				t.Fatalf("goal status = %q, want paused", request.Params.Status)
+			}
+			respondCodexRequest(t, provider, request.ID, `{"goal":{"objective":"improve coverage","status":"paused"}}`)
+		case "turn/interrupt":
+			if request.Params.TurnID != "turn-1" {
+				t.Fatalf("turn ID = %q, want turn-1", request.Params.TurnID)
+			}
+			respondCodexRequest(t, provider, request.ID, `{}`)
+		}
+	}
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("Interrupt() error = %v", err)
+	}
+	select {
+	case <-interactionCtx.Done():
+	default:
+		t.Fatal("Codex interaction context was not cancelled")
+	}
+	assertEventTypes(t, sink.events, EventGoalUpdated)
+	if sink.events[0].Status != "paused" {
+		t.Fatalf("goal event = %#v", sink.events[0])
+	}
+}
+
+func TestCodexInterruptPausesActiveGoalBetweenTurns(t *testing.T) {
+	reader, writer := io.Pipe()
+	ready := make(chan struct{})
+	close(ready)
+	sink := &collectingSink{}
+	provider := &CodexProvider{
+		ctx:             context.Background(),
+		stdin:           writer,
+		pending:         map[string]chan codexResponse{},
+		threadID:        "thread-1",
+		activeSink:      sink,
+		activeReady:     ready,
+		interactionKind: codexInteractionGoal,
+		turnDone:        make(chan codexTurnResult, 1),
+		done:            make(chan struct{}),
+	}
+	provider.setGoal(&Goal{Objective: "improve coverage", Status: "active"})
+
+	interruptDone := make(chan error, 1)
+	go func() { interruptDone <- provider.Interrupt(t.Context()) }()
+	decoder := json.NewDecoder(reader)
+	for _, wantMethod := range []string{"thread/goal/get", "thread/goal/set"} {
+		var request struct {
+			ID     int64  `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				Status string `json:"status"`
+			} `json:"params"`
+		}
+		if err := decoder.Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Method != wantMethod {
+			t.Fatalf("request method = %q, want %q", request.Method, wantMethod)
+		}
+		if wantMethod == "thread/goal/get" {
+			respondCodexRequest(t, provider, request.ID, `{"goal":{"objective":"improve coverage","status":"active"}}`)
+		} else {
+			if request.Params.Status != "paused" {
+				t.Fatalf("goal status = %q, want paused", request.Params.Status)
+			}
+			respondCodexRequest(t, provider, request.ID, `{"goal":{"objective":"improve coverage","status":"paused"}}`)
+		}
+	}
+	if err := <-interruptDone; err != nil {
+		t.Fatalf("Interrupt() error = %v", err)
+	}
+	select {
+	case result := <-provider.turnDone:
+		if result.status != "completed" {
+			t.Fatalf("Codex goal result = %#v", result)
+		}
+	default:
+		t.Fatal("paused Codex goal did not finish its interaction")
+	}
+}
+
+func TestCodexInterruptDoesNotPauseGoalWithoutInteraction(t *testing.T) {
+	provider := &CodexProvider{}
+	provider.setGoal(&Goal{Objective: "improve coverage", Status: "active"})
+	if err := provider.Interrupt(t.Context()); !errors.Is(err, ErrNoActiveTurn) {
+		t.Fatalf("Interrupt() error = %v, want ErrNoActiveTurn", err)
+	}
+	if !provider.goalIsActive() {
+		t.Fatal("Interrupt() paused a goal without an active interaction")
+	}
+}
+
+func respondCodexRequest(t *testing.T, provider *CodexProvider, requestID int64, result string) {
+	t.Helper()
+	provider.pendingMu.Lock()
+	pending := provider.pending[strconv.FormatInt(requestID, 10)]
+	provider.pendingMu.Unlock()
+	if pending == nil {
+		t.Fatalf("Codex request %d is not pending", requestID)
+	}
+	pending <- codexResponse{Result: json.RawMessage(result)}
 }
 
 func TestCodexOpenThreadReplacesUnmaterializedThread(t *testing.T) {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -718,8 +718,8 @@ func TestSessionComposerAllowsMultilinePromptsOnTouchDevices(t *testing.T) {
 	javascript := string(source)
 	for description, expected := range map[string]string{
 		"touch device detection":  `window.matchMedia('(pointer: coarse)').matches`,
-		"touch composer hint":     "? `Tap ${actionSymbol} to ${action} · Return for a new line`",
-		"desktop composer hint":   "`Enter to ${action} · Shift+Enter for a new line`",
+		"touch composer hint":     "? `Tap ${actionSymbol} to ${action} · Return for a new line · !COMMAND · /goal`",
+		"desktop composer hint":   "`Enter to ${action} · Shift+Enter for a new line · !COMMAND · /goal`",
 		"disabled interrupt hint": "`Click ${actionSymbol} to interrupt`",
 		"desktop-only Enter send": `!event.isComposing && !usesTouchComposer()`,
 	} {

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -367,7 +367,7 @@ function testComposerInterruptsWhileInputIsDisabled() {
   assert.equal(elements.input.value, 'preserved draft');
   window.matchMedia = () => ({matches: true});
   updateComposerAction();
-  assert.equal(elements.composerHint.textContent, 'Tap ■ to interrupt · Return for a new line');
+  assert.equal(elements.composerHint.textContent, 'Tap ■ to interrupt · Return for a new line · !COMMAND · /goal');
   window.matchMedia = () => ({matches: false});
 
   submitComposer();
@@ -383,12 +383,17 @@ function testComposerInterruptsWhileInputIsDisabled() {
 function testComposerLabelsPendingSubmission() {
   resetHarness();
   state.socket = {readyState: WebSocket.OPEN};
+  state.activeTurn = true;
   state.pendingMessage = {event: {turnId: 'turn-2'}};
   elements.input.value = 'another detail';
 
   updateComposerAction();
 
-  assert.equal(elements.composerHint.textContent, 'Enter to add to pending · Shift+Enter for a new line');
+  assert.equal(elements.composerHint.textContent, 'Enter to add to pending · Shift+Enter for a new line · !COMMAND · /goal');
+
+  elements.input.value = '/goal pause';
+  updateComposerAction();
+  assert.equal(elements.composerHint.textContent, 'Enter to run goal command · Shift+Enter for a new line · !COMMAND · /goal');
 }
 
 async function testComposerIgnoresReentrantSubmission() {
@@ -758,6 +763,32 @@ function testToolOutputRendering() {
   );
 }
 
+function testToolOutputStreamsBeforeCompletion() {
+  resetHarness();
+  renderTool({type: 'tool.started', toolId: 'tool-1', toolName: 'make test', status: 'running'});
+  appendToolDelta({type: 'tool.delta', toolId: 'tool-1', output: 'first\n'});
+  appendToolDelta({type: 'tool.delta', toolId: 'tool-1', output: 'second\n'});
+
+  const card = state.tools.get('tool-1');
+  assert.equal(card.querySelector('.tool-output-preview').textContent, 'first\nsecond');
+
+  completeTool({type: 'tool.completed', toolId: 'tool-1', status: 'completed', output: 'first\nsecond\n'});
+  assert.equal(card.querySelector('.tool-output-preview').textContent, 'first\nsecond');
+}
+
+function testGoalRendering() {
+  resetHarness();
+  renderGoal({
+    type: 'goal.updated',
+    goal: {objective: 'Improve coverage', status: 'active', tokenBudget: 1000, tokensUsed: 125},
+  });
+  assert.equal(elements.messages.querySelector('.goal-card').textContent, 'Goal active · 125/1000 tokensImprove coverage');
+
+  renderGoal({type: 'goal.updated', status: 'cleared'});
+  const cards = elements.messages.querySelectorAll('.goal-card');
+  assert.equal(cards[1].textContent, 'Goal cleared.');
+}
+
 function testToolOutputRenderingNormalizesCarriageReturns() {
   resetHarness();
   state.replayingHistory = true;
@@ -887,6 +918,8 @@ testReselectRefreshesStatusPlaceholder();
 testSessionTimestampFormatting();
 testSessionTimestampElement();
 testToolOutputRendering();
+testToolOutputStreamsBeforeCompletion();
+testGoalRendering();
 testToolOutputRenderingNormalizesCarriageReturns();
 testHistoryToolCompletionRendersOutputWithoutStart();
 testUserAttachmentRendering();

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -1626,7 +1626,11 @@ function composerInterruptAction() {
 function updateComposerAction() {
   const connected = state.socket && state.socket.readyState === WebSocket.OPEN;
   const interrupt = composerInterruptAction();
-  const action = interrupt ? 'interrupt' : ((state.activeTurn || state.pendingMessage) ? 'add to pending' : 'send');
+  const goalControl = state.activeTurn && /^\/goal(?:\s|$)/.test(elements.input.value.trim());
+  let action = 'send';
+  if (interrupt) action = 'interrupt';
+  else if (goalControl) action = 'run goal command';
+  else if (state.activeTurn || state.pendingMessage) action = 'add to pending';
   const actionSymbol = interrupt ? '■' : '↑';
   elements.send.dataset.action = interrupt ? 'interrupt' : 'send';
   elements.send.textContent = actionSymbol;
@@ -1634,10 +1638,10 @@ function updateComposerAction() {
   elements.send.title = interrupt ? 'Interrupt active work' : 'Send message';
   elements.send.disabled = !connected || state.sendingMessage || (interrupt ? state.interrupting : elements.input.disabled);
   elements.composerHint.textContent = usesTouchComposer()
-    ? `Tap ${actionSymbol} to ${action} · Return for a new line`
+    ? `Tap ${actionSymbol} to ${action} · Return for a new line · !COMMAND · /goal`
     : (interrupt && elements.input.disabled
       ? `Click ${actionSymbol} to interrupt`
-      : `Enter to ${action} · Shift+Enter for a new line`);
+      : `Enter to ${action} · Shift+Enter for a new line · !COMMAND · /goal`);
 }
 
 function closeSocket() {
@@ -2632,9 +2636,16 @@ function handleEvent(event) {
       endAssistantSegment(event.turnId);
       renderTool(event);
       break;
+    case 'tool.delta':
+      appendToolDelta(event);
+      break;
     case 'tool.completed':
       endAssistantSegment(event.turnId);
       completeTool(event);
+      break;
+    case 'goal.updated':
+      endAssistantSegment(event.turnId);
+      renderGoal(event);
       break;
     case 'input.requested':
       endAssistantSegment(event.turnId);
@@ -2915,6 +2926,18 @@ function renderTool(event) {
   scrollToBottom();
 }
 
+function appendToolDelta(event) {
+  let card = state.tools.get(event.toolId);
+  if (!card) {
+    renderTool({...event, status: 'running'});
+    card = state.tools.get(event.toolId);
+  }
+  if (!card) return;
+  card.toolOutput = (card.toolOutput || '') + (event.output || '');
+  renderToolOutput(card, card.toolOutput);
+  scrollToBottom();
+}
+
 function toolOutputPreview(output, maxLines = 5) {
   const text = String(output || '').replace(/\r\n?/g, '\n').replace(/\n+$/, '');
   if (!text) return {text: '', fullText: '', totalLines: 0, omittedLines: 0};
@@ -2970,7 +2993,30 @@ function completeTool(event) {
   card.dataset.status = event.status || 'completed';
   card.querySelector('.tool-status').textContent = event.status || 'completed';
   card.querySelector('.tool-icon').textContent = event.status === 'failed' ? '!' : '✓';
-  renderToolOutput(card, event.output);
+  card.toolOutput = event.output || card.toolOutput || '';
+  renderToolOutput(card, card.toolOutput);
+  scrollToBottom();
+}
+
+function renderGoal(event) {
+  ensureConversation();
+  const card = document.createElement('div');
+  card.className = 'goal-card';
+  if (!event.goal) {
+    card.textContent = event.status === 'cleared' ? 'Goal cleared.' : 'No goal is currently set.';
+  } else {
+    const goal = event.goal;
+    let usage = '';
+    if (goal.tokenBudget != null) usage = ` · ${goal.tokensUsed || 0}/${goal.tokenBudget} tokens`;
+    else if (goal.tokensUsed) usage = ` · ${goal.tokensUsed} tokens`;
+    const status = document.createElement('strong');
+    status.textContent = `Goal ${goal.status}${usage}`;
+    const objective = document.createElement('div');
+    objective.textContent = goal.objective || '';
+    card.append(status, objective);
+  }
+  elements.messages.append(card);
+  scrollToBottom();
 }
 
 function bindOtherAnswer(controls, other, multiSelect) {

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -95,7 +95,7 @@
           <button class="send-button" id="send-message" type="submit" aria-label="Send message" data-action="send" disabled>↑</button>
         </form>
         <div class="session-runtime-status" id="session-runtime-status" role="status" aria-live="polite" hidden></div>
-        <div class="composer-hint" id="composer-hint">Enter to send · Shift+Enter for a new line</div>
+        <div class="composer-hint" id="composer-hint">Enter to send · Shift+Enter for a new line · !COMMAND · /goal</div>
       </footer>
     </main>
   </div>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -198,7 +198,7 @@ button { color: inherit; }
 .agent-avatar { flex: 0 0 auto; width: 29px; height: 29px; display: grid; place-items: center; margin-top: 2px; border-radius: 9px; background: var(--accent); color: white; font: 700 11px/1 ui-monospace, monospace; }
 .assistant .message-bubble { max-width: calc(100% - 45px); padding: 2px 2px 3px; border-radius: 0; background: transparent; }
 .assistant .message-bubble:empty::after { content: "Thinking…"; color: var(--faint); animation: pulse 1.1s infinite; }
-.tool-card, .input-card, .diff-card, .error-card, .recovery-card { margin: -7px 0 19px 40px; border: 1px solid var(--line); border-radius: 13px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.tool-card, .input-card, .diff-card, .error-card, .recovery-card, .goal-card { margin: -7px 0 19px 40px; border: 1px solid var(--line); border-radius: 13px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
 .tool-card { padding: 10px 13px; color: var(--muted); font-size: 12px; }
 .tool-card-header { display: flex; align-items: center; gap: 10px; }
 .tool-icon { width: 25px; height: 25px; display: grid; place-items: center; border-radius: 8px; background: var(--panel); font-size: 12px; }
@@ -256,6 +256,8 @@ button { color: inherit; }
 .diff-line.metadata { color: var(--muted); }
 .error-card { padding: 12px 14px; border-color: rgba(167,63,63,.25); background: #fff6f6; color: var(--danger); font-size: 12px; line-height: 1.5; }
 .recovery-card { padding: 12px 14px; border-color: rgba(197,138,62,.3); background: #fff9ef; color: #8a5b1f; font-size: 12px; line-height: 1.5; }
+.goal-card { padding: 12px 14px; border-color: rgba(70,116,91,.25); background: #f3faf6; color: var(--ink); font-size: 12px; line-height: 1.5; }
+.goal-card strong { display: block; margin-bottom: 3px; color: var(--accent); }
 .turn-divider { margin: 2px 0 22px 40px; color: var(--faint); font-size: 10px; line-height: 1; white-space: nowrap; }
 .turn-divider:empty { height: 1px; background: linear-gradient(90deg,var(--line),transparent); }
 .turn-divider:not(:empty) { display: flex; align-items: center; gap: 8px; }
@@ -393,7 +395,7 @@ button { color: inherit; }
   .composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }
   .send-button { width: 48px; height: 48px; }
   .message-bubble, .user-message { max-width: 90%; }
-  .tool-card, .input-card, .diff-card, .error-card, .recovery-card { margin-left: 0; }
+  .tool-card, .input-card, .diff-card, .error-card, .recovery-card, .goal-card { margin-left: 0; }
   .turn-divider { margin-left: 0; }
   .session-dialog { width: calc(100vw - 16px - env(safe-area-inset-left) - env(safe-area-inset-right)); max-width: none; max-height: calc(100dvh - 16px - env(safe-area-inset-top) - env(safe-area-inset-bottom)); border-radius: 16px; }
   .session-dialog form { padding: 18px 16px calc(16px + env(safe-area-inset-bottom)); }
@@ -411,6 +413,7 @@ button { color: inherit; }
   .user .message-bubble { background: #263b30; }
   .error-card { background: #2d1e1e; }
   .recovery-card { background: #2d281e; color: #e7bd78; }
+  .goal-card { background: #1e2923; }
   .diff-lines { background: #121915; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds shared Session command handling for terminal and web clients.

- Runs `!COMMAND` directly in the Session workspace, streams and retains its output, and interrupts the shell process group without stopping the agent conversation.
- Adds persisted Codex `/goal` commands to show, create, edit, pause, resume, and clear an objective.
- Keeps active Codex goals running across client detaches and runtime restarts while preserving pending user messages.
- Documents that `/quit` and `/exit` detach without interrupting active work.

This gives both Session clients the same concise command interface and avoids sending direct shell commands or goal-management requests as ordinary model prompts.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`/goal` uses the Codex app-server goal protocol and is available only for Codex Sessions. `!COMMAND` is provider-independent. `/loop` is intentionally outside this PR.

Validation:

- `make update`
- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
Session terminal and web clients now support direct `!COMMAND` shell execution, and Codex Sessions support persistent `/goal` management.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direct shell execution with !COMMAND and persistent Codex `/goal` management to Session terminal and web clients. Previously these were prompts sent to the model; now the runtime intercepts them, runs shell commands locally, and keeps goals running across detaches and restarts.

- `!COMMAND` (all providers): runs `/bin/sh -lc` in the Session workspace; streams `tool.delta`, retains bounded output on `tool.completed`, and interrupts by killing the process group without ending the conversation. Output is never sent to the model.
- `/goal` (Codex only): show/create/edit/pause/resume/clear the persisted goal via the app-server protocol; emits `goal.updated`. Interrupting pauses the goal first; detaching leaves it running. On runtime start, an active goal resumes before pending messages. While a goal interaction is active, client `/goal …` controls it immediately (not queued as a new turn).
- Protocol/UI: adds `tool.delta` and `goal.updated` events and a `Goal` payload. Terminal and web UIs stream tool output without duplication and render goal status cards; composer hints include `!COMMAND` and `/goal` and show “run goal command” when applicable. Docs now clarify `/quit` and `/exit` detach without stopping work.
- Server/runtime: parses commands (`!`, `/goal`), rejects attachments with commands, and prevents mixing commands and pending messages. Introduces `goalProvider` and a Codex implementation (`thread/goal/get|set|clear`), tracks turn start/finish notifications, resumes/pauses goals across restarts and interrupts, and retains bounded tool output and goal snapshots in history. Extensive tests cover streaming, goal flow/control, and recovery.

**Review focus**
- `internal/sessionruntime`: command parsing, new events (`tool.delta`, `goal.updated`), history projection, and `goalProvider` implementation in Codex.
- `internal/sessionruntime/server.go`: shell execution/interrupt (`runShellCommand`), goal resume/control path, and submit/edit validation.
- Terminal/web: streaming tool output and goal rendering (`internal/cli/*tui*`, `internal/sessionserver/web/*`).

<sup>Written for commit 4bf005624264322ba4c45cf2e0dc1cf47b54e403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

